### PR TITLE
Enforce Windows single-instance with tauri-plugin-single-instance

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
  "time",
  "tokio",
  "url",
@@ -5475,6 +5476,21 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows 0.61.3",
+ "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
  "zbus",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,6 +45,7 @@ zip = "2"
 windows = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Com", "Win32_System_DataExchange", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Ole", "Win32_System_Variant", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging"] }
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Graphics_Gdi", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_System_DataExchange", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Ole", "Win32_System_Power", "Win32_System_ProcessStatus", "Win32_System_Shutdown", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 windows-native-keyring-store = "1.0.0"
+tauri-plugin-single-instance = "2"
 
 
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1172,11 +1172,35 @@ fn get_wiki_attachments_folder(paths: tauri::State<'_, wiki::WikiPaths>) -> Resu
     Ok(paths.root().display().to_string())
 }
 
+#[cfg(target_os = "windows")]
+fn configure_single_instance<R: tauri::Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
+    builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+        focus_main_window(app);
+    }))
+}
+
+#[cfg(not(target_os = "windows"))]
+fn configure_single_instance<R: tauri::Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
+    builder
+}
+
+#[cfg(target_os = "windows")]
+fn focus_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    if let Some(main_window) = app.get_window(window_state::MAIN_WINDOW_LABEL) {
+        if main_window.is_minimized().unwrap_or(false) {
+            let _ = main_window.unminimize();
+        }
+
+        let _ = main_window.show();
+        let _ = main_window.set_focus();
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     logging::init();
 
-    tauri::Builder::default()
+    configure_single_instance(tauri::Builder::default())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_opener::init())


### PR DESCRIPTION
### Motivation
- Prevent accidental multi-instance launches on Windows by explicitly enforcing a single-instance policy instead of relying on incidental behavior (for example a DB lock) to terminate secondary launches.
- Ensure the secondary-launch path runs before durable initialization so the app never begins opening the SQLite database or other managed resources for a duplicate process.

### Description
- Added `tauri-plugin-single-instance` as a Windows-only dependency in `src-tauri/Cargo.toml` and its lockfile entry to make singleton behavior explicit on Windows.  
- Registered the single-instance plugin early by introducing `configure_single_instance(builder)` and calling `configure_single_instance(tauri::Builder::default())` before other plugins and the `.setup(...)` path.  
- Implemented a `focus_main_window` handler called by the plugin on secondary launches to `unminimize`, `show`, and `set_focus` on the existing main window (Windows-only).  
- Kept storage initialization unchanged, but moved plugin registration ahead of the code that calls `storage::Storage::open(...)` so secondary instances exit before the DB is opened.

### Testing
- Ran `npm run check` and it completed successfully.  
- Ran `npm run build` and the frontend build completed successfully.  
- Ran `cargo check --manifest-path src-tauri/Cargo.toml` and it completed successfully.  
- Ran `cargo test --manifest-path src-tauri/Cargo.toml` and all library tests passed (`113` passed, `1` ignored).  
- Ran `cargo check --manifest-path src-tauri/Cargo.toml --target x86_64-pc-windows-gnu` and it completed successfully in the environment after the cross-toolchain install.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5e11bae4832f928e34bc2746cf0d)