### PR TITLE
Prevent UI blocking during remote connection commands

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -310,7 +310,7 @@ fn delete_secret(
 }
 
 #[tauri::command]
-fn start_terminal_session(
+async fn start_terminal_session(
     app: tauri::AppHandle,
     sessions: tauri::State<'_, sessions::SessionManager>,
     secrets: tauri::State<'_, secrets::Secrets>,
@@ -349,7 +349,7 @@ fn close_terminal_session(
 }
 
 #[tauri::command]
-fn list_tmux_sessions(
+async fn list_tmux_sessions(
     app: tauri::AppHandle,
     sessions: tauri::State<'_, sessions::SessionManager>,
     secrets: tauri::State<'_, secrets::Secrets>,
@@ -359,7 +359,7 @@ fn list_tmux_sessions(
 }
 
 #[tauri::command]
-fn close_tmux_session(
+async fn close_tmux_session(
     app: tauri::AppHandle,
     sessions: tauri::State<'_, sessions::SessionManager>,
     secrets: tauri::State<'_, secrets::Secrets>,
@@ -369,7 +369,7 @@ fn close_tmux_session(
 }
 
 #[tauri::command]
-fn set_tmux_mouse(
+async fn set_tmux_mouse(
     app: tauri::AppHandle,
     sessions: tauri::State<'_, sessions::SessionManager>,
     secrets: tauri::State<'_, secrets::Secrets>,
@@ -379,7 +379,7 @@ fn set_tmux_mouse(
 }
 
 #[tauri::command]
-fn capture_tmux_pane(
+async fn capture_tmux_pane(
     app: tauri::AppHandle,
     sessions: tauri::State<'_, sessions::SessionManager>,
     secrets: tauri::State<'_, secrets::Secrets>,
@@ -389,7 +389,7 @@ fn capture_tmux_pane(
 }
 
 #[tauri::command]
-fn inspect_ssh_system_context(
+async fn inspect_ssh_system_context(
     app: tauri::AppHandle,
     sessions: tauri::State<'_, sessions::SessionManager>,
     secrets: tauri::State<'_, secrets::Secrets>,
@@ -406,7 +406,7 @@ fn launch_elevated_terminal(
 }
 
 #[tauri::command]
-fn start_sftp_session(
+async fn start_sftp_session(
     app: tauri::AppHandle,
     sftp_sessions: tauri::State<'_, sftp::SftpSessionManager>,
     secrets: tauri::State<'_, secrets::Secrets>,
@@ -591,7 +591,7 @@ fn close_webview_session(
 }
 
 #[tauri::command]
-fn start_rdp_session(
+async fn start_rdp_session(
     app: tauri::AppHandle,
     rdp_sessions: tauri::State<'_, rdp::RdpSessionManager>,
     secrets: tauri::State<'_, secrets::Secrets>,

--- a/src-tauri/src/rdp.rs
+++ b/src-tauri/src/rdp.rs
@@ -24,9 +24,9 @@ mod platform {
                 Variant::{VariantClear, VARIANT, VT_BOOL, VT_BSTR, VT_DISPATCH, VT_I2, VT_I4},
             },
             UI::WindowsAndMessaging::{
-                CreateWindowExW, DestroyWindow, SetWindowPos, ShowWindow, HMENU,
-                SWP_NOACTIVATE, SWP_NOZORDER, SW_HIDE, SW_SHOW, WS_CLIPCHILDREN, WS_CLIPSIBLINGS,
-                WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_POPUP, WS_VISIBLE,
+                CreateWindowExW, DestroyWindow, SetWindowPos, ShowWindow, HMENU, SWP_NOACTIVATE,
+                SWP_NOZORDER, SW_HIDE, SW_SHOW, WS_CLIPCHILDREN, WS_CLIPSIBLINGS, WS_EX_NOACTIVATE,
+                WS_EX_TOOLWINDOW, WS_POPUP, WS_VISIBLE,
             },
         },
     };

--- a/src-tauri/src/webview.rs
+++ b/src-tauri/src/webview.rs
@@ -235,19 +235,21 @@ impl WebviewSessionManager {
         {
             let mut starting_sessions = self.lock_starting()?;
             if !starting_sessions.insert(session_id.clone()) {
-                return Err(format!("webview session '{session_id}' is already starting"));
+                return Err(format!(
+                    "webview session '{session_id}' is already starting"
+                ));
             }
         }
 
-        let host_window = app
-            .get_window(HOST_WINDOW_LABEL)
-            .map_or_else(
-                || {
-                    self.clear_starting(&session_id);
-                    Err(format!("host window '{HOST_WINDOW_LABEL}' is not available"))
-                },
-                Ok,
-            )?;
+        let host_window = app.get_window(HOST_WINDOW_LABEL).map_or_else(
+            || {
+                self.clear_starting(&session_id);
+                Err(format!(
+                    "host window '{HOST_WINDOW_LABEL}' is not available"
+                ))
+            },
+            Ok,
+        )?;
 
         let label = webview_label_for(&session_id);
         let navigation_app = app.clone();


### PR DESCRIPTION
### Motivation
- Remote connection and session startup paths (SSH/terminal, tmux, SFTP, RDP) can block the Tauri command path when hosts are flaky or unresponsive, risking frontend freezes. 
- Move long-running invoke handlers off the synchronous UI path so connection operations do not lock the UI.

### Description
- Converted several Tauri command handlers in `src-tauri/src/lib.rs` from synchronous `fn` to `async fn`, notably `start_terminal_session`, `list_tmux_sessions`, `close_tmux_session`, `set_tmux_mouse`, `capture_tmux_pane`, `inspect_ssh_system_context`, `start_sftp_session`, and `start_rdp_session` so they run without blocking the invoke thread. 
- Ensured these handlers continue to call the existing session/sftp/rdp managers without changing their APIs. 
- Ran `cargo fmt`, producing formatting-only changes in `src-tauri/src/rdp.rs` and `src-tauri/src/webview.rs` (no behavioral changes).

### Testing
- Ran `npm run check` which succeeded. 
- Ran `npm run build` which succeeded. 
- Ran `cargo check --manifest-path src-tauri/Cargo.toml` which failed in this environment due to a missing system `glib-2.0` pkg-config/development library. 
- Ran `cargo test --manifest-path src-tauri/Cargo.toml` which also failed for the same missing system dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f87aa85a14832f938e1d43fe488e7b)