### PR TITLE
Keep display awake in Don't Sleep mode

### DIFF
--- a/src-tauri/src/power.rs
+++ b/src-tauri/src/power.rs
@@ -85,7 +85,8 @@ mod platform {
         System::{
             LibraryLoader::GetModuleHandleW,
             Power::{
-                SetThreadExecutionState, ES_AWAYMODE_REQUIRED, ES_CONTINUOUS, ES_SYSTEM_REQUIRED,
+                SetThreadExecutionState, ES_AWAYMODE_REQUIRED, ES_CONTINUOUS, ES_DISPLAY_REQUIRED,
+                ES_SYSTEM_REQUIRED,
             },
             Shutdown::{ShutdownBlockReasonCreate, ShutdownBlockReasonDestroy},
         },
@@ -195,8 +196,9 @@ mod platform {
                     ));
                 }
 
-                let full_flags = ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_AWAYMODE_REQUIRED;
-                let base_flags = ES_CONTINUOUS | ES_SYSTEM_REQUIRED;
+                let full_flags =
+                    ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED | ES_AWAYMODE_REQUIRED;
+                let base_flags = ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED;
                 if SetThreadExecutionState(full_flags) == 0
                     && SetThreadExecutionState(base_flags) == 0
                 {


### PR DESCRIPTION
### Motivation
- The Don't Sleep feature prevented system idle sleep but still allowed the display to turn off, so enabling it did not keep the screen awake when the app was unfocused or minimized.
- The intent is to ensure the Windows execution state also prevents display idle timeout while preserving the existing away-mode fallback and shutdown behavior.

### Description
- Add `ES_DISPLAY_REQUIRED` to the Windows power flags import in `src-tauri/src/power.rs` so the symbol is available to the worker.
- Include `ES_DISPLAY_REQUIRED` in both the primary `full_flags` and the fallback `base_flags` used by `SetThreadExecutionState` to request the display remain awake.
- Keep the existing `ES_AWAYMODE_REQUIRED` attempt and the teardown logic unchanged, and confine changes to `src-tauri/src/power.rs`.

### Testing
- Ran `npm run check` which completed successfully (TypeScript `tsc --noEmit`).
- Ran `npm run build` which completed successfully (`vite build`).
- `cargo check --manifest-path src-tauri/Cargo.toml` could not complete in this environment due to a missing system dependency (`gdk-3.0` pkg-config) required by `gdk-sys` and thus failed the Rust build step in this CI-like container.
- `cargo test --manifest-path src-tauri/Cargo.toml` could not run for the same missing system dependency and environment limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd42356700832f89ede7cd6afe717a)