### PR TITLE
feat(settings): route all settings status messages to the bottom status bar

### DIFF
--- a/src/settings/AiSettings.tsx
+++ b/src/settings/AiSettings.tsx
@@ -260,11 +260,10 @@ export function AiSettings() {
   const aiProviderHasApiKey = useWorkspaceStore((state) => state.aiProviderHasApiKey);
   const setAiProviderSettings = useWorkspaceStore((state) => state.setAiProviderSettings);
   const setAiProviderHasApiKey = useWorkspaceStore((state) => state.setAiProviderHasApiKey);
+  const showStatusBarNotice = useWorkspaceStore((state) => state.showStatusBarNotice);
   const [draft, setDraft] = useState(aiProviderSettings);
   const [apiKeyDraft, setApiKeyDraft] = useState("");
   const [apiKeyStoredMask, setApiKeyStoredMask] = useState(createStoredApiKeyMask);
-  const [status, setStatus] = useState("");
-  const [error, setError] = useState("");
   const hasChanges =
     JSON.stringify(draft) !== JSON.stringify(aiProviderSettings) || apiKeyDraft.trim().length > 0;
   const aiProviderDefinition = getAiProviderDefinition(draft.providerKind);
@@ -275,8 +274,6 @@ export function AiSettings() {
 
   async function handleSave() {
     try {
-      setError("");
-      setStatus("");
       const nextSettings = normalizeAiProviderDraft(draft);
 
       if (apiKeyDraft.trim()) {
@@ -299,9 +296,9 @@ export function AiSettings() {
         : nextSettings;
       setAiProviderSettings(saved);
       setDraft(saved);
-      setStatus(t("settings.aiProviderSaved"));
+      showStatusBarNotice(t("settings.aiProviderSaved"), { tone: "success" });
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      showStatusBarNotice(err instanceof Error ? err.message : String(err), { tone: "error" });
     }
   }
 
@@ -315,8 +312,6 @@ export function AiSettings() {
       reasoningEffort: defaults.reasoningEffort,
     }));
     setApiKeyDraft("");
-    setStatus("");
-    setError("");
   }
 
   return (
@@ -424,8 +419,6 @@ export function AiSettings() {
           value={formatReasoningEffort(draft.reasoningEffort)}
         />
       </div>
-      {status ? <p className="settings-status success">{status}</p> : null}
-      {error ? <p className="settings-status error">{error}</p> : null}
     </section>
   );
 }

--- a/src/settings/GeneralSettings.tsx
+++ b/src/settings/GeneralSettings.tsx
@@ -82,9 +82,8 @@ export function GeneralSettings() {
   const setAiProviderHasApiKey = useWorkspaceStore(
     (state) => state.setAiProviderHasApiKey,
   );
+  const showStatusBarNotice = useWorkspaceStore((state) => state.showStatusBarNotice);
   const [draft, setDraft] = useState(generalSettings);
-  const [status, setStatus] = useState("");
-  const [error, setError] = useState("");
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
   const [dashboardResetDialogOpen, setDashboardResetDialogOpen] = useState(false);
@@ -96,56 +95,40 @@ export function GeneralSettings() {
 
   async function handleSave() {
     try {
-      setError("");
-      setStatus("");
       const saved = isTauriRuntime()
         ? await invokeCommand("update_general_settings", { request: draft })
         : draft;
       setGeneralSettings(saved);
       setDraft(saved);
-      setStatus(t("settings.generalDefaultsSaved"));
+      showStatusBarNotice(t("settings.generalDefaultsSaved"), { tone: "success" });
     } catch (saveError) {
-      setError(
-        saveError instanceof Error ? saveError.message : String(saveError),
-      );
+      showStatusBarNotice(saveError instanceof Error ? saveError.message : String(saveError), { tone: "error" });
     }
   }
 
   async function handleBackupSettings() {
-    setStatus("");
-    setError("");
     try {
       const backup = await invokeCommand("backup_settings_database");
       setGeneralSettings({
         ...generalSettings,
         lastBackupAt: backup.createdAt,
       });
-      setStatus(
-        t("settings.backupSettingsComplete", { filename: backup.filename }),
-      );
+      showStatusBarNotice(t("settings.backupSettingsComplete", { filename: backup.filename }), { tone: "success" });
     } catch (backupError) {
-      setError(
-        backupError instanceof Error
-          ? backupError.message
-          : String(backupError),
-      );
+      showStatusBarNotice(backupError instanceof Error ? backupError.message : String(backupError), { tone: "error" });
     }
   }
 
   async function handleOpenDatabaseFolder() {
-    setStatus("");
-    setError("");
     try {
       const path = await invokeCommand("get_database_folder");
       await openFilesystemPath(path);
     } catch (openError) {
-      setError(openError instanceof Error ? openError.message : String(openError));
+      showStatusBarNotice(openError instanceof Error ? openError.message : String(openError), { tone: "error" });
     }
   }
 
   async function handleImportSettings() {
-    setStatus("");
-    setError("");
     try {
       const path = await selectSettingsImportFile({
         title: t("settings.importSettings"),
@@ -172,24 +155,14 @@ export function GeneralSettings() {
       window.dispatchEvent(
         new CustomEvent("kkterm:connection-tree-invalidated"),
       );
-      setStatus(
-        t("settings.importSettingsComplete", {
-          filename: snapshot.backup.filename,
-        }),
-      );
+      showStatusBarNotice(t("settings.importSettingsComplete", { filename: snapshot.backup.filename }), { tone: "success" });
       setImportDialogOpen(false);
     } catch (importError) {
-      setError(
-        importError instanceof Error
-          ? importError.message
-          : String(importError),
-      );
+      showStatusBarNotice(importError instanceof Error ? importError.message : String(importError), { tone: "error" });
     }
   }
 
   async function handleResetAllSettings() {
-    setStatus("");
-    setError("");
     try {
       closeAllTabs();
       resetAllLayouts();
@@ -262,22 +235,20 @@ export function GeneralSettings() {
       window.dispatchEvent(
 new CustomEvent("kkterm:connection-tree-invalidated"),
       );
-      setStatus(t("settings.resetAllSettingsComplete"));
+      showStatusBarNotice(t("settings.resetAllSettingsComplete"), { tone: "success" });
       setResetDialogOpen(false);
     } catch (resetError) {
-      setError(resetError instanceof Error ? resetError.message : String(resetError));
+      showStatusBarNotice(resetError instanceof Error ? resetError.message : String(resetError), { tone: "error" });
     }
   }
 
   async function handleResetDashboard() {
-    setStatus("");
-    setError("");
     try {
       await useDashboardStore.getState().resetDashboard();
-      setStatus(t("settings.dashboardResetDone"));
+      showStatusBarNotice(t("settings.dashboardResetDone"), { tone: "success" });
       setDashboardResetDialogOpen(false);
     } catch (resetError) {
-      setError(resetError instanceof Error ? resetError.message : String(resetError));
+      showStatusBarNotice(resetError instanceof Error ? resetError.message : String(resetError), { tone: "error" });
     }
   }
 
@@ -439,8 +410,6 @@ new CustomEvent("kkterm:connection-tree-invalidated"),
         </div>
       </fieldset>
 
-      {status ? <p className="settings-status success">{status}</p> : null}
-      {error ? <p className="settings-status error">{error}</p> : null}
       {importDialogOpen ? (
         <div className="dialog-backdrop connection-dialog-backdrop" role="presentation">
           <div

--- a/src/settings/RdpSettings.tsx
+++ b/src/settings/RdpSettings.tsx
@@ -11,9 +11,8 @@ export function RdpSettings() {
   const { t } = useTranslation();
   const rdpSettings = useWorkspaceStore((state) => state.rdpSettings);
   const setRdpSettings = useWorkspaceStore((state) => state.setRdpSettings);
+  const showStatusBarNotice = useWorkspaceStore((state) => state.showStatusBarNotice);
   const [draft, setDraft] = useState(rdpSettings);
-  const [status, setStatus] = useState("");
-  const [error, setError] = useState("");
   const hasChanges = JSON.stringify(draft) !== JSON.stringify(rdpSettings);
 
   useEffect(() => {
@@ -21,17 +20,15 @@ export function RdpSettings() {
   }, [rdpSettings]);
 
   async function handleSave() {
-    setStatus("");
-    setError("");
     try {
       const saved = isTauriRuntime()
         ? await invokeCommand("update_rdp_settings", { request: draft })
         : draft;
       setRdpSettings(saved);
       setDraft(saved);
-      setStatus(t("settings.rdpSettingsSaved"));
+      showStatusBarNotice(t("settings.rdpSettingsSaved"), { tone: "success" });
     } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : String(saveError));
+      showStatusBarNotice(saveError instanceof Error ? saveError.message : String(saveError), { tone: "error" });
     }
   }
 
@@ -48,8 +45,6 @@ export function RdpSettings() {
         label={t("settings.sectionRdp")}
         title={t("settings.qualityDefaults")}
       />
-      {status ? <p className="settings-status success">{status}</p> : null}
-      {error ? <p className="settings-status error">{error}</p> : null}
       <fieldset className="settings-subsection settings-fieldset">
         <legend>{t("settings.display")}</legend>
         <div className="form-grid two-columns">

--- a/src/settings/SshSettings.tsx
+++ b/src/settings/SshSettings.tsx
@@ -40,11 +40,11 @@ export function SshSettings() {
   const { t } = useTranslation();
   const sshSettings = useWorkspaceStore((state) => state.sshSettings);
   const setSshSettings = useWorkspaceStore((state) => state.setSshSettings);
+  const showStatusBarNotice = useWorkspaceStore((state) => state.showStatusBarNotice);
   const [sshDraft, setSshDraft] = useState(sshSettings);
   const [keyEmailDialogOpen, setKeyEmailDialogOpen] = useState(false);
   const [keyEmailDraft, setKeyEmailDraft] = useState("");
   const [isGeneratingKey, setIsGeneratingKey] = useState(false);
-  const [status, setStatus] = useState("");
   const [error, setError] = useState("");
   const hasChanges = JSON.stringify(sshDraft) !== JSON.stringify(sshSettings);
 
@@ -53,8 +53,6 @@ export function SshSettings() {
   }, [sshSettings]);
 
   async function handleBrowseKeyFile() {
-    setStatus("");
-    setError("");
     try {
       const selectedPath = await selectKeyFile(sshDraft.defaultKeyPath);
       if (!selectedPath) {
@@ -65,13 +63,12 @@ export function SshSettings() {
         defaultKeyPath: selectedPath,
       }));
     } catch (browseError) {
-      setError(browseError instanceof Error ? browseError.message : String(browseError));
+      showStatusBarNotice(browseError instanceof Error ? browseError.message : String(browseError), { tone: "error" });
     }
   }
 
   function handleOpenKeyEmailDialog() {
     setError("");
-    setStatus("");
     setKeyEmailDraft("");
     setKeyEmailDialogOpen(true);
   }
@@ -84,7 +81,6 @@ export function SshSettings() {
     try {
       setIsGeneratingKey(true);
       setError("");
-      setStatus("");
       const generated = await invokeCommand("generate_ssh_key_pair", {
         request: { email },
       });
@@ -98,11 +94,12 @@ export function SshSettings() {
         : normalized;
       setSshSettings(saved);
       setSshDraft(saved);
-      setStatus(
+      showStatusBarNotice(
         t("settings.sshKeyGenerated", {
           privateKeyPath: generated.privateKeyPath,
           publicKeyPath: generated.publicKeyPath,
         }),
+        { tone: "success" },
       );
       setKeyEmailDialogOpen(false);
       setKeyEmailDraft("");
@@ -115,17 +112,15 @@ export function SshSettings() {
 
   async function handleSave() {
     try {
-      setError("");
-      setStatus("");
       const nextSshSettings = normalizeSshSettingsDraft(sshDraft, t);
       const savedSshSettings = isTauriRuntime()
         ? await invokeCommand("update_ssh_settings", { request: nextSshSettings })
         : nextSshSettings;
       setSshSettings(savedSshSettings);
       setSshDraft(savedSshSettings);
-      setStatus(t("settings.sshDefaultsSaved"));
+      showStatusBarNotice(t("settings.sshDefaultsSaved"), { tone: "success" });
     } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : String(saveError));
+      showStatusBarNotice(saveError instanceof Error ? saveError.message : String(saveError), { tone: "error" });
     }
   }
 
@@ -310,8 +305,6 @@ export function SshSettings() {
         </div>
       </fieldset>
 
-      {status ? <p className="settings-status success">{status}</p> : null}
-      {error ? <p className="settings-status error">{error}</p> : null}
       {keyEmailDialogOpen ? (
         <SshKeyEmailDialog
           email={keyEmailDraft}

--- a/src/settings/TerminalSettings.tsx
+++ b/src/settings/TerminalSettings.tsx
@@ -43,9 +43,8 @@ export function TerminalSettings() {
   const { t } = useTranslation();
   const terminalSettings = useWorkspaceStore((state) => state.terminalSettings);
   const setTerminalSettings = useWorkspaceStore((state) => state.setTerminalSettings);
+  const showStatusBarNotice = useWorkspaceStore((state) => state.showStatusBarNotice);
   const [draft, setDraft] = useState(terminalSettings);
-  const [status, setStatus] = useState("");
-  const [error, setError] = useState("");
   const hasChanges = JSON.stringify(draft) !== JSON.stringify(terminalSettings);
 
   useEffect(() => {
@@ -54,17 +53,15 @@ export function TerminalSettings() {
 
   async function handleSave() {
     try {
-      setError("");
-      setStatus("");
       const nextSettings = normalizeTerminalSettingsDraft(draft, t);
       const saved = isTauriRuntime()
         ? await invokeCommand("update_terminal_settings", { request: nextSettings })
         : nextSettings;
       setTerminalSettings(saved);
       setDraft(saved);
-      setStatus(t("settings.terminalSaved"));
+      showStatusBarNotice(t("settings.terminalSaved"), { tone: "success" });
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      showStatusBarNotice(err instanceof Error ? err.message : String(err), { tone: "error" });
     }
   }
 
@@ -249,8 +246,6 @@ export function TerminalSettings() {
         </div>
       </fieldset>
 
-      {status ? <p className="settings-status success">{status}</p> : null}
-      {error ? <p className="settings-status error">{error}</p> : null}
     </section>
   );
 }

--- a/src/settings/UrlSettings.tsx
+++ b/src/settings/UrlSettings.tsx
@@ -32,13 +32,12 @@ export function UrlSettings() {
   const { t } = useTranslation();
   const urlSettings = useWorkspaceStore((state) => state.urlSettings);
   const setUrlSettings = useWorkspaceStore((state) => state.setUrlSettings);
+  const showStatusBarNotice = useWorkspaceStore((state) => state.showStatusBarNotice);
   const [draft, setDraft] = useState(urlSettings);
   const [credentials, setCredentials] = useState<UrlCredentialSummary[]>([]);
   const [partitions, setPartitions] = useState<UrlDataPartitionSummary[]>([]);
   const [editingCredentialId, setEditingCredentialId] = useState<string | null>(null);
   const [credentialDraft, setCredentialDraft] = useState<UrlCredentialEditDraft | null>(null);
-  const [status, setStatus] = useState("");
-  const [error, setError] = useState("");
   const hasChanges = JSON.stringify(draft) !== JSON.stringify(urlSettings);
 
   useEffect(() => {
@@ -49,7 +48,6 @@ export function UrlSettings() {
     if (!isTauriRuntime()) {
       return;
     }
-    setError("");
     try {
       const [credentialRows, partitionRows] = await Promise.all([
         invokeCommand("list_url_credentials", undefined),
@@ -62,7 +60,7 @@ export function UrlSettings() {
         setCredentialDraft(null);
       }
     } catch (loadError) {
-      setError(loadError instanceof Error ? loadError.message : String(loadError));
+      showStatusBarNotice(loadError instanceof Error ? loadError.message : String(loadError), { tone: "error" });
     }
   }
 
@@ -71,24 +69,20 @@ export function UrlSettings() {
   }, []);
 
   async function handleSave() {
-    setStatus("");
-    setError("");
     try {
       const saved = isTauriRuntime() ? await invokeCommand("update_url_settings", { request: draft }) : draft;
       setUrlSettings(saved);
       setDraft(saved);
-      setStatus(t("settings.urlSettingsSaved"));
+      showStatusBarNotice(t("settings.urlSettingsSaved"), { tone: "success" });
     } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : String(saveError));
+      showStatusBarNotice(saveError instanceof Error ? saveError.message : String(saveError), { tone: "error" });
     }
   }
 
   async function deleteCredential(connectionId: string) {
-    setStatus("");
-    setError("");
     try {
       await invokeCommand("delete_url_credential", { connectionId });
-      setStatus(t("settings.urlPasswordDeleted"));
+      showStatusBarNotice(t("settings.urlPasswordDeleted"), { tone: "success" });
       if (editingCredentialId === connectionId) {
         setEditingCredentialId(null);
         setCredentialDraft(null);
@@ -96,13 +90,11 @@ export function UrlSettings() {
       window.dispatchEvent(new CustomEvent("kkterm:connection-tree-invalidated"));
       await load();
     } catch (deleteError) {
-      setError(deleteError instanceof Error ? deleteError.message : String(deleteError));
+      showStatusBarNotice(deleteError instanceof Error ? deleteError.message : String(deleteError), { tone: "error" });
     }
   }
 
   function beginCredentialEdit(credential: UrlCredentialSummary) {
-    setStatus("");
-    setError("");
     setEditingCredentialId(credential.connectionId);
     setCredentialDraft(draftFromCredential(credential));
   }
@@ -120,8 +112,6 @@ export function UrlSettings() {
     if (!credentialDraft) {
       return;
     }
-    setStatus("");
-    setError("");
     try {
       if (credentialDraft.password) {
         await invokeCommand("store_secret", {
@@ -141,26 +131,24 @@ export function UrlSettings() {
           passwordSelector: credentialDraft.passwordSelector || undefined,
         },
       });
-      setStatus(t("settings.urlPasswordUpdated"));
+      showStatusBarNotice(t("settings.urlPasswordUpdated"), { tone: "success" });
       setEditingCredentialId(null);
       setCredentialDraft(null);
       window.dispatchEvent(new CustomEvent("kkterm:connection-tree-invalidated"));
       await load();
     } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : String(saveError));
+      showStatusBarNotice(saveError instanceof Error ? saveError.message : String(saveError), { tone: "error" });
     }
   }
 
   async function clearPartition(name: string) {
-    setStatus("");
-    setError("");
     try {
       await invokeCommand("clear_url_data_partition", { name });
-      setStatus(t("settings.urlDataShardCleared", { name }));
+      showStatusBarNotice(t("settings.urlDataShardCleared", { name }), { tone: "success" });
       window.dispatchEvent(new CustomEvent("kkterm:connection-tree-invalidated"));
       await load();
     } catch (clearError) {
-      setError(clearError instanceof Error ? clearError.message : String(clearError));
+      showStatusBarNotice(clearError instanceof Error ? clearError.message : String(clearError), { tone: "error" });
     }
   }
 
@@ -177,9 +165,6 @@ export function UrlSettings() {
         label={t("settings.sectionUrl")}
         title={t("settings.urlDefaults")}
       />
-
-      {status ? <p className="settings-status success">{status}</p> : null}
-      {error ? <p className="settings-status error">{error}</p> : null}
 
       <fieldset className="settings-subsection settings-fieldset">
         <legend>{t("settings.urlSecurity")}</legend>

--- a/src/settings/VncSettings.tsx
+++ b/src/settings/VncSettings.tsx
@@ -11,9 +11,8 @@ export function VncSettings() {
   const { t } = useTranslation();
   const vncSettings = useWorkspaceStore((state) => state.vncSettings);
   const setVncSettings = useWorkspaceStore((state) => state.setVncSettings);
+  const showStatusBarNotice = useWorkspaceStore((state) => state.showStatusBarNotice);
   const [draft, setDraft] = useState(vncSettings);
-  const [status, setStatus] = useState("");
-  const [error, setError] = useState("");
   const hasChanges = JSON.stringify(draft) !== JSON.stringify(vncSettings);
 
   useEffect(() => {
@@ -21,17 +20,15 @@ export function VncSettings() {
   }, [vncSettings]);
 
   async function handleSave() {
-    setStatus("");
-    setError("");
     try {
       const saved = isTauriRuntime()
         ? await invokeCommand("update_vnc_settings", { request: draft })
         : draft;
       setVncSettings(saved);
       setDraft(saved);
-      setStatus(t("settings.vncSettingsSaved"));
+      showStatusBarNotice(t("settings.vncSettingsSaved"), { tone: "success" });
     } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : String(saveError));
+      showStatusBarNotice(saveError instanceof Error ? saveError.message : String(saveError), { tone: "error" });
     }
   }
 
@@ -48,8 +45,6 @@ export function VncSettings() {
         label={t("settings.sectionVnc")}
         title={t("settings.qualityDefaults")}
       />
-      {status ? <p className="settings-status success">{status}</p> : null}
-      {error ? <p className="settings-status error">{error}</p> : null}
       <fieldset className="settings-subsection settings-fieldset">
         <legend>{t("settings.encoding")}</legend>
         <div className="form-grid two-columns">


### PR DESCRIPTION
## Summary

- Removes inline `<p class=\"settings-status\">` success/error banners from all 7 settings components (`RdpSettings`, `VncSettings`, `SshSettings`, `TerminalSettings`, `UrlSettings`, `AiSettings`, `GeneralSettings`)
- All save confirmations and error messages now call `showStatusBarNotice()` and appear in the shared bottom status bar, which auto-dismisses after 5 seconds
- `SshSettings` retains its local `error` state exclusively for the `SshKeyEmailDialog` overlay, where in-dialog inline feedback is still needed for key-generation errors

## Why

The inline status banners were visually intrusive and inconsistent with how other parts of the app (e.g. workspace toggles) already report feedback via the status bar. Centralizing to the status bar keeps the settings panels cleaner and the feedback pattern uniform across the app.

## Reviewer notes

- No logic changes — only the feedback destination changed from local state → `showStatusBarNotice`
- TypeScript compiles cleanly (`tsc --noEmit` passes)
- The `SshKeyEmailDialog` `error` prop/flow is intentionally preserved; dialog-level errors still show inline inside the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)