### PR TITLE
Add in-app quit confirmation when Connections are open

### DIFF
--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -333,3 +333,51 @@ When a key is translated into every supported locale, remove its entry from this
 - Placeholders: None
 - Domain notes: AdminDeck is the product name; export refers to the zipped SQLite database file.
 - Translation status: Pending for fr, it, de, es, es-MX, pt-BR, zh-TW, zh-CN, ja, ko, th, id
+
+### `app.quitConfirmTitle`
+
+- English: "Close AdminDeck?"
+- Namespace: `app`
+- Appears in: `src/App.tsx` (`QuitConfirmDialog`)
+- UI role: Dialog title / aria-label
+- Context: Title of the in-app confirmation dialog shown when the user requests to close the AdminDeck main window while one or more workspace Tabs (open Connections) are present. Cancel keeps the window open; confirming destroys the window and exits the app.
+- Tone: Direct, calm question
+- Placeholders: None
+- Domain notes: AdminDeck is the product name. The dialog is in-app (React modal), not OS-native, to avoid the close-requested race that previously broke the close button.
+- Translation status: Pending for fr, it, de, es, es-MX, pt-BR, zh-TW, zh-CN, ja, ko, th, id
+
+### `app.quitConfirmBody_one` / `app.quitConfirmBody_other`
+
+- English: "1 open Connection will end." / "{{count}} open Connections will end."
+- Namespace: `app`
+- Appears in: `src/App.tsx` (`QuitConfirmDialog`)
+- UI role: Dialog body line
+- Context: Primary body line of the close-confirmation dialog. States how many open Connections (live Sessions presented in workspace Tabs) will be terminated if the user proceeds.
+- Tone: Plain factual warning
+- Placeholders: `{{count}}` is the number of open workspace Tabs.
+- Domain notes: Use **Connection** (capital C) for the openable resource term, consistent with `CONTEXT.md`. The dialog deliberately avoids the Connection-vs-Session distinction in copy.
+- Translation status: Pending for fr, it, de, es, es-MX, pt-BR, zh-TW, zh-CN, ja, ko, th, id
+
+### `app.quitConfirmHint`
+
+- English: "Any unsaved work in those Sessions will be lost."
+- Namespace: `app`
+- Appears in: `src/App.tsx` (`QuitConfirmDialog`)
+- UI role: Secondary muted hint line
+- Context: Secondary line under the count, emphasizing that proceeding ends live work (terminal output, SFTP transfers, RDP/VNC sessions, AI chats).
+- Tone: Cautionary, brief
+- Placeholders: None
+- Domain notes: **Session** is the live runtime term from `CONTEXT.md`.
+- Translation status: Pending for fr, it, de, es, es-MX, pt-BR, zh-TW, zh-CN, ja, ko, th, id
+
+### `app.quitConfirmAction`
+
+- English: "Close anyway"
+- Namespace: `app`
+- Appears in: `src/App.tsx` (`QuitConfirmDialog`)
+- UI role: Confirm button (destructive)
+- Context: The destructive button that, when clicked, destroys the AdminDeck main window and exits the app, ending all open Connections.
+- Tone: Direct, slightly informal "anyway" softens the destructive action.
+- Placeholders: None
+- Domain notes: Pairs with the standard `common.cancel` key for the cancel action.
+- Translation status: Pending for fr, it, de, es, es-MX, pt-BR, zh-TW, zh-CN, ja, ko, th, id

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { ChevronLeft, ChevronRight, LayoutDashboard, Settings } from "lucide-rea
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { useTranslation } from "react-i18next";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { invokeCommand, isTauriRuntime } from "./lib/tauri";
 import { useBootstrapSettings } from "./lib/settings";
 import { SettingsPage } from "./settings/SettingsPage";
@@ -110,7 +111,14 @@ function App() {
   const setPerformanceSnapshot = useWorkspaceStore((state) => state.setPerformanceSnapshot);
   const appShellRef = useRef<HTMLDivElement | null>(null);
   const resetAllLayouts = useWorkspaceStore((state) => state.resetAllLayouts);
+  const openConnectionCount = useWorkspaceStore((state) => state.tabs.length);
+  const openConnectionCountRef = useRef(openConnectionCount);
+  const [quitConfirm, setQuitConfirm] = useState<{ count: number } | null>(null);
   useBootstrapSettings();
+
+  useEffect(() => {
+    openConnectionCountRef.current = openConnectionCount;
+  }, [openConnectionCount]);
   const [connectionPanelLayout, setConnectionPanelLayout] = useState(() =>
     loadPanelLayout(
       CONNECTION_PANEL_LAYOUT_KEY,
@@ -210,6 +218,38 @@ function App() {
       window.clearInterval(interval);
     };
   }, [setPerformanceSnapshot]);
+
+  useEffect(() => {
+    if (!isTauriRuntime()) {
+      return;
+    }
+
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+
+    const appWindow = getCurrentWindow();
+    void appWindow
+      .onCloseRequested((event) => {
+        const count = openConnectionCountRef.current;
+        if (count <= 0) {
+          return;
+        }
+        event.preventDefault();
+        setQuitConfirm({ count });
+      })
+      .then((dispose) => {
+        if (disposed) {
+          dispose();
+          return;
+        }
+        unlisten = dispose;
+      });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
 
   useEffect(() => {
     const preventDefaultContextMenu = (event: globalThis.MouseEvent) => {
@@ -314,6 +354,46 @@ function App() {
           onResetLayout={handleResetLayout}
         />
       ) : null}
+      {quitConfirm ? (
+        <QuitConfirmDialog
+          count={quitConfirm.count}
+          onCancel={() => setQuitConfirm(null)}
+          onConfirm={() => {
+            setQuitConfirm(null);
+            void getCurrentWindow().destroy();
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function QuitConfirmDialog({
+  count,
+  onCancel,
+  onConfirm,
+}: {
+  count: number;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const { t } = useTranslation();
+  const title = t("app.quitConfirmTitle");
+  return (
+    <div className="dialog-backdrop confirm-delete-backdrop" role="presentation">
+      <div className="confirm-delete-dialog" role="alertdialog" aria-label={title}>
+        <p className="panel-label">{title}</p>
+        <p className="confirm-delete-name">{t("app.quitConfirmBody", { count })}</p>
+        <p className="confirm-delete-warning">{t("app.quitConfirmHint")}</p>
+        <div className="dialog-actions">
+          <button className="approve-button danger" type="button" onClick={onConfirm}>
+            {t("app.quitConfirmAction")}
+          </button>
+          <button className="toolbar-button" type="button" onClick={onCancel}>
+            {t("common.cancel")}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -5,7 +5,12 @@
     "primaryNav": "Primary",
     "resizeConnections": "Resize Connections column",
     "resizeAiAssistant": "Resize AI Assistant panel",
-    "aiAssistant": "AI Assistant"
+    "aiAssistant": "AI Assistant",
+    "quitConfirmTitle": "Close AdminDeck?",
+    "quitConfirmBody_one": "1 open Connection will end.",
+    "quitConfirmBody_other": "{{count}} open Connections will end.",
+    "quitConfirmHint": "Any unsaved work in those Sessions will be lost.",
+    "quitConfirmAction": "Close anyway"
   },
   "settings": {
     "title": "Settings",


### PR DESCRIPTION
Replaces the previously-removed window.confirm() approach (which blocked
the close button entirely) with a React modal driven by Tauri 2's
onCloseRequested. The handler synchronously preventDefaults when tab
count > 0 and surfaces a state-driven dialog; "Close anyway" calls
getCurrentWindow().destroy() outside the close-event lifecycle to avoid
the prevent-flag race that broke prior attempts.