### PR TITLE
docs+refactor: document App.tsx module map, extract settings bootstrap, drop dead command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,9 @@ Follow `AGENTS.md` for repository workflow and `CONTEXT.md` for product language
 
 ## Frontend Module Boundaries
 
-- `src/App.tsx` owns app shell routing, workspace composition, and startup/bootstrap effects.
+- `src/App.tsx` owns app shell routing, workspace composition, and startup/bootstrap effects. It currently still hosts the workspace surface components (terminal, SFTP, webview, remote-desktop, assistant panel, connection tree); see `docs/ARCHITECTURE.md` "Frontend Module Map" for the planned extraction targets. Keep new code in the cluster of components it logically belongs to so future extraction stays mechanical, instead of adding new helpers above the `App` component.
 - `src/settings/SettingsPage.tsx` owns Settings UI sections, settings draft state, save/reset handlers, and settings-specific helper controls.
+- `src/lib/settings.ts` owns the persisted-settings bootstrap into the workspace store (`useBootstrapSettings`) and the `AI_PROVIDER_SECRET_OWNER_ID` keychain owner constant. Add new persisted settings here rather than cloning a `useEffect` in `App.tsx`.
 - Keep typed Tauri calls behind `src/lib/tauri.ts`; do not call backend commands with ad hoc stringly wrappers from Settings or App code.
 
 ## Critical Domain Boundaries

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,7 +30,7 @@ Provides a typed command wrapper between React and Rust. The frontend should not
 
 ### Frontend Settings
 
-`src/settings/SettingsPage.tsx` owns the Settings surface, including settings-specific draft state, save/reset handlers, summaries, placeholder entries, and small helper controls. `src/App.tsx` should only route to Settings and bootstrap persisted settings into the workspace store. New Settings sections should stay in the settings module unless they become large enough to justify a submodule under `src/settings/`.
+`src/settings/SettingsPage.tsx` owns the Settings surface, including settings-specific draft state, save/reset handlers, summaries, placeholder entries, and small helper controls. `src/App.tsx` only routes to Settings; the persisted-settings bootstrap into the workspace store lives in `src/lib/settings.ts` as a single `useBootstrapSettings()` hook so new persisted settings can be added in one place. The OS keychain owner id for the AI API key (`AI_PROVIDER_SECRET_OWNER_ID`) is also defined in `src/lib/settings.ts` so SettingsPage and bootstrap share one constant. New Settings sections should stay in the settings module unless they become large enough to justify a submodule under `src/settings/`.
 
 ### Storage
 
@@ -194,6 +194,23 @@ AdminDeck does not include a global command palette in the current product scope
 The main workspace treats Tabs as frontend containers over live Sessions. Selecting another Tab changes visibility and focus only; it must not run backend Session close commands. Closing a Tab via the tab-strip close control removes that container and tears down the live Session resources it owns.
 
 Workspace chrome layout is global state. Connection-specific live context may change assistant copy, selected terminal context, or prompt construction, but should not change the left/right panel widths or collapsed state when the active Tab changes. Native HWND-backed surfaces such as WebView2 and RDP depend on stable host bounds; changing chrome dimensions as a side effect of Tab activation creates visible native resize artifacts.
+
+## Frontend Module Map
+
+The current `src/App.tsx` is a dense single file that hosts the app shell plus most workspace surfaces inline. The intended seams, which are already visible as named components inside `App.tsx`, are listed here so future extraction work has one canonical target shape:
+
+- `App` and `ActivityRail` — app shell, page routing, panel layout, chrome bootstrap.
+- `ConnectionSidebar` (and the connection dialog/folder/tile helpers it composes) — root tree, search, drag/drop, CRUD, quick connect. Future home: `src/connections/`.
+- `TabStrip` and `WorkspaceCanvas` — workspace tab strip and the active Tab surface dispatcher.
+- `TerminalWorkspace`, `TerminalLayoutView`, `TerminalPaneView`, `TerminalContextMenu`, `TmuxSessionTag` — terminal Pane host. Future home: `src/terminal/`.
+- `SftpWorkspace`, `FilePane`, `TransferConflictDialog`, `SftpContextMenu`, `SftpPropertiesPopup` — SFTP browser. Future home: `src/sftp/`.
+- `WebViewWorkspace` and the `acquireWebviewSession`/`releaseWebviewSession` lease pair — URL Connection host. Future home: `src/webview/`.
+- `RemoteDesktopWorkspace` — RDP/VNC host. Future home: `src/remote-desktop/`.
+- `AssistantPanel`, `AssistantMessageView`, `MarkdownContent` — AI Assistant chat surface. Future home: `src/ai/`.
+- `ScreenshotMenu` and the screenshot Region overlay helpers — workspace screenshot capture. Future home: `src/workspace/`.
+- `StatusBar` — performance/budget status. Future home: `src/workspace/`.
+
+Until those moves happen, contributors should treat the listed component clusters as logical modules: a change to terminal Pane behavior should keep its edits inside the `Terminal*` cluster rather than scattering helpers above the `App` component, so a future extraction is mechanical. Workspace state, settings I/O, layout serialization, terminal rendering, and the Tauri command boundary are already separated under `src/store.ts`, `src/lib/`, `src/workspace/`, `src/terminal/`, and `src/lib/tauri.ts`; new shared logic should land there rather than at the top of `App.tsx`.
 
 ## Performance Strategy
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,13 +49,6 @@ fn app_bootstrap(
 }
 
 #[tauri::command]
-fn list_connection_groups(
-    storage: tauri::State<'_, storage::Storage>,
-) -> Result<storage::ConnectionTree, String> {
-    storage.list_connection_groups()
-}
-
-#[tauri::command]
 fn list_connection_tree(
     storage: tauri::State<'_, storage::Storage>,
 ) -> Result<storage::ConnectionTree, String> {
@@ -734,7 +727,6 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             app_bootstrap,
-            list_connection_groups,
             list_connection_tree,
             create_connection,
             create_connection_folder,

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -313,10 +313,6 @@ impl Storage {
         })
     }
 
-    pub fn list_connection_groups(&self) -> Result<ConnectionTree, String> {
-        self.list_connection_tree()
-    }
-
     pub fn terminal_settings(&self) -> Result<TerminalSettings, String> {
         let connection = self.lock()?;
         let value = connection

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -126,12 +126,13 @@ import {
   type TerminalOutput,
   type TmuxSession,
 } from "./lib/tauri";
+import { useBootstrapSettings } from "./lib/settings";
 import {
   getAiProviderDefinition,
   validateAiProviderForChat,
 } from "./ai/providers";
 import { connectionTree, defaultTerminalSettings } from "./sample-data";
-import { AI_PROVIDER_SECRET_OWNER_ID, SettingsPage } from "./settings/SettingsPage";
+import { SettingsPage } from "./settings/SettingsPage";
 import { useWorkspaceStore } from "./store";
 import {
   createTerminalRenderer,
@@ -1161,16 +1162,11 @@ function removeLayoutStorageKeys() {
 
 function App() {
   const [activePage, setActivePage] = useState<"workspace" | "settings">("workspace");
-  const setTerminalSettings = useWorkspaceStore((state) => state.setTerminalSettings);
   const appearanceSettings = useWorkspaceStore((state) => state.appearanceSettings);
-  const setAppearanceSettings = useWorkspaceStore((state) => state.setAppearanceSettings);
-  const setSshSettings = useWorkspaceStore((state) => state.setSshSettings);
-  const setSftpSettings = useWorkspaceStore((state) => state.setSftpSettings);
-  const setAiProviderSettings = useWorkspaceStore((state) => state.setAiProviderSettings);
-  const setAiProviderHasApiKey = useWorkspaceStore((state) => state.setAiProviderHasApiKey);
   const setFrontendLaunchMs = useWorkspaceStore((state) => state.setFrontendLaunchMs);
   const setPerformanceSnapshot = useWorkspaceStore((state) => state.setPerformanceSnapshot);
   const resetAllLayouts = useWorkspaceStore((state) => state.resetAllLayouts);
+  useBootstrapSettings();
   const [connectionPanelLayout, setConnectionPanelLayout] = useState(() =>
     loadPanelLayout(
       CONNECTION_PANEL_LAYOUT_KEY,
@@ -1270,47 +1266,6 @@ function App() {
       window.clearInterval(interval);
     };
   }, [setPerformanceSnapshot]);
-
-  useEffect(() => {
-    invokeCommand("get_terminal_settings")
-      .then(setTerminalSettings)
-      .catch(() => undefined);
-  }, [setTerminalSettings]);
-
-  useEffect(() => {
-    invokeCommand("get_appearance_settings")
-      .then(setAppearanceSettings)
-      .catch(() => undefined);
-  }, [setAppearanceSettings]);
-
-  useEffect(() => {
-    invokeCommand("get_ssh_settings")
-      .then(setSshSettings)
-      .catch(() => undefined);
-  }, [setSshSettings]);
-
-  useEffect(() => {
-    invokeCommand("get_sftp_settings")
-      .then(setSftpSettings)
-      .catch(() => undefined);
-  }, [setSftpSettings]);
-
-  useEffect(() => {
-    invokeCommand("get_ai_provider_settings")
-      .then(setAiProviderSettings)
-      .catch(() => undefined);
-  }, [setAiProviderSettings]);
-
-  useEffect(() => {
-    invokeCommand("secret_exists", {
-      request: {
-        kind: "aiApiKey",
-        ownerId: AI_PROVIDER_SECRET_OWNER_ID,
-      },
-    })
-      .then((presence) => setAiProviderHasApiKey(presence.exists))
-      .catch(() => undefined);
-  }, [setAiProviderHasApiKey]);
 
   useEffect(() => {
     const preventDefaultContextMenu = (event: globalThis.MouseEvent) => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,0 +1,85 @@
+import { useEffect } from "react";
+
+import { useWorkspaceStore } from "../store";
+import { invokeCommand, isTauriRuntime } from "./tauri";
+
+// Stable keychain owner id for the OpenAI-compatible AI API key. Lives in the
+// settings module so both bootstrap and the Settings UI can reference one
+// canonical name without an App.tsx -> SettingsPage import cycle.
+export const AI_PROVIDER_SECRET_OWNER_ID = "openai-compatible-provider";
+
+// Loads persisted settings from the Tauri backend into the workspace store.
+// Combines the previously separate per-key effects into one parallel load so
+// new settings can be added in one place instead of cloning a useEffect each
+// time. Bootstrap is best-effort: any single load failure is ignored so the
+// app still renders with the in-memory defaults from `sample-data`.
+export function useBootstrapSettings() {
+  const setTerminalSettings = useWorkspaceStore((state) => state.setTerminalSettings);
+  const setAppearanceSettings = useWorkspaceStore((state) => state.setAppearanceSettings);
+  const setSshSettings = useWorkspaceStore((state) => state.setSshSettings);
+  const setSftpSettings = useWorkspaceStore((state) => state.setSftpSettings);
+  const setAiProviderSettings = useWorkspaceStore((state) => state.setAiProviderSettings);
+  const setAiProviderHasApiKey = useWorkspaceStore((state) => state.setAiProviderHasApiKey);
+
+  useEffect(() => {
+    if (!isTauriRuntime()) {
+      return;
+    }
+
+    let disposed = false;
+
+    const swallow = (_error: unknown) => undefined;
+
+    void invokeCommand("get_terminal_settings")
+      .then((settings) => {
+        if (!disposed) setTerminalSettings(settings);
+      })
+      .catch(swallow);
+
+    void invokeCommand("get_appearance_settings")
+      .then((settings) => {
+        if (!disposed) setAppearanceSettings(settings);
+      })
+      .catch(swallow);
+
+    void invokeCommand("get_ssh_settings")
+      .then((settings) => {
+        if (!disposed) setSshSettings(settings);
+      })
+      .catch(swallow);
+
+    void invokeCommand("get_sftp_settings")
+      .then((settings) => {
+        if (!disposed) setSftpSettings(settings);
+      })
+      .catch(swallow);
+
+    void invokeCommand("get_ai_provider_settings")
+      .then((settings) => {
+        if (!disposed) setAiProviderSettings(settings);
+      })
+      .catch(swallow);
+
+    void invokeCommand("secret_exists", {
+      request: {
+        kind: "aiApiKey",
+        ownerId: AI_PROVIDER_SECRET_OWNER_ID,
+      },
+    })
+      .then((presence) => {
+        if (!disposed) setAiProviderHasApiKey(presence.exists);
+      })
+      .catch(swallow);
+
+    return () => {
+      disposed = true;
+    };
+  }, [
+    setAiProviderHasApiKey,
+    setAiProviderSettings,
+    setAppearanceSettings,
+    setSftpSettings,
+    setSshSettings,
+    setTerminalSettings,
+  ]);
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -360,10 +360,6 @@ type CommandMap = {
     args: undefined;
     result: AppBootstrap;
   };
-  list_connection_groups: {
-    args: undefined;
-    result: ConnectionTree;
-  };
   list_connection_tree: {
     args: undefined;
     result: ConnectionTree;

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -19,6 +19,7 @@ import {
   type AiProviderDefinition,
   type AiProviderSettingsField,
 } from "../ai/providers";
+import { AI_PROVIDER_SECRET_OWNER_ID } from "../lib/settings";
 import { invokeCommand, isTauriRuntime } from "../lib/tauri";
 import { defaultAppearanceSettings } from "../sample-data";
 import { useWorkspaceStore } from "../store";
@@ -31,7 +32,9 @@ import type {
   TerminalSettings,
 } from "../types";
 
-export const AI_PROVIDER_SECRET_OWNER_ID = "openai-compatible-provider";
+// Re-exported for any external callers; new code should import from
+// `lib/settings` directly so the keychain owner id has one source of truth.
+export { AI_PROVIDER_SECRET_OWNER_ID };
 
 export function SettingsPage({
   onBack,


### PR DESCRIPTION
ARCHITECTURE.md and CLAUDE.md now describe the actual frontend module map: the
App.tsx file still hosts the workspace surface components inline, and the doc
calls out the planned extraction targets (terminal/sftp/webview/remote-desktop/
assistant/connection-tree) so future moves stay mechanical.

Settings bootstrap moves out of App.tsx into a single useBootstrapSettings hook
in src/lib/settings.ts, replacing five duplicated useEffect calls. The
AI_PROVIDER_SECRET_OWNER_ID keychain owner constant moves with it so App and
SettingsPage share one source of truth.

list_connection_groups was an unused alias for list_connection_tree (declared
in lib/tauri.ts but never invoked). Removed the alias method, the Tauri
command registration, and the typed wrapper.