### PR TITLE
Add browser bookmark import source (Edge/Chrome/Firefox)

### DIFF
--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -544,3 +544,157 @@ When a key is translated into every supported locale, remove its entry from this
 - Tone: direct action label.
 - Placeholder details: `{{name}}` is the user-defined Connection name.
 - Domain notes: This action opens/switches to an existing Tab for a connected Connection; it does not start a duplicate Session.
+
+### connections.import.tileSubtitle
+
+- English value: "From file, bookmarks, or network scan"
+- Namespace: `connections`
+- File/component: `src/connections/ConnectionSidebar.tsx`, `src/connections/ImportDialog.tsx`
+- UI role: import entry tile helper text
+- Surrounding user flow: Appears on the New Connection wizard Import tile before the user opens the import source chooser.
+- Tone: compact feature summary.
+- Placeholder details: none.
+- Domain notes: "bookmarks" means browser URL bookmarks from Edge, Chrome, and Firefox; imported items become URL Connections.
+
+### connections.import.bookmarksTitle
+
+- English value: "Import browser bookmarks"
+- Namespace: `connections`
+- File/component: `src/connections/ImportDialog.tsx`
+- UI role: import source title/dialog heading
+- Surrounding user flow: Appears in the import source chooser and as the dialog heading after choosing the browser bookmarks source.
+- Tone: direct action label.
+- Placeholder details: none.
+- Domain notes: Browser bookmarks are imported as URL Connections, not browser tabs.
+
+### connections.import.bookmarksSubtitle
+
+- English value: "Edge, Chrome, Firefox URL bookmarks"
+- Namespace: `connections`
+- File/component: `src/connections/ImportDialog.tsx`
+- UI role: import source helper text
+- Surrounding user flow: Appears below the browser bookmarks import tile in the source chooser.
+- Tone: concise capability summary.
+- Placeholder details: none.
+- Domain notes: Browser product names should remain recognizable; URL can remain English as a technical term.
+
+### connections.import.bookmarksLoading
+
+- English value: "Looking for browser bookmark sources..."
+- Namespace: `connections`
+- File/component: `src/connections/ImportDialog.tsx` / `BookmarksPanel`
+- UI role: loading status
+- Surrounding user flow: Displayed while AdminDeck searches local browser profile folders for supported bookmark stores.
+- Tone: brief progress update.
+- Placeholder details: none.
+- Domain notes: Sources are local Edge/Chrome JSON bookmark files and Firefox `places.sqlite` databases.
+
+### connections.import.bookmarksNoSources
+
+- English value: "No Edge, Chrome, or Firefox bookmark sources were found on this device."
+- Namespace: `connections`
+- File/component: `src/connections/ImportDialog.tsx` / `BookmarksPanel`
+- UI role: empty-state message
+- Surrounding user flow: Shown when no supported browser bookmark stores are discovered on the local machine.
+- Tone: clear neutral status.
+- Placeholder details: none.
+- Domain notes: This does not indicate a failed import; users may not have those browsers/profiles.
+
+### connections.import.bookmarksSourceLabel
+
+- English value: "Browser profile"
+- Namespace: `connections`
+- File/component: `src/connections/ImportDialog.tsx` / `BookmarksPanel`
+- UI role: select label
+- Surrounding user flow: Labels the dropdown of discovered browser profiles before the user selects folders/bookmarks.
+- Tone: concise field label.
+- Placeholder details: none.
+- Domain notes: Profile refers to a browser profile here, not an AdminDeck Connection.
+
+### connections.import.bookmarksSourcePath
+
+- English value: "Source file: {{path}}"
+- Namespace: `connections`
+- File/component: `src/connections/ImportDialog.tsx` / `BookmarksPanel`
+- UI role: helper text
+- Surrounding user flow: Shows the local bookmark file or database path for the selected browser profile.
+- Tone: factual diagnostic helper.
+- Placeholder details: `{{path}}` is an absolute local filesystem path.
+- Domain notes: Path may point to a Chromium `Bookmarks` JSON file or a Firefox `places.sqlite` database.
+
+### connections.import.bookmarksTreeLabel
+
+- English value: "Bookmark folders and links"
+- Namespace: `connections`
+- File/component: `src/connections/ImportDialog.tsx` / `BookmarkTreeRow`
+- UI role: ARIA label
+- Surrounding user flow: Labels the tree of bookmark folders and individual bookmark links for assistive technologies.
+- Tone: descriptive accessibility label.
+- Placeholder details: none.
+- Domain notes: Links imported from the tree become URL Connections.
+
+### connections.import.bookmarksPreview
+
+- English value: "Preview {{count}} selected"
+- Namespace: `connections`
+- File/component: `src/connections/ImportDialog.tsx` / `BookmarksPanel`
+- UI role: button label
+- Surrounding user flow: The user clicks this after selecting bookmark folders/links to generate the editable import preview.
+- Tone: direct action label.
+- Placeholder details: `{{count}}` is the number of selected tree nodes, including folders and bookmarks.
+- Domain notes: Preview rows may be fewer than selected nodes because folders expand to importable http/https bookmarks only.
+
+### connections.import.bookmarksSourceRequired
+
+- English value: "Choose a browser bookmark source."
+- Namespace: `connections`
+- File/component: `src/connections/ImportDialog.tsx` / `BookmarksPanel`
+- UI role: validation error
+- Surrounding user flow: Shown if the user attempts to preview bookmarks without a selected browser profile.
+- Tone: direct corrective instruction.
+- Placeholder details: none.
+- Domain notes: Source means the discovered browser profile/bookmark store.
+
+### connections.import.bookmarksSelectionRequired
+
+- English value: "Select at least one folder or bookmark to import."
+- Namespace: `connections`
+- File/component: `src/connections/ImportDialog.tsx` / `BookmarksPanel`
+- UI role: validation error
+- Surrounding user flow: Shown if the user attempts to preview without checking any bookmark tree item.
+- Tone: direct corrective instruction.
+- Placeholder details: none.
+- Domain notes: Selected folders include their descendant bookmarks.
+
+### connections.import.bookmarksNoImportable
+
+- English value: "The selected bookmarks did not include any http or https URLs."
+- Namespace: `connections`
+- File/component: `src/connections/ImportDialog.tsx` / `BookmarksPanel`
+- UI role: validation/status error
+- Surrounding user flow: Shown when selected browser bookmark nodes contain no URLs that AdminDeck can store as URL Connections.
+- Tone: explanatory, not alarming.
+- Placeholder details: none.
+- Domain notes: Non-web schemes such as `chrome://`, `about:`, `file:`, and `javascript:` are intentionally skipped.
+
+### connections.import.bookmarkFallbackName
+
+- English value: "Imported bookmark"
+- Namespace: `connections`
+- File/component: `src/connections/ImportDialog.tsx` / `ImportPreviewSection`
+- UI role: fallback Connection name fragment
+- Surrounding user flow: Used only if an imported URL bookmark row has no usable bookmark title, host, or URL text.
+- Tone: neutral default name.
+- Placeholder details: none.
+- Domain notes: The saved durable resource is a URL Connection.
+
+### connections.import.importBookmarksComplete
+
+- English value: "Imported {{count}} Connections from bookmarks."
+- Namespace: `connections`
+- File/component: `src/connections/ConnectionSidebar.tsx`, `src/connections/ImportDialog.tsx`
+- UI role: transient status
+- Surrounding user flow: Appears in the bottom workspace status bar after selected browser bookmark preview rows are saved as Connections.
+- Tone: brief success confirmation.
+- Placeholder details: `{{count}}` is the number of imported URL Connection rows.
+- Domain notes: Connection is capitalized for the durable stored resource; imported bookmarks become URL Connections.

--- a/src-tauri/src/import.rs
+++ b/src-tauri/src/import.rs
@@ -1,8 +1,11 @@
+use rusqlite::{Connection as SqliteConnection, OpenFlags};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::{
-    fs,
+    collections::BTreeMap,
+    env, fs,
     net::Ipv4Addr,
-    path::Path,
+    path::{Path, PathBuf},
     str::FromStr,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -23,6 +26,7 @@ pub struct ImportedConnectionDraft {
     pub name: String,
     pub host: String,
     pub user: String,
+    pub url: Option<String>,
     pub port: Option<u16>,
     #[serde(rename = "type")]
     pub connection_type: &'static str,
@@ -314,6 +318,7 @@ fn draft_from_row(
         name,
         host,
         user,
+        url: None,
         port,
         connection_type,
         folder_path,
@@ -491,6 +496,7 @@ impl RdcmanServer {
             name: display,
             host,
             user,
+            url: None,
             port: self.port,
             connection_type: "rdp",
             folder_path,
@@ -588,6 +594,7 @@ fn parse_mobaxterm_session(
             name: name.to_string(),
             host: String::new(),
             user: String::new(),
+            url: None,
             port: None,
             connection_type,
             folder_path: folder_path.to_vec(),
@@ -616,6 +623,7 @@ fn parse_mobaxterm_session(
         name: name.to_string(),
         host,
         user,
+        url: None,
         port,
         connection_type,
         folder_path: folder_path.to_vec(),
@@ -736,6 +744,7 @@ fn finalize_putty_session(
         name,
         host,
         user: values.user.unwrap_or_default(),
+        url: None,
         port: values.port,
         connection_type,
         folder_path: Vec::new(),
@@ -785,6 +794,473 @@ fn strip_quotes(value: &str) -> Option<String> {
     } else {
         None
     }
+}
+
+// ===== Browser bookmark import ==============================================
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BookmarkImportSource {
+    pub id: String,
+    pub label: String,
+    pub browser: String,
+    pub path: String,
+    pub root: BookmarkTreeNode,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BookmarkTreeNode {
+    pub id: String,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub node_type: &'static str,
+    pub url: Option<String>,
+    pub children: Vec<BookmarkTreeNode>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrowserBookmarkSourcesResponse {
+    pub sources: Vec<BookmarkImportSource>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewBrowserBookmarkImportRequest {
+    pub source_id: String,
+    pub selected_node_ids: Vec<String>,
+}
+
+pub fn list_browser_bookmark_sources() -> BrowserBookmarkSourcesResponse {
+    let mut sources = Vec::new();
+    for candidate in browser_bookmark_candidates() {
+        if !candidate.path.exists() {
+            continue;
+        }
+        match parse_bookmark_source(&candidate.browser, &candidate.label, &candidate.path) {
+            Ok(mut source) => {
+                if !source.root.children.is_empty() {
+                    source.id = candidate.id;
+                    sources.push(source);
+                }
+            }
+            Err(error) => sources.push(BookmarkImportSource {
+                id: candidate.id,
+                label: candidate.label,
+                browser: candidate.browser,
+                path: candidate.path.to_string_lossy().into_owned(),
+                root: BookmarkTreeNode {
+                    id: "root".to_string(),
+                    name: "Bookmarks".to_string(),
+                    node_type: "folder",
+                    url: None,
+                    children: Vec::new(),
+                },
+                warnings: vec![error],
+            }),
+        }
+    }
+    BrowserBookmarkSourcesResponse { sources }
+}
+
+pub fn preview_browser_bookmark_import(
+    request: PreviewBrowserBookmarkImportRequest,
+) -> Result<ImportFilePreview, String> {
+    let candidates = browser_bookmark_candidates();
+    let candidate = candidates
+        .into_iter()
+        .find(|candidate| candidate.id == request.source_id)
+        .ok_or_else(|| "bookmark source was not found".to_string())?;
+    let source = parse_bookmark_source(&candidate.browser, &candidate.label, &candidate.path)?;
+    let selected: std::collections::HashSet<String> =
+        request.selected_node_ids.into_iter().collect();
+    let mut drafts = Vec::new();
+    collect_selected_bookmark_drafts(&source.root, &selected, &mut Vec::new(), false, &mut drafts);
+    Ok(ImportFilePreview {
+        format: "bookmarks",
+        drafts,
+        warnings: source.warnings,
+    })
+}
+
+struct BookmarkCandidate {
+    id: String,
+    label: String,
+    browser: String,
+    path: PathBuf,
+}
+
+fn browser_bookmark_candidates() -> Vec<BookmarkCandidate> {
+    let mut candidates = Vec::new();
+    add_chromium_candidates(&mut candidates, "chrome", "Chrome", chrome_user_data_dirs());
+    add_chromium_candidates(&mut candidates, "edge", "Edge", edge_user_data_dirs());
+    add_firefox_candidates(&mut candidates);
+    candidates
+}
+
+fn add_chromium_candidates(
+    candidates: &mut Vec<BookmarkCandidate>,
+    id_prefix: &str,
+    browser: &str,
+    roots: Vec<PathBuf>,
+) {
+    for root in roots {
+        for profile in chromium_profiles(&root) {
+            let bookmarks = profile.join("Bookmarks");
+            let profile_name = profile
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("Default")
+                .to_string();
+            candidates.push(BookmarkCandidate {
+                id: format!("{id_prefix}:{}", profile.to_string_lossy()),
+                label: format!("{browser} — {profile_name}"),
+                browser: browser.to_string(),
+                path: bookmarks,
+            });
+        }
+    }
+}
+
+fn add_firefox_candidates(candidates: &mut Vec<BookmarkCandidate>) {
+    for root in firefox_profile_roots() {
+        if let Ok(entries) = fs::read_dir(root) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if !path.is_dir() {
+                    continue;
+                }
+                let places = path.join("places.sqlite");
+                let profile_name = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("Profile")
+                    .to_string();
+                candidates.push(BookmarkCandidate {
+                    id: format!("firefox:{}", path.to_string_lossy()),
+                    label: format!("Firefox — {profile_name}"),
+                    browser: "Firefox".to_string(),
+                    path: places,
+                });
+            }
+        }
+    }
+}
+
+fn chromium_profiles(root: &Path) -> Vec<PathBuf> {
+    let mut profiles = Vec::new();
+    if let Ok(entries) = fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() || !path.join("Bookmarks").exists() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if name == "Default" || name.starts_with("Profile ") {
+                profiles.push(path);
+            }
+        }
+    }
+    if profiles.is_empty() {
+        profiles.push(root.join("Default"));
+    }
+    profiles.sort();
+    profiles
+}
+
+fn chrome_user_data_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Ok(local_app_data) = env::var("LOCALAPPDATA") {
+        dirs.push(PathBuf::from(local_app_data).join("Google/Chrome/User Data"));
+    }
+    if let Ok(home) = env::var("HOME") {
+        dirs.push(PathBuf::from(&home).join(".config/google-chrome"));
+        dirs.push(PathBuf::from(&home).join("Library/Application Support/Google/Chrome"));
+    }
+    dirs
+}
+
+fn edge_user_data_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Ok(local_app_data) = env::var("LOCALAPPDATA") {
+        dirs.push(PathBuf::from(local_app_data).join("Microsoft/Edge/User Data"));
+    }
+    if let Ok(home) = env::var("HOME") {
+        dirs.push(PathBuf::from(&home).join(".config/microsoft-edge"));
+        dirs.push(PathBuf::from(&home).join("Library/Application Support/Microsoft Edge"));
+    }
+    dirs
+}
+
+fn firefox_profile_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Ok(app_data) = env::var("APPDATA") {
+        roots.push(PathBuf::from(app_data).join("Mozilla/Firefox/Profiles"));
+    }
+    if let Ok(home) = env::var("HOME") {
+        roots.push(PathBuf::from(&home).join(".mozilla/firefox"));
+        roots.push(PathBuf::from(&home).join("Library/Application Support/Firefox/Profiles"));
+    }
+    roots
+}
+
+fn parse_bookmark_source(
+    browser: &str,
+    label: &str,
+    path: &Path,
+) -> Result<BookmarkImportSource, String> {
+    let (root, warnings) = if browser == "Firefox" {
+        parse_firefox_bookmarks(path)?
+    } else {
+        parse_chromium_bookmarks(path)?
+    };
+    Ok(BookmarkImportSource {
+        id: String::new(),
+        label: label.to_string(),
+        browser: browser.to_string(),
+        path: path.to_string_lossy().into_owned(),
+        root,
+        warnings,
+    })
+}
+
+fn parse_chromium_bookmarks(path: &Path) -> Result<(BookmarkTreeNode, Vec<String>), String> {
+    let text =
+        fs::read_to_string(path).map_err(|error| format!("failed to read bookmarks: {error}"))?;
+    let value: Value = serde_json::from_str(&text)
+        .map_err(|error| format!("failed to parse bookmarks JSON: {error}"))?;
+    let roots = value
+        .get("roots")
+        .and_then(|roots| roots.as_object())
+        .ok_or_else(|| "bookmarks file does not contain a roots object".to_string())?;
+    let mut root = BookmarkTreeNode {
+        id: "root".to_string(),
+        name: "Bookmarks".to_string(),
+        node_type: "folder",
+        url: None,
+        children: Vec::new(),
+    };
+    for key in ["bookmark_bar", "other", "synced"] {
+        if let Some(node) = roots
+            .get(key)
+            .and_then(|node| parse_chromium_node(node, key.to_string()))
+        {
+            if !node.children.is_empty() {
+                root.children.push(node);
+            }
+        }
+    }
+    Ok((root, Vec::new()))
+}
+
+fn parse_chromium_node(value: &Value, fallback_id: String) -> Option<BookmarkTreeNode> {
+    let node_type = value.get("type")?.as_str()?;
+    let id = value
+        .get("id")
+        .and_then(|id| id.as_str())
+        .map(|id| format!("chromium-{id}"))
+        .unwrap_or_else(|| format!("chromium-{fallback_id}"));
+    let name = value
+        .get("name")
+        .and_then(|name| name.as_str())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or("Bookmarks")
+        .trim()
+        .to_string();
+    if node_type == "url" {
+        let url = value.get("url")?.as_str()?.trim().to_string();
+        if !is_importable_bookmark_url(&url) {
+            return None;
+        }
+        return Some(BookmarkTreeNode {
+            id,
+            name: if name.is_empty() {
+                bookmark_name_from_url(&url)
+            } else {
+                name
+            },
+            node_type: "bookmark",
+            url: Some(url),
+            children: Vec::new(),
+        });
+    }
+    if node_type != "folder" {
+        return None;
+    }
+    let mut children = Vec::new();
+    if let Some(raw_children) = value
+        .get("children")
+        .and_then(|children| children.as_array())
+    {
+        for (index, child) in raw_children.iter().enumerate() {
+            if let Some(parsed) = parse_chromium_node(child, format!("{fallback_id}-{index}")) {
+                children.push(parsed);
+            }
+        }
+    }
+    Some(BookmarkTreeNode {
+        id,
+        name,
+        node_type: "folder",
+        url: None,
+        children,
+    })
+}
+
+#[derive(Clone)]
+struct FirefoxBookmarkRow {
+    id: i64,
+    parent: i64,
+    node_type: i64,
+    title: String,
+    url: Option<String>,
+}
+
+fn parse_firefox_bookmarks(path: &Path) -> Result<(BookmarkTreeNode, Vec<String>), String> {
+    let connection = SqliteConnection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|error| format!("failed to open Firefox bookmarks database: {error}"))?;
+    let mut statement = connection
+        .prepare(
+            "SELECT b.id, b.parent, b.type, COALESCE(b.title, ''), p.url
+             FROM moz_bookmarks b
+             LEFT JOIN moz_places p ON b.fk = p.id
+             ORDER BY b.position, b.id",
+        )
+        .map_err(|error| format!("failed to read Firefox bookmarks: {error}"))?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok(FirefoxBookmarkRow {
+                id: row.get(0)?,
+                parent: row.get(1)?,
+                node_type: row.get(2)?,
+                title: row.get(3)?,
+                url: row.get(4)?,
+            })
+        })
+        .map_err(|error| format!("failed to query Firefox bookmarks: {error}"))?;
+    let mut by_parent: BTreeMap<i64, Vec<FirefoxBookmarkRow>> = BTreeMap::new();
+    for row in rows {
+        let row = row.map_err(|error| format!("failed to read Firefox bookmark row: {error}"))?;
+        by_parent.entry(row.parent).or_default().push(row);
+    }
+    let mut root = BookmarkTreeNode {
+        id: "root".to_string(),
+        name: "Bookmarks".to_string(),
+        node_type: "folder",
+        url: None,
+        children: Vec::new(),
+    };
+    let root_rows = by_parent.remove(&0).unwrap_or_default();
+    for row in root_rows {
+        if let Some(node) = build_firefox_node(row, &by_parent) {
+            if node.node_type == "bookmark" || !node.children.is_empty() {
+                root.children.push(node);
+            }
+        }
+    }
+    Ok((root, Vec::new()))
+}
+
+fn build_firefox_node(
+    row: FirefoxBookmarkRow,
+    by_parent: &BTreeMap<i64, Vec<FirefoxBookmarkRow>>,
+) -> Option<BookmarkTreeNode> {
+    if row.node_type == 1 {
+        let url = row.url?.trim().to_string();
+        if !is_importable_bookmark_url(&url) {
+            return None;
+        }
+        let name = if row.title.trim().is_empty() {
+            bookmark_name_from_url(&url)
+        } else {
+            row.title.trim().to_string()
+        };
+        return Some(BookmarkTreeNode {
+            id: format!("firefox-{}", row.id),
+            name,
+            node_type: "bookmark",
+            url: Some(url),
+            children: Vec::new(),
+        });
+    }
+    if row.node_type != 2 {
+        return None;
+    }
+    let mut children = Vec::new();
+    if let Some(raw_children) = by_parent.get(&row.id) {
+        for child in raw_children {
+            if let Some(node) = build_firefox_node(child.clone(), by_parent) {
+                children.push(node);
+            }
+        }
+    }
+    Some(BookmarkTreeNode {
+        id: format!("firefox-{}", row.id),
+        name: if row.title.trim().is_empty() {
+            "Bookmarks".to_string()
+        } else {
+            row.title.trim().to_string()
+        },
+        node_type: "folder",
+        url: None,
+        children,
+    })
+}
+
+fn collect_selected_bookmark_drafts(
+    node: &BookmarkTreeNode,
+    selected: &std::collections::HashSet<String>,
+    folder_path: &mut Vec<String>,
+    _inherited: bool,
+    drafts: &mut Vec<ImportedConnectionDraft>,
+) {
+    if node.node_type == "bookmark" {
+        if selected.contains(&node.id) {
+            if let Some(url) = node.url.as_deref() {
+                drafts.push(ImportedConnectionDraft {
+                    name: node.name.clone(),
+                    host: bookmark_host_from_url(url),
+                    user: String::new(),
+                    url: Some(url.to_string()),
+                    port: None,
+                    connection_type: "url",
+                    folder_path: folder_path.clone(),
+                });
+            }
+        }
+        return;
+    }
+    let pushed = node.id != "root" && !node.name.trim().is_empty();
+    if pushed {
+        folder_path.push(node.name.clone());
+    }
+    for child in &node.children {
+        collect_selected_bookmark_drafts(child, selected, folder_path, false, drafts);
+    }
+    if pushed {
+        folder_path.pop();
+    }
+}
+
+fn is_importable_bookmark_url(url: &str) -> bool {
+    url::Url::parse(url)
+        .map(|parsed| matches!(parsed.scheme(), "http" | "https"))
+        .unwrap_or(false)
+}
+
+fn bookmark_host_from_url(value: &str) -> String {
+    url::Url::parse(value)
+        .ok()
+        .and_then(|parsed| parsed.host_str().map(|host| host.to_string()))
+        .unwrap_or_else(|| value.to_string())
+}
+
+fn bookmark_name_from_url(value: &str) -> String {
+    bookmark_host_from_url(value)
 }
 
 // ===== Lightweight XML event scanner ========================================
@@ -1267,5 +1743,46 @@ mod tests {
         assert_eq!(connection_type_for_port(23), "telnet");
         assert_eq!(connection_type_for_port(3389), "rdp");
         assert_eq!(connection_type_for_port(5900), "vnc");
+    }
+    #[test]
+    fn parses_chromium_bookmarks_as_url_tree() {
+        let path =
+            std::env::temp_dir().join(format!("admindeck-bookmarks-{}.json", std::process::id()));
+        std::fs::write(
+            &path,
+            r#"{
+              "roots": {
+                "bookmark_bar": {
+                  "id": "1",
+                  "name": "Bookmarks bar",
+                  "type": "folder",
+                  "children": [
+                    {"id": "2", "name": "AdminDeck", "type": "url", "url": "https://example.com/admin"},
+                    {"id": "3", "name": "Internal", "type": "folder", "children": [
+                      {"id": "4", "name": "Ignored", "type": "url", "url": "chrome://settings"},
+                      {"id": "5", "name": "Docs", "type": "url", "url": "https://docs.example.com/"}
+                    ]}
+                  ]
+                }
+              }
+            }"#,
+        )
+        .expect("write bookmark fixture");
+
+        let (root, warnings) = parse_chromium_bookmarks(&path).expect("parse bookmarks");
+        std::fs::remove_file(&path).ok();
+        assert!(warnings.is_empty());
+        assert_eq!(root.children.len(), 1);
+        let selected = std::collections::HashSet::from(["chromium-3".to_string()]);
+        let mut drafts = Vec::new();
+        collect_selected_bookmark_drafts(&root, &selected, &mut Vec::new(), false, &mut drafts);
+        assert_eq!(drafts.len(), 1);
+        assert_eq!(drafts[0].connection_type, "url");
+        assert_eq!(drafts[0].url.as_deref(), Some("https://docs.example.com/"));
+        assert_eq!(drafts[0].host, "docs.example.com");
+        assert_eq!(
+            drafts[0].folder_path,
+            vec!["Bookmarks bar".to_string(), "Internal".to_string()]
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -525,6 +525,18 @@ fn parse_import_file(
 }
 
 #[tauri::command]
+fn list_browser_bookmark_sources() -> import::BrowserBookmarkSourcesResponse {
+    import::list_browser_bookmark_sources()
+}
+
+#[tauri::command]
+fn preview_browser_bookmark_import(
+    request: import::PreviewBrowserBookmarkImportRequest,
+) -> Result<import::ImportFilePreview, String> {
+    import::preview_browser_bookmark_import(request)
+}
+
+#[tauri::command]
 fn scan_network_for_connections(
     app: tauri::AppHandle,
     request: import::ScanNetworkRequest,
@@ -1304,6 +1316,8 @@ pub fn run() {
             ssh_transport_plan,
             import_ssh_config,
             parse_import_file,
+            list_browser_bookmark_sources,
+            preview_browser_bookmark_import,
             scan_network_for_connections,
             inspect_ssh_host_key,
             trust_ssh_host_key,

--- a/src/App.css
+++ b/src/App.css
@@ -5831,3 +5831,58 @@ progress {
   font-size: 11px;
   line-height: 1.35;
 }
+
+.import-bookmark-tree {
+  display: grid;
+  gap: 4px;
+  max-height: 260px;
+  padding: 10px;
+  overflow: auto;
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+}
+
+.import-bookmark-node {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.import-bookmark-label {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  min-width: 0;
+  padding: 3px 4px;
+  color: var(--text);
+  font-size: 12px;
+  border-radius: 5px;
+}
+
+.import-bookmark-label:hover {
+  background: var(--surface);
+}
+
+.import-bookmark-label span {
+  overflow: hidden;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.import-bookmark-label small {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.import-bookmark-children {
+  display: grid;
+  gap: 4px;
+  margin-left: 20px;
+  padding-left: 10px;
+  border-left: 1px solid var(--border);
+}

--- a/src/connections/ConnectionSidebar.tsx
+++ b/src/connections/ConnectionSidebar.tsx
@@ -1192,7 +1192,9 @@ export function ConnectionSidebar({
               t(
                 source === "scan"
                   ? "connections.import.importScanComplete"
-                  : "connections.import.importFileComplete",
+                  : source === "bookmarks"
+                    ? "connections.import.importBookmarksComplete"
+                    : "connections.import.importFileComplete",
                 { count },
               ),
             );

--- a/src/connections/ImportDialog.tsx
+++ b/src/connections/ImportDialog.tsx
@@ -1,10 +1,19 @@
-import { ChevronLeft, FileUp, Loader2, Network, X } from "lucide-react";
+import {
+  BookMarked,
+  ChevronLeft,
+  FileUp,
+  Loader2,
+  Network,
+  X,
+} from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { listen } from "@tauri-apps/api/event";
 import {
   invokeCommand,
   selectConnectionImportFile,
+  type BookmarkImportSource,
+  type BookmarkTreeNode,
   type ImportFilePreview,
   type ScanProgressEvent,
   type ScanResultEntry,
@@ -22,10 +31,13 @@ type ImportDialogProps = {
   tree: ConnectionTree;
   sshSettings: SshSettings;
   onClose: () => void;
-  onImported: (result: { count: number; source: "file" | "scan" }) => void;
+  onImported: (result: {
+    count: number;
+    source: "file" | "scan" | "bookmarks";
+  }) => void;
 };
 
-type Stage = "menu" | "file" | "scan";
+type Stage = "menu" | "file" | "scan" | "bookmarks";
 
 type Candidate = {
   id: string;
@@ -34,6 +46,7 @@ type Candidate = {
   host: string;
   user: string;
   password: string;
+  url?: string;
   port?: number;
   type: ConnectionType;
   folderPath: string[];
@@ -76,7 +89,9 @@ export function ImportDialog({ tree, sshSettings, onClose, onImported }: ImportD
                   ? t("connections.import.chooseSource")
                   : stage === "file"
                     ? t("connections.import.fromFileTitle")
-                    : t("connections.import.scanTitle")}
+                    : stage === "scan"
+                      ? t("connections.import.scanTitle")
+                      : t("connections.import.bookmarksTitle")}
               </h2>
             </div>
           </div>
@@ -115,12 +130,26 @@ export function ImportDialog({ tree, sshSettings, onClose, onImported }: ImportD
             onImported={onImported}
           />
         ) : null}
+        {stage === "bookmarks" ? (
+          <BookmarksPanel
+            tree={tree}
+            sshSettings={sshSettings}
+            onError={setError}
+            onClearError={() => setError("")}
+            onClose={onClose}
+            onImported={onImported}
+          />
+        ) : null}
       </div>
     </div>
   );
 }
 
-function ImportMenu({ onPick }: { onPick: (stage: "file" | "scan") => void }) {
+function ImportMenu({
+  onPick,
+}: {
+  onPick: (stage: "file" | "scan" | "bookmarks") => void;
+}) {
   const { t } = useTranslation();
   return (
     <div className="import-menu">
@@ -150,6 +179,19 @@ function ImportMenu({ onPick }: { onPick: (stage: "file" | "scan") => void }) {
           <small>{t("connections.import.scanSubtitle")}</small>
         </span>
       </button>
+      <button
+        className="import-menu-tile"
+        onClick={() => onPick("bookmarks")}
+        type="button"
+      >
+        <span className="import-menu-icon">
+          <BookMarked size={20} />
+        </span>
+        <span className="import-menu-copy">
+          <strong>{t("connections.import.bookmarksTitle")}</strong>
+          <small>{t("connections.import.bookmarksSubtitle")}</small>
+        </span>
+      </button>
     </div>
   );
 }
@@ -167,7 +209,10 @@ function FileImportPanel({
   onError: (message: string) => void;
   onClearError: () => void;
   onClose: () => void;
-  onImported: (result: { count: number; source: "file" | "scan" }) => void;
+  onImported: (result: {
+    count: number;
+    source: "file" | "scan" | "bookmarks";
+  }) => void;
 }) {
   const { t } = useTranslation();
   const [filePath, setFilePath] = useState("");
@@ -194,6 +239,7 @@ function FileImportPanel({
           host: draft.host,
           user: draft.user,
           password: "",
+          url: draft.url,
           port: draft.port,
           type: draft.type,
           folderPath: draft.folderPath,
@@ -265,7 +311,10 @@ function ScanPanel({
   onError: (message: string) => void;
   onClearError: () => void;
   onClose: () => void;
-  onImported: (result: { count: number; source: "file" | "scan" }) => void;
+  onImported: (result: {
+    count: number;
+    source: "file" | "scan" | "bookmarks";
+  }) => void;
 }) {
   const { t } = useTranslation();
   const [target, setTarget] = useState("");
@@ -445,6 +494,299 @@ function ScanPanel({
   );
 }
 
+
+function BookmarksPanel({
+  tree,
+  sshSettings,
+  onError,
+  onClearError,
+  onClose,
+  onImported,
+}: {
+  tree: ConnectionTree;
+  sshSettings: SshSettings;
+  onError: (message: string) => void;
+  onClearError: () => void;
+  onClose: () => void;
+  onImported: (result: {
+    count: number;
+    source: "file" | "scan" | "bookmarks";
+  }) => void;
+}) {
+  const { t } = useTranslation();
+  const [sources, setSources] = useState<BookmarkImportSource[]>([]);
+  const [selectedSourceId, setSelectedSourceId] = useState("");
+  const [selectedNodeIds, setSelectedNodeIds] = useState<Set<string>>(() => new Set());
+  const [preview, setPreview] = useState<ImportFilePreview | null>(null);
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [previewing, setPreviewing] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    onClearError();
+    setLoading(true);
+    invokeCommand("list_browser_bookmark_sources", undefined)
+      .then((response) => {
+        if (cancelled) {
+          return;
+        }
+        setSources(response.sources);
+        const first =
+          response.sources.find((source) => source.root.children.length > 0) ??
+          response.sources[0];
+        if (first) {
+          setSelectedSourceId(first.id);
+        }
+      })
+      .catch((failure) => {
+        if (!cancelled) {
+          onError(failure instanceof Error ? failure.message : String(failure));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const selectedSource = sources.find((source) => source.id === selectedSourceId) ?? null;
+  const selectedCount = selectedNodeIds.size;
+
+  function handleSourceChange(sourceId: string) {
+    setSelectedSourceId(sourceId);
+    setSelectedNodeIds(new Set());
+    setPreview(null);
+    setCandidates([]);
+    onClearError();
+  }
+
+  function toggleNode(node: BookmarkTreeNode, checked: boolean) {
+    setSelectedNodeIds((current) => {
+      const next = new Set(current);
+      collectBookmarkNodeIds(node).forEach((id) => {
+        if (checked) {
+          next.add(id);
+        } else {
+          next.delete(id);
+        }
+      });
+      return next;
+    });
+    setPreview(null);
+    setCandidates([]);
+  }
+
+  async function handlePreview() {
+    if (!selectedSource) {
+      onError(t("connections.import.bookmarksSourceRequired"));
+      return;
+    }
+    if (selectedNodeIds.size === 0) {
+      onError(t("connections.import.bookmarksSelectionRequired"));
+      return;
+    }
+    onClearError();
+    setPreviewing(true);
+    try {
+      const result = await invokeCommand("preview_browser_bookmark_import", {
+        request: {
+          sourceId: selectedSource.id,
+          selectedNodeIds: Array.from(selectedNodeIds),
+        },
+      });
+      setPreview(result);
+      setCandidates(
+        result.drafts.map((draft, index) => ({
+          id: `${index}`,
+          selected: true,
+          name: draft.name,
+          host: draft.host,
+          user: draft.user,
+          password: "",
+          url: draft.url,
+          port: draft.port,
+          type: draft.type,
+          folderPath: draft.folderPath,
+        })),
+      );
+      if (result.drafts.length === 0) {
+        onError(t("connections.import.bookmarksNoImportable"));
+      }
+    } catch (failure) {
+      onError(failure instanceof Error ? failure.message : String(failure));
+      setPreview(null);
+      setCandidates([]);
+    } finally {
+      setPreviewing(false);
+    }
+  }
+
+  return (
+    <div className="import-panel">
+      {loading ? (
+        <p className="import-empty">
+          <Loader2 className="spin" size={14} />
+          <span>{t("connections.import.bookmarksLoading")}</span>
+        </p>
+      ) : null}
+
+      {!loading && sources.length === 0 ? (
+        <p className="import-empty">{t("connections.import.bookmarksNoSources")}</p>
+      ) : null}
+
+      {!loading && sources.length > 0 ? (
+        <>
+          <label className="import-field">
+            <span>{t("connections.import.bookmarksSourceLabel")}</span>
+            <select
+              onChange={(event) => handleSourceChange(event.currentTarget.value)}
+              value={selectedSourceId}
+            >
+              {sources.map((source) => (
+                <option key={source.id} value={source.id}>
+                  {source.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          {selectedSource ? (
+            <p className="import-hint">
+              {t("connections.import.bookmarksSourcePath", {
+                path: selectedSource.path,
+              })}
+            </p>
+          ) : null}
+
+          {selectedSource && selectedSource.warnings.length > 0 ? (
+            <div className="import-warnings" role="status">
+              <strong>{t("connections.import.warningsHeading")}</strong>
+              <ul>
+                {selectedSource.warnings.map((message, index) => (
+                  <li key={index}>{message}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {selectedSource ? (
+            <div
+              className="import-bookmark-tree"
+              role="tree"
+              aria-label={t("connections.import.bookmarksTreeLabel")}
+            >
+              {selectedSource.root.children.map((node) => (
+                <BookmarkTreeRow
+                  key={node.id}
+                  node={node}
+                  selectedNodeIds={selectedNodeIds}
+                  onToggle={toggleNode}
+                />
+              ))}
+            </div>
+          ) : null}
+
+          <div className="import-scan-actions">
+            <button
+              className="approve-button"
+              disabled={previewing || !selectedSource || selectedCount === 0}
+              onClick={() => void handlePreview()}
+              type="button"
+            >
+              {previewing ? (
+                <Loader2 className="spin" size={14} />
+              ) : (
+                <BookMarked size={14} />
+              )}
+              <span>
+                {t("connections.import.bookmarksPreview", {
+                  count: selectedCount,
+                })}
+              </span>
+            </button>
+          </div>
+        </>
+      ) : null}
+
+      {preview && candidates.length > 0 ? (
+        <ImportPreviewSection
+          candidates={candidates}
+          format="bookmarks"
+          onCancel={onClose}
+          onCandidatesChange={setCandidates}
+          onError={onError}
+          onImported={onImported}
+          sshSettings={sshSettings}
+          tree={tree}
+          warnings={preview.warnings}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function BookmarkTreeRow({
+  node,
+  selectedNodeIds,
+  onToggle,
+}: {
+  node: BookmarkTreeNode;
+  selectedNodeIds: Set<string>;
+  onToggle: (node: BookmarkTreeNode, checked: boolean) => void;
+}) {
+  const descendantIds = useMemo(() => collectBookmarkNodeIds(node), [node]);
+  const checked = descendantIds.every((id) => selectedNodeIds.has(id));
+  const partiallyChecked =
+    !checked && descendantIds.some((id) => selectedNodeIds.has(id));
+  const checkboxRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (checkboxRef.current) {
+      checkboxRef.current.indeterminate = partiallyChecked;
+    }
+  }, [partiallyChecked]);
+
+  return (
+    <div className="import-bookmark-node" role="treeitem">
+      <label className="import-bookmark-label">
+        <input
+          ref={checkboxRef}
+          checked={checked}
+          onChange={(event) => onToggle(node, event.currentTarget.checked)}
+          type="checkbox"
+        />
+        <span>{node.name}</span>
+        {node.type === "bookmark" && node.url ? (
+          <small>{node.url}</small>
+        ) : null}
+      </label>
+      {node.children.length > 0 ? (
+        <div className="import-bookmark-children" role="group">
+          {node.children.map((child) => (
+            <BookmarkTreeRow
+              key={child.id}
+              node={child}
+              selectedNodeIds={selectedNodeIds}
+              onToggle={onToggle}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function collectBookmarkNodeIds(node: BookmarkTreeNode): string[] {
+  return [
+    node.id,
+    ...node.children.flatMap((child) => collectBookmarkNodeIds(child)),
+  ];
+}
+
 function ImportPreviewSection({
   candidates,
   format,
@@ -461,7 +803,10 @@ function ImportPreviewSection({
   onCancel: () => void;
   onCandidatesChange: (next: Candidate[]) => void;
   onError: (message: string) => void;
-  onImported: (result: { count: number; source: "file" | "scan" }) => void;
+  onImported: (result: {
+    count: number;
+    source: "file" | "scan" | "bookmarks";
+  }) => void;
   sshSettings: SshSettings;
   tree: ConnectionTree;
   warnings: string[];
@@ -615,8 +960,9 @@ function ImportPreviewSection({
         if (!row.selected) {
           continue;
         }
-        const port =
-          row.port ?? defaultPortForConnectionType(row.type, sshSettings);
+        const port = ["local", "serial", "url"].includes(row.type)
+          ? row.port
+          : row.port ?? defaultPortForConnectionType(row.type, sshSettings);
         const rowFolderId = await resolveFolderPath(
           targetFolderId,
           row.folderPath,
@@ -626,19 +972,32 @@ function ImportPreviewSection({
           ? row.password
           : "";
         const request: CreateConnectionRequest = {
-          name: row.name.trim() || row.host,
+          name:
+            row.name.trim() ||
+            row.host ||
+            row.url ||
+            t("connections.import.bookmarkFallbackName"),
           type: row.type,
-          host: row.host,
+          host: row.type === "url" ? undefined : row.host,
           user: row.user,
           folderId: rowFolderId,
           port,
+          url: row.type === "url" ? row.url ?? row.host : undefined,
           authMethod: password && row.type === "ssh" ? "password" : undefined,
         };
         const connection = await invokeCommand("create_connection", { request });
         await storeImportedPassword(connection.id, password);
       }
 
-      onImported({ count: selectedCount, source: format === "scan" ? "scan" : "file" });
+      onImported({
+        count: selectedCount,
+        source:
+          format === "scan"
+            ? "scan"
+            : format === "bookmarks"
+              ? "bookmarks"
+              : "file",
+      });
     } catch (failure) {
       onError(failure instanceof Error ? failure.message : String(failure));
     } finally {
@@ -941,8 +1300,10 @@ function suggestFolderName(format: string) {
   const today = new Date();
   const stamp = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
   const label =
-    format === "scan"
-      ? "Scan"
+    format === "bookmarks"
+      ? "Bookmarks"
+      : format === "scan"
+        ? "Scan"
       : format === "rdcman"
         ? "RDCMan"
         : format === "mobaxterm"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -328,7 +328,7 @@
     "folderSubfoldersCount": "subfolder(s)",
     "import": {
       "tileTitle": "Import",
-      "tileSubtitle": "From file or network scan",
+      "tileSubtitle": "From file, bookmarks, or network scan",
       "title": "Import connections",
       "back": "Back",
       "chooseSource": "Choose an import source",
@@ -383,7 +383,20 @@
       "noneSelected": "Select at least one row to import.",
       "importCount": "Import {{count}}",
       "importFileComplete": "Imported {{count}} Connections from file.",
-      "importScanComplete": "Imported {{count}} Connections from scan."
+      "importScanComplete": "Imported {{count}} Connections from scan.",
+      "bookmarksTitle": "Import browser bookmarks",
+      "bookmarksSubtitle": "Edge, Chrome, Firefox URL bookmarks",
+      "bookmarksLoading": "Looking for browser bookmark sources...",
+      "bookmarksNoSources": "No Edge, Chrome, or Firefox bookmark sources were found on this device.",
+      "bookmarksSourceLabel": "Browser profile",
+      "bookmarksSourcePath": "Source file: {{path}}",
+      "bookmarksTreeLabel": "Bookmark folders and links",
+      "bookmarksPreview": "Preview {{count}} selected",
+      "bookmarksSourceRequired": "Choose a browser bookmark source.",
+      "bookmarksSelectionRequired": "Select at least one folder or bookmark to import.",
+      "bookmarksNoImportable": "The selected bookmarks did not include any http or https URLs.",
+      "bookmarkFallbackName": "Imported bookmark",
+      "importBookmarksComplete": "Imported {{count}} Connections from bookmarks."
     }
   },
   "terminal": {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -73,6 +73,7 @@ export interface StartTerminalSessionRequest {
   type: "local" | "ssh" | "telnet" | "serial";
   host: string;
   user: string;
+  url?: string;
   port?: number;
   keyPath?: string;
   proxyJump?: string;
@@ -114,6 +115,7 @@ export interface StartSftpSessionRequest {
   title: string;
   host: string;
   user: string;
+  url?: string;
   port?: number;
   keyPath?: string;
   proxyJump?: string;
@@ -205,12 +207,13 @@ export interface SshConfigImportPreview {
   unsupportedDirectives: UnsupportedSshDirective[];
 }
 
-export type ImportFileFormat = "csv" | "tsv" | "rdcman" | "mobaxterm" | "putty";
+export type ImportFileFormat = "csv" | "tsv" | "rdcman" | "mobaxterm" | "putty" | "bookmarks";
 
 export interface ImportedConnectionDraft {
   name: string;
   host: string;
   user: string;
+  url?: string;
   port?: number;
   type: "local" | "ssh" | "telnet" | "serial" | "url" | "rdp" | "vnc";
   folderPath: string[];
@@ -220,6 +223,27 @@ export interface ImportFilePreview {
   format: ImportFileFormat;
   drafts: ImportedConnectionDraft[];
   warnings: string[];
+}
+
+export interface BookmarkTreeNode {
+  id: string;
+  name: string;
+  type: "folder" | "bookmark";
+  url?: string;
+  children: BookmarkTreeNode[];
+}
+
+export interface BookmarkImportSource {
+  id: string;
+  label: string;
+  browser: string;
+  path: string;
+  root: BookmarkTreeNode;
+  warnings: string[];
+}
+
+export interface BrowserBookmarkSourcesResponse {
+  sources: BookmarkImportSource[];
 }
 
 export interface ScanResultEntry {
@@ -380,6 +404,7 @@ export interface StartRdpSessionRequest {
   sessionId: string;
   host: string;
   user: string;
+  url?: string;
   port?: number;
   secretOwnerId?: string;
   password?: string;
@@ -716,6 +741,14 @@ type CommandMap = {
   };
   parse_import_file: {
     args: { request: { path: string } };
+    result: ImportFilePreview;
+  };
+  list_browser_bookmark_sources: {
+    args: undefined;
+    result: BrowserBookmarkSourcesResponse;
+  };
+  preview_browser_bookmark_import: {
+    args: { request: { sourceId: string; selectedNodeIds: string[] } };
     result: ImportFilePreview;
   };
   scan_network_for_connections: {


### PR DESCRIPTION
### Motivation
- Provide a convenient way to import browser URL bookmarks as URL Connections while preserving folder paths and letting users pick which bookmark folders/links to import.

### Description
- Backend: add Chromium JSON and Firefox `places.sqlite` discovery/parsing and preview logic in `src-tauri/src/import.rs`, and expose two Tauri commands `list_browser_bookmark_sources` and `preview_browser_bookmark_import` via `src-tauri/src/lib.rs` and the typed frontend contract in `src/lib/tauri.ts`.
- Frontend: add a Bookmarks import tile and a `BookmarksPanel` with selectable bookmark tree, `BookmarkTreeRow`, preview mapping, and integration into the existing import preview/import flow in `src/connections/ImportDialog.tsx`, plus tree styling in `src/App.css`.
- Import mapping: extend `ImportedConnectionDraft`/preview to carry an optional `url`, map selected http/https bookmarks to URL Connection drafts (preserving folder paths), and set the `url` field when creating URL Connections; added fallback naming (`connections.import.bookmarkFallbackName`).
- i18n & docs: add English keys in `src/i18n/locales/en.json` and localization backlog entries in `docs/LOCALIZATION.md`; add a Rust unit test fixture for Chromium bookmark parsing in `src-tauri/src/import.rs`.

### Testing
- Ran `npm run check` (TypeScript typecheck) — succeeded.
- Ran `npm run build` (frontend build via `tsc && vite build`) — succeeded and produced `dist` assets.
- Ran `cargo fmt --manifest-path src-tauri/Cargo.toml` and `git diff --check` — succeeded.
- Attempted `cargo check --manifest-path src-tauri/Cargo.toml` and `cargo test --manifest-path src-tauri/Cargo.toml`, but Rust compile/tests were blocked by a missing system library required by `gdk-sys` (`gdk-3.0` / pkg-config) in the environment, so those checks could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdbe67e790832f9117bf4a362e1d3b)