### PR TITLE
Allow leaving SSH password blank when editing Connection properties

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3381,7 +3381,7 @@ function ConnectionDialog({
                     <input
                       name="password"
                       placeholder={isEditMode ? "Leave blank to keep stored password" : "Stored in OS keychain"}
-                      required={!isEditMode || !initialConnection?.hasPassword}
+                      required={!isEditMode}
                       type="password"
                     />
                   </label>


### PR DESCRIPTION
### Motivation
- Editing an existing SSH Connection that used password authentication incorrectly required re-entering a password, preventing users from saving other property changes; the UX should preserve the previously stored keychain password when the password field is left blank in edit mode.

### Description
- Update the password input validation in `src/App.tsx` by changing the `required` check from `required={!isEditMode || !initialConnection?.hasPassword}` to `required={!isEditMode}`, so password is only mandatory when creating a new connection.

### Testing
- `npm run check` — passed.
- `npm run build` — passed (produced build and chunk-size warnings only).
- `cargo check --manifest-path src-tauri/Cargo.toml` — failed in this environment due to missing system `glib-2.0` pkg-config dependency.
- `cargo test --manifest-path src-tauri/Cargo.toml` — failed for the same missing `glib-2.0` dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f869dd86bc832f86cb7847739491ff)