### PR TITLE
Add setting to show connected Connection icons in left activity rail

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,7 +38,7 @@ Debug-only observability should use local debug logs, console output, or the dia
 
 `src/settings/SettingsPage.tsx` owns the Settings shell — the header, sidebar nav, and section routing. Each settings section is a separate page component under `src/settings/`, owning its own draft state, save/reset handlers, and helper controls:
 
-- `src/settings/GeneralSettings.tsx` — Language (i18n) selector, Auto Backup toggle and last-backup status, settings backup/import actions, database folder opener.
+- `src/settings/GeneralSettings.tsx` — Language (i18n) selector, Auto Backup toggle and last-backup status, connected Connection rail shortcut toggle, settings backup/import actions, database folder opener.
 - `src/settings/AppearanceSettings.tsx` — App UI font family, layout reset, Color Scheme placeholder.
 - `src/settings/AiSettings.tsx` — AI provider kind, dynamic provider fields, provider-specific model selector, custom model ID input, API key, output language.
 - `src/settings/SshSettings.tsx` — Read-only SSH defaults and SFTP transfer defaults summary.
@@ -242,7 +242,7 @@ The primary UI is a dense desktop workspace:
 
 Default visual direction: quiet productivity light chrome with dark terminal panes.
 
-The activity rail uses icons with delayed hover labels for top-level destinations. The top rail entry is Dashboard, and the second entry is Settings. The current Settings surface lives in `src/settings/SettingsPage.tsx`; it is ordered as General, Appearance, AI Assistant, SSH, Terminal, URL, Remote Desktop(RDP), VNC, and About. General exposes Language (i18n) as a selectable dropdown, Appearance owns App UI font, layout reset, and Color Scheme as a placeholder, SSH folds in SFTP transfer defaults, Terminal owns editable terminal behavior, and RDP/VNC expose planned quality default summaries.
+The activity rail uses icons with delayed hover labels for top-level destinations. The top rail entry is Dashboard, and the second entry is Settings. The current Settings surface lives in `src/settings/SettingsPage.tsx`; it is ordered as General, Appearance, AI Assistant, SSH, Terminal, URL, Remote Desktop(RDP), VNC, and About. General exposes Language (i18n) as a selectable dropdown plus connected Connection rail shortcuts and Auto Backup controls, Appearance owns App UI font, layout reset, and Color Scheme as a placeholder, SSH folds in SFTP transfer defaults, Terminal owns editable terminal behavior, and RDP/VNC expose planned quality default summaries.
 
 AdminDeck does not include a global command palette in the current product scope; navigation and workflow entry points should stay visible in the Dashboard/connection tree, tab workspace, SFTP toolbar/context actions, assistant panel, and Settings.
 

--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -489,3 +489,58 @@ When a key is translated into every supported locale, remove its entry from this
 - Tone: compact UI-part label.
 - Placeholder details: none.
 - Domain notes: Refers to foreground text and icon color for the themed navigation toolbar, not terminal text or workspace content text.
+
+### settings.connectedConnectionsRail
+
+- English value: "Show connected Connection icons in the left rail"
+- Namespace: `settings`
+- File/component: `src/settings/GeneralSettings.tsx`
+- UI role: checkbox label
+- Surrounding user flow: Settings -> General lets the user enable or disable adding currently connected Connections to the left activity rail.
+- Tone: concise settings label.
+- Placeholder details: none.
+- Domain notes: Connection is the stored openable resource; the rail item appears only while a live Session exists for that Connection. Defaults to off.
+
+### settings.connectedConnectionsRailHint
+
+- English value: "Adds an icon for each connected Connection to the left rail so you can switch back to it quickly."
+- Namespace: `settings`
+- File/component: `src/settings/GeneralSettings.tsx`
+- UI role: helper text
+- Surrounding user flow: Shown below the Settings -> General checkbox that controls connected Connection icons in the activity rail.
+- Tone: brief explanatory helper.
+- Placeholder details: none.
+- Domain notes: Connection is the durable resource and the icon opens the existing workspace Tab for quick switching; this does not create a new Connection or persist live Session state.
+
+### settings.connectedConnectionsRailSaved
+
+- English value: "Connected Connection icons setting saved."
+- Namespace: `settings`
+- File/component: `src/settings/GeneralSettings.tsx`
+- UI role: save confirmation status
+- Surrounding user flow: Appears after the Settings -> General connected Connection icons checkbox is persisted successfully.
+- Tone: short confirmation.
+- Placeholder details: none.
+- Domain notes: Refers to the persisted General setting only, not to a new Connection lifecycle event.
+
+### app.connectedConnectionsRail
+
+- English value: "Connected Connections"
+- Namespace: `app`
+- File/component: `src/App.tsx` / `ActivityRail`
+- UI role: rail group aria-label
+- Surrounding user flow: Labels the optional group of connected Connection shortcut icons in the left activity rail for assistive technologies.
+- Tone: compact navigation label.
+- Placeholder details: none.
+- Domain notes: The group is visible only when the General setting is enabled and at least one Connection has an active Session.
+
+### app.openConnectedConnection
+
+- English value: "Open {{name}}"
+- Namespace: `app`
+- File/component: `src/App.tsx` / `ActivityRail`
+- UI role: button aria-label
+- Surrounding user flow: Used on each connected Connection shortcut in the left activity rail; activating it switches to the existing workspace Tab for that Connection.
+- Tone: direct action label.
+- Placeholder details: `{{name}}` is the user-defined Connection name.
+- Domain notes: This action opens/switches to an existing Tab for a connected Connection; it does not start a duplicate Session.

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -158,6 +158,8 @@ pub struct Storage {
 pub struct GeneralSettings {
     auto_backup_enabled: bool,
     #[serde(default)]
+    show_connected_connections_in_rail: bool,
+    #[serde(default)]
     last_backup_at: Option<String>,
 }
 
@@ -2840,6 +2842,7 @@ fn required_field(field: &str, value: String) -> Result<String, String> {
 fn default_general_settings() -> GeneralSettings {
     GeneralSettings {
         auto_backup_enabled: true,
+        show_connected_connections_in_rail: false,
         last_backup_at: None,
     }
 }
@@ -3981,18 +3984,22 @@ mod tests {
             .general_settings()
             .expect("default general settings load");
         assert!(defaults.auto_backup_enabled);
+        assert!(!defaults.show_connected_connections_in_rail);
         assert!(defaults.last_backup_at.is_none());
 
         let updated = storage
             .update_general_settings(GeneralSettings {
                 auto_backup_enabled: false,
+                show_connected_connections_in_rail: true,
                 last_backup_at: None,
             })
             .expect("general settings update");
         assert!(!updated.auto_backup_enabled);
+        assert!(updated.show_connected_connections_in_rail);
 
         let reloaded = storage.general_settings().expect("general settings reload");
         assert!(!reloaded.auto_backup_enabled);
+        assert!(reloaded.show_connected_connections_in_rail);
         assert!(reloaded.last_backup_at.is_none());
     }
 
@@ -4003,6 +4010,7 @@ mod tests {
         storage
             .update_general_settings(GeneralSettings {
                 auto_backup_enabled: false,
+                show_connected_connections_in_rail: true,
                 last_backup_at: None,
             })
             .expect("general settings update");
@@ -4012,6 +4020,7 @@ mod tests {
         storage
             .update_general_settings(GeneralSettings {
                 auto_backup_enabled: true,
+                show_connected_connections_in_rail: false,
                 last_backup_at: None,
             })
             .expect("general settings changes after export");
@@ -4024,6 +4033,7 @@ mod tests {
             .expect("database imports");
 
         assert!(!imported.general_settings.auto_backup_enabled);
+        assert!(imported.general_settings.show_connected_connections_in_rail);
         assert_eq!(
             imported.general_settings.last_backup_at.as_deref(),
             Some(imported.backup.created_at.as_str())

--- a/src/App.css
+++ b/src/App.css
@@ -314,6 +314,20 @@ button {
   position: relative;
 }
 
+.rail-connected-connections {
+  display: grid;
+  gap: 6px;
+  justify-items: center;
+  width: 100%;
+  padding-top: 6px;
+  margin-top: 2px;
+  border-top: 1px solid var(--nav-toolbar-tooltip-border);
+}
+
+.rail-button-connection .connection-icon-image {
+  border-radius: 4px;
+}
+
 .rail-button-dont-sleep {
   margin-top: auto;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import {
   Moon,
   Settings,
 } from "lucide-react";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { invokeCommand, isTauriRuntime } from "./lib/tauri";
@@ -18,6 +18,7 @@ import "@icon-park/react/styles/index.css";
 import "@xterm/xterm/css/xterm.css";
 import "./App.css";
 import { AssistantPanel } from "./ai/AssistantPanel";
+import { ConnectionIcon } from "./connections/ConnectionIcon";
 import { ConnectionSidebar } from "./connections/ConnectionSidebar";
 import { StatusBar } from "./workspace/StatusBar";
 import { TabStrip, WorkspaceCanvas } from "./workspace/WorkspaceCanvas";
@@ -427,6 +428,11 @@ function ActivityRail({
 }) {
   const { t } = useTranslation();
   const showWorkspaceStatus = useWorkspaceStore((state) => state.showWorkspaceStatus);
+  const activeTabId = useWorkspaceStore((state) => state.activeTabId);
+  const activeSessionCounts = useWorkspaceStore((state) => state.activeSessionCounts);
+  const tabs = useWorkspaceStore((state) => state.tabs);
+  const generalSettings = useWorkspaceStore((state) => state.generalSettings);
+  const activateTab = useWorkspaceStore((state) => state.activateTab);
   const [dontSleepEnabled, setDontSleepEnabled] = useState(false);
   const [dontSleepUpdating, setDontSleepUpdating] = useState(false);
 
@@ -457,6 +463,36 @@ function ActivityRail({
       onConnectionsRestore();
     }
   }
+
+  function handleConnectedConnectionClick(tabId: string) {
+    onNavigate("workspace");
+    activateTab(tabId);
+  }
+
+  const activeTabConnectionId = useMemo(
+    () => tabs.find((tab) => tab.id === activeTabId)?.connection?.id,
+    [activeTabId, tabs],
+  );
+
+  const connectedRailItems = useMemo(() => {
+    if (!generalSettings.showConnectedConnectionsInRail) {
+      return [];
+    }
+
+    const seenConnectionIds = new Set<string>();
+    return tabs.flatMap((tab) => {
+      const connection = tab.connection;
+      if (
+        !connection ||
+        seenConnectionIds.has(connection.id) ||
+        !activeSessionCounts[connection.id]
+      ) {
+        return [];
+      }
+      seenConnectionIds.add(connection.id);
+      return [{ connection, tabId: tab.id }];
+    });
+  }, [activeSessionCounts, generalSettings.showConnectedConnectionsInRail, tabs]);
 
   async function handleDontSleepClick() {
     if (dontSleepUpdating) {
@@ -502,6 +538,36 @@ function ActivityRail({
           {t("app.connections")}
         </span>
       </button>
+      {connectedRailItems.length > 0 ? (
+        <div
+          className="rail-connected-connections"
+          aria-label={t("app.connectedConnectionsRail")}
+        >
+          {connectedRailItems.map(({ connection, tabId }) => (
+            <button
+              key={connection.id}
+              className={`rail-button rail-button-connection ${
+                activePage === "workspace" && activeTabConnectionId === connection.id
+                  ? "active"
+                  : ""
+              }`}
+              aria-label={t("app.openConnectedConnection", {
+                name: connection.name,
+              })}
+              onClick={() => handleConnectedConnectionClick(tabId)}
+            >
+              <ConnectionIcon
+                localShell={connection.localShell}
+                size={18}
+                type={connection.type}
+              />
+              <span className="rail-tooltip" role="tooltip">
+                {connection.name}
+              </span>
+            </button>
+          ))}
+        </div>
+      ) : null}
       <button
         className={`rail-button ${activePage === "wiki" ? "active" : ""}`}
         aria-label={t("app.wiki")}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -12,7 +12,9 @@
     "resizeConnections": "Resize Connections column",
     "resizeAiAssistant": "Resize AI Assistant panel",
     "aiAssistant": "AI Assistant",
-    "wiki": "Wiki"
+    "wiki": "Wiki",
+    "connectedConnectionsRail": "Connected Connections",
+    "openConnectedConnection": "Open {{name}}"
   },
   "settings": {
     "title": "Settings",
@@ -218,7 +220,10 @@
         "label": "PowerShell / batch commands",
         "description": "Run non-destructive PowerShell or batch commands from AdminDeck app data only."
       }
-    }
+    },
+    "connectedConnectionsRail": "Show connected Connection icons in the left rail",
+    "connectedConnectionsRailHint": "Adds an icon for each connected Connection to the left rail so you can switch back to it quickly.",
+    "connectedConnectionsRailSaved": "Connected Connection icons setting saved."
   },
   "connections": {
     "title": "Connections",

--- a/src/sample-data.ts
+++ b/src/sample-data.ts
@@ -18,6 +18,7 @@ export const initialTabs: WorkspaceTab[] = [];
 
 export const defaultGeneralSettings: GeneralSettings = {
   autoBackupEnabled: true,
+  showConnectedConnectionsInRail: false,
   lastBackupAt: null,
 };
 

--- a/src/settings/GeneralSettings.tsx
+++ b/src/settings/GeneralSettings.tsx
@@ -51,8 +51,10 @@ export function GeneralSettings() {
   const [status, setStatus] = useState("");
   const [error, setError] = useState("");
 
-  async function updateAutoBackup(enabled: boolean) {
-    const nextSettings = { ...generalSettings, autoBackupEnabled: enabled };
+  async function updateGeneralSettings(
+    nextSettings: typeof generalSettings,
+    successMessage: string,
+  ) {
     setGeneralSettings(nextSettings);
     setStatus("");
     setError("");
@@ -64,12 +66,26 @@ export function GeneralSettings() {
         request: nextSettings,
       });
       setGeneralSettings(saved);
-      setStatus(t("settings.autoBackupSaved"));
+      setStatus(successMessage);
     } catch (saveError) {
       setError(
         saveError instanceof Error ? saveError.message : String(saveError),
       );
     }
+  }
+
+  function updateAutoBackup(enabled: boolean) {
+    return updateGeneralSettings(
+      { ...generalSettings, autoBackupEnabled: enabled },
+      t("settings.autoBackupSaved"),
+    );
+  }
+
+  function updateConnectedConnectionsInRail(enabled: boolean) {
+    return updateGeneralSettings(
+      { ...generalSettings, showConnectedConnectionsInRail: enabled },
+      t("settings.connectedConnectionsRailSaved"),
+    );
   }
 
   async function handleBackupSettings() {
@@ -196,6 +212,19 @@ export function GeneralSettings() {
           {t("settings.lastBackup", {
             value: lastBackup ?? t("settings.lastBackupNever"),
           })}
+        </small>
+        <label>
+          <input
+            type="checkbox"
+            checked={generalSettings.showConnectedConnectionsInRail}
+            onChange={(event) =>
+              void updateConnectedConnectionsInRail(event.currentTarget.checked)
+            }
+          />
+          {t("settings.connectedConnectionsRail")}
+        </label>
+        <small className="field-hint">
+          {t("settings.connectedConnectionsRailHint")}
         </small>
       </div>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,6 +161,7 @@ export type TerminalCursorStyle = "block" | "bar" | "underline";
 
 export interface GeneralSettings {
   autoBackupEnabled: boolean;
+  showConnectedConnectionsInRail: boolean;
   lastBackupAt?: string | null;
 }
 


### PR DESCRIPTION
### Motivation
- Provide a quick-switch affordance by surfacing connected Connections as icons in the left activity rail so users can jump back to an existing connected Tab quickly.
- Make the behavior opt-in and default to off to avoid changing the default rail layout.

### Description
- Add a persisted General setting `showConnectedConnectionsInRail` (TypeScript + Rust) with default `false` and wire it into the frontend settings model (`src/types.ts`, `src/sample-data.ts`, `src-tauri/src/storage.rs`).
- Add a Settings → General checkbox and save handler that persists the new flag via the existing `update_general_settings` command and reuses a shared `updateGeneralSettings` helper (`src/settings/GeneralSettings.tsx`).
- Render optional ActivityRail shortcuts when the setting is enabled and a Connection has an active Session, using tab metadata to avoid creating duplicate Sessions and activating the existing Tab on click (`src/App.tsx`, `src/connections/ConnectionIcon.tsx`, `src/workspace/WorkspaceCanvas.tsx` usage).
- Add CSS for the connected-connection group and icon styling (`src/App.css`) and add new English i18n keys plus localization notes and architecture docs entries (`src/i18n/locales/en.json`, `docs/LOCALIZATION.md`, `docs/ARCHITECTURE.md`).
- Update Rust storage tests to include the new field in round-trip/import checks (`src-tauri/src/storage.rs`).

### Testing
- Ran TypeScript checks with `npm run check` which completed successfully (no type errors).
- Built the frontend with `npm run build` which produced a `dist/` output successfully.
- Ran `cargo fmt --manifest-path src-tauri/Cargo.toml` and `git diff --check` which succeeded (formatting / whitespace checks clean).
- Attempted `cargo check --manifest-path src-tauri/Cargo.toml` and `cargo test --manifest-path src-tauri/Cargo.toml` but they could not complete in this environment due to a missing system dependency: the `gdk-3.0` pkg-config entry required by `gdk-sys` is not available in the container, causing the Rust build/test to fail at the native dependency resolution step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb4618a94832f9f9db996a077dcd3)