### PR TITLE
fix(appearance): live preview for font/scheme, grey off-toggle in kuai-kuai, fix RDP/VNC legend overlap

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -243,6 +243,7 @@
   --text-faint: #6f86aa;
   --border: #8bcf4c;
   --border-strong: #5ea72c;
+  --toggle-off-bg: #9eaab7;
   --accent: #082d68;
   --accent-soft: #dde8fa;
   --green-soft: #edfbdc;
@@ -5759,6 +5760,18 @@ progress {
   padding: 0 16px;
 }
 
+fieldset.connection-session-fields {
+  padding-top: 10px;
+}
+
+fieldset.connection-session-fields > legend {
+  padding: 0 2px;
+  margin-bottom: 4px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
 .connection-session-toggle {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -5781,7 +5794,7 @@ progress {
   height: 28px;
   padding: 0;
   appearance: none;
-  background: var(--border-strong);
+  background: var(--toggle-off-bg, var(--border-strong));
   border: 0;
   border-radius: 999px;
   cursor: pointer;
@@ -7934,7 +7947,7 @@ progress {
   width: 36px;
   height: 20px;
   border-radius: 20px;
-  background: var(--border);
+  background: var(--toggle-off-bg, var(--border));
   transition: background 0.2s ease;
 }
 
@@ -8372,7 +8385,7 @@ progress {
   width: 48px;
   height: 28px;
   border-radius: 999px;
-  background: #c7c8cc;
+  background: var(--toggle-off-bg, #c7c8cc);
 }
 
 .toggle-switch-on .toggle-switch-track {

--- a/src/settings/AppearanceSettings.tsx
+++ b/src/settings/AppearanceSettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FolderOpen, Palette, RotateCcw, Save } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
@@ -177,18 +177,17 @@ export function AppearanceSettings({ onResetLayout }: { onResetLayout: () => voi
   const showStatusBarNotice = useWorkspaceStore((state) => state.showStatusBarNotice);
   const [customFonts, setCustomFonts] = useState<CustomFontOption[]>([]);
   const [draft, setDraft] = useState<AppearanceSettingsType>(appearanceSettings);
-  const hasChanges = JSON.stringify(draft) !== JSON.stringify(appearanceSettings);
+  // Tracks the last persisted settings so we can revert live preview on navigate-away
+  const savedRef = useRef<AppearanceSettingsType>(appearanceSettings);
+  const hasChanges = JSON.stringify(draft) !== JSON.stringify(savedRef.current);
 
+  // Revert live preview when navigating away without saving
   useEffect(() => {
-    setDraft(appearanceSettings);
-  }, [appearanceSettings]);
-
-  async function applyAppearance(settings: AppearanceSettingsType) {
-    setAppearanceSettings(settings);
-    if (isTauriRuntime()) {
-      invokeCommand("update_appearance_settings", { request: settings }).catch(() => undefined);
-    }
-  }
+    return () => {
+      setAppearanceSettings(savedRef.current);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   async function handleSave() {
     try {
@@ -205,6 +204,7 @@ export function AppearanceSettings({ onResetLayout }: { onResetLayout: () => voi
         : next;
       setAppearanceSettings(saved);
       setDraft(saved);
+      savedRef.current = saved;
       showStatusBarNotice(t("settings.appearanceSaved"), { tone: "success" });
     } catch (saveError) {
       showStatusBarNotice(
@@ -226,9 +226,13 @@ export function AppearanceSettings({ onResetLayout }: { onResetLayout: () => voi
       .then((fonts) => {
         if (disposed) return;
         setCustomFonts(fonts);
-        const normalized = normalizeAvailableAppearance(appearanceSettings, fonts);
-        if (JSON.stringify(normalized) !== JSON.stringify(appearanceSettings)) {
-          void applyAppearance(normalized);
+        const base = savedRef.current;
+        const normalized = normalizeAvailableAppearance(base, fonts);
+        if (JSON.stringify(normalized) !== JSON.stringify(base)) {
+          savedRef.current = normalized;
+          setDraft(normalized);
+          setAppearanceSettings(normalized);
+          invokeCommand("update_appearance_settings", { request: normalized }).catch(() => undefined);
         }
       })
       .catch(() => undefined);
@@ -236,7 +240,7 @@ export function AppearanceSettings({ onResetLayout }: { onResetLayout: () => voi
     return () => {
       disposed = true;
     };
-  }, [appearanceSettings]);
+  }, []);
 
   async function handleOpenCustomFontsFolder() {
     if (!isTauriRuntime()) {
@@ -279,7 +283,11 @@ export function AppearanceSettings({ onResetLayout }: { onResetLayout: () => voi
               <select
                 onChange={(event) => {
                   const selectedValue = event.currentTarget.value;
-                  setDraft((s) => ({ ...s, appFontFamily: selectedValue }));
+                  setDraft((s) => {
+                    const next = { ...s, appFontFamily: selectedValue };
+                    setAppearanceSettings(next);
+                    return next;
+                  });
                 }}
                 value={draft.appFontFamily}
               >
@@ -325,7 +333,11 @@ export function AppearanceSettings({ onResetLayout }: { onResetLayout: () => voi
             <select
               onChange={(event) => {
                 const colorScheme = event.currentTarget.value as ColorScheme;
-                setDraft((s) => ({ ...s, colorScheme }));
+                setDraft((s) => {
+                  const next = { ...s, colorScheme };
+                  setAppearanceSettings(next);
+                  return next;
+                });
               }}
               value={draft.colorScheme}
             >


### PR DESCRIPTION
## Summary

- **Appearance live preview**: Font family and color scheme changes in Settings > Appearance now apply immediately so users can preview the result. Navigating away without pressing Save reverts to the last saved state (via unmount cleanup using a `savedRef`). Pressing Save persists the change as before.
- **Green Kuai Kuai off-toggle color**: The off state of toggle switches was using `--border` / `--border-strong` which are both green in this theme, making it ambiguous whether the toggle was on or off. Added `--toggle-off-bg: #9eaab7` (neutral grey) to the theme. All three toggle CSS rules (`toggle-switch-track` × 2 and connection dialog checkbox) now use `var(--toggle-off-bg, <fallback>)` so other themes are unaffected.
- **RDP/VNC options fieldset legend overlap**: `fieldset.connection-session-fields` had `padding: 0 16px` with no top padding, causing the `<legend>` text ("RDP options" / "VNC options") to sit flush against the top edge of the rounded panel background. Added `padding-top: 10px` and explicit legend styling for fieldset elements specifically.

## Test plan

- [ ] Settings > Appearance: change Color Scheme — UI updates immediately; navigate to General and back, confirm scheme reverted; change again and Save — scheme persists after navigating away
- [ ] Settings > Appearance: same flow for App UI Font Family
- [ ] Green Kuai Kuai theme: open an RDP/VNC connection dialog, confirm off-state toggles appear grey not green
- [ ] Open an RDP or VNC connection dialog — confirm "RDP options" / "VNC options" legend is visually inside the panel with proper spacing, not overlapping the top edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)