### PR TITLE
docs(ROADMAP): expand AI Assistant orchestration roadmap item

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -157,6 +157,7 @@ Latest validation on May 3, 2026: `npm run check`, `npm run build`, `cargo check
 - [x] Add durable RDP connection type.
 - [x] Add durable VNC connection type.
 - [x] Implement Windows-native RDP session transport with Microsoft RDP ActiveX COM hosting.
+- [ ] Add configurable RDP session options (for example: display quality/performance tuning, clipboard mapping, and related redirect/security controls).
 - [ ] Implement VNC session transport.
 - [ ] Add MobaXterm/RDCMan import.
 - [ ] Add SFTP folder sync/diff/resume.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -130,6 +130,7 @@ Latest validation on May 3, 2026: `npm run check`, `npm run build`, `cargo check
 - [ ] Support asking the AI Assistant to create extensions.
 - [ ] Keep extension-generation flows approval-based before installing or running generated code.
 - [ ] Language output setting for UI assistant - follow UI language or specific language.
+- [ ] Expand AI Assistant orchestration so it can (with explicit approval) automate more workflows: import Connection entries from multiple formats, monitor existing Connections, rename/reorganize layouts, help create plugins, assist with wiki workflows (once wiki ships), and optionally relay remote-assistant interactions through Telegram/WhatsApp/LINE integrations.
 
 ### UI Customization
 


### PR DESCRIPTION
### Motivation
- Expand the v0.2 roadmap to capture planned AI Assistant orchestration capabilities and make the intended automation scope explicit.

### Description
- Add a new unchecked roadmap checklist item under "Assistant Context and Automation" that lists orchestration features such as importing Connection entries from multiple formats, monitoring existing Connections, renaming/reorganizing layouts, helping create plugins and wiki workflows, and optionally relaying remote-assistant interactions via Telegram/WhatsApp/LINE.

### Testing
- No automated tests were required or run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e04689b8832f9899cc5f4110d6c9)