### PR TITLE
fix(settings): prevent tab-switch nudge on AI Assistant page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5281,6 +5281,7 @@ progress {
   min-width: 0;
   height: calc(100vh - 28px);
   overflow: auto;
+  scrollbar-gutter: stable;
   padding: 22px 24px 28px;
   background: var(--app-bg);
 }


### PR DESCRIPTION
## Summary
- Switching to the **AI Assistant** settings tab caused a slight horizontal nudge of all content compared to other tabs.
- Root cause: `.settings-page` uses `overflow: auto`. The AI Assistant tab is the only one tall enough to trigger a vertical scrollbar, which consumes ~15px of width. Because `.settings-layout` is centered with `margin: 0 auto`, the centered layout re-centers into the narrower area whenever the scrollbar appears.
- Fix: add `scrollbar-gutter: stable` to `.settings-page` so the gutter is permanently reserved. The scrollbar only paints when needed, but the layout no longer shifts.

## Test plan
- [ ] Open Settings, switch between General / Appearance / Dashboard / AI Assistant tabs and confirm content stays at the same horizontal position
- [ ] Verify AI Assistant tab still scrolls vertically when content overflows
- [ ] Sanity-check other tabs render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)