### PR TITLE
Fix close confirmation and SSH context runtime

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -111,6 +111,10 @@ Current implementation note: a Connection may have no folder and live directly i
 
 For tmux-enabled SSH Connections, per-Pane friendly tmux session names are generated and remembered in the frontend workspace layer so split Panes can resume independently. Current Pane names use the `admindeck-<sci-fi-name><number>` shape, for example `admindeck-cockpit001`. The frontend stores these Pane names under `admindeck.tmuxSessions.<connectionId>` so the same Connection can reopen its previous Pane-to-tmux mapping. Stored Pane ids that do not match the current friendly format are ignored when new Panes are built. The durable Connection stores only the launch preference and legacy/non-user-facing namespace fields; those fields are not the active Pane tmux session id.
 
+### Backend Command Runtime Boundaries
+
+Tauri commands that need synchronous native integrations, OS process calls, network control loops, or helper functions that internally create and `block_on` a Tokio runtime must cross that boundary with `run_blocking_command`/`tauri::async_runtime::spawn_blocking` before calling the helper. Async command handlers must not directly call code that starts a nested runtime or blocks the current Tokio worker; doing so can panic with "Cannot start a runtime from within a runtime" and can also starve unrelated Connection types. This invariant applies across all live Session families: local terminal helpers, SSH/tmux/AI context inspection, SFTP transfers, URL/WebView2 lifecycle calls, RDP ActiveX operations, and VNC RFB operations. When adding a command for any Connection or Session type, choose one of these shapes explicitly: pure async all the way down, synchronous command with no nested async runtime, or async command that immediately moves the blocking/nested-runtime work into `run_blocking_command`.
+
 ### Terminal Session
 
 Owns local PTY lifecycle, SSH terminal channel lifecycle, Telnet TCP lifecycle, Serial port lifecycle, input/output streams, resize events, tab integration, split pane integration, and terminal compatibility behavior.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -409,51 +409,66 @@ fn close_terminal_session(
 #[tauri::command]
 async fn list_tmux_sessions(
     app: tauri::AppHandle,
-    sessions: tauri::State<'_, sessions::SessionManager>,
-    secrets: tauri::State<'_, secrets::Secrets>,
     request: sessions::TmuxConnectionRequest,
 ) -> Result<Vec<sessions::TmuxSession>, String> {
-    sessions.list_tmux_sessions(app, &secrets, request)
+    run_blocking_command("tmux list sessions", move || {
+        let sessions = app.state::<sessions::SessionManager>();
+        let secrets = app.state::<secrets::Secrets>();
+        sessions.list_tmux_sessions(app.clone(), &secrets, request)
+    })
+    .await
 }
 
 #[tauri::command]
 async fn close_tmux_session(
     app: tauri::AppHandle,
-    sessions: tauri::State<'_, sessions::SessionManager>,
-    secrets: tauri::State<'_, secrets::Secrets>,
     request: sessions::CloseTmuxSessionRequest,
 ) -> Result<(), String> {
-    sessions.close_tmux_session(app, &secrets, request)
+    run_blocking_command("tmux close session", move || {
+        let sessions = app.state::<sessions::SessionManager>();
+        let secrets = app.state::<secrets::Secrets>();
+        sessions.close_tmux_session(app.clone(), &secrets, request)
+    })
+    .await
 }
 
 #[tauri::command]
 async fn set_tmux_mouse(
     app: tauri::AppHandle,
-    sessions: tauri::State<'_, sessions::SessionManager>,
-    secrets: tauri::State<'_, secrets::Secrets>,
     request: sessions::SetTmuxSessionMouseRequest,
 ) -> Result<(), String> {
-    sessions.set_tmux_session_mouse(app, &secrets, request)
+    run_blocking_command("tmux set mouse", move || {
+        let sessions = app.state::<sessions::SessionManager>();
+        let secrets = app.state::<secrets::Secrets>();
+        sessions.set_tmux_session_mouse(app.clone(), &secrets, request)
+    })
+    .await
 }
 
 #[tauri::command]
 async fn capture_tmux_pane(
     app: tauri::AppHandle,
-    sessions: tauri::State<'_, sessions::SessionManager>,
-    secrets: tauri::State<'_, secrets::Secrets>,
     request: sessions::CaptureTmuxPaneRequest,
 ) -> Result<String, String> {
-    sessions.capture_tmux_pane(app, &secrets, request)
+    run_blocking_command("tmux capture pane", move || {
+        let sessions = app.state::<sessions::SessionManager>();
+        let secrets = app.state::<secrets::Secrets>();
+        sessions.capture_tmux_pane(app.clone(), &secrets, request)
+    })
+    .await
 }
 
 #[tauri::command]
 async fn inspect_ssh_system_context(
     app: tauri::AppHandle,
-    sessions: tauri::State<'_, sessions::SessionManager>,
-    secrets: tauri::State<'_, secrets::Secrets>,
     request: sessions::TmuxConnectionRequest,
 ) -> Result<String, String> {
-    sessions.inspect_ssh_system_context(app, &secrets, request)
+    run_blocking_command("SSH system context inspection", move || {
+        let sessions = app.state::<sessions::SessionManager>();
+        let secrets = app.state::<secrets::Secrets>();
+        sessions.inspect_ssh_system_context(app.clone(), &secrets, request)
+    })
+    .await
 }
 
 #[tauri::command]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -113,6 +113,7 @@ function App() {
   const resetAllLayouts = useWorkspaceStore((state) => state.resetAllLayouts);
   const openConnectionCount = useWorkspaceStore((state) => state.tabs.length);
   const openConnectionCountRef = useRef(openConnectionCount);
+  const allowWindowCloseRef = useRef(false);
   useBootstrapSettings();
   const [connectionPanelLayout, setConnectionPanelLayout] = useState(() =>
     loadPanelLayout(
@@ -201,18 +202,25 @@ function App() {
     let disposed = false;
     let unlisten: (() => void) | undefined;
 
-    void getCurrentWindow()
+    const appWindow = getCurrentWindow();
+    void appWindow
       .onCloseRequested((event) => {
+        if (allowWindowCloseRef.current) {
+          return;
+        }
+
         const openConnections = openConnectionCountRef.current;
         if (openConnections === 0) {
           return;
         }
 
+        event.preventDefault();
         const shouldQuit = window.confirm(
           t("app.quitOpenConnectionsConfirm", { count: openConnections }),
         );
-        if (!shouldQuit) {
-          event.preventDefault();
+        if (shouldQuit) {
+          allowWindowCloseRef.current = true;
+          void appWindow.close();
         }
       })
       .then((dispose) => {


### PR DESCRIPTION
### Motivation
- The app close flow could never exit when open Connections existed because the close handler prevented the window from closing without scheduling a proper follow-up close. 
- AI assistant SSH context inspection and several tmux-related Tauri commands sometimes created or blocked on a Tokio runtime inside an async Tauri worker, which can panic or starve other connection work. 
- The runtime/nested-blocking invariant needed documentation so future commands don’t reintroduce nested runtime issues across connection types. 

### Description
- Update `src/App.tsx` to use an `allowWindowCloseRef` and call `getCurrentWindow().close()` after the user confirms, ensuring the app actually quits once the confirmation is accepted. 
- Move tmux and SSH system-context command implementations in `src-tauri/src/lib.rs` onto a blocking worker using the new helper `run_blocking_command` (which uses `tauri::async_runtime::spawn_blocking`) so code that may `block_on` or create a Tokio runtime runs off the async worker. 
- Add `Backend Command Runtime Boundaries` guidance to `docs/ARCHITECTURE.md` that requires blocking/native work to cross a blocking-command boundary (applies to SSH/tmux/SFTP/WebView2/RDP/VNC and other session families). 

### Testing
- Ran `npm run check` and TypeScript type checks succeeded. 
- Ran `npm run build` and the frontend production build completed successfully. 
- Ran `cargo check --manifest-path src-tauri/Cargo.toml` and compilation succeeded. 
- Ran `cargo test --manifest-path src-tauri/Cargo.toml` and Rust unit tests passed (`88 passed, 0 failed, 1 ignored`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fac733ed64832f8ff0fd55bc9b66d5)