### PR TITLE
feat(settings): back button returns to the prior page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,15 @@ import "./App.css";
 function App() {
   const { t } = useTranslation();
   const [activePage, setActivePage] = useState<ActivePage>("workspace");
+  const previousNonSettingsPageRef = useRef<Exclude<ActivePage, "settings">>("workspace");
+
+  function navigateToPage(page: ActivePage) {
+    if (page === "settings" && activePage !== "settings") {
+      previousNonSettingsPageRef.current = activePage as Exclude<ActivePage, "settings">;
+    }
+    setActivePage(page);
+  }
+
   const [dashboardAssistantContext, setDashboardAssistantContext] =
     useState<AssistantPageContext>();
   const appearanceSettings = useWorkspaceStore((state) => state.appearanceSettings);
@@ -69,7 +78,7 @@ function App() {
         activePage={activePage}
         connectionsCollapsed={connectionPanelLayout.collapsed}
         onConnectionsToggle={toggleConnectionPanel}
-        onNavigate={setActivePage}
+        onNavigate={navigateToPage}
       />
       <div className="workspace-page" aria-hidden={activePage !== "workspace"}>
         <ConnectionSidebar
@@ -103,14 +112,14 @@ function App() {
       {activePage !== "settings" ? (
         <AssistantPanel
           collapsed={aiPanelLayout.collapsed}
-          onOpenSettings={() => setActivePage("settings")}
+          onOpenSettings={() => navigateToPage("settings")}
           onToggleCollapsed={toggleAiPanel}
           pageContext={activePage === "dashboard" ? dashboardAssistantContext : undefined}
         />
       ) : null}
       {activePage === "settings" ? (
         <SettingsPage
-          onBack={() => setActivePage("workspace")}
+          onBack={() => setActivePage(previousNonSettingsPageRef.current)}
           onResetLayout={resetWorkspaceChromeLayout}
         />
       ) : null}

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -83,7 +83,7 @@ export function SettingsPage({
         </div>
         <button className="toolbar-button" type="button" onClick={onBack}>
           <ArrowLeft size={15} />
-          {t("settings.workspace")}
+          {t("common.back")}
         </button>
       </header>
 


### PR DESCRIPTION
## Summary
- Settings page's back button now returns to whichever non-settings page the user came from (workspace or dashboard) instead of always defaulting to workspace.
- Renamed the button label from "Workspace" to the existing shared `common.back` ("Back") key — already translated in all 13 locales, no i18n additions needed.

## Implementation
- [src/App.tsx](src/App.tsx): added a `previousNonSettingsPageRef` and a `navigateToPage` wrapper that records the outgoing page whenever the user enters settings. `useRef` (not state) since the value is only read on the Back click and doesn't drive rendering. ActivityRail and AssistantPanel's "open settings" both route through the wrapper; the Back click is the only remaining direct `setActivePage` call (intentional — restoring without recording).
- [src/settings/SettingsPage.tsx](src/settings/SettingsPage.tsx:86): swapped `settings.workspace` for `common.back`.

The orphaned `settings.workspace` i18n key is left in place — other namespaces (`workspace.workspace`, `app.workspace`) still cover the literal string, so removal would be a separate cleanup.

## Test plan
- [ ] Workspace → Settings → Back returns to Workspace
- [ ] Dashboard → Settings → Back returns to Dashboard
- [ ] Workspace → Dashboard → Settings → Back returns to Dashboard
- [ ] Open Settings via AssistantPanel's settings shortcut from each page — Back still restores the originating page
- [ ] Button reads "Back" (or the localized equivalent) in non-English locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)