### PR TITLE
Compact connection tree rows

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1739,7 +1739,7 @@ h2 {
 
 .tree-group {
   padding-left: var(--tree-level-indent, 0);
-  margin-bottom: 12px;
+  margin-bottom: 6px;
 }
 
 .pending-folder-group {
@@ -1831,10 +1831,10 @@ h2 {
 
 .tree-folder {
   flex: 1 1 auto;
-  gap: 7px;
-  height: 28px;
-  padding: 0 7px;
-  font-size: 12px;
+  gap: 5px;
+  height: 24px;
+  padding: 0 5px;
+  font-size: 11px;
   font-weight: 800;
 }
 
@@ -1843,9 +1843,9 @@ h2 {
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
-  width: 18px;
-  height: 18px;
-  margin-left: -4px;
+  width: 16px;
+  height: 16px;
+  margin-left: -3px;
   color: var(--text-muted);
   background: transparent;
   border: 0;
@@ -1890,13 +1890,13 @@ h2 {
 }
 
 .tree-folder-connections {
-  padding-left: 22px;
+  padding-left: 16px;
 }
 
 .connection-row {
-  gap: 9px;
-  min-height: 42px;
-  padding: 6px;
+  gap: 5px;
+  min-height: 28px;
+  padding: 2px 4px;
 }
 
 .connection-row:hover {
@@ -1905,7 +1905,7 @@ h2 {
 
 .connection-open {
   flex: 1 1 auto;
-  gap: 9px;
+  gap: 6px;
   min-width: 0;
   padding: 0;
   text-align: left;
@@ -1947,6 +1947,11 @@ h2 {
 .connection-main strong {
   font-size: 13px;
   line-height: 1.3;
+}
+
+.connection-row .connection-main strong {
+  font-size: 12px;
+  line-height: 1.2;
 }
 
 .connection-main small,

--- a/src/connections/ConnectionSidebar.tsx
+++ b/src/connections/ConnectionSidebar.tsx
@@ -1072,7 +1072,7 @@ export function ConnectionSidebar({
           title={t("connections.newFolder")}
           type="button"
         >
-          <FolderPlus size={13} />
+          <FolderPlus size={12} />
         </button>
         <button
           aria-label={t("connections.collapseAll")}
@@ -1436,9 +1436,9 @@ function ConnectionFolderNode({
             title={isCollapsed ? t("connections.expandFolder") : t("connections.collapseFolder")}
             type="button"
           >
-            {isCollapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
+            {isCollapsed ? <ChevronRight size={12} /> : <ChevronDown size={12} />}
           </button>
-          <Folder size={15} />
+          <Folder size={13} />
           <span>{folder.name}</span>
           <small>{connectionCount + folderCount}</small>
         </div>
@@ -1448,7 +1448,7 @@ function ConnectionFolderNode({
             aria-label={`${t("connections.newSubfolderIn")} ${folder.name}`}
             onClick={() => void onCreateFolder(folder.id)}
           >
-            <FolderPlus size={13} />
+            <FolderPlus size={12} />
           </button>
         </span>
       </div>
@@ -1559,8 +1559,8 @@ function NewFolderDraftRow({
     <div className="tree-group pending-folder-group" ref={groupRef}>
       <div className="tree-folder-row pending-folder-row">
         <div className="tree-folder pending-folder">
-          <ChevronDown size={14} />
-          <Folder size={15} />
+          <ChevronDown size={12} />
+          <Folder size={13} />
           <input
             aria-label={t("connections.newFolderName")}
             className="pending-folder-input"
@@ -2891,10 +2891,9 @@ function ConnectionRow({
       onPointerDown={onPointerDragStart}
     >
       <button className="connection-open" onClick={onOpen}>
-        <ConnectionGlyph localShell={connection.localShell} size={32} type={connection.type} />
+        <ConnectionGlyph localShell={connection.localShell} size={18} type={connection.type} />
         <span className="connection-main">
           <strong>{connection.name}</strong>
-          <small>{connectionSubtitle(connection)}</small>
         </span>
       </button>
       <span className={`status-dot ${connection.status}`} />


### PR DESCRIPTION
### Motivation
- Make the connections tree visually denser and show only the saved connection name in each tree row (remove the username@host:port subtitle) so the sidebar is more compact and scannable.

### Description
- Tightened tree spacing and typography in `src/App.css` by reducing `.tree-group` margin, folder row height, gaps, padding, disclosure size, folder indentation, and connection row padding/gap/height.
- Reduced icon sizes used in the folder controls and pending-folder UI in `src/connections/ConnectionSidebar.tsx` (disclosure, folder and action icons).
- Updated connection row rendering in `src/connections/ConnectionSidebar.tsx` to use a smaller `ConnectionGlyph` and removed the secondary `<small>{connectionSubtitle(connection)}</small>` so only `connection.name` is shown in the tree.
- Added a targeted rule to reduce the connection-name font-size inside tree rows for tighter layout.

### Testing
- Ran `npm run check` (`tsc --noEmit`) which completed successfully. 
- Ran `npm run build` (`tsc && vite build`) which built the web assets successfully and produced `dist/` artifacts. 
- Attempted `cargo check --manifest-path src-tauri/Cargo.toml` and `cargo test --manifest-path src-tauri/Cargo.toml`, but both were blocked by a missing system dependency (`glib-2.0` not found via `pkg-config`) in the environment so the Rust checks could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04483db0088323a6a02f6e4b4706bb)