### PR TITLE
feat(rdp): send text from AI assistant into RDP sessions

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "admin-deck"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64 0.22.1",
  "image",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,7 +41,7 @@ time = { version = "0.3", features = ["formatting", "macros"] }
 zip = "2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Com", "Win32_System_LibraryLoader", "Win32_System_Ole", "Win32_System_Variant", "Win32_UI_WindowsAndMessaging"] }
+windows = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Com", "Win32_System_DataExchange", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Ole", "Win32_System_Variant", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging"] }
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Graphics_Gdi", "Win32_System_DataExchange", "Win32_System_Memory", "Win32_System_Ole", "Win32_System_ProcessStatus", "Win32_System_Threading", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 windows-native-keyring-store = "1.0.0"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -791,6 +791,15 @@ fn send_rdp_ctrl_alt_delete(
 }
 
 #[tauri::command]
+fn send_rdp_text(
+    app: tauri::AppHandle,
+    rdp_sessions: tauri::State<'_, rdp::RdpSessionManager>,
+    request: rdp::SendRdpTextRequest,
+) -> Result<rdp::RdpTextSent, String> {
+    rdp_sessions.send_text(app, request)
+}
+
+#[tauri::command]
 fn start_vnc_session(
     app: tauri::AppHandle,
     vnc_sessions: tauri::State<'_, vnc::VncSessionManager>,
@@ -997,6 +1006,7 @@ pub fn run() {
             close_rdp_session,
             get_rdp_session_status,
             send_rdp_ctrl_alt_delete,
+            send_rdp_text,
             start_vnc_session,
             send_vnc_pointer_event,
             send_vnc_key_event,

--- a/src-tauri/src/rdp.rs
+++ b/src-tauri/src/rdp.rs
@@ -12,22 +12,29 @@ mod platform {
     use windows::{
         core::{Interface, BSTR, PCSTR, PCWSTR},
         Win32::{
-            Foundation::{HWND, LPARAM, POINT, RECT, VARIANT_FALSE, VARIANT_TRUE, WPARAM},
+            Foundation::{HANDLE, HGLOBAL, HWND, LPARAM, POINT, RECT, VARIANT_FALSE, VARIANT_TRUE, WPARAM},
             Graphics::Gdi::ClientToScreen,
             System::{
                 Com::{
                     IDispatch, DISPATCH_METHOD, DISPATCH_PROPERTYGET, DISPATCH_PROPERTYPUT,
                     DISPPARAMS,
                 },
+                DataExchange::{
+                    CloseClipboard, EmptyClipboard, OpenClipboard, SetClipboardData,
+                },
                 LibraryLoader::{GetProcAddress, LoadLibraryW},
-                Ole::{OleInitialize, DISPID_PROPERTYPUT},
+                Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE},
+                Ole::{CF_UNICODETEXT, OleInitialize, DISPID_PROPERTYPUT},
                 Variant::{VariantClear, VARIANT, VT_BOOL, VT_BSTR, VT_DISPATCH, VT_I2, VT_I4},
             },
-            UI::WindowsAndMessaging::{
-                CreateWindowExW, DestroyWindow, GetWindowRect, SendMessageW, SetWindowPos,
-                ShowWindow, HMENU, SWP_NOACTIVATE, SWP_NOZORDER, SW_SHOWNOACTIVATE, WM_KEYDOWN,
-                WM_KEYUP, WS_CLIPCHILDREN, WS_CLIPSIBLINGS, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW,
-                WS_POPUP, WS_VISIBLE,
+            UI::{
+                Input::KeyboardAndMouse::{SetFocus, VkKeyScanW},
+                WindowsAndMessaging::{
+                    CreateWindowExW, DestroyWindow, GetWindowRect, SendMessageW, SetForegroundWindow,
+                    SetWindowPos, ShowWindow, HMENU, SWP_NOACTIVATE, SWP_NOZORDER,
+                    SW_SHOWNOACTIVATE, WM_KEYDOWN, WM_KEYUP, WS_CLIPCHILDREN, WS_CLIPSIBLINGS,
+                    WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_POPUP, WS_VISIBLE,
+                },
             },
         },
     };
@@ -42,6 +49,13 @@ mod platform {
     const VK_CONTROL_KEY: usize = 0x11;
     const VK_ALT_KEY: usize = 0x12;
     const VK_END_KEY: usize = 0x23;
+    const VK_RETURN_KEY: usize = 0x0D;
+    const VK_TAB_KEY: usize = 0x09;
+    const VK_SHIFT_KEY: usize = 0x10;
+    const VK_V_KEY: usize = 0x56;
+    const RDP_TEXT_MODE_CLIPBOARD: &str = "clipboard";
+    const RDP_TEXT_MODE_SEND_KEYS: &str = "sendKeys";
+    const RDP_TEXT_LIMIT: usize = 64 * 1024;
     const RDP_PROGIDS: &[&str] = &[
         "MsTscAx.MsTscAx.13",
         "MsTscAx.MsTscAx.12",
@@ -165,6 +179,24 @@ mod platform {
     #[serde(rename_all = "camelCase")]
     pub struct RdpSimpleRequest {
         session_id: String,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct SendRdpTextRequest {
+        session_id: String,
+        text: String,
+        mode: Option<String>,
+        press_enter: Option<bool>,
+    }
+
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct RdpTextSent {
+        session_id: String,
+        mode: String,
+        fell_back: bool,
+        char_count: u32,
     }
 
     struct RdpSession {
@@ -373,6 +405,79 @@ mod platform {
                     .ok_or_else(|| format!("RDP session '{}' was not found", request.session_id))?;
                 invoke_method(&session.dispatch, "SendCtrlAltDel")
                     .or_else(|_| send_ctrl_alt_end_to_rdp(session.hwnd))
+            })
+        }
+
+        pub fn send_text(
+            &self,
+            app: AppHandle,
+            request: SendRdpTextRequest,
+        ) -> Result<RdpTextSent, String> {
+            let sessions = Arc::clone(&self.sessions);
+            run_on_main_thread(app, move |_app| {
+                if request.text.len() > RDP_TEXT_LIMIT {
+                    return Err(format!(
+                        "RDP text payload is {} bytes which exceeds the {RDP_TEXT_LIMIT}-byte limit",
+                        request.text.len()
+                    ));
+                }
+                let press_enter = request.press_enter.unwrap_or(false);
+                let requested_mode = request
+                    .mode
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or(RDP_TEXT_MODE_CLIPBOARD)
+                    .to_string();
+                let sessions = lock_sessions(&sessions)?;
+                let session = sessions.get(&request.session_id).ok_or_else(|| {
+                    format!("RDP session '{}' was not found", request.session_id)
+                })?;
+                let connection_state = get_property_i32(&session.dispatch, "Connected").unwrap_or(0);
+                if !is_rdp_connected_state(connection_state) {
+                    return Err(
+                        "RDP session is not connected; cannot send text to remote desktop"
+                            .to_string(),
+                    );
+                }
+                let char_count = request.text.chars().count() as u32;
+                if char_count == 0 && !press_enter {
+                    return Ok(RdpTextSent {
+                        session_id: request.session_id,
+                        mode: requested_mode,
+                        fell_back: false,
+                        char_count: 0,
+                    });
+                }
+                focus_rdp_control(session.hwnd);
+                match requested_mode.as_str() {
+                    RDP_TEXT_MODE_SEND_KEYS => {
+                        send_text_via_keys(session.hwnd, &request.text, press_enter)?;
+                        Ok(RdpTextSent {
+                            session_id: request.session_id,
+                            mode: RDP_TEXT_MODE_SEND_KEYS.to_string(),
+                            fell_back: false,
+                            char_count,
+                        })
+                    }
+                    _ => match send_text_via_clipboard(session.hwnd, &request.text, press_enter) {
+                        Ok(()) => Ok(RdpTextSent {
+                            session_id: request.session_id,
+                            mode: RDP_TEXT_MODE_CLIPBOARD.to_string(),
+                            fell_back: false,
+                            char_count,
+                        }),
+                        Err(_) => {
+                            send_text_via_keys(session.hwnd, &request.text, press_enter)?;
+                            Ok(RdpTextSent {
+                                session_id: request.session_id,
+                                mode: RDP_TEXT_MODE_SEND_KEYS.to_string(),
+                                fell_back: true,
+                                char_count,
+                            })
+                        }
+                    },
+                }
             })
         }
     }
@@ -767,6 +872,173 @@ mod platform {
 
     fn invoke_method(dispatch: &IDispatch, name: &str) -> Result<(), String> {
         invoke_method_with_i32_args(dispatch, name, &[])
+    }
+
+    fn send_text_via_clipboard(hwnd: HWND, text: &str, press_enter: bool) -> Result<(), String> {
+        if !text.is_empty() {
+            write_unicode_clipboard(hwnd, text)?;
+            unsafe {
+                let _ = SendMessageW(
+                    hwnd,
+                    WM_KEYDOWN,
+                    Some(WPARAM(VK_CONTROL_KEY)),
+                    Some(LPARAM(0)),
+                );
+                let _ = SendMessageW(hwnd, WM_KEYDOWN, Some(WPARAM(VK_V_KEY)), Some(LPARAM(0)));
+                let _ = SendMessageW(hwnd, WM_KEYUP, Some(WPARAM(VK_V_KEY)), Some(LPARAM(0)));
+                let _ = SendMessageW(
+                    hwnd,
+                    WM_KEYUP,
+                    Some(WPARAM(VK_CONTROL_KEY)),
+                    Some(LPARAM(0)),
+                );
+            }
+        }
+        if press_enter {
+            post_vk(hwnd, VK_RETURN_KEY);
+        }
+        Ok(())
+    }
+
+    fn write_unicode_clipboard(owner: HWND, text: &str) -> Result<(), String> {
+        let mut wide: Vec<u16> = text.encode_utf16().collect();
+        wide.push(0);
+        let bytes = wide.len() * std::mem::size_of::<u16>();
+
+        unsafe {
+            OpenClipboard(Some(owner))
+                .map_err(|error| format!("failed to open clipboard for RDP paste: {error}"))?;
+
+            let result = (|| -> Result<(), String> {
+                EmptyClipboard().map_err(|error| {
+                    format!("failed to empty clipboard for RDP paste: {error}")
+                })?;
+                let hmem: HGLOBAL = GlobalAlloc(GMEM_MOVEABLE, bytes).map_err(|error| {
+                    format!("failed to allocate clipboard memory for RDP paste: {error}")
+                })?;
+                let dst = GlobalLock(hmem) as *mut u16;
+                if dst.is_null() {
+                    return Err("failed to lock clipboard memory for RDP paste".to_string());
+                }
+                std::ptr::copy_nonoverlapping(wide.as_ptr(), dst, wide.len());
+                let _ = GlobalUnlock(hmem);
+                let handle = HANDLE(hmem.0);
+                if SetClipboardData(CF_UNICODETEXT.0 as u32, Some(handle)).is_err() {
+                    return Err("failed to set clipboard data for RDP paste".to_string());
+                }
+                Ok(())
+            })();
+
+            let _ = CloseClipboard();
+            result
+        }
+    }
+
+    fn send_text_via_keys(hwnd: HWND, text: &str, press_enter: bool) -> Result<(), String> {
+        for ch in text.chars() {
+            match ch {
+                '\r' => {}
+                '\n' => post_vk(hwnd, VK_RETURN_KEY),
+                '\t' => post_vk(hwnd, VK_TAB_KEY),
+                _ => post_unicode_char_via_keys(hwnd, ch)?,
+            }
+        }
+        if press_enter {
+            post_vk(hwnd, VK_RETURN_KEY);
+        }
+        Ok(())
+    }
+
+    fn post_unicode_char_via_keys(hwnd: HWND, ch: char) -> Result<(), String> {
+        let code = ch as u32;
+        if code > u16::MAX as u32 {
+            return Err(format!(
+                "character U+{code:04X} cannot be typed via SendKeys: only BMP characters are supported"
+            ));
+        }
+        let scan = unsafe { VkKeyScanW(code as u16) };
+        if scan == -1 {
+            return Err(format!(
+                "character '{ch}' cannot be typed via SendKeys on the active keyboard layout; switch to clipboard mode"
+            ));
+        }
+        let vk = (scan & 0xff) as usize;
+        let modifiers = (scan >> 8) & 0xff;
+        let need_shift = modifiers & 0x01 != 0;
+        let need_ctrl = modifiers & 0x02 != 0;
+        let need_alt = modifiers & 0x04 != 0;
+        unsafe {
+            if need_shift {
+                let _ = SendMessageW(
+                    hwnd,
+                    WM_KEYDOWN,
+                    Some(WPARAM(VK_SHIFT_KEY)),
+                    Some(LPARAM(0)),
+                );
+            }
+            if need_ctrl {
+                let _ = SendMessageW(
+                    hwnd,
+                    WM_KEYDOWN,
+                    Some(WPARAM(VK_CONTROL_KEY)),
+                    Some(LPARAM(0)),
+                );
+            }
+            if need_alt {
+                let _ = SendMessageW(
+                    hwnd,
+                    WM_KEYDOWN,
+                    Some(WPARAM(VK_ALT_KEY)),
+                    Some(LPARAM(0)),
+                );
+            }
+            let _ = SendMessageW(hwnd, WM_KEYDOWN, Some(WPARAM(vk)), Some(LPARAM(0)));
+            let _ = SendMessageW(hwnd, WM_KEYUP, Some(WPARAM(vk)), Some(LPARAM(0)));
+            if need_alt {
+                let _ = SendMessageW(
+                    hwnd,
+                    WM_KEYUP,
+                    Some(WPARAM(VK_ALT_KEY)),
+                    Some(LPARAM(0)),
+                );
+            }
+            if need_ctrl {
+                let _ = SendMessageW(
+                    hwnd,
+                    WM_KEYUP,
+                    Some(WPARAM(VK_CONTROL_KEY)),
+                    Some(LPARAM(0)),
+                );
+            }
+            if need_shift {
+                let _ = SendMessageW(
+                    hwnd,
+                    WM_KEYUP,
+                    Some(WPARAM(VK_SHIFT_KEY)),
+                    Some(LPARAM(0)),
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn focus_rdp_control(hwnd: HWND) {
+        // Bring the RDP ActiveX HWND forward and give it keyboard focus so synthesised
+        // keystrokes route into the remote session even when the assistant panel
+        // currently holds focus. Ignore errors: SetForegroundWindow can be denied by
+        // Windows foreground-lock rules, but SetFocus on the in-process HWND still
+        // delivers messages to the control.
+        unsafe {
+            let _ = SetForegroundWindow(hwnd);
+            let _ = SetFocus(Some(hwnd));
+        }
+    }
+
+    fn post_vk(hwnd: HWND, vk: usize) {
+        unsafe {
+            let _ = SendMessageW(hwnd, WM_KEYDOWN, Some(WPARAM(vk)), Some(LPARAM(0)));
+            let _ = SendMessageW(hwnd, WM_KEYUP, Some(WPARAM(vk)), Some(LPARAM(0)));
+        }
     }
 
     fn send_ctrl_alt_end_to_rdp(hwnd: HWND) -> Result<(), String> {
@@ -1346,6 +1618,24 @@ mod platform {
         pub session_id: String,
     }
 
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct SendRdpTextRequest {
+        pub session_id: String,
+        pub text: String,
+        pub mode: Option<String>,
+        pub press_enter: Option<bool>,
+    }
+
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct RdpTextSent {
+        session_id: String,
+        mode: String,
+        fell_back: bool,
+        char_count: u32,
+    }
+
     impl RdpSessionManager {
         pub fn new() -> Self {
             Self
@@ -1417,6 +1707,17 @@ mod platform {
         ) -> Result<(), String> {
             Err(
                 "RDP Ctrl+Alt+Delete requires Windows and the Microsoft RDP ActiveX control"
+                    .to_string(),
+            )
+        }
+
+        pub fn send_text(
+            &self,
+            _app: AppHandle,
+            _request: SendRdpTextRequest,
+        ) -> Result<RdpTextSent, String> {
+            Err(
+                "RDP text injection requires Windows and the Microsoft RDP ActiveX control"
                     .to_string(),
             )
         }

--- a/src/ai/AssistantPanel.tsx
+++ b/src/ai/AssistantPanel.tsx
@@ -31,7 +31,7 @@ import {
   validateAiProviderForChat,
 } from "./providers";
 import { useWorkspaceStore } from "../store";
-import { writeInputToPane } from "../workspace/paneRegistry";
+import { sendTextToRdpPane, writeInputToPane } from "../workspace/paneRegistry";
 import i18next from "../i18n/config";
 
 function resolveAssistantOutputLanguage(outputLanguage: string): string | undefined {
@@ -429,6 +429,10 @@ export function AssistantPanel({
     !currentModelSupportsImageInput && (hasPendingImageContext || imagePasteRejected);
   const activeTerminalPaneId =
     activeTab?.kind === "terminal" ? activeTab.focusedPaneId ?? activeTab.panes[0]?.id : undefined;
+  const activeRdpPaneId =
+    activeTab?.kind === "remoteDesktop" && activeTab.connection?.type === "rdp"
+      ? activeTab.focusedPaneId ?? activeTab.panes[0]?.id
+      : undefined;
   const sortedChatHistory = useMemo(() => sortedAssistantThreads(chatHistory), [chatHistory]);
   const recentChatHistory = sortedChatHistory.slice(0, 5);
   const shouldShowChatHistory = messages.length === 0 && !prompt.trim() && !isSendingPrompt;
@@ -499,12 +503,21 @@ export function AssistantPanel({
   }, [addContextMenuOpen]);
 
   function handleSendCodeToTerminal(code: string) {
-    if (!activeTerminalPaneId) {
+    if (activeTerminalPaneId) {
+      const data = code.endsWith("\n") ? code : `${code}\n`;
+      writeInputToPane(activeTerminalPaneId, data);
       return;
     }
 
-    const data = code.endsWith("\n") ? code : `${code}\n`;
-    writeInputToPane(activeTerminalPaneId, data);
+    if (activeRdpPaneId) {
+      const trimmed = code.replace(/\r?\n$/, "");
+      const send = sendTextToRdpPane(activeRdpPaneId, trimmed, true);
+      if (send) {
+        send.catch((error) => {
+          setChatError(error instanceof Error ? error.message : String(error));
+        });
+      }
+    }
   }
 
   function handleChatSubmit(event: FormEvent) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -369,6 +369,22 @@ export interface RdpSimpleRequest {
   sessionId: string;
 }
 
+export type RdpTextMode = "clipboard" | "sendKeys";
+
+export interface SendRdpTextRequest {
+  sessionId: string;
+  text: string;
+  mode?: RdpTextMode;
+  pressEnter?: boolean;
+}
+
+export interface RdpTextSent {
+  sessionId: string;
+  mode: RdpTextMode;
+  fellBack: boolean;
+  charCount: number;
+}
+
 export interface StartVncSessionRequest {
   sessionId: string;
   host: string;
@@ -819,6 +835,10 @@ type CommandMap = {
   send_rdp_ctrl_alt_delete: {
     args: { request: RdpSimpleRequest };
     result: null;
+  };
+  send_rdp_text: {
+    args: { request: SendRdpTextRequest };
+    result: RdpTextSent;
   };
   start_vnc_session: {
     args: { request: StartVncSessionRequest };

--- a/src/remote-desktop/RemoteDesktopWorkspace.tsx
+++ b/src/remote-desktop/RemoteDesktopWorkspace.tsx
@@ -13,6 +13,7 @@ import type {
 import { invokeCommand, isTauriRuntime, type AssistantScreenshot } from "../lib/tauri";
 import { useWorkspaceStore } from "../store";
 import type { WorkspaceTab } from "../types";
+import { registerRdpTextSender, unregisterRdpTextSender } from "../workspace/paneRegistry";
 
 type VncSessionEvent =
   | { kind: "connected"; sessionId: string; name: string }
@@ -395,6 +396,10 @@ export function RemoteDesktopWorkspace({
     }
     let disposed = false;
     let sessionId = "";
+    const rdpPaneId = tab.panes[0]?.id;
+    let registeredRdpSender:
+      | ((text: string, pressEnter: boolean) => Promise<void>)
+      | null = null;
     void readSettledBounds().then((bounds) => {
       if (disposed || !bounds) {
         return;
@@ -428,6 +433,19 @@ export function RemoteDesktopWorkspace({
           rdpControlRef.current = started.control;
           setRdpStatus(t("remoteDesktop.preparingDisplay"));
           markConnectionSessionStarted(connection.id);
+          if (rdpPaneId) {
+            const startedSessionId = started.sessionId;
+            registeredRdpSender = async (text, pressEnter) => {
+              await invokeCommand("send_rdp_text", {
+                request: {
+                  sessionId: startedSessionId,
+                  text,
+                  pressEnter,
+                },
+              });
+            };
+            registerRdpTextSender(rdpPaneId, registeredRdpSender);
+          }
           attemptRdpDisplaySync();
         })
         .catch((error) => {
@@ -455,6 +473,10 @@ export function RemoteDesktopWorkspace({
       rdpVisibleRef.current = false;
       if (sessionIdRef.current === sessionId) {
         sessionIdRef.current = null;
+      }
+      if (rdpPaneId && registeredRdpSender) {
+        unregisterRdpTextSender(rdpPaneId, registeredRdpSender);
+        registeredRdpSender = null;
       }
       if (ownsSession) {
         void invokeCommand("close_rdp_session", { request: { sessionId } });

--- a/src/workspace/paneRegistry.ts
+++ b/src/workspace/paneRegistry.ts
@@ -2,6 +2,7 @@ import type { TerminalRenderer } from "../terminal/renderer";
 
 const renderers = new Map<string, TerminalRenderer>();
 const inputWriters = new Map<string, (data: string) => void>();
+const rdpTextSenders = new Map<string, (text: string, pressEnter: boolean) => Promise<void>>();
 
 export function registerPaneRenderer(paneId: string, renderer: TerminalRenderer) {
   renderers.set(paneId, renderer);
@@ -34,4 +35,28 @@ export function writeInputToPane(paneId: string, data: string) {
   }
   writer(data);
   return true;
+}
+
+export function registerRdpTextSender(
+  paneId: string,
+  sender: (text: string, pressEnter: boolean) => Promise<void>,
+) {
+  rdpTextSenders.set(paneId, sender);
+}
+
+export function unregisterRdpTextSender(
+  paneId: string,
+  sender: (text: string, pressEnter: boolean) => Promise<void>,
+) {
+  if (rdpTextSenders.get(paneId) === sender) {
+    rdpTextSenders.delete(paneId);
+  }
+}
+
+export function sendTextToRdpPane(paneId: string, text: string, pressEnter: boolean) {
+  const sender = rdpTextSenders.get(paneId);
+  if (!sender) {
+    return null;
+  }
+  return sender(text, pressEnter);
 }


### PR DESCRIPTION
## Summary

Wires the existing assistant **Send Code** button to deliver commands into the active RDP remote-desktop tab, so AI-proposed PowerShell can be handed straight to the focused server without switching apps. Same UX as terminal tabs today; the assistant doesn't need to know which kind of tab is active.

## Why

AdminDeck's RDP workspace is a native mstscax ActiveX child window — keystrokes can't be delivered through the existing terminal write path. This PR adds a dedicated Tauri command that targets the RDP control's HWND directly, with two delivery paths to handle the real-world variance in server policies.

## What changed

**Backend (`src-tauri/src/rdp.rs`)**
- New `send_rdp_text` command + `SendRdpTextRequest` / `RdpTextSent` types.
- **Clipboard path** (default): writes `CF_UNICODETEXT` via `OpenClipboard` / `SetClipboardData`, then synthesises `Ctrl+V` on the RDP HWND with `SendMessageW`. Relies on `RedirectClipboard` (already enabled on the control).
- **SendKeys fallback**: per-Unicode-char `VkKeyScanW` → VK + shift state → `WM_KEYDOWN` / `WM_KEYUP` pairs with proper Shift/Ctrl/Alt wrapping, plus `\n` → `VK_RETURN`, `\t` → `VK_TAB`. Used when servers disable clipboard redirection (caller selects mode) or when the local clipboard call itself errors (auto-fallback, reported as `fellBack: true`).
- `SetForegroundWindow` + `SetFocus` on the mstscax HWND before delivery so synthesised keystrokes route into the remote session even when the assistant panel currently has focus.
- Connectivity precheck (`Connected` property) and a 64 KB payload cap.
- `windows` crate features added: `Win32_System_DataExchange`, `Win32_System_Memory`, `Win32_UI_Input_KeyboardAndMouse`.

**Frontend**
- `src/workspace/paneRegistry.ts` — new `registerRdpTextSender` / `sendTextToRdpPane` mirroring the existing `writeInputToPane` pattern; lets the AssistantPanel reach the live RDP session id by pane id without prop-drilling.
- `src/remote-desktop/RemoteDesktopWorkspace.tsx` — registers a sender once the RDP session is started, unregisters on cleanup.
- `src/ai/AssistantPanel.tsx` — `handleSendCodeToTerminal` now dispatches to terminal vs. RDP based on `activeTab.kind`. Trailing newline is trimmed before the RDP send because `pressEnter: true` already supplies the Enter (no doubled commits).
- `src/lib/tauri.ts` — typed wrapper: `RdpTextMode`, `SendRdpTextRequest`, `RdpTextSent`, and `send_rdp_text` `CommandMap` entry.

## Reviewer notes

- **Server-side clipboard policy** can disable redirection independent of `RedirectClipboard = true` on the client. There's no reliable runtime probe for "did the remote actually accept the paste," so auto-detection isn't possible — the API is `mode` + `fellBack`. A future toolbar/AssistantPanel toggle can let users force `sendKeys` after observing a missed paste.
- **No clipboard restore.** Remote paste is asynchronous over the RDP wire; a synchronous sleep-then-restore would block the UI without guaranteeing the remote consumed the clipboard. The new text simply remains on the clipboard.
- **VNC tabs** are not wired up in this PR (would need to go via the existing VNC key-event command).
- **i18n** — no new user-visible strings; errors surface through the existing chat error banner. If we add a "Mode: clipboard / SendKeys" toggle later, that wave will need `ai.*` keys plus `docs/LOCALIZATION.md` entries per AGENTS.md.

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml`
- [x] `npm run check` (tsc --noEmit)
- [x] `npm run build`
- [ ] Manual: open an RDP Connection, focus PowerShell on the remote, ask the assistant for a command, click **Send Code**. Verify the command lands in PowerShell and Enter executes it.
- [ ] Manual: repeat against a server with clipboard redirection disabled by GPO; switch to `mode: "sendKeys"` (via dev tools `invokeCommand` or future toggle) and verify keystrokes still arrive.
- [ ] Manual: confirm the existing terminal tab Send Code path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)