### PR TITLE
Warn on app quit when workspace tabs are open and make Settings a modal overlay

### DIFF
--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -333,3 +333,15 @@ When a key is translated into every supported locale, remove its entry from this
 - Placeholders: None
 - Domain notes: AdminDeck is the product name; export refers to the zipped SQLite database file.
 - Translation status: Pending for fr, it, de, es, es-MX, pt-BR, zh-TW, zh-CN, ja, ko, th, id
+
+### `app.quitOpenConnectionsConfirm_one` / `app.quitOpenConnectionsConfirm_other`
+
+- English: "Closing AdminDeck will end 1 open Connection. Continue?" / "Closing AdminDeck will end {{count}} open Connections. Continue?"
+- Namespace: `app`
+- Appears in: `src/App.tsx`
+- UI role: Confirmation prompt
+- Context: Shown when the user requests to close the main AdminDeck window while one or more workspace tabs are open. Confirming quits the app and ends the live Sessions represented by those open tabs; canceling keeps the app open.
+- Tone: Direct warning, concise
+- Placeholders: `{{count}}` is the number of open workspace tabs/Connections that will be ended.
+- Domain notes: Use **Connection** for the open resource wording. The prompt warns about ending live Sessions without introducing the stored Connection versus Session distinction in the dialog copy.
+- Translation status: Pending for fr, it, de, es, es-MX, pt-BR, zh-TW, zh-CN, ja, ko, th, id

--- a/src/App.css
+++ b/src/App.css
@@ -226,8 +226,13 @@ button {
   border-top: 1px solid var(--border);
 }
 
-.app-shell.settings-mode {
-  grid-template-columns: 48px minmax(0, 1fr);
+.workspace-page {
+  display: contents;
+}
+
+.workspace-page[aria-hidden="true"] > * {
+  visibility: hidden;
+  pointer-events: none;
 }
 
 .activity-rail {
@@ -3398,6 +3403,9 @@ progress {
 }
 
 .settings-page {
+  position: fixed;
+  inset: 0 0 0 48px;
+  z-index: 1000;
   min-width: 0;
   height: 100vh;
   overflow: auto;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { ChevronLeft, ChevronRight, LayoutDashboard, Settings } from "lucide-rea
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { useTranslation } from "react-i18next";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { invokeCommand, isTauriRuntime } from "./lib/tauri";
 import { useBootstrapSettings } from "./lib/settings";
 import { SettingsPage } from "./settings/SettingsPage";
@@ -110,6 +111,8 @@ function App() {
   const setPerformanceSnapshot = useWorkspaceStore((state) => state.setPerformanceSnapshot);
   const appShellRef = useRef<HTMLDivElement | null>(null);
   const resetAllLayouts = useWorkspaceStore((state) => state.resetAllLayouts);
+  const openConnectionCount = useWorkspaceStore((state) => state.tabs.length);
+  const openConnectionCountRef = useRef(openConnectionCount);
   useBootstrapSettings();
   const [connectionPanelLayout, setConnectionPanelLayout] = useState(() =>
     loadPanelLayout(
@@ -127,6 +130,10 @@ function App() {
       AI_PANEL_MAX_WIDTH,
     ),
   );
+
+  useEffect(() => {
+    openConnectionCountRef.current = openConnectionCount;
+  }, [openConnectionCount]);
 
   useEffect(() => {
     persistPanelLayout(CONNECTION_PANEL_LAYOUT_KEY, connectionPanelLayout);
@@ -185,6 +192,42 @@ function App() {
     });
     return () => window.cancelAnimationFrame(frame);
   }, [setFrontendLaunchMs]);
+
+  useEffect(() => {
+    if (!isTauriRuntime()) {
+      return;
+    }
+
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+
+    void getCurrentWindow()
+      .onCloseRequested((event) => {
+        const openConnections = openConnectionCountRef.current;
+        if (openConnections === 0) {
+          return;
+        }
+
+        const shouldQuit = window.confirm(
+          t("app.quitOpenConnectionsConfirm", { count: openConnections }),
+        );
+        if (!shouldQuit) {
+          event.preventDefault();
+        }
+      })
+      .then((dispose) => {
+        if (disposed) {
+          dispose();
+          return;
+        }
+        unlisten = dispose;
+      });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [t]);
 
   useEffect(() => {
     if (!isTauriRuntime()) {
@@ -261,57 +304,59 @@ function App() {
         }
         onNavigate={setActivePage}
       />
-      {activePage === "settings" ? (
-        <SettingsPage onBack={() => setActivePage("workspace")} onResetLayout={handleResetLayout} />
-      ) : (
-        <>
-          <ConnectionSidebar
-            collapsed={connectionPanelLayout.collapsed}
-            onToggleCollapsed={() =>
-              setConnectionPanelLayout((layout) => ({
-                ...layout,
-                collapsed: !layout.collapsed,
-              }))
-            }
-          />
-          {connectionPanelLayout.collapsed ? (
-            <div className="connection-collapsed-separator" aria-hidden="true" />
-          ) : (
-            <PanelResizeHandle
-              ariaLabel={t("app.resizeConnections")}
-              side="left"
-              onPointerDown={handleConnectionPanelResize}
-            />
-          )}
-          <main className="workspace">
-            <TabStrip />
-            <WorkspaceCanvas />
-            <StatusBar />
-          </main>
+      <div className="workspace-page" aria-hidden={activePage === "settings"}>
+        <ConnectionSidebar
+          collapsed={connectionPanelLayout.collapsed}
+          onToggleCollapsed={() =>
+            setConnectionPanelLayout((layout) => ({
+              ...layout,
+              collapsed: !layout.collapsed,
+            }))
+          }
+        />
+        {connectionPanelLayout.collapsed ? (
+          <div className="connection-collapsed-separator" aria-hidden="true" />
+        ) : (
           <PanelResizeHandle
-            ariaLabel={t("app.resizeAiAssistant")}
-            side="right"
-            collapsed={aiPanelLayout.collapsed}
-            collapsedLabel={t("app.aiAssistant")}
-            onClick={() =>
-              aiPanelLayout.collapsed
-                ? setAiPanelLayout((layout) => ({ ...layout, collapsed: false }))
-                : undefined
-            }
-            onPointerDown={handleAiPanelResize}
+            ariaLabel={t("app.resizeConnections")}
+            side="left"
+            onPointerDown={handleConnectionPanelResize}
           />
-          <AssistantPanel
-            collapsed={aiPanelLayout.collapsed}
-            onOpenSettings={() => setActivePage("settings")}
-            onToggleCollapsed={() =>
-              setAiPanelLayout((layout) => ({
-                ...layout,
-                collapsed: !layout.collapsed,
-              }))
-            }
-          />
-        </>
-      )}
+        )}
+        <main className="workspace">
+          <TabStrip />
+          <WorkspaceCanvas workspaceActive={activePage === "workspace"} />
+          <StatusBar />
+        </main>
+        <PanelResizeHandle
+          ariaLabel={t("app.resizeAiAssistant")}
+          side="right"
+          collapsed={aiPanelLayout.collapsed}
+          collapsedLabel={t("app.aiAssistant")}
+          onClick={() =>
+            aiPanelLayout.collapsed
+              ? setAiPanelLayout((layout) => ({ ...layout, collapsed: false }))
+              : undefined
+          }
+          onPointerDown={handleAiPanelResize}
+        />
+        <AssistantPanel
+          collapsed={aiPanelLayout.collapsed}
+          onOpenSettings={() => setActivePage("settings")}
+          onToggleCollapsed={() =>
+            setAiPanelLayout((layout) => ({
+              ...layout,
+              collapsed: !layout.collapsed,
+            }))
+          }
+        />
+      </div>
+      {activePage === "settings" ? (
+        <SettingsPage
+          onBack={() => setActivePage("workspace")}
+          onResetLayout={handleResetLayout}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -5,7 +5,9 @@
     "primaryNav": "Primary",
     "resizeConnections": "Resize Connections column",
     "resizeAiAssistant": "Resize AI Assistant panel",
-    "aiAssistant": "AI Assistant"
+    "aiAssistant": "AI Assistant",
+    "quitOpenConnectionsConfirm_one": "Closing AdminDeck will end 1 open Connection. Continue?",
+    "quitOpenConnectionsConfirm_other": "Closing AdminDeck will end {{count}} open Connections. Continue?"
   },
   "settings": {
     "title": "Settings",

--- a/src/workspace/WorkspaceCanvas.tsx
+++ b/src/workspace/WorkspaceCanvas.tsx
@@ -140,7 +140,11 @@ export function TabStrip() {
   );
 }
 
-export function WorkspaceCanvas() {
+export function WorkspaceCanvas({
+  workspaceActive = true,
+}: {
+  workspaceActive?: boolean;
+} = {}) {
   const { t } = useTranslation();
   const tabs = useWorkspaceStore((state) => state.tabs);
   const activeTabId = useWorkspaceStore((state) => state.activeTabId);
@@ -161,17 +165,39 @@ export function WorkspaceCanvas() {
     <div className="workspace-canvas">
       {tabs.map((tab) => {
         if (tab.kind === "sftp") {
-          return <SftpWorkspace isActive={tab.id === activeTabId} key={tab.id} tab={tab} />;
+          return (
+            <SftpWorkspace
+              isActive={workspaceActive && tab.id === activeTabId}
+              key={tab.id}
+              tab={tab}
+            />
+          );
         }
         if (tab.kind === "webview") {
-          return <WebViewWorkspace isActive={tab.id === activeTabId} key={tab.id} tab={tab} />;
+          return (
+            <WebViewWorkspace
+              isActive={workspaceActive && tab.id === activeTabId}
+              key={tab.id}
+              tab={tab}
+            />
+          );
         }
         if (tab.kind === "remoteDesktop") {
           return (
-            <RemoteDesktopWorkspace isActive={tab.id === activeTabId} key={tab.id} tab={tab} />
+            <RemoteDesktopWorkspace
+              isActive={workspaceActive && tab.id === activeTabId}
+              key={tab.id}
+              tab={tab}
+            />
           );
         }
-        return <TerminalWorkspace isActive={tab.id === activeTabId} key={tab.id} tab={tab} />;
+        return (
+          <TerminalWorkspace
+            isActive={workspaceActive && tab.id === activeTabId}
+            key={tab.id}
+            tab={tab}
+          />
+        );
       })}
     </div>
   );

--- a/src/workspace/nativeOverlay.ts
+++ b/src/workspace/nativeOverlay.ts
@@ -4,7 +4,7 @@ export function documentHasWebviewOverlay() {
   // these menus/overlays are open.
   return Boolean(
     document.querySelector(
-      ".quick-connect-menu, .sftp-context-menu, .sftp-properties-popover, .screenshot-menu, .screenshot-region-overlay, .transfer-conflict-backdrop, .connection-dialog-backdrop",
+      ".quick-connect-menu, .sftp-context-menu, .sftp-properties-popover, .screenshot-menu, .screenshot-region-overlay, .transfer-conflict-backdrop, .connection-dialog-backdrop, .settings-page",
     ),
   );
 }


### PR DESCRIPTION
### Motivation
- Prevent accidental termination of live Sessions when the user closes the main window while workspace tabs are open. 
- Make the Settings UI render as a top-layer overlay so the workspace can be hidden/disabled without unmounting components and native overlays behave correctly.

### Description
- Add a Tauri `onCloseRequested` handler using `getCurrentWindow` that prompts with the i18n key `app.quitOpenConnectionsConfirm` when there are open workspace tabs, using a ref to read the current open tab count.
- Add English localization strings for the close-confirm plural forms in `src/i18n/locales/en.json` and document the new key in `docs/LOCALIZATION.md`.
- Convert the settings page into a fixed overlay by updating `src/App.css` (`.settings-page` fixed inset, `.workspace-page` display and hidden state handling) and change `App.tsx` layout to render the workspace inside a `.workspace-page` container that is toggled with `aria-hidden` rather than unmounting when settings are active; reorder panels and resize handles accordingly.
- Make workspace children aware of whether the workspace is active by adding a `workspaceActive` prop to `WorkspaceCanvas` and passing `workspaceActive && tab.id === activeTabId` down to workspace components so active state is suppressed when the Settings overlay is shown.
- Ensure DOM-native overlay logic treats the settings overlay like other overlays by adding `.settings-page` to the selector in `src/workspace/nativeOverlay.ts`.

### Testing
- Ran the project typecheck and unit test suite (`tsc` and `yarn test`); all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9d380930832fb28d723a74a7d6e4)