### PR TITLE
Support multi-connection terminal panes (Add-to split)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1471,6 +1471,9 @@ function ConnectionSidebar({
   const query = useWorkspaceStore((state) => state.query);
   const setQuery = useWorkspaceStore((state) => state.setQuery);
   const openConnection = useWorkspaceStore((state) => state.openConnection);
+  const tabs = useWorkspaceStore((state) => state.tabs);
+  const activeTabId = useWorkspaceStore((state) => state.activeTabId);
+  const addConnectionToTerminalPane = useWorkspaceStore((state) => state.addConnectionToTerminalPane);
   const activeSessionCounts = useWorkspaceStore((state) => state.activeSessionCounts);
   const sshSettings = useWorkspaceStore((state) => state.sshSettings);
   const [tree, setTree] = useState<ConnectionTree>(connectionTree);
@@ -1574,6 +1577,16 @@ function ConnectionSidebar({
   function handleOpenConnection(connection: Connection) {
     rememberConnection(connection);
     openConnection(connection);
+  }
+
+  function handleAddConnectionToFocusedPane(connection: Connection, direction: SplitDirection) {
+    const activeTab = tabs.find((tab) => tab.id === activeTabId);
+    if (!activeTab || activeTab.kind !== "terminal") {
+      handleOpenConnection(connection);
+      return;
+    }
+    rememberConnection(connection);
+    addConnectionToTerminalPane(activeTab.id, connection, direction);
   }
 
   function handleQuickLocalShell(option: LocalShellOption) {
@@ -2355,6 +2368,7 @@ function ConnectionSidebar({
       {treeContextMenu ? (
         <TreeContextMenu
           menu={treeContextMenu}
+          canAddToPane={Boolean(tabs.find((tab) => tab.id === activeTabId && tab.kind === "terminal"))}
           onClose={() => setTreeContextMenu(null)}
           onCollapseAll={handleCollapseAllFolders}
           onCreateConnection={() => {
@@ -2390,6 +2404,13 @@ function ConnectionSidebar({
               void handleRenameConnection(menu.connection);
             } else if (menu.kind === "folder") {
               void handleRenameFolder(menu.folder);
+            }
+          }}
+          onAddToPane={(direction) => {
+            const menu = treeContextMenu;
+            setTreeContextMenu(null);
+            if (menu.kind === "connection") {
+              handleAddConnectionToFocusedPane(menu.connection, direction);
             }
           }}
         />
@@ -2654,6 +2675,7 @@ function NewFolderDraftRow({
 
 function TreeContextMenu({
   menu,
+  canAddToPane,
   onClose,
   onCollapseAll,
   onCreateConnection,
@@ -2662,8 +2684,10 @@ function TreeContextMenu({
   onExpandAll,
   onProperties,
   onRename,
+  onAddToPane,
 }: {
   menu: TreeContextMenuState;
+  canAddToPane: boolean;
   onClose: () => void;
   onCollapseAll: () => void;
   onCreateConnection: () => void;
@@ -2672,6 +2696,7 @@ function TreeContextMenu({
   onExpandAll: () => void;
   onProperties: () => void;
   onRename: () => void;
+  onAddToPane: (direction: SplitDirection) => void;
 }) {
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -2745,10 +2770,32 @@ function TreeContextMenu({
         </>
       ) : null}
       {menu.kind === "connection" ? (
-        <button onClick={onProperties} role="menuitem" type="button">
-          <IconParkSetting className="menu-item-icon" size={15} />
-          <span>Properties</span>
-        </button>
+        <>
+          {canAddToPane ? (
+            <>
+              <button onClick={() => onAddToPane("right")} role="menuitem" type="button">
+                <ArrowRight className="menu-item-icon" size={15} />
+                <span>Add to Right Pane</span>
+              </button>
+              <button onClick={() => onAddToPane("left")} role="menuitem" type="button">
+                <ArrowLeft className="menu-item-icon" size={15} />
+                <span>Add to Left Pane</span>
+              </button>
+              <button onClick={() => onAddToPane("down")} role="menuitem" type="button">
+                <ArrowDown className="menu-item-icon" size={15} />
+                <span>Add to Lower Pane</span>
+              </button>
+              <button onClick={() => onAddToPane("up")} role="menuitem" type="button">
+                <ArrowUp className="menu-item-icon" size={15} />
+                <span>Add to Upper Pane</span>
+              </button>
+            </>
+          ) : null}
+          <button onClick={onProperties} role="menuitem" type="button">
+            <IconParkSetting className="menu-item-icon" size={15} />
+            <span>Properties</span>
+          </button>
+        </>
       ) : null}
     </div>
   );

--- a/src/store.ts
+++ b/src/store.ts
@@ -295,6 +295,27 @@ function buildPanesForConnection(connection: Connection, count: number): Termina
   return panes;
 }
 
+function buildPanesFromStoredLayout(connection: Connection, stored?: StoredConnectionLayout): TerminalPane[] {
+  const paneCount = Math.max(1, stored?.paneCount ?? 1);
+  const fallback = buildPanesForConnection(connection, paneCount);
+  if (!stored?.panes?.length) {
+    return fallback;
+  }
+  return fallback.map((pane, index) => {
+    const storedPane = stored.panes?.[index];
+    if (!storedPane?.connection) {
+      return pane;
+    }
+    return {
+      ...pane,
+      title: storedPane.title?.trim() || pane.title,
+      cwd: storedPane.cwd?.trim() || pane.cwd,
+      connection: storedPane.connection,
+      tmuxSessionId: storedPane.tmuxSessionId,
+    };
+  });
+}
+
 interface WorkspaceState {
   query: string;
   tabs: WorkspaceTab[];
@@ -329,6 +350,11 @@ interface WorkspaceState {
   openLocalTerminal: () => void;
   splitTerminalPane: (tabId: string) => void;
   splitTerminalPaneDirected: (tabId: string, direction: SplitDirection) => void;
+  addConnectionToTerminalPane: (
+    tabId: string,
+    connection: Connection,
+    direction: SplitDirection,
+  ) => void;
   closePane: (tabId: string, paneId: string) => void;
   openTmuxSessionInPane: (tabId: string, connection: Connection, tmuxSessionId: string, direction: SplitDirection) => void;
   setFocusedPane: (tabId: string, paneId: string) => void;
@@ -438,8 +464,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
 
     const stored = loadStoredLayout(connection.id);
-    const paneCount = Math.max(1, stored?.paneCount ?? 1);
-    const panes = buildPanesForConnection(connection, paneCount);
+    const panes = buildPanesFromStoredLayout(connection, stored);
     const paneIds = panes.map((pane) => pane.id);
     const layout =
       (stored ? hydrateLayout(stored.layout, paneIds) : undefined) ?? defaultLayoutFor(panes);
@@ -628,6 +653,37 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
           layout: nextLayout,
           focusedPaneId: newPane.id,
         };
+      }),
+    }));
+  },
+  addConnectionToTerminalPane: (tabId, connection, direction) => {
+    set((state) => ({
+      tabs: state.tabs.map((tab) => {
+        if (tab.id !== tabId || tab.kind !== "terminal") {
+          return tab;
+        }
+        const focusedPane = tab.panes.find((pane) => pane.id === tab.focusedPaneId) ?? tab.panes[0];
+        if (!focusedPane) {
+          return tab;
+        }
+        const newPane: TerminalPane = {
+          id: `pane-${connection.id}-${Date.now()}`,
+          title: connection.type === "local" ? connection.name : "ssh",
+          cwd: focusedPane.cwd,
+          buffer: "",
+          connection,
+          tmuxSessionId: appendTmuxSessionId(connection),
+        };
+        const nextPanes = [...tab.panes, newPane];
+        const baseLayout = ensureLayout(tab.layout, tab.panes);
+        const nextLayout = splitLayout(
+          baseLayout,
+          focusedPane.id,
+          direction,
+          newPane.id,
+          tab.panes.map((pane) => pane.id),
+        );
+        return { ...tab, panes: nextPanes, layout: nextLayout, focusedPaneId: newPane.id };
       }),
     }));
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,14 @@ export type StoredLayoutNode =
 export interface StoredConnectionLayout {
   paneCount: number;
   layout: StoredLayoutNode;
+  panes?: StoredLayoutPane[];
+}
+
+export interface StoredLayoutPane {
+  connection: Connection;
+  title?: string;
+  cwd?: string;
+  tmuxSessionId?: string;
 }
 
 export type TerminalCursorStyle = "block" | "bar" | "underline";

--- a/src/workspace/layout.ts
+++ b/src/workspace/layout.ts
@@ -3,6 +3,7 @@ import type {
   SplitDirection,
   SplitOrientation,
   StoredConnectionLayout,
+  StoredLayoutPane,
   StoredLayoutNode,
   TerminalPane,
 } from "../types";
@@ -192,7 +193,20 @@ export function serializeLayout(
   if (!stored) {
     return undefined;
   }
-  return { paneCount: panes.length, layout: stored };
+  const storedPanes: StoredLayoutPane[] = [];
+  for (const pane of panes) {
+    const connection = pane.connection ?? panes[0]?.connection;
+    if (!connection) {
+      continue;
+    }
+    storedPanes.push({
+      connection,
+      title: pane.title,
+      cwd: pane.cwd,
+      tmuxSessionId: pane.tmuxSessionId,
+    });
+  }
+  return { paneCount: panes.length, layout: stored, panes: storedPanes };
 }
 
 function serializeNode(


### PR DESCRIPTION
### Motivation
- Allow a single terminal tab to host panes connected to different Connections so users can build multi-server layouts and re-open them later. 
- Let users right-click a Connection in the tree and choose to insert it relative to the currently focused pane (right/left/down/up) with the same split semantics as the existing split actions.

### Description
- Persist per-pane connection metadata by adding `StoredLayoutPane` and storing `connection`, `title`, `cwd`, and `tmuxSessionId` when serializing layouts. (`src/types.ts`, `src/workspace/layout.ts`)
- Serialize per-pane metadata in `serializeLayout` and hydrate pane list from stored layout on open, enabling mixed-server pane restoration. (`src/workspace/layout.ts`, `src/store.ts`)
- Add `buildPanesFromStoredLayout` and update `openConnection` to rebuild `WorkspaceTab.panes` from stored layout metadata. (`src/store.ts`)
- Add `addConnectionToTerminalPane(tabId, connection, direction)` store action to insert a selected Connection as a new pane adjacent to the focused pane and focus the new pane. (`src/store.ts`)
- Extend the connection tree context menu to show "Add to Right/Left/Lower/Upper Pane" when a terminal tab is active and wire those menu actions to the new store action. (`src/App.tsx`)

### Testing
- Ran `npm run check` (`tsc --noEmit`) and it succeeded. 
- Ran `npm run build` (`tsc && vite build`) and it succeeded. 
- `cargo check --manifest-path src-tauri/Cargo.toml` failed in this environment because the system `glib-2.0` development package (pkg-config metadata) is not available, so native backend checks could not complete here. 
- `cargo test --manifest-path src-tauri/Cargo.toml` could not complete for the same missing system dependency in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f824dd22e4832f92f0e100b6ee0c21)