### PR TITLE
Avoid title-bar flicker when switching RDP panes by preventing z-order changes

### DIFF
--- a/src-tauri/src/rdp.rs
+++ b/src-tauri/src/rdp.rs
@@ -24,7 +24,7 @@ mod platform {
                 Variant::{VariantClear, VARIANT, VT_BOOL, VT_BSTR, VT_DISPATCH, VT_I2, VT_I4},
             },
             UI::WindowsAndMessaging::{
-                CreateWindowExW, DestroyWindow, SetWindowPos, ShowWindow, HMENU, HWND_TOP,
+                CreateWindowExW, DestroyWindow, SetWindowPos, ShowWindow, HMENU,
                 SWP_NOACTIVATE, SWP_NOZORDER, SW_HIDE, SW_SHOW, WS_CLIPCHILDREN, WS_CLIPSIBLINGS,
                 WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_POPUP, WS_VISIBLE,
             },
@@ -788,12 +788,12 @@ mod platform {
         unsafe {
             SetWindowPos(
                 hwnd,
-                Some(HWND_TOP),
+                None,
                 origin.0,
                 origin.1,
                 rect.2,
                 rect.3,
-                SWP_NOACTIVATE,
+                SWP_NOACTIVATE | SWP_NOZORDER,
             )
             .map_err(|error| format!("failed to position RDP control: {error}"))?;
             let _ = ShowWindow(hwnd, SW_SHOW);


### PR DESCRIPTION
### Motivation
- Switching to/from RDP panes caused the native RDP host window to change z-order and steal focus, producing title-bar flicker; the change prevents that focus churn. 

### Description
- In `src-tauri/src/rdp.rs` the `show_rdp` call to `SetWindowPos` now uses `None` for the insert-after parameter and adds the `SWP_NOZORDER` flag so the window is positioned without changing z-order (`SWP_NOACTIVATE | SWP_NOZORDER`).
- Removed the now-unused `HWND_TOP` import from the Windows API imports.
- Change targets the native RDP host positioning logic to keep no-activate behavior while avoiding window-order modifications that cause focus/title flicker.

### Testing
- Ran `npm run check` and it completed successfully. ✅
- Ran `npm run build` and it completed successfully. ✅
- Ran `cargo check --manifest-path src-tauri/Cargo.toml` which failed in this Linux container due to missing system `glib-2.0` development files required by `glib-sys`. ⚠️
- Ran `cargo test --manifest-path src-tauri/Cargo.toml` which likewise failed in this environment for the same missing `glib-2.0` system dependency. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f829642c24832fa15badf200e2389f)