### PR TITLE
Finish URL credential saving and autofill

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -50,6 +50,7 @@ struct FillWebviewCredentialRequest {
     session_id: String,
     secret_owner_id: String,
     username: String,
+    automatic: Option<bool>,
 }
 
 #[tauri::command]
@@ -909,13 +910,14 @@ fn fill_webview_credential(
         password,
         username_selector: credential.username_selector,
         password_selector: credential.password_selector,
+        automatic: request.automatic.unwrap_or(false),
     })
 }
 
 #[tauri::command]
 fn capture_webview_credential(
     webviews: tauri::State<'_, webview::WebviewSessionManager>,
-    request: webview::WebviewSimpleRequest,
+    request: webview::WebviewCaptureCredentialRequest,
 ) -> Result<(), String> {
     webviews.capture_credential(request)
 }

--- a/src-tauri/src/webview.rs
+++ b/src-tauri/src/webview.rs
@@ -17,38 +17,33 @@ const AUTOFILL_AGENT: &str = r#"
   const TITLE_CHANNEL = "__ADMINDECK_URL_CREDENTIAL__";
   const agent = {
     fill(credential) {
-      const passwordInput = inputFromSelector(credential.passwordSelector) || findPasswordInput(false);
-      if (!passwordInput) {
-        return { filled: false, reason: "no-password-field" };
+      const result = fillCredential(credential);
+      if (result.filled) {
+        return result;
       }
-
-      const usernameInput = inputFromSelector(credential.usernameSelector) || findUsernameInput(passwordInput);
-      if (usernameInput && credential.username) {
-        setInputValue(usernameInput, credential.username);
-      }
-      setInputValue(passwordInput, credential.password);
-      passwordInput.focus({ preventScroll: true });
-      return { filled: true, usernameFilled: Boolean(usernameInput && credential.username) };
+      observeForCredentialFields(credential);
+      return result;
     },
-    capture() {
+    capture(nonce) {
       const passwordInput = findPasswordInput(true);
       if (!passwordInput) {
-        publish({ ok: false, reason: "no-password-field", url: window.location.href });
+        publish({ ok: false, nonce, reason: "no-password-field", url: window.location.href });
         return;
       }
       const password = passwordInput.value || "";
       if (!password) {
-        publish({ ok: false, reason: "empty-password", url: window.location.href });
+        publish({ ok: false, nonce, reason: "empty-password", url: window.location.href });
         return;
       }
       const usernameInput = findUsernameInput(passwordInput);
       const username = usernameInput?.value || "";
       if (!username) {
-        publish({ ok: false, reason: "empty-username", url: window.location.href });
+        publish({ ok: false, nonce, reason: "empty-username", url: window.location.href });
         return;
       }
       publish({
         ok: true,
+        nonce,
         url: window.location.href,
         username,
         password,
@@ -66,6 +61,58 @@ const AUTOFILL_AGENT: &str = r#"
         document.title = previousTitle;
       }
     }, 150);
+  }
+
+  let pendingFillObserver;
+  let pendingFillTimer;
+
+  function fillCredential(credential) {
+    const passwordInput = inputFromSelector(credential.passwordSelector) || findPasswordInput(false);
+    if (!passwordInput) {
+      return { filled: false, reason: "no-password-field" };
+    }
+    if (credential.automatic && passwordInput.value) {
+      return { filled: false, reason: "password-already-entered" };
+    }
+
+    const usernameInput = inputFromSelector(credential.usernameSelector) || findUsernameInput(passwordInput);
+    if (usernameInput && credential.username && (!credential.automatic || !usernameInput.value)) {
+      setInputValue(usernameInput, credential.username);
+    }
+    setInputValue(passwordInput, credential.password);
+    if (!credential.automatic) {
+      passwordInput.focus({ preventScroll: true });
+    }
+    return { filled: true, usernameFilled: Boolean(usernameInput && credential.username) };
+  }
+
+  function observeForCredentialFields(credential) {
+    if (pendingFillObserver) {
+      pendingFillObserver.disconnect();
+    }
+    if (pendingFillTimer) {
+      window.clearTimeout(pendingFillTimer);
+    }
+    pendingFillObserver = new MutationObserver(() => {
+      if (fillCredential(credential).filled) {
+        pendingFillObserver?.disconnect();
+        pendingFillObserver = undefined;
+        if (pendingFillTimer) {
+          window.clearTimeout(pendingFillTimer);
+          pendingFillTimer = undefined;
+        }
+      }
+    });
+    pendingFillObserver.observe(document.documentElement, {
+      attributes: true,
+      childList: true,
+      subtree: true,
+    });
+    pendingFillTimer = window.setTimeout(() => {
+      pendingFillObserver?.disconnect();
+      pendingFillObserver = undefined;
+      pendingFillTimer = undefined;
+    }, 10000);
   }
 
   function inputFromSelector(selector) {
@@ -235,12 +282,20 @@ pub struct WebviewSimpleRequest {
     session_id: String,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebviewCaptureCredentialRequest {
+    session_id: String,
+    nonce: String,
+}
+
 pub(crate) struct WebviewFillCredentialRequest {
     pub(crate) session_id: String,
     pub(crate) username: String,
     pub(crate) password: String,
     pub(crate) username_selector: Option<String>,
     pub(crate) password_selector: Option<String>,
+    pub(crate) automatic: bool,
 }
 
 #[derive(Clone, Serialize)]
@@ -524,6 +579,7 @@ impl WebviewSessionManager {
             "password": request.password,
             "usernameSelector": request.username_selector,
             "passwordSelector": request.password_selector,
+            "automatic": request.automatic,
         });
         let payload = serde_json::to_string(&payload)
             .map_err(|error| format!("failed to prepare URL credential payload: {error}"))?;
@@ -538,13 +594,20 @@ impl WebviewSessionManager {
             .map_err(|error| format!("failed to fill webview credential: {error}"))
     }
 
-    pub fn capture_credential(&self, request: WebviewSimpleRequest) -> Result<(), String> {
+    pub fn capture_credential(
+        &self,
+        request: WebviewCaptureCredentialRequest,
+    ) -> Result<(), String> {
+        let nonce = serde_json::to_string(&request.nonce)
+            .map_err(|error| format!("failed to prepare URL credential capture nonce: {error}"))?;
         let sessions = self.lock()?;
         let webview = sessions
             .get(&request.session_id)
             .ok_or_else(|| format!("webview session '{}' was not found", request.session_id))?;
         webview
-            .eval("window.__ADMINDECK_URL_AUTOFILL__?.capture();")
+            .eval(format!(
+                "window.__ADMINDECK_URL_AUTOFILL__?.capture({nonce});"
+            ))
             .map_err(|error| format!("failed to capture webview credential: {error}"))
     }
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -365,10 +365,15 @@ export interface WebviewSimpleRequest {
   sessionId: string;
 }
 
+export interface WebviewCaptureCredentialRequest extends WebviewSimpleRequest {
+  nonce: string;
+}
+
 export interface FillWebviewCredentialRequest {
   sessionId: string;
   secretOwnerId: string;
   username: string;
+  automatic?: boolean;
 }
 
 export interface StartRdpSessionRequest {
@@ -951,7 +956,7 @@ type CommandMap = {
     result: null;
   };
   capture_webview_credential: {
-    args: { request: WebviewSimpleRequest };
+    args: { request: WebviewCaptureCredentialRequest };
     result: null;
   };
   close_webview_session: {

--- a/src/webview/WebViewWorkspace.tsx
+++ b/src/webview/WebViewWorkspace.tsx
@@ -112,6 +112,7 @@ function releaseWebviewSession(sessionId: string) {
 
 type CapturedCredentialPayload = {
   ok: boolean;
+  nonce?: string;
   reason?: string;
   url?: string;
   username?: string;
@@ -121,6 +122,10 @@ type CapturedCredentialPayload = {
 };
 
 const CREDENTIAL_TITLE_PREFIX = "__ADMINDECK_URL_CREDENTIAL__";
+
+function createCredentialCaptureNonce() {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
 
 export function WebViewWorkspace({ isActive, tab }: { isActive: boolean; tab: WorkspaceTab }) {
   const { t } = useTranslation();
@@ -133,6 +138,8 @@ export function WebViewWorkspace({ isActive, tab }: { isActive: boolean; tab: Wo
   const lastBoundsRef = useRef<{ x: number; y: number; width: number; height: number } | null>(null);
   const rafRef = useRef<number | null>(null);
   const visibilityRef = useRef({ isActive, webviewSuppressed: false });
+  const pendingCaptureNonceRef = useRef<string | null>(null);
+  const credentialRef = useRef({ canFillCredential: false, username: "" });
   const [navError, setNavError] = useState("");
   const [fillStatus, setFillStatus] = useState("");
   const [webviewSuppressed, setWebviewSuppressed] = useState(false);
@@ -143,6 +150,13 @@ export function WebViewWorkspace({ isActive, tab }: { isActive: boolean; tab: Wo
   const [hasSavedCredential, setHasSavedCredential] = useState(Boolean(tab.connection?.hasUrlCredential));
   const urlCredentialUsername = savedCredentialUsername || tab.connection?.urlCredentialUsername;
   const canFillCredential = Boolean(hasSavedCredential && urlCredentialUsername);
+
+  useEffect(() => {
+    credentialRef.current = {
+      canFillCredential,
+      username: urlCredentialUsername ?? "",
+    };
+  }, [canFillCredential, urlCredentialUsername]);
 
   const computeBounds = () => {
     const node = placeholderRef.current;
@@ -349,6 +363,7 @@ export function WebViewWorkspace({ isActive, tab }: { isActive: boolean; tab: Wo
         setAddressInput(event.payload.url);
         if (event.payload.status === "finished") {
           setFillStatus("");
+          void fillCredential({ automatic: true, showStatus: false });
         }
       }),
       listen<WebviewTitleChangedEvent>("webview-title-changed", (event) => {
@@ -415,17 +430,22 @@ export function WebViewWorkspace({ isActive, tab }: { isActive: boolean; tab: Wo
   }
 
   function handleCapturedCredential(rawPayload: string) {
-    if (!tab.connection) {
+    if (!tab.connection || !pendingCaptureNonceRef.current) {
       return;
     }
     let payload: CapturedCredentialPayload;
     try {
       payload = JSON.parse(rawPayload) as CapturedCredentialPayload;
     } catch {
+      pendingCaptureNonceRef.current = null;
       setFillStatus("");
       setNavError(t("webview.savePasswordInvalidCapture"));
       return;
     }
+    if (payload.nonce !== pendingCaptureNonceRef.current) {
+      return;
+    }
+    pendingCaptureNonceRef.current = null;
     if (!payload.ok || !payload.username || !payload.password) {
       setFillStatus("");
       const reason = payload.reason === "no-password-field"
@@ -474,32 +494,49 @@ export function WebViewWorkspace({ isActive, tab }: { isActive: boolean; tab: Wo
     }
     setNavError("");
     setFillStatus(t("webview.capturingPassword"));
+    const nonce = createCredentialCaptureNonce();
+    pendingCaptureNonceRef.current = nonce;
     void invokeCommand("capture_webview_credential", {
-      request: { sessionId: sessionIdRef.current },
+      request: { sessionId: sessionIdRef.current, nonce },
     }).catch((error) => {
+      pendingCaptureNonceRef.current = null;
       setFillStatus("");
       setNavError(error instanceof Error ? error.message : String(error));
     });
   }
 
-  function handleFillCredential() {
-    if (!isTauriRuntime() || !sessionStartedRef.current || !tab.connection || !urlCredentialUsername) {
-      return;
+  function fillCredential({ automatic, showStatus }: { automatic: boolean; showStatus: boolean }) {
+    const credential = credentialRef.current;
+    if (!isTauriRuntime() || !sessionStartedRef.current || !tab.connection || !credential.canFillCredential) {
+      return Promise.resolve();
     }
-    setNavError("");
-    setFillStatus(t("webview.fillingCredential"));
-    void invokeCommand("fill_webview_credential", {
+    if (showStatus) {
+      setNavError("");
+      setFillStatus(t("webview.fillingCredential"));
+    }
+    return invokeCommand("fill_webview_credential", {
       request: {
         sessionId: sessionIdRef.current,
         secretOwnerId: tab.connection.id,
-        username: urlCredentialUsername,
+        username: credential.username,
+        automatic,
       },
     })
-      .then(() => setFillStatus(t("webview.credentialFilled")))
+      .then(() => {
+        if (showStatus) {
+          setFillStatus(t("webview.credentialFilled"));
+        }
+      })
       .catch((error) => {
-        setFillStatus("");
-        setNavError(error instanceof Error ? error.message : String(error));
+        if (showStatus) {
+          setFillStatus("");
+          setNavError(error instanceof Error ? error.message : String(error));
+        }
       });
+  }
+
+  function handleFillCredential() {
+    void fillCredential({ automatic: false, showStatus: true });
   }
 
   return (


### PR DESCRIPTION
### Motivation
- Complete the URL Connection username/password save and autofill feature so saved credentials can be captured from pages and autofilled into embedded WebView2 sessions safely and reliably.
- Prevent spurious title-based captures and avoid overwriting user-typed values during automatic fills, and support dynamically-rendered login fields.

### Description
- Update the injected autofill agent (`src-tauri/src/webview.rs`) to add `fillCredential` and `observeForCredentialFields` helpers, add an `automatic` fill mode, and emit a nonce on successful capture so captures are bound to an active request.
- Thread a capture `nonce` and an `automatic` flag through the Tauri type layer (`src/lib/tauri.ts`), Rust command handlers (`src-tauri/src/lib.rs`), and the WebView session manager (`src-tauri/src/webview.rs`) so captures and fills are protected and parameterized.
- Add nonce-driven capture and automatic/manual fill flows to the frontend WebView workspace (`src/webview/WebViewWorkspace.tsx`), including `createCredentialCaptureNonce`, pending-nonce tracking, automatic fill after page load, and a unified `fillCredential` helper that supports silent automatic fills and visible manual fills.
- Keep the existing manual save/fill toolbar actions and update them to use the new nonce/automatic behavior and stored credential plumbing (`store_secret`, `upsert_url_credential`, `fill_webview_credential`, `capture_webview_credential`).

### Testing
- Ran `npm run check` and `npm run build`, both completed successfully (the build emitted an existing Vite chunk-size warning). 
- Ran `cargo fmt --manifest-path src-tauri/Cargo.toml` and `git diff --check`, both succeeded.
- Attempted `cargo check --manifest-path src-tauri/Cargo.toml` and `cargo test --manifest-path src-tauri/Cargo.toml`, but both were blocked in this environment due to a missing system dependency required by a native crate (`gdk-3.0` via pkg-config).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd95959184832fb9f9119246aaef43)