### PR TITLE
Update tmux session naming and AI assistant waiting animation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2238,6 +2238,11 @@ progress {
   animation: assistant-spinner-spin 0.78s linear infinite;
 }
 
+.assistant-waiting-dots {
+  display: inline-block;
+  min-width: 0.95em;
+}
+
 .assistant-chat-history-backdrop {
   position: fixed;
   inset: 0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8618,6 +8618,7 @@ function AssistantPanel({
   const [chatError, setChatError] = useState("");
   const [isSendingPrompt, setIsSendingPrompt] = useState(false);
   const [waitingPhrase, setWaitingPhrase] = useState("");
+  const [waitingDots, setWaitingDots] = useState(0);
   const [messageCopyStatus, setMessageCopyStatus] = useState("");
   const [terminalSendStatus, setTerminalSendStatus] = useState("");
   const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -8636,6 +8637,35 @@ function AssistantPanel({
   useEffect(() => {
     writeAssistantChatHistory(chatHistory);
   }, [chatHistory]);
+
+  useEffect(() => {
+    if (!isSendingPrompt) {
+      setWaitingDots(0);
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      setWaitingDots((current) => (current + 1) % 4);
+    }, 300);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [isSendingPrompt]);
+
+  useEffect(() => {
+    if (!isSendingPrompt) {
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      setWaitingPhrase(randomAssistantWaitingPhrase());
+    }, 3000);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [isSendingPrompt]);
 
   function handleSendCodeToTerminal(code: string) {
     if (!activeTerminalPaneId) {
@@ -8942,7 +8972,7 @@ function AssistantPanel({
         {isSendingPrompt ? (
           <article className="assistant-message assistant-waiting" aria-live="polite">
             <span className="assistant-spinner" aria-hidden="true" />
-            <span>{waitingPhrase || "Charging the answer beacon"}...</span>
+            <span>{waitingPhrase || "Charging the answer beacon"}<span className="assistant-waiting-dots" aria-hidden="true">{".".repeat(waitingDots)}</span></span>
           </article>
         ) : null}
       </div>

--- a/src/store.ts
+++ b/src/store.ts
@@ -32,7 +32,7 @@ import type {
 
 const LAYOUT_STORAGE_PREFIX = "admindeck.layout.";
 const TMUX_SESSION_STORAGE_PREFIX = "admindeck.tmuxSessions.";
-const TMUX_SESSION_ID_PATTERN = /^admindeck-[a-z]+[0-9]{3}$/;
+const TMUX_SESSION_ID_PATTERN = /^(?:admindeck-)?[a-z]+(?:[0-9]{2}|[0-9]{3})?$/;
 // Stable ASCII slugs for remote tmux session names. Keep these code-facing and
 // locale-neutral; future UI localization can translate display labels separately
 // without renaming remote tmux sessions.
@@ -244,14 +244,25 @@ function appendTmuxSessionId(connection: Connection) {
 }
 
 function generateTmuxSessionId(existingSessionIds: string[]) {
-  const nextNumber = existingSessionIds.length + 1;
+  const existing = new Set(existingSessionIds);
+
   for (let attempt = 0; attempt < TMUX_SESSION_NAMES.length * 2; attempt += 1) {
-    const sessionId = `admindeck-${randomTmuxName()}${formatTmuxSessionNumber(nextNumber)}`;
-    if (!existingSessionIds.includes(sessionId)) {
-      return sessionId;
+    const candidate = randomTmuxName();
+    if (!existing.has(candidate)) {
+      return candidate;
     }
   }
-  return `admindeck-${randomTmuxName()}${formatTmuxSessionNumber(Date.now() % 1000)}`;
+
+  for (let suffix = 2; suffix <= 99; suffix += 1) {
+    for (let attempt = 0; attempt < TMUX_SESSION_NAMES.length; attempt += 1) {
+      const candidate = `${randomTmuxName()}${formatTmuxSessionNumber(suffix)}`;
+      if (!existing.has(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return `${randomTmuxName()}${formatTmuxSessionNumber((Date.now() % 98) + 2)}`;
 }
 
 function isCurrentTmuxSessionId(value: unknown): value is string {
@@ -273,7 +284,7 @@ function randomTmuxIndex(max: number) {
 }
 
 function formatTmuxSessionNumber(value: number) {
-  return String(Math.max(1, value)).padStart(3, "0");
+  return String(Math.max(2, value)).padStart(2, "0");
 }
 
 function buildPanesForConnection(connection: Connection, count: number): TerminalPane[] {


### PR DESCRIPTION
### Motivation
- Simplify generated tmux session IDs by removing the fixed `admindeck-` prefix and prefer bare sci‑fi names for readability and parity with user expectations.
- Avoid unnecessary numeric suffixes by only appending a 2‑digit suffix (`02`, `03`, …) when base names are exhausted while preserving compatibility with previously stored IDs.
- Make the AI Assistant waiting UI feel more responsive by rotating waiting phrases and animating dots while waiting for an AI response.

### Description
- Updated tmux session validation and generation in `src/store.ts` by changing `TMUX_SESSION_ID_PATTERN` to accept both legacy `admindeck-` IDs and the new bare-name format, and reworked `generateTmuxSessionId` to: try plain names first, then 2‑digit suffixes (`02`–`99`) before falling back to a timestamp-based suffix; also adjusted `formatTmuxSessionNumber` to produce 2‑digit suffixes. (files: `src/store.ts`)
- Kept `isCurrentTmuxSessionId` compatible with existing stored IDs so local storage remains usable. (file: `src/store.ts`)
- Added animated waiting behavior to the AI Assistant in `src/App.tsx` by introducing `waitingDots` state with a 300ms per‑dot cycle (0→1→2→3→reset) and rotating the waiting phrase every 3 seconds while a prompt is in flight, and updated the rendered waiting span to include the animated dots. (file: `src/App.tsx`)
- Added a small CSS helper `.assistant-waiting-dots` to reserve width for the dots and avoid layout jitter. (file: `src/App.css`)

### Testing
- Ran `npm run check` which executed `tsc --noEmit` and succeeded.
- Ran `npm run build` which runs `tsc` and `vite build` and succeeded (production build completed).
- Ran `cargo check --manifest-path src-tauri/Cargo.toml` which failed due to missing system dependency `glib-2.0` required by `glib-sys` in this environment (error: `Package glib-2.0 was not found`), so Rust checks could not complete here.
- Ran `cargo test --manifest-path src-tauri/Cargo.toml` which likewise failed for the same missing `glib-2.0` system library in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f86aeec638832f904b91168092c9ad)