### PR TITLE
Restore URL option in Add Connection and Quick Connect dialogs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -242,7 +242,7 @@ type ConnectionDialogRequest = CreateConnectionRequest & {
   urlPassword?: string;
 };
 
-type ConnectionTileType = Extract<ConnectionType, "ssh" | "local" | "rdp" | "vnc">;
+type ConnectionTileType = ConnectionType;
 
 type WebviewNavigationEvent = {
   sessionId: string;
@@ -2917,6 +2917,12 @@ const CONNECTION_TYPE_TILES: Array<{
     accent: "#13a085",
   },
   {
+    type: "url",
+    title: "URL",
+    description: "Embedded web app",
+    accent: "#0ea5e9",
+  },
+  {
     type: "rdp",
     title: "Remote Desktop",
     description: "Windows RDP",
@@ -2930,7 +2936,7 @@ const CONNECTION_TYPE_TILES: Array<{
   },
 ];
 
-const CONNECTION_ICON_FILLS: Record<ConnectionTileType, string[]> = {
+const CONNECTION_ICON_FILLS: Record<Exclude<ConnectionTileType, "url">, string[]> = {
   ssh: ["#1f2937", "#f3f4f6", "#111827", "#6b7280"],
   local: ["#047857", "#d1fae5", "#065f46", "#34d399"],
   rdp: ["#1e3a8a", "#dbeafe", "#172554", "#60a5fa"],
@@ -2946,6 +2952,10 @@ function ConnectionTypeGlyph({
   size?: number;
   type: ConnectionTileType;
 }) {
+  if (type === "url") {
+    return <Globe2 className={className} size={size} />;
+  }
+
   const iconProps = {
     className,
     fill: CONNECTION_ICON_FILLS[type],


### PR DESCRIPTION
### Motivation
- Reintroduce the `url` connection kind to the shared connection dialog so users can create/open embedded webview sessions from both Add Connection and Quick Connect flows.
- Keep UI behavior and visual language consistent with existing connection tiles and glyph styling.

### Description
- Restore a `URL` tile in the connection-type picker by adding a `url` entry to `CONNECTION_TYPE_TILES` in `src/App.tsx`.
- Broaden the picker typing by changing `ConnectionTileType` from a narrowed `Extract<...>` to `ConnectionType` so `url` is accepted.
- Preserve the existing multi-color icon fills for non-URL tiles by narrowing `CONNECTION_ICON_FILLS` to exclude `url` and render a globe icon (`Globe2`) when `type === "url"` inside `ConnectionTypeGlyph`.

### Testing
- Ran `npm run check` which completed successfully.
- Ran `npm run build` which completed successfully.
- Ran `cargo check --manifest-path src-tauri/Cargo.toml` which failed in this environment due to missing system library metadata for `glib-2.0` (pkg-config `glib-2.0.pc` not available). 
- Ran `cargo test --manifest-path src-tauri/Cargo.toml` which could not complete for the same `glib-2.0` system dependency issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8338a3bcc832faf71ff8ea8a3bcf2)