### PR TITLE
Use page favicons for URL Connection icons (best-effort, non-blocking)

### DIFF
--- a/src-tauri/src/favicon.rs
+++ b/src-tauri/src/favicon.rs
@@ -1,0 +1,191 @@
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use reqwest::{header, Client};
+use std::time::Duration;
+use url::Url;
+
+const MAX_ICON_BYTES: u64 = 256 * 1024;
+const MAX_HTML_BYTES: u64 = 512 * 1024;
+
+pub async fn fetch_favicon_data_url(page_url: &str) -> Option<String> {
+    let page_url = Url::parse(page_url).ok()?;
+    if !matches!(page_url.scheme(), "http" | "https") {
+        return None;
+    }
+    let client = Client::builder()
+        .timeout(Duration::from_secs(4))
+        .redirect(reqwest::redirect::Policy::limited(5))
+        .user_agent("KKTerm favicon fetcher")
+        .build()
+        .ok()?;
+
+    let mut candidates = favicon_candidates_from_page(&client, &page_url).await;
+    if let Ok(fallback) = page_url.join("/favicon.ico") {
+        candidates.push(fallback);
+    }
+    for url in dedupe_urls(candidates) {
+        if let Some(data_url) = fetch_icon_data_url(&client, url).await {
+            return Some(data_url);
+        }
+    }
+    None
+}
+
+async fn favicon_candidates_from_page(client: &Client, page_url: &Url) -> Vec<Url> {
+    let response = match client.get(page_url.clone()).send().await {
+        Ok(response) if response.status().is_success() => response,
+        _ => return Vec::new(),
+    };
+    let content_type = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    if !content_type.contains("text/html") && !content_type.contains("application/xhtml") {
+        return Vec::new();
+    }
+    let bytes = match response.bytes().await {
+        Ok(bytes) if bytes.len() as u64 <= MAX_HTML_BYTES => bytes,
+        _ => return Vec::new(),
+    };
+    let html = String::from_utf8_lossy(&bytes);
+    parse_icon_links(&html)
+        .into_iter()
+        .filter_map(|href| page_url.join(&href).ok())
+        .collect()
+}
+
+async fn fetch_icon_data_url(client: &Client, url: Url) -> Option<String> {
+    let response = client.get(url.clone()).send().await.ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let mime_type = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(normalize_image_mime_type)
+        .or_else(|| image_mime_type_for_path(url.path()))?;
+    let bytes = response.bytes().await.ok()?;
+    if bytes.is_empty() || bytes.len() as u64 > MAX_ICON_BYTES {
+        return None;
+    }
+    Some(format!(
+        "data:{mime_type};base64,{}",
+        STANDARD.encode(bytes)
+    ))
+}
+
+fn dedupe_urls(urls: Vec<Url>) -> Vec<Url> {
+    let mut deduped = Vec::new();
+    for url in urls {
+        if !deduped.iter().any(|existing| existing == &url) {
+            deduped.push(url);
+        }
+    }
+    deduped
+}
+
+fn parse_icon_links(html: &str) -> Vec<String> {
+    let mut links = Vec::new();
+    let lower = html.to_ascii_lowercase();
+    let mut offset = 0;
+    while let Some(start) = lower[offset..].find("<link") {
+        let tag_start = offset + start;
+        let Some(tag_end_offset) = lower[tag_start..].find('>') else {
+            break;
+        };
+        let tag_end = tag_start + tag_end_offset + 1;
+        let tag = &html[tag_start..tag_end];
+        let lower_tag = &lower[tag_start..tag_end];
+        if attribute_value(lower_tag, tag, "rel")
+            .map(|rel| rel.to_ascii_lowercase().contains("icon"))
+            .unwrap_or(false)
+        {
+            if let Some(href) = attribute_value(lower_tag, tag, "href") {
+                links.push(href);
+            }
+        }
+        offset = tag_end;
+    }
+    links
+}
+
+fn attribute_value(lower_tag: &str, original_tag: &str, name: &str) -> Option<String> {
+    let pattern = format!("{name}=");
+    let index = lower_tag.find(&pattern)? + pattern.len();
+    let bytes = original_tag.as_bytes();
+    let quote = *bytes.get(index)?;
+    if quote == b'\'' || quote == b'\"' {
+        let rest = &original_tag[index + 1..];
+        let end = rest.find(quote as char)?;
+        return Some(rest[..end].trim().to_string()).filter(|value| !value.is_empty());
+    }
+    let rest = &original_tag[index..];
+    let end = rest
+        .find(|ch: char| ch.is_ascii_whitespace() || ch == '>')
+        .unwrap_or(rest.len());
+    Some(rest[..end].trim().to_string()).filter(|value| !value.is_empty())
+}
+
+fn normalize_image_mime_type(value: &str) -> Option<&'static str> {
+    match value
+        .split(';')
+        .next()?
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "image/png" => Some("image/png"),
+        "image/jpeg" | "image/jpg" => Some("image/jpeg"),
+        "image/gif" => Some("image/gif"),
+        "image/svg+xml" => Some("image/svg+xml"),
+        "image/x-icon" | "image/vnd.microsoft.icon" => Some("image/x-icon"),
+        "image/webp" => Some("image/webp"),
+        _ => None,
+    }
+}
+
+fn image_mime_type_for_path(path: &str) -> Option<&'static str> {
+    match path.rsplit('.').next()?.to_ascii_lowercase().as_str() {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "svg" => Some("image/svg+xml"),
+        "ico" => Some("image/x-icon"),
+        "webp" => Some("image/webp"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_icon_links_reads_rel_icon_hrefs() {
+        let html = r#"<html><head>
+            <link rel="stylesheet" href="app.css">
+            <link href="/favicon.png" rel="shortcut icon">
+            <link rel='apple-touch-icon' href='/apple.png'>
+        </head></html>"#;
+
+        assert_eq!(parse_icon_links(html), vec!["/favicon.png", "/apple.png"]);
+    }
+
+    #[test]
+    fn normalizes_common_icon_mime_types() {
+        assert_eq!(
+            normalize_image_mime_type("image/vnd.microsoft.icon"),
+            Some("image/x-icon")
+        );
+        assert_eq!(
+            normalize_image_mime_type("image/png; charset=binary"),
+            Some("image/png")
+        );
+        assert_eq!(
+            image_mime_type_for_path("/favicon.ico"),
+            Some("image/x-icon")
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod dashboard_ids;
 mod dashboard_storage;
 mod dashboard_validation;
 mod diagnostics;
+mod favicon;
 mod ftp;
 mod import;
 mod logging;
@@ -312,6 +313,16 @@ fn move_connection(
     request: storage::MoveConnectionRequest,
 ) -> Result<storage::ConnectionTree, String> {
     storage.move_connection(request)
+}
+
+#[tauri::command]
+async fn update_url_connection_icon_from_page(
+    storage: tauri::State<'_, storage::Storage>,
+    connection_id: String,
+    page_url: String,
+) -> Result<Option<storage::SavedConnection>, String> {
+    let icon_data_url = favicon::fetch_favicon_data_url(&page_url).await;
+    storage.update_url_connection_icon_data_url(connection_id, icon_data_url)
 }
 
 #[tauri::command]
@@ -1749,6 +1760,7 @@ pub fn run() {
             duplicate_connection,
             move_connection_folder,
             move_connection,
+            update_url_connection_icon_from_page,
             upsert_url_credential,
             list_url_credentials,
             delete_url_credential,

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -12,7 +12,7 @@ use std::{
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use zip::{write::SimpleFileOptions, ZipArchive, ZipWriter};
 
-const SCHEMA_USER_VERSION: i32 = 11;
+const SCHEMA_USER_VERSION: i32 = 12;
 
 const CURRENT_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS connection_folders (
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS connections (
     rdp_options TEXT,
     vnc_options TEXT,
     ftp_options TEXT,
+    icon_data_url TEXT,
     connection_type TEXT NOT NULL CHECK (connection_type IN ('local', 'ssh', 'telnet', 'serial', 'url', 'rdp', 'vnc', 'ftp')),
     status TEXT NOT NULL CHECK (status IN ('connected', 'idle', 'offline')),
     sort_order INTEGER NOT NULL
@@ -512,6 +513,7 @@ pub struct SavedConnection {
     vnc_options: Option<VncConnectionOptions>,
     #[serde(default)]
     ftp_options: Option<crate::ftp::FtpOptions>,
+    icon_data_url: Option<String>,
     #[serde(rename = "type")]
     connection_type: String,
     tags: Vec<String>,
@@ -1461,6 +1463,7 @@ impl Storage {
         ensure_column(&connection, "connections", "rdp_options", "TEXT")?;
         ensure_column(&connection, "connections", "vnc_options", "TEXT")?;
         ensure_column(&connection, "connections", "ftp_options", "TEXT")?;
+        ensure_column(&connection, "connections", "icon_data_url", "TEXT")?;
         ensure_column(&connection, "url_credentials", "field_values", "TEXT")?;
         connection
             .execute_batch(&format!("PRAGMA user_version = {SCHEMA_USER_VERSION}"))
@@ -1583,6 +1586,7 @@ impl Storage {
             rdp_options,
             vnc_options,
             ftp_options,
+            icon_data_url: None,
             connection_type,
             tags,
             status: "idle".to_string(),
@@ -1723,6 +1727,39 @@ impl Storage {
 
         transaction.commit().map_err(to_storage_error)?;
         get_connection_by_id(&connection, &id)
+    }
+
+    pub fn update_url_connection_icon_data_url(
+        &self,
+        connection_id: String,
+        icon_data_url: Option<String>,
+    ) -> Result<Option<SavedConnection>, String> {
+        let connection_id = required_field("connection id", connection_id)?;
+        let icon_data_url = normalize_connection_icon_data_url(icon_data_url)?;
+        let connection = self.lock()?;
+        let existing = connection
+            .query_row(
+                "SELECT connection_type, icon_data_url FROM connections WHERE id = ?1",
+                params![&connection_id],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?)),
+            )
+            .optional()
+            .map_err(to_storage_error)?
+            .ok_or_else(|| "connection was not found".to_string())?;
+        let (connection_type, current_icon_data_url) = existing;
+        if connection_type != "url" {
+            return Err("connection icon updates only apply to URL connections".to_string());
+        }
+        if current_icon_data_url == icon_data_url {
+            return Ok(None);
+        }
+        connection
+            .execute(
+                "UPDATE connections SET icon_data_url = ?1 WHERE id = ?2",
+                params![icon_data_url, &connection_id],
+            )
+            .map_err(to_storage_error)?;
+        get_connection_by_id(&connection, &connection_id).map(Some)
     }
 
     pub fn upsert_url_credential(
@@ -1984,7 +2021,7 @@ impl Storage {
 
         let source = transaction
             .query_row(
-                "SELECT folder_id, name, host, username, port, key_path, proxy_jump, auth_method, local_shell, url, data_partition, use_tmux_sessions, serial_line, serial_speed, connection_type
+                "SELECT folder_id, name, host, username, port, key_path, proxy_jump, auth_method, local_shell, url, data_partition, use_tmux_sessions, serial_line, serial_speed, connection_type, icon_data_url
                  FROM connections
                  WHERE id = ?1",
                 params![source_id],
@@ -2005,6 +2042,7 @@ impl Storage {
                         row.get::<_, Option<String>>(12)?,
                         optional_serial_speed(row.get::<_, Option<i64>>(13)?)?,
                         row.get::<_, String>(14)?,
+                        row.get::<_, Option<String>>(15)?,
                     ))
                 },
             )
@@ -2027,6 +2065,7 @@ impl Storage {
             serial_line,
             serial_speed,
             connection_type,
+            icon_data_url,
         ) = source;
         let duplicate_name = request
             .name
@@ -2044,8 +2083,8 @@ impl Storage {
         transaction
             .execute(
                 "INSERT INTO connections (
-                    id, folder_id, name, host, username, port, key_path, proxy_jump, auth_method, local_shell, url, data_partition, use_tmux_sessions, tmux_connection_id, serial_line, serial_speed, connection_type, status, sort_order
-                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, 'idle', ?18)",
+                    id, folder_id, name, host, username, port, key_path, proxy_jump, auth_method, local_shell, url, data_partition, use_tmux_sessions, tmux_connection_id, serial_line, serial_speed, connection_type, icon_data_url, status, sort_order
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, 'idle', ?19)",
                 params![
                     duplicate_id,
                     folder_id,
@@ -2064,6 +2103,7 @@ impl Storage {
                     serial_line,
                     serial_speed,
                     connection_type,
+                    icon_data_url,
                     next_sort_order
                 ],
             )
@@ -2407,7 +2447,7 @@ fn list_connections_for_folder(
     };
     let mut statement = connection
         .prepare(&format!(
-            "SELECT connections.id, name, host, connections.username, port, key_path, proxy_jump, auth_method, local_shell, url, data_partition, use_tmux_sessions, tmux_connection_id, connection_type, serial_line, serial_speed, rdp_options, vnc_options, ftp_options,
+            "SELECT connections.id, name, host, connections.username, port, key_path, proxy_jump, auth_method, local_shell, url, data_partition, use_tmux_sessions, tmux_connection_id, connection_type, serial_line, serial_speed, rdp_options, vnc_options, ftp_options, icon_data_url,
                     url_credentials.username
              FROM connections
              LEFT JOIN url_credentials ON url_credentials.connection_id = connections.id
@@ -2669,14 +2709,14 @@ fn get_connection_by_id(
 ) -> Result<SavedConnection, String> {
     let saved_connection = connection
         .query_row(
-            "SELECT connections.id, name, host, connections.username, port, key_path, proxy_jump, auth_method, local_shell, url, data_partition, use_tmux_sessions, tmux_connection_id, connection_type, serial_line, serial_speed, rdp_options, vnc_options, ftp_options,
+            "SELECT connections.id, name, host, connections.username, port, key_path, proxy_jump, auth_method, local_shell, url, data_partition, use_tmux_sessions, tmux_connection_id, connection_type, serial_line, serial_speed, rdp_options, vnc_options, ftp_options, icon_data_url,
                     url_credentials.username
              FROM connections
              LEFT JOIN url_credentials ON url_credentials.connection_id = connections.id
              WHERE connections.id = ?1",
             params![connection_id],
             |row| {
-                let url_credential_username: Option<String> = row.get(19)?;
+                let url_credential_username: Option<String> = row.get(20)?;
                 Ok(SavedConnection {
                     id: row.get(0)?,
                     name: row.get(1)?,
@@ -2697,6 +2737,7 @@ fn get_connection_by_id(
                     rdp_options: parse_rdp_connection_options(row.get(16)?)?,
                     vnc_options: parse_vnc_connection_options(row.get(17)?)?,
                     ftp_options: parse_ftp_connection_options(row.get(18)?)?,
+                    icon_data_url: row.get(19)?,
                     url_credential_username: url_credential_username.clone(),
                     has_url_credential: url_credential_username.is_some(),
                     status: "idle".to_string(),
@@ -2715,7 +2756,7 @@ fn get_connection_by_id(
 }
 
 fn saved_connection_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SavedConnection> {
-    let url_credential_username: Option<String> = row.get(19)?;
+    let url_credential_username: Option<String> = row.get(20)?;
     Ok(SavedConnection {
         id: row.get(0)?,
         name: row.get(1)?,
@@ -2736,6 +2777,7 @@ fn saved_connection_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SavedC
         rdp_options: parse_rdp_connection_options(row.get(16)?)?,
         vnc_options: parse_vnc_connection_options(row.get(17)?)?,
         ftp_options: parse_ftp_connection_options(row.get(18)?)?,
+        icon_data_url: row.get(19)?,
         url_credential_username: url_credential_username.clone(),
         has_url_credential: url_credential_username.is_some(),
         status: "idle".to_string(),
@@ -3119,6 +3161,19 @@ where
             })
         })
         .transpose()
+}
+
+fn normalize_connection_icon_data_url(value: Option<String>) -> Result<Option<String>, String> {
+    let value = trim_optional(value);
+    if let Some(value) = value.as_deref() {
+        if value.len() > 512 * 1024 {
+            return Err("connection icon data URL is too large".to_string());
+        }
+        if !value.starts_with("data:image/") {
+            return Err("connection icon must be an image data URL".to_string());
+        }
+    }
+    Ok(value)
 }
 
 fn required_field(field: &str, value: String) -> Result<String, String> {

--- a/src/app/ActivityRail.tsx
+++ b/src/app/ActivityRail.tsx
@@ -520,6 +520,7 @@ export function ActivityRail({
               onPointerUp={item.pinned ? undefined : handleConnectedRailPointerEnd}
             >
               <ConnectionIcon
+                iconDataUrl={item.connection.iconDataUrl}
                 localShell={item.connection.localShell}
                 size={18}
                 type={item.connection.type}

--- a/src/connections/ConnectionGlyph.tsx
+++ b/src/connections/ConnectionGlyph.tsx
@@ -44,11 +44,13 @@ export function ConnectionTypeGlyph({
 
 export function ConnectionGlyph({
   className,
+  iconDataUrl,
   localShell,
   size = 16,
   type,
 }: {
   className?: string;
+  iconDataUrl?: string | null;
   localShell?: string;
   size?: number;
   type: ConnectionType;
@@ -56,6 +58,7 @@ export function ConnectionGlyph({
   return (
     <ConnectionIcon
       className={className}
+      iconDataUrl={iconDataUrl}
       localShell={localShell}
       size={size}
       type={type}

--- a/src/connections/ConnectionIcon.tsx
+++ b/src/connections/ConnectionIcon.tsx
@@ -23,19 +23,23 @@ const CONNECTION_ICON_SRC: Record<ConnectionType, string> = {
 
 export function ConnectionIcon({
   className,
+  iconDataUrl,
   localShell,
   size = 16,
   type,
 }: {
   className?: string;
+  iconDataUrl?: string | null;
   localShell?: string;
   size?: number;
   type: ConnectionType;
 }) {
   const src =
-    type === "local" && localShell === "wsl.exe"
-      ? wslIcon
-      : CONNECTION_ICON_SRC[type];
+    type === "url" && iconDataUrl
+      ? iconDataUrl
+      : type === "local" && localShell === "wsl.exe"
+        ? wslIcon
+        : CONNECTION_ICON_SRC[type];
   return (
     <img
       alt=""

--- a/src/connections/ConnectionMenus.tsx
+++ b/src/connections/ConnectionMenus.tsx
@@ -131,7 +131,7 @@ export function QuickConnectMenu({
             onClick={() => onOpenConnection(connection)}
             type="button"
           >
-            <ConnectionGlyph localShell={connection.localShell} size={15} type={connection.type} />
+            <ConnectionGlyph iconDataUrl={connection.iconDataUrl} localShell={connection.localShell} size={15} type={connection.type} />
             <span className="connection-main">
               <strong>{connection.name}</strong>
               <small>{connectionSubtitle(connection)}</small>

--- a/src/connections/ConnectionSidebar.tsx
+++ b/src/connections/ConnectionSidebar.tsx
@@ -2096,6 +2096,7 @@ function ConnectionDialog({
         {connectionType ? (
           <div className="connection-type-summary">
             <ConnectionGlyph
+              iconDataUrl={initialConnection?.iconDataUrl}
               localShell={initialConnection?.localShell}
               size={20}
               type={connectionType}
@@ -2891,7 +2892,7 @@ function ConnectionRow({
       onPointerDown={onPointerDragStart}
     >
       <button className="connection-open" onClick={onOpen}>
-        <ConnectionGlyph localShell={connection.localShell} size={18} type={connection.type} />
+        <ConnectionGlyph iconDataUrl={connection.iconDataUrl} localShell={connection.localShell} size={18} type={connection.type} />
         <span className="connection-main">
           <strong>{connection.name}</strong>
         </span>

--- a/src/connections/utils.tsx
+++ b/src/connections/utils.tsx
@@ -160,11 +160,13 @@ export function connectionIconForType(type: ConnectionType) {
 
 export function connectionTypeForTab(tab: WorkspaceTab): {
   type: ConnectionType;
+  iconDataUrl?: string | null;
   localShell?: string;
 } {
   if (tab.connection) {
     return {
       type: tab.connection.type,
+      iconDataUrl: tab.connection.iconDataUrl,
       localShell: tab.connection.localShell,
     };
   }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -697,6 +697,10 @@ type CommandMap = {
     args: { request: MoveConnectionRequest };
     result: ConnectionTree;
   };
+  update_url_connection_icon_from_page: {
+    args: { connectionId: string; pageUrl: string };
+    result: Connection | null;
+  };
   upsert_url_credential: {
     args: {
       request: {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1466,6 +1466,7 @@ function refreshTabConnectionMetadata(tab: WorkspaceTab, connection: Connection)
     }
     return {
       ...pane,
+      connection,
       title: refreshedPaneTitle(pane, connection),
       toolbarTitle,
     };
@@ -1481,6 +1482,7 @@ function refreshTabConnectionMetadata(tab: WorkspaceTab, connection: Connection)
 
   return {
     ...tab,
+    connection,
     title: refreshedTabTitle(tab, connection),
     toolbarTitle,
     subtitle: refreshedTabSubtitle(tab, connection),

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface Connection {
   tmuxConnectionId?: string;
   urlCredentialUsername?: string;
   hasUrlCredential?: boolean;
+  iconDataUrl?: string | null;
   rdpOptions?: RdpConnectionOptions;
   vncOptions?: VncConnectionOptions;
   ftpOptions?: FtpConnectionOptions;

--- a/src/webview/WebViewWorkspace.tsx
+++ b/src/webview/WebViewWorkspace.tsx
@@ -133,6 +133,7 @@ function createCredentialCaptureNonce() {
 export function WebViewWorkspace({ isActive, tab }: { isActive: boolean; tab: WorkspaceTab }) {
   const { t } = useTranslation();
   const updateWebviewTabMetadata = useWorkspaceStore((state) => state.updateWebviewTabMetadata);
+  const refreshOpenConnectionMetadata = useWorkspaceStore((state) => state.refreshOpenConnectionMetadata);
   const ignoreCertificateErrors = useWorkspaceStore((state) => state.urlSettings.ignoreCertificateErrors);
   const workspaceRef = useRef<HTMLElement | null>(null);
   const placeholderRef = useRef<HTMLDivElement | null>(null);
@@ -143,6 +144,7 @@ export function WebViewWorkspace({ isActive, tab }: { isActive: boolean; tab: Wo
   const rafRef = useRef<number | null>(null);
   const visibilityRef = useRef({ isActive, webviewSuppressed: false });
   const pendingCaptureNonceRef = useRef<string | null>(null);
+  const faviconUpdatedRef = useRef(false);
   const credentialRef = useRef({ canFillCredential: false });
   const [navError, setNavError] = useState("");
   const [fillStatus, setFillStatus] = useState("");
@@ -393,6 +395,7 @@ export function WebViewWorkspace({ isActive, tab }: { isActive: boolean; tab: Wo
         setAddressInput(event.payload.url);
         if (event.payload.status === "finished") {
           setFillStatus("");
+          void maybeUpdateConnectionIcon(event.payload.url);
           void fillCredential({ automatic: true, showStatus: false });
         }
       }),
@@ -433,7 +436,7 @@ export function WebViewWorkspace({ isActive, tab }: { isActive: boolean; tab: Wo
       disposed = true;
       disposers.forEach((dispose) => dispose());
     };
-  }, [tab.id, t, updateWebviewTabMetadata]);
+  }, [refreshOpenConnectionMetadata, tab.id, t, updateWebviewTabMetadata]);
 
   function handleNavigate(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -457,6 +460,24 @@ export function WebViewWorkspace({ isActive, tab }: { isActive: boolean; tab: Wo
     }).catch((error) => {
       setNavError(error instanceof Error ? error.message : String(error));
     });
+  }
+
+  function maybeUpdateConnectionIcon(pageUrl: string) {
+    if (!tab.connection || tab.connection.type !== "url" || faviconUpdatedRef.current) {
+      return;
+    }
+    faviconUpdatedRef.current = true;
+    void invokeCommand("update_url_connection_icon_from_page", {
+      connectionId: tab.connection.id,
+      pageUrl,
+    })
+      .then((connection) => {
+        if (connection) {
+          refreshOpenConnectionMetadata(connection);
+          window.dispatchEvent(new CustomEvent("kkterm:connection-tree-invalidated"));
+        }
+      })
+      .catch(() => undefined);
   }
 
   function handleCapturedCredential(rawPayload: string) {

--- a/src/workspace/WorkspaceCanvas.tsx
+++ b/src/workspace/WorkspaceCanvas.tsx
@@ -81,6 +81,7 @@ export function TabStrip() {
           <div className={tab.id === activeTabId ? "tab active" : "tab"} key={tab.id}>
             <button className="tab-button" onClick={() => activateTab(tab.id)} type="button">
               <ConnectionIcon
+                iconDataUrl={connectionTypeForTab(tab).iconDataUrl}
                 localShell={connectionTypeForTab(tab).localShell}
                 size={14}
                 type={connectionTypeForTab(tab).type}


### PR DESCRIPTION
### Motivation
- Improve the visual fidelity of URL Connections by showing a site's favicon when a URL loads for the first time. 
- Do this as a best-effort, non-blocking update with a clear fallback to the existing default URL icon when the page or favicon cannot be fetched.

### Description
- Persisted an `icon_data_url` field for connections (SQLite column `icon_data_url`, `Connection.iconDataUrl`/`iconDataUrl`) and added storage helpers including `normalize_connection_icon_data_url` and `update_url_connection_icon_data_url` to validate and store data-URLs. 
- Added a Rust `favicon` helper (`src-tauri/src/favicon.rs`) that fetches favicon candidates (parses `<link rel=...icon...>` and falls back to `/favicon.ico`), validates image mime/size, and returns a `data:image/...;base64,` string. 
- Exposed a new async Tauri command `update_url_connection_icon_from_page` that runs the favicon fetcher and updates the stored `icon_data_url` without blocking the UI thread. 
- Wired the front-end to call the command on the URL WebView `page-load` finished event (once per WebView mount), and refreshed open-connection metadata when an icon change was persisted, plus updated UI glyphs (`ConnectionIcon` / `ConnectionGlyph` and all call sites) to prefer `iconDataUrl` with a fallback to the default URL glyph.

### Testing
- Ran `npm run check` (TypeScript typecheck) and it succeeded. 
- Ran `npm run build` (frontend build) and it succeeded and produced the production bundle. 
- Attempted `cargo check --manifest-path src-tauri/Cargo.toml` but the run is blocked in this environment due to a missing system dependency (`glib-2.0` / pkg-config) required by `glib-sys`, so Rust compile checks could not complete here. 
- Attempted `cargo test --manifest-path src-tauri/Cargo.toml` but it is blocked for the same system dependency reason and did not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0454dc49f483239a7d8479cb0991ea)