### PR TITLE
Fix close-window quit path to avoid hang during quit-time DB backup

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -192,6 +192,18 @@ fn backup_settings_database(
 }
 
 #[tauri::command]
+fn prepare_main_window_for_quit(
+    window: tauri::Window,
+    storage: tauri::State<'_, storage::Storage>,
+    window_tracker: tauri::State<'_, window_state::MainWindowState>,
+) -> Result<(), String> {
+    let settings = window_tracker.snapshot_for_window(&window);
+    storage.update_main_window_settings(settings)?;
+    storage.backup_if_enabled_for_quit()?;
+    Ok(())
+}
+
+#[tauri::command]
 fn update_terminal_settings(
     storage: tauri::State<'_, storage::Storage>,
     request: storage::TerminalSettings,
@@ -895,13 +907,7 @@ pub fn run() {
                             window_tracker.update_normal_size(*size);
                         }
                     }
-                    tauri::WindowEvent::CloseRequested { .. } => {
-                        let settings = window_tracker.snapshot_for_window(window);
-                        if let Some(storage) = window.try_state::<storage::Storage>() {
-                            let _ = storage.update_main_window_settings(settings);
-                            let _ = storage.backup_if_enabled_for_quit();
-                        }
-                    }
+                    tauri::WindowEvent::CloseRequested { .. } => {}
                     _ => {}
                 }
             }
@@ -925,6 +931,7 @@ pub fn run() {
             export_settings_database,
             import_settings_database,
             backup_settings_database,
+            prepare_main_window_for_quit,
             get_terminal_settings,
             update_terminal_settings,
             get_appearance_settings,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,8 @@ const CONNECTION_PANEL_LAYOUT_KEY = "admindeck.layout.connectionsPanel.v1";
 
 const AI_PANEL_LAYOUT_KEY = "admindeck.layout.aiAssistPanel.v2";
 
+const QUIT_PREPARE_TIMEOUT_MS = 5000;
+
 const defaultConnectionPanelLayout: PanelLayoutState = {
   collapsed: false,
   width: CONNECTION_PANEL_DEFAULT_WIDTH,
@@ -113,7 +115,7 @@ function App() {
   const resetAllLayouts = useWorkspaceStore((state) => state.resetAllLayouts);
   const openConnectionCount = useWorkspaceStore((state) => state.tabs.length);
   const openConnectionCountRef = useRef(openConnectionCount);
-  const allowWindowCloseRef = useRef(false);
+  const quitInProgressRef = useRef(false);
   useBootstrapSettings();
   const [connectionPanelLayout, setConnectionPanelLayout] = useState(() =>
     loadPanelLayout(
@@ -205,23 +207,41 @@ function App() {
     const appWindow = getCurrentWindow();
     void appWindow
       .onCloseRequested((event) => {
-        if (allowWindowCloseRef.current) {
+        event.preventDefault();
+        if (quitInProgressRef.current) {
           return;
         }
 
         const openConnections = openConnectionCountRef.current;
-        if (openConnections === 0) {
+        if (
+          openConnections > 0 &&
+          !window.confirm(
+            t("app.quitOpenConnectionsConfirm", { count: openConnections }),
+          )
+        ) {
           return;
         }
 
-        event.preventDefault();
-        const shouldQuit = window.confirm(
-          t("app.quitOpenConnectionsConfirm", { count: openConnections }),
+        quitInProgressRef.current = true;
+        let timeoutId: number | undefined;
+        const preparation = invokeCommand("prepare_main_window_for_quit").catch(
+          (error: unknown) => {
+            console.error("Failed to prepare AdminDeck for quit", error);
+          },
         );
-        if (shouldQuit) {
-          allowWindowCloseRef.current = true;
-          void appWindow.close();
-        }
+        const timeout = new Promise<void>((resolve) => {
+          timeoutId = window.setTimeout(resolve, QUIT_PREPARE_TIMEOUT_MS);
+        });
+
+        void Promise.race([preparation, timeout])
+          .finally(() => {
+            if (timeoutId !== undefined) {
+              window.clearTimeout(timeoutId);
+            }
+          })
+          .finally(() => {
+            void appWindow.destroy();
+          });
       })
       .then((dispose) => {
         if (disposed) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -473,6 +473,10 @@ type CommandMap = {
     args: undefined;
     result: DatabaseBackupInfo;
   };
+  prepare_main_window_for_quit: {
+    args: undefined;
+    result: null;
+  };
   get_terminal_settings: {
     args: undefined;
     result: TerminalSettings;


### PR DESCRIPTION
### Motivation
- Prevent the main window close button from appearing to do nothing when quit-time database backup or cleanup runs synchronously on the native `CloseRequested` path. 
- Ensure the open-Connections confirmation runs in the frontend before any long-running shutdown work, and avoid leaving the app running until Task Manager is used.

### Description
- Route main-window close requests through the frontend by intercepting `onCloseRequested` in `src/App.tsx` and showing the existing open-Connections confirmation before preparing for quit. 
- Add a typed Tauri command `prepare_main_window_for_quit` in `src-tauri/src/lib.rs` and expose it in `src/lib/tauri.ts`; this command snapshots window settings and calls the existing `backup_if_enabled_for_quit` path. 
- Remove synchronous backup work from the Rust `CloseRequested` handler so the native event no longer blocks on SQLite backup, and instead call the new `prepare_main_window_for_quit` from the frontend. 
- Add a 5s fallback and call `appWindow.destroy()` after preparation completes or the timeout elapses, and ignore repeated close events while quit is in progress to avoid multiple parallel attempts.

### Testing
- Ran `npm run check` which completed successfully. 
- Ran `npm run build` which completed successfully. 
- Ran `cargo check --manifest-path src-tauri/Cargo.toml` which failed/was blocked by a missing system dependency (`glib-2.0.pc` needed by `glib-sys`) in this Linux environment. 
- Ran `cargo test --manifest-path src-tauri/Cargo.toml` which could not complete for the same missing system dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faeff83cf0832fa7c27c7fc2b2810d)