### PR TITLE
fix(i18n): unwrap array-wrapped locale bundles in loadLocale

### DIFF
--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -152,7 +152,9 @@ async function loadLocale(language: SupportedLanguage): Promise<void> {
 
   try {
     const module = await localeLoaders[language]();
-    i18next.addResourceBundle(language, "translation", module.default ?? module, true, true);
+    const raw: unknown = module.default ?? module;
+    const bundle = Array.isArray(raw) ? raw[0] : raw;
+    i18next.addResourceBundle(language, "translation", bundle, true, true);
   } catch {
     // Fall back to English silently
   }


### PR DESCRIPTION
All non-English locale JSON files are serialised as a single-element
array ([{...}]) instead of a plain object. loadLocale was passing that
array directly to i18next.addResourceBundle, which expects an object,
so every language switch silently produced no translations.

Unwrap the first element when the loaded bundle is an array so the
correct translation map is registered.

https://claude.ai/code/session_012NXGNvsoPGznhL4YpQkjrj