### PR TITLE
Fix delete-connection dialog hidden by native surfaces; persist tree expanded state

### DIFF
--- a/src/connections/ConnectionSidebar.tsx
+++ b/src/connections/ConnectionSidebar.tsx
@@ -2,7 +2,7 @@ import { ConnectionGlyph, connectionSubtitle, connectionTypeSubtitle } from "./C
 import { AddConnectionMenu, QuickConnectMenu } from "./ConnectionMenus";
 import { ImportDialog } from "./ImportDialog";
 import { confirmTrustedSshHostKey, defaultPortForConnectionType, connectionTypeLabel, isRemoteDesktopConnectionType, localShellOptionsForPlatform, uniqueRuntimeId, type LocalShellOption } from "./utils";
-import { RECENT_CONNECTION_LIMIT, createStoredSecretMask, loadRecentConnectionIds, notifyConnectionTreeInvalidated, saveRecentConnectionIds } from "./connectionSidebarState";
+import { RECENT_CONNECTION_LIMIT, createStoredSecretMask, loadCollapsedFolderIds, loadRecentConnectionIds, notifyConnectionTreeInvalidated, saveCollapsedFolderIds, saveRecentConnectionIds } from "./connectionSidebarState";
 import { collectConnectionFolderIds, countConnections, countFolders, filterConnectionTree, flattenConnections, flattenFolders, upsertRootConnection, withLiveConnectionStatuses } from "./treeUtils";
 import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, ChevronDown, ChevronRight, Folder, FolderPlus, KeyRound, LayoutDashboard, PanelRight, Pin, PinOff, Play, Plus, RotateCcw, Save, Search, X } from "lucide-react";
 import { AddComputer as IconParkAddComputer, CollapseTextInput as IconParkCollapseTextInput, Delete as IconParkDelete, Edit as IconParkEdit, ExpandTextInput as IconParkExpandTextInput, FolderPlus as IconParkFolderPlus, Setting as IconParkSetting } from "@icon-park/react";
@@ -118,7 +118,7 @@ export function ConnectionSidebar({
   const [dropTarget, setDropTarget] = useState("");
   const [dragPreview, setDragPreview] = useState<TreeDragPreview | null>(null);
   const [draggedSourceId, setDraggedSourceId] = useState("");
-  const [collapsedFolderIds, setCollapsedFolderIds] = useState<Set<string>>(() => new Set());
+  const [collapsedFolderIds, setCollapsedFolderIds] = useState<Set<string>>(loadCollapsedFolderIds);
   const [pendingFolderDraft, setPendingFolderDraft] = useState<PendingFolderDraft | null>(null);
   const [treeContextMenu, setTreeContextMenu] = useState<TreeContextMenuState | null>(null);
   const [editConnection, setEditConnection] = useState<EditConnectionState | null>(null);
@@ -151,6 +151,10 @@ export function ConnectionSidebar({
       window.removeEventListener("kkterm:connection-tree-invalidated", handleTreeInvalidated);
     };
   }, []);
+
+  useEffect(() => {
+    saveCollapsedFolderIds(collapsedFolderIds);
+  }, [collapsedFolderIds]);
 
   useEffect(() => {
     if (!quickConnectMenuOpen && !addConnectionMenuOpen) {

--- a/src/connections/connectionSidebarState.ts
+++ b/src/connections/connectionSidebarState.ts
@@ -1,4 +1,5 @@
 const RECENT_CONNECTION_STORAGE_KEY = "kkterm.recentConnectionIds";
+const COLLAPSED_FOLDER_IDS_KEY = "kkterm.collapsedFolderIds";
 
 export const RECENT_CONNECTION_LIMIT = 5;
 
@@ -31,6 +32,29 @@ export function saveRecentConnectionIds(connectionIds: string[]) {
     RECENT_CONNECTION_STORAGE_KEY,
     JSON.stringify(connectionIds.slice(0, RECENT_CONNECTION_LIMIT)),
   );
+}
+
+export function loadCollapsedFolderIds(): Set<string> {
+  if (typeof localStorage === "undefined") {
+    return new Set();
+  }
+  try {
+    const stored = JSON.parse(localStorage.getItem(COLLAPSED_FOLDER_IDS_KEY) ?? "[]");
+    return new Set(
+      Array.isArray(stored)
+        ? stored.filter((id): id is string => typeof id === "string")
+        : [],
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+export function saveCollapsedFolderIds(ids: Set<string>) {
+  if (typeof localStorage === "undefined") {
+    return;
+  }
+  localStorage.setItem(COLLAPSED_FOLDER_IDS_KEY, JSON.stringify([...ids]));
 }
 
 export function notifyConnectionTreeInvalidated() {

--- a/src/workspace/nativeOverlay.ts
+++ b/src/workspace/nativeOverlay.ts
@@ -4,7 +4,7 @@ export function documentHasWebviewOverlay() {
   // these menus/overlays are open.
   return Boolean(
     document.querySelector(
-      ".quick-connect-menu, .tree-context-menu, .tree-context-submenu-menu, .add-connection-menu, .rail-context-menu, .sftp-context-menu, .sftp-properties-popover, .screenshot-menu, .screenshot-region-overlay, .transfer-conflict-backdrop, .connection-dialog-backdrop, .settings-page, .dw-catalog-backdrop, .dw-customize",
+      ".quick-connect-menu, .tree-context-menu, .tree-context-submenu-menu, .add-connection-menu, .rail-context-menu, .sftp-context-menu, .sftp-properties-popover, .screenshot-menu, .screenshot-region-overlay, .transfer-conflict-backdrop, .connection-dialog-backdrop, .confirm-delete-backdrop, .app-launcher-dialog-backdrop, .settings-page, .dw-catalog-backdrop, .dw-customize",
     ),
   );
 }


### PR DESCRIPTION
- Add .confirm-delete-backdrop and .app-launcher-dialog-backdrop to
  nativeOverlay.ts so RDP/WebView2 surfaces park when these dialogs open,
  matching the same pattern already used for .connection-dialog-backdrop
- Persist connection tree collapsed-folder state in localStorage
  (kkterm.collapsedFolderIds) so the expanded/collapsed layout survives
  app restarts; uses load/save helpers in connectionSidebarState.ts

https://claude.ai/code/session_01TZhhFWuUrfG5JWwusoM1pq