### PR TITLE
Fix URL (WebView) workspace layout and toolbar flex

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5094,32 +5094,64 @@ progress {
   margin: -4px 0 10px;
 }
 
+.webview-workspace {
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 10px;
+}
+
+.webview-workspace .workspace-toolbar {
+  gap: 10px;
+  margin-bottom: 0;
+}
+
+.webview-workspace .workspace-toolbar > div:first-child {
+  flex: 0 1 220px;
+}
+
+.webview-workspace .toolbar-cluster {
+  flex: 1 1 auto;
+  min-width: 0;
+  justify-content: flex-end;
+}
+
 .webview-toolbar-form {
   display: flex;
-  flex: 1;
+  flex: 1 1 260px;
+  min-width: 0;
 }
 
 .webview-address-input {
-  flex: 1;
-  min-width: 200px;
+  flex: 1 1 auto;
+  min-width: 160px;
 }
 
 .webview-toolbar-status {
+  flex: 0 1 auto;
+  max-width: 220px;
+  overflow: hidden;
   color: var(--muted);
   font-size: 12px;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .webview-placeholder {
-  flex: 1;
+  display: grid;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
   min-height: 0;
+  overflow: hidden;
+  place-items: center;
 }
 
 .webview-placeholder-message {
   padding: 24px;
+  text-align: center;
 }
 
 .webview-placeholder-error {
+  justify-self: stretch;
   padding: 12px;
 }
 

--- a/src/webview/WebViewWorkspace.tsx
+++ b/src/webview/WebViewWorkspace.tsx
@@ -503,7 +503,7 @@ export function WebViewWorkspace({ isActive, tab }: { isActive: boolean; tab: Wo
 
   return (
     <section
-      className={isActive ? "terminal-workspace active" : "terminal-workspace"}
+      className={isActive ? "terminal-workspace webview-workspace active" : "terminal-workspace webview-workspace"}
       ref={workspaceRef}
     >
       <div className="workspace-toolbar">


### PR DESCRIPTION
### Motivation
- The embedded WebView2 surface was inheriting the terminal single-row layout which allowed toolbar contents (long titles/status/address text) to change the workspace bounds and push the native WebView host off-center after navigation.
- The intent is to keep the toolbar sized to its content and let the native WebView host occupy the remaining centered area so native HWND-backed surfaces keep stable bounds.

### Description
- Added a dedicated `webview-workspace` CSS class and applied it to the WebView workspace section so the workspace uses `grid-template-rows: auto minmax(0, 1fr)` and the toolbar becomes an auto-height row (`src/App.css`, `src/webview/WebViewWorkspace.tsx`).
- Tightened toolbar flex rules by constraining the left title block and making the `.toolbar-cluster` and `.webview-toolbar-form` flex responsibly to avoid growing the host bounds (`src/App.css`).
- Made the WebView placeholder fill the available area, hide overflow, and center the placeholder messages so the native WebView host bounds remain stable (`src/App.css`).
- Updated the WebView component markup to include the new `webview-workspace` class so the new CSS applies (`src/webview/WebViewWorkspace.tsx`).

### Testing
- `npm run check` (`tsc --noEmit`) completed successfully.
- `npm run build` (TypeScript build + `vite build`) completed successfully.
- `cargo check --manifest-path src-tauri/Cargo.toml` could not complete due to a missing system dependency (`gdk-3.0` / `gdk-3.0.pc`) required by `gdk-sys` on the Linux environment, so the Rust checks are blocked.
- `cargo test --manifest-path src-tauri/Cargo.toml` is similarly blocked by the missing `gdk-3.0` system package in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc5f26dda0832f80b508a7cc1abf61)