### PR TITLE
Prevent RDP tab switch title-bar focus flicker

### DIFF
--- a/src-tauri/src/rdp.rs
+++ b/src-tauri/src/rdp.rs
@@ -796,7 +796,7 @@ mod platform {
                 SWP_NOACTIVATE | SWP_NOZORDER,
             )
             .map_err(|error| format!("failed to position RDP control: {error}"))?;
-            let _ = ShowWindow(hwnd, SW_SHOW);
+            let _ = ShowWindow(hwnd, SW_SHOWNOACTIVATE);
         }
         Ok((origin.0, origin.1, rect.2, rect.3))
     }
@@ -819,7 +819,7 @@ mod platform {
                 HIDDEN_RDP_POSITION,
                 1,
                 1,
-                SWP_NOZORDER,
+                SWP_NOACTIVATE | SWP_NOZORDER,
             )
             .map_err(|error| format!("failed to hide RDP control: {error}"))?;
             let _ = ShowWindow(hwnd, SW_HIDE);


### PR DESCRIPTION
### Motivation
- Switching to/from RDP tabs caused the embedded RDP host window to activate and steal focus, producing a title-bar unfocus/flicker; make show/hide operations non-activating to stop that behavior.

### Description
- In `src-tauri/src/rdp.rs` replace `ShowWindow(hwnd, SW_SHOW)` with `ShowWindow(hwnd, SW_SHOWNOACTIVATE)` and add `SWP_NOACTIVATE` to the `SetWindowPos` call in the hide path so the RDP host is shown/hidden without activating the main window.

### Testing
- Ran `npm run check` (passed) and `npm run build` (passed); `cargo check --manifest-path src-tauri/Cargo.toml` and `cargo test --manifest-path src-tauri/Cargo.toml` could not complete in this container due to a missing system dependency (`glib-2.0` required by `glib-sys`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8645616e0832fb0b2b7ea79abc8ac)