### PR TITLE
Include nav toolbar and toolbar text in color schemes and previews

### DIFF
--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -467,3 +467,25 @@ When a key is translated into every supported locale, remove its entry from this
 - Tone: concise safety-focused explanation.
 - Placeholder details: none.
 - Domain notes: Commands are local and constrained; destructive actions require explicit approval before any future execution path.
+
+### settings.navToolbar
+
+- English value: "Nav toolbar"
+- Namespace: `settings`
+- File/component: `src/settings/AppearanceSettings.tsx` / color scheme preview
+- UI role: preview swatch label
+- Surrounding user flow: Settings -> Appearance -> Color Scheme shows the left Activity Rail/navigation toolbar color included in each selectable color scheme.
+- Tone: compact UI-part label.
+- Placeholder details: none.
+- Domain notes: Refers to the narrow left column navigation rail that contains Connections, Wiki, Don't Sleep, and Settings controls.
+
+### settings.toolbarText
+
+- English value: "Toolbar text"
+- Namespace: `settings`
+- File/component: `src/settings/AppearanceSettings.tsx` / color scheme preview
+- UI role: preview swatch label
+- Surrounding user flow: Settings -> Appearance -> Color Scheme shows the icon/text color used on the left Activity Rail/navigation toolbar as part of each selectable color scheme.
+- Tone: compact UI-part label.
+- Placeholder details: none.
+- Domain notes: Refers to foreground text and icon color for the themed navigation toolbar, not terminal text or workspace content text.

--- a/src/App.css
+++ b/src/App.css
@@ -36,6 +36,14 @@
   --green: #15915f;
   --amber: #b7791f;
   --red: #c2413b;
+  --nav-toolbar-bg: #202936;
+  --nav-toolbar-text: #d8e1ef;
+  --nav-toolbar-hover-bg: rgba(255, 255, 255, 0.12);
+  --nav-toolbar-accent: #60a5fa;
+  --nav-toolbar-warning: #fbbf24;
+  --nav-toolbar-tooltip-bg: #111827;
+  --nav-toolbar-tooltip-text: #f8fafc;
+  --nav-toolbar-tooltip-border: rgba(255, 255, 255, 0.14);
   --shadow: 0 18px 50px rgba(31, 42, 58, 0.12);
   --app-ui-font-family:
     "Satoshi", Inter, ui-sans-serif, system-ui, -apple-system,
@@ -60,6 +68,14 @@
   --green: #3fb87b;
   --amber: #d99a3d;
   --red: #d9534f;
+  --nav-toolbar-bg: #202936;
+  --nav-toolbar-text: #d8e1ef;
+  --nav-toolbar-hover-bg: rgba(255, 255, 255, 0.12);
+  --nav-toolbar-accent: #60a5fa;
+  --nav-toolbar-warning: #fbbf24;
+  --nav-toolbar-tooltip-bg: #111827;
+  --nav-toolbar-tooltip-text: #f8fafc;
+  --nav-toolbar-tooltip-border: rgba(255, 255, 255, 0.14);
   --shadow: 0 18px 50px rgba(0, 0, 0, 0.35);
 }
 
@@ -81,6 +97,14 @@
   --green: #0d6b3d;
   --amber: #a3620a;
   --red: #b91c1c;
+  --nav-toolbar-bg: #202936;
+  --nav-toolbar-text: #d8e1ef;
+  --nav-toolbar-hover-bg: rgba(255, 255, 255, 0.12);
+  --nav-toolbar-accent: #60a5fa;
+  --nav-toolbar-warning: #fbbf24;
+  --nav-toolbar-tooltip-bg: #111827;
+  --nav-toolbar-tooltip-text: #f8fafc;
+  --nav-toolbar-tooltip-border: rgba(255, 255, 255, 0.14);
   --shadow: 0 12px 40px rgba(0, 8, 32, 0.1);
 }
 
@@ -102,6 +126,14 @@
   --green: #34c759;
   --amber: #ff9500;
   --red: #ff3b30;
+  --nav-toolbar-bg: #e4e4e8;
+  --nav-toolbar-text: #1d1d1f;
+  --nav-toolbar-hover-bg: rgba(0, 0, 0, 0.08);
+  --nav-toolbar-accent: #0071e3;
+  --nav-toolbar-warning: #b36b00;
+  --nav-toolbar-tooltip-bg: #1d1d1f;
+  --nav-toolbar-tooltip-text: #f5f5f7;
+  --nav-toolbar-tooltip-border: rgba(255, 255, 255, 0.18);
   --shadow: 0 8px 32px rgba(0, 0, 0, 0.08);
 }
 
@@ -123,6 +155,14 @@
   --green: #2d8a4e;
   --amber: #cc6600;
   --red: #cc3333;
+  --nav-toolbar-bg: #4a2b12;
+  --nav-toolbar-text: #ffe6cc;
+  --nav-toolbar-hover-bg: rgba(255, 180, 90, 0.18);
+  --nav-toolbar-accent: #ffb86c;
+  --nav-toolbar-warning: #ffd166;
+  --nav-toolbar-tooltip-bg: #2a1708;
+  --nav-toolbar-tooltip-text: #fff4e8;
+  --nav-toolbar-tooltip-border: rgba(255, 200, 140, 0.22);
   --shadow: 0 12px 40px rgba(100, 50, 0, 0.1);
 }
 
@@ -144,6 +184,14 @@
   --green: #4ade80;
   --amber: #fbbf24;
   --red: #f87171;
+  --nav-toolbar-bg: #1b1536;
+  --nav-toolbar-text: #ece6ff;
+  --nav-toolbar-hover-bg: rgba(167, 139, 250, 0.18);
+  --nav-toolbar-accent: #c4b5fd;
+  --nav-toolbar-warning: #fbbf24;
+  --nav-toolbar-tooltip-bg: #120d27;
+  --nav-toolbar-tooltip-text: #f5f1ff;
+  --nav-toolbar-tooltip-border: rgba(196, 181, 253, 0.25);
   --shadow: 0 18px 50px rgba(10, 6, 30, 0.45);
 }
 
@@ -165,6 +213,14 @@
   --green: #15803d;
   --amber: #b45309;
   --red: #dc2626;
+  --nav-toolbar-bg: #5a2148;
+  --nav-toolbar-text: #ffe3f1;
+  --nav-toolbar-hover-bg: rgba(255, 190, 220, 0.18);
+  --nav-toolbar-accent: #f9a8d4;
+  --nav-toolbar-warning: #fbbf24;
+  --nav-toolbar-tooltip-bg: #3b1430;
+  --nav-toolbar-tooltip-text: #fff0f7;
+  --nav-toolbar-tooltip-border: rgba(255, 190, 220, 0.25);
   --shadow: 0 12px 40px rgba(80, 20, 60, 0.1);
 }
 
@@ -236,8 +292,8 @@ button {
   align-items: center;
   padding: 10px 7px;
   overflow: visible;
-  background: #202936;
-  color: #d8e1ef;
+  background: var(--nav-toolbar-bg);
+  color: var(--nav-toolbar-text);
 }
 
 .rail-button,
@@ -267,7 +323,7 @@ button {
 }
 
 .rail-button-dont-sleep.dont-sleep-enabled {
-  color: #fbbf24;
+  color: var(--nav-toolbar-warning);
 }
 
 .rail-button:disabled {
@@ -277,11 +333,11 @@ button {
 
 .rail-button:hover,
 .rail-button.active {
-  background: rgba(255, 255, 255, 0.12);
+  background: var(--nav-toolbar-hover-bg);
 }
 
 .rail-button.connections-collapsed-indicator {
-  color: #60a5fa;
+  color: var(--nav-toolbar-accent);
 }
 
 .rail-tooltip {
@@ -290,11 +346,11 @@ button {
   top: 50%;
   z-index: 30;
   padding: 5px 8px;
-  color: #f8fafc;
+  color: var(--nav-toolbar-tooltip-text);
   white-space: nowrap;
   pointer-events: none;
-  background: #111827;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: var(--nav-toolbar-tooltip-bg);
+  border: 1px solid var(--nav-toolbar-tooltip-border);
   border-radius: 5px;
   box-shadow: var(--shadow);
   opacity: 0;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -49,6 +49,8 @@
     "text": "Text",
     "accent": "Accent",
     "green": "Green",
+    "navToolbar": "Nav toolbar",
+    "toolbarText": "Toolbar text",
     "language": "Language",
     "autoBackup": "Auto Backup",
     "autoBackupHint": "Automatic backups older than 1 week are deleted after each startup backup.",

--- a/src/settings/AppearanceSettings.tsx
+++ b/src/settings/AppearanceSettings.tsx
@@ -60,16 +60,72 @@ const COLOR_SCHEME_OPTIONS: { value: ColorScheme; labelKey: string }[] = [
   { value: "pink", labelKey: "settings.schemePink" },
 ];
 
-const SCHEME_PREVIEW_LABELS = ["settings.appBg", "settings.surface", "settings.text", "settings.accent", "settings.green"] as const;
+type SchemePreviewColor = { color: string; labelKey: string };
 
-const SCHEME_PREVIEW_COLORS: Record<ColorScheme, string[]> = {
-  default: ["#eef1f5", "#ffffff", "#17202b", "#2563eb", "#15915f"],
-  dark: ["#1a1d24", "#2b303b", "#e4e7ee", "#4b8bff", "#3fb87b"],
-  light: ["#ffffff", "#f5f7fa", "#0a1628", "#1d4ed8", "#0d6b3d"],
-  mac: ["#ececec", "#ffffff", "#1d1d1f", "#0071e3", "#34c759"],
-  orange: ["#fff5ec", "#ffffff", "#1a1a1a", "#e87a00", "#2d8a4e"],
-  purple: ["#1e1836", "#2d2650", "#e8e4f4", "#a78bfa", "#4ade80"],
-  pink: ["#fff0f5", "#ffffff", "#2d1b3a", "#c026d3", "#15803d"],
+const SCHEME_PREVIEW_COLORS: Record<ColorScheme, SchemePreviewColor[]> = {
+  default: [
+    { color: "#eef1f5", labelKey: "settings.appBg" },
+    { color: "#ffffff", labelKey: "settings.surface" },
+    { color: "#17202b", labelKey: "settings.text" },
+    { color: "#2563eb", labelKey: "settings.accent" },
+    { color: "#15915f", labelKey: "settings.green" },
+    { color: "#202936", labelKey: "settings.navToolbar" },
+    { color: "#d8e1ef", labelKey: "settings.toolbarText" },
+  ],
+  dark: [
+    { color: "#1a1d24", labelKey: "settings.appBg" },
+    { color: "#2b303b", labelKey: "settings.surface" },
+    { color: "#e4e7ee", labelKey: "settings.text" },
+    { color: "#4b8bff", labelKey: "settings.accent" },
+    { color: "#3fb87b", labelKey: "settings.green" },
+    { color: "#202936", labelKey: "settings.navToolbar" },
+    { color: "#d8e1ef", labelKey: "settings.toolbarText" },
+  ],
+  light: [
+    { color: "#ffffff", labelKey: "settings.appBg" },
+    { color: "#f5f7fa", labelKey: "settings.surface" },
+    { color: "#0a1628", labelKey: "settings.text" },
+    { color: "#1d4ed8", labelKey: "settings.accent" },
+    { color: "#0d6b3d", labelKey: "settings.green" },
+    { color: "#202936", labelKey: "settings.navToolbar" },
+    { color: "#d8e1ef", labelKey: "settings.toolbarText" },
+  ],
+  mac: [
+    { color: "#ececec", labelKey: "settings.appBg" },
+    { color: "#ffffff", labelKey: "settings.surface" },
+    { color: "#1d1d1f", labelKey: "settings.text" },
+    { color: "#0071e3", labelKey: "settings.accent" },
+    { color: "#34c759", labelKey: "settings.green" },
+    { color: "#e4e4e8", labelKey: "settings.navToolbar" },
+    { color: "#1d1d1f", labelKey: "settings.toolbarText" },
+  ],
+  orange: [
+    { color: "#fff5ec", labelKey: "settings.appBg" },
+    { color: "#ffffff", labelKey: "settings.surface" },
+    { color: "#1a1a1a", labelKey: "settings.text" },
+    { color: "#e87a00", labelKey: "settings.accent" },
+    { color: "#2d8a4e", labelKey: "settings.green" },
+    { color: "#4a2b12", labelKey: "settings.navToolbar" },
+    { color: "#ffe6cc", labelKey: "settings.toolbarText" },
+  ],
+  purple: [
+    { color: "#1e1836", labelKey: "settings.appBg" },
+    { color: "#2d2650", labelKey: "settings.surface" },
+    { color: "#e8e4f4", labelKey: "settings.text" },
+    { color: "#a78bfa", labelKey: "settings.accent" },
+    { color: "#4ade80", labelKey: "settings.green" },
+    { color: "#1b1536", labelKey: "settings.navToolbar" },
+    { color: "#ece6ff", labelKey: "settings.toolbarText" },
+  ],
+  pink: [
+    { color: "#fff0f5", labelKey: "settings.appBg" },
+    { color: "#ffffff", labelKey: "settings.surface" },
+    { color: "#2d1b3a", labelKey: "settings.text" },
+    { color: "#c026d3", labelKey: "settings.accent" },
+    { color: "#15803d", labelKey: "settings.green" },
+    { color: "#5a2148", labelKey: "settings.navToolbar" },
+    { color: "#ffe3f1", labelKey: "settings.toolbarText" },
+  ],
 };
 
 export function AppearanceSettings({ onResetLayout }: { onResetLayout: () => void }) {
@@ -196,14 +252,14 @@ export function AppearanceSettings({ onResetLayout }: { onResetLayout: () => voi
       <div className="color-scheme-preview" aria-label={t("settings.colorSchemePreview")}>
         <span className="color-scheme-preview-label">{t("settings.colorSchemePreview")}</span>
         <div className="color-scheme-preview-swatches">
-          {previewColors.map((color, i) => (
+          {previewColors.map((previewColor) => (
             <div
-              key={i}
+              key={previewColor.labelKey}
               className="color-scheme-preview-swatch"
-              style={{ background: color }}
+              style={{ background: previewColor.color }}
             >
               <span className="color-scheme-preview-swatch-label">
-                {t(SCHEME_PREVIEW_LABELS[i])}
+                {t(previewColor.labelKey)}
               </span>
             </div>
           ))}


### PR DESCRIPTION
### Motivation
- Make the left Activity Rail (nav toolbar) and its toolbar text/icon color part of the settable color-scheme so users can theme the app rail consistently with each scheme.
- Preserve the existing dark-gray treatment for the Default, Dark, and Light schemes while enabling scheme-specific rail colors for the others.

### Description
- Add new CSS variables for nav toolbar theming (background, text, hover, accent, warning, tooltip colors/borders) to each `data-color-scheme` block in `src/App.css` and apply them to the Activity Rail and related rail states.
- Update the Activity Rail styles in `src/App.css` to consume the new variables for rail background, text, hover/active, collapsed indicator, Don't Sleep state, and rail tooltips.
- Expand the Appearance preview data in `src/settings/AppearanceSettings.tsx` to include two new preview swatches per scheme (`settings.navToolbar` and `settings.toolbarText`) and change the preview map to carry color+label keys, then render those swatches in the preview UI.
- Add the new English keys `settings.navToolbar` and `settings.toolbarText` to `src/i18n/locales/en.json` and document them in `docs/LOCALIZATION.md` for translation context.

### Testing
- Ran `npm run check` (TypeScript `tsc --noEmit`) and it completed successfully.
- Ran `npm run build` (`tsc && vite build`) and the frontend build completed successfully (production bundle created with warnings about large chunks).
- Ran `cargo check --manifest-path src-tauri/Cargo.toml` and `cargo test --manifest-path src-tauri/Cargo.toml`, both were blocked by a missing system dependency (`glib-2.0` not found via `pkg-config`), so the Rust checks could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda4fec5e8832fac1ec8c0eb77a0ab)