### PR TITLE
Add expandable truncation for long user messages in AI Assistant chat

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2193,6 +2193,26 @@ progress {
   justify-self: end;
 }
 
+.assistant-message-bubble-truncated {
+  max-height: calc(10 * 1.5em);
+  overflow: hidden;
+}
+
+.assistant-message-expand {
+  justify-self: end;
+  padding: 0;
+  color: #4b70f5;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.assistant-message-expand:hover {
+  text-decoration: underline;
+}
+
 .assistant-waiting {
   display: inline-flex;
   align-items: center;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8934,11 +8934,26 @@ function AssistantMessageView({
   onCopyMessage: (message: AssistantChatMessage) => void;
   onSendCode: (code: string) => void;
 }) {
+  const userMessageLineCount = message.role === "user" ? message.content.split(/\r?\n/).length : 0;
+  const shouldTruncateUserMessage = message.role === "user" && userMessageLineCount > 10;
+  const [isUserMessageExpanded, setIsUserMessageExpanded] = useState(false);
+
   return (
     <article className={`assistant-message ${message.role}`}>
-      <div className="assistant-message-bubble">
+      <div
+        className={`assistant-message-bubble${shouldTruncateUserMessage && !isUserMessageExpanded ? " assistant-message-bubble-truncated" : ""}`}
+      >
         <MarkdownContent content={message.content} onCopyCode={onCopyCode} onSendCode={onSendCode} />
       </div>
+      {shouldTruncateUserMessage ? (
+        <button
+          className="assistant-message-expand"
+          onClick={() => setIsUserMessageExpanded((expanded) => !expanded)}
+          type="button"
+        >
+          {isUserMessageExpanded ? "Show less" : "More"}
+        </button>
+      ) : null}
       <div className="assistant-message-actions">
         <time dateTime={message.createdAt}>{formatAssistantMessageTime(message.createdAt)}</time>
         <button


### PR DESCRIPTION
### Motivation

- Prevent very long user messages from dominating the AI Assistant chat UI by collapsing them by default when they exceed a reasonable line limit.  
- Provide a simple inline control so users can expand/collapse their long messages without changing assistant message behavior.

### Description

- Truncate user-role chat bubbles that exceed 10 lines by applying a `assistant-message-bubble-truncated` class and show a `More` / `Show less` toggle to expand or collapse the content.  
- Added local state in `AssistantMessageView` (`src/App.tsx`) to track expansion and compute `userMessageLineCount` using `message.content.split(/\r?\n/)`.  
- Only user messages (where `message.role === "user"`) get truncation and the toggle; assistant messages are unchanged.  
- Added CSS rules in `src/App.css` for `.assistant-message-bubble-truncated` and `.assistant-message-expand` to implement the max-height, overflow, and toggle styling.

### Testing

- Ran `npm run check` (TypeScript typecheck) and it succeeded.  
- Ran `npm run build` (Vite production build) and it succeeded.  
- Ran `cargo check --manifest-path src-tauri/Cargo.toml` and it failed in this environment due to a missing system dependency (`glib-2.0.pc` / `glib-2.0` not found).  
- Ran `cargo test --manifest-path src-tauri/Cargo.toml` and it failed for the same `glib-2.0` environment dependency reason.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f855af97c4832fbd0a1d94c9211e1a)