### PR TITLE
Chore: optimize frontend chunking and locale loading

### DIFF
--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -2,6 +2,21 @@ import i18next from "i18next";
 import { initReactI18next } from "react-i18next";
 import en from "./locales/en.json";
 
+const localeLoaders = {
+  fr: () => import("./locales/fr.json"),
+  it: () => import("./locales/it.json"),
+  de: () => import("./locales/de.json"),
+  es: () => import("./locales/es.json"),
+  "es-MX": () => import("./locales/es-MX.json"),
+  "pt-BR": () => import("./locales/pt-BR.json"),
+  "zh-TW": () => import("./locales/zh-TW.json"),
+  "zh-CN": () => import("./locales/zh-CN.json"),
+  ja: () => import("./locales/ja.json"),
+  ko: () => import("./locales/ko.json"),
+  th: () => import("./locales/th.json"),
+  id: () => import("./locales/id.json"),
+} as const;
+
 export const SUPPORTED_LANGUAGES = [
   "en",
   "fr",
@@ -19,7 +34,6 @@ export const SUPPORTED_LANGUAGES = [
 ] as const;
 
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
-
 export const LANGUAGE_STORAGE_KEY = "admindeck.language";
 
 export function detectLanguage(): SupportedLanguage {
@@ -127,32 +141,35 @@ i18next.use(initReactI18next).init({
   returnEmptyString: false,
 });
 
-let resourcesLoaded = false;
+let readyLanguage: SupportedLanguage | null = null;
 
-export async function ensureI18nReady(): Promise<void> {
-  if (resourcesLoaded) {
-    return;
-  }
-
-  const language = detectLanguage();
-  if (language === "en") {
-    resourcesLoaded = true;
+async function loadLocale(language: SupportedLanguage): Promise<void> {
+  if (language === "en" || i18next.hasResourceBundle(language, "translation")) {
     return;
   }
 
   try {
-    const module = await import(`./locales/${language}.json`);
+    const module = await localeLoaders[language]();
     i18next.addResourceBundle(language, "translation", module.default ?? module, true, true);
   } catch {
     // Fall back to English silently
   }
+}
+
+export async function ensureI18nReady(): Promise<void> {
+  const language = detectLanguage();
+  if (readyLanguage === language) {
+    return;
+  }
+
+  await loadLocale(language);
 
   if (i18next.language !== language) {
     await i18next.changeLanguage(language);
     persistLanguage(language);
   }
 
-  resourcesLoaded = true;
+  readyLanguage = language;
 }
 
 export async function switchLanguage(language: SupportedLanguage): Promise<void> {
@@ -160,17 +177,10 @@ export async function switchLanguage(language: SupportedLanguage): Promise<void>
     return;
   }
 
-  if (language !== "en" && !i18next.hasResourceBundle(language, "translation")) {
-    try {
-      const module = await import(`./locales/${language}.json`);
-      i18next.addResourceBundle(language, "translation", module.default ?? module, true, true);
-    } catch {
-      // Fall back to English silently
-    }
-  }
-
+  await loadLocale(language);
   await i18next.changeLanguage(language);
   persistLanguage(language);
+  readyLanguage = language;
 }
 
 export default i18next;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,4 +30,22 @@ export default defineConfig(async () => ({
       ignored: ["**/src-tauri/**"],
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          react: ["react", "react-dom", "react/jsx-runtime"],
+          i18n: ["i18next", "react-i18next"],
+          icons: ["lucide-react", "@icon-park/react"],
+          xterm: [
+            "@xterm/xterm",
+            "@xterm/addon-fit",
+            "@xterm/addon-search",
+            "@xterm/addon-web-links",
+            "@xterm/addon-webgl",
+          ],
+        },
+      },
+    },
+  },
 }));


### PR DESCRIPTION
### Motivation
- Reduce the large single production bundle and make common dependencies cacheable by extracting manual Rollup chunks. 
- Eliminate Vite's mixed static/dynamic import warning for the English locale and make non-English locales load on demand with explicit loaders. 
- Clean up and centralize locale-loading logic for clearer behavior and safer lazy-loading.

### Description
- Add an explicit `localeLoaders` map and `loadLocale()` helper in `src/i18n/config.ts` and replace ad-hoc dynamic imports with that shared path, plus an idempotent `readyLanguage` guard to avoid redundant loads. 
- Update `ensureI18nReady()` and `switchLanguage()` to use `loadLocale()` and to persist `readyLanguage` when a locale is loaded. 
- Add Rollup `manualChunks` configuration in `vite.config.ts` to split `react`, `i18n` (`i18next`/`react-i18next`), `icons` (`lucide-react`/`@icon-park/react`), and `xterm` related packages into separate chunks. 
- Small TypeScript cleanups to remove the previous resourcesLoaded flag and keep behavior functionally equivalent while avoiding the Vite static/dynamic import edge-case for `en`.

### Testing
- Ran `npm run check` (TypeScript `tsc --noEmit`), which completed successfully. 
- Ran `npm run build` (production build + Vite), which completed successfully and produced split chunks (notably `react`, `i18n`, `icons`, `xterm`, and per-locale assets). 
- Attempted `cargo check --manifest-path src-tauri/Cargo.toml` and `cargo test --manifest-path src-tauri/Cargo.toml`, but both are blocked in this environment due to a missing system dependency: `pkg-config` could not find `gdk-3.0` (`gdk-3.0.pc`), causing the Rust build to fail; this is an environment/system package issue rather than a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2c0ccf90832fbaaf1e9991fdd823)