### PR TITLE
Tray icon menu + default minimize-to-tray on

### DIFF
--- a/docs/localization_todo/app.trayDontSleep.md
+++ b/docs/localization_todo/app.trayDontSleep.md
@@ -1,0 +1,15 @@
+# app.trayDontSleep
+
+- **English value**: `Don't Sleep`
+- **Namespace**: `app`
+- **File/component**: `src/app/trayMenu.ts` (pushed to the native tray menu via the `update_tray_menu` command)
+- **UI role**: `label`
+- **User flow**: Shown as a checkable item in the OS notification-area (system tray) right-click menu. Checked when Don't Sleep mode is currently enabled; selecting it toggles the mode.
+- **Tone**: concise/neutral, matches the existing in-app Don't Sleep control
+- **Placeholders**: none
+- **Domain notes**: "Don't Sleep" is KKTerm's mode that keeps Windows awake (blocks system/display sleep) while the app runs. Should match the wording already used for the existing `app.dontSleep` key in this locale.
+
+<!--
+Filename: app.trayDontSleep.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/app.trayExit.md
+++ b/docs/localization_todo/app.trayExit.md
@@ -1,0 +1,15 @@
+# app.trayExit
+
+- **English value**: `Exit`
+- **Namespace**: `app`
+- **File/component**: `src/app/trayMenu.ts` (pushed to the native tray menu via the `update_tray_menu` command)
+- **UI role**: `label`
+- **User flow**: Bottom item of the OS notification-area (system tray) right-click menu. Selecting it quits KKTerm completely.
+- **Tone**: concise/neutral, single word
+- **Placeholders**: none
+- **Domain notes**: Standard "quit the application" action; use the conventional tray-menu exit/quit term for the target language.
+
+<!--
+Filename: app.trayExit.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/superpowers/specs/2026-05-14-tray-menu-design.md
+++ b/docs/superpowers/specs/2026-05-14-tray-menu-design.md
@@ -1,0 +1,99 @@
+# Tray Icon Menu & Minimize-to-Tray Default — Design
+
+Date: 2026-05-14
+
+## Goal
+
+1. Make minimize-to-tray ON by default for new installs.
+2. Give the tray icon a right-click menu: the 3 most recent connections, a "Don't Sleep" toggle (checked when enabled), and "Exit" (quits the app completely).
+
+## Context
+
+- Tray lives in `src-tauri/src/app_tray.rs`. It currently has **no menu** — left-click restores the window; that is all.
+- `minimizeToTray` is a persisted `GeneralSettings` field, defaulting to `false` in `src/app-defaults.ts`.
+- "Don't Sleep" already exists as a backend feature: `power::DontSleepManager` with the `get_dont_sleep_enabled` / `set_dont_sleep_enabled` commands. It is also toggled from the Status Bar (`src/workspace/StatusBar.tsx`).
+- Recent connections live in **frontend localStorage** (`kkterm.recentConnectionIds`), resolved to names against the connection tree in `ConnectionSidebar.tsx`. The Rust tray has no access to connection names or recency.
+- `store.ts openConnection()` already dedupes: if `tab-${connection.id}` exists it focuses that tab, otherwise it creates a new one.
+- Tray menus are built in Rust, which has no i18n. All translated strings are owned by the frontend.
+
+## Approach
+
+**Frontend pushes a fully-localized menu snapshot to the backend.** A typed Tauri command receives everything the tray needs to render; the backend renders exactly what it is given. This respects the i18n rule (all user-visible strings go through `t()`), keeps recency as frontend workspace state (not the durable Connection model), and follows existing typed-wrapper + event patterns.
+
+Rejected alternatives:
+- Moving recency tracking into the backend/SQLite — recency is workspace UI state, and AGENTS.md says not to push UI state into the durable model.
+- Lazy menu build on right-click — still needs the frontend push, so it collapses into the chosen approach.
+
+## Components
+
+### 1. Minimize-to-tray default
+
+Flip `minimizeToTray` to `true` in `src/app-defaults.ts`. Scope: **new installs only** — existing users keep whatever they previously saved. No migration.
+
+### 2. Tray menu (Rust, `app_tray.rs`)
+
+- `TrayState` gains a `Mutex` holding the last pushed snapshot: recent connections (`Vec<{id, label}>`), localized labels for "Don't Sleep" and "Exit", and the current Don't Sleep flag.
+- A `rebuild_menu` helper constructs the menu:
+  - Up to 3 recent connection `MenuItem`s (omitted entirely when the list is empty).
+  - Separator (only when recent items exist).
+  - A `CheckMenuItem` for "Don't Sleep", checked when enabled.
+  - Separator.
+  - "Exit".
+- Left-click still restores the window. Right-click shows this menu.
+- The menu is applied via the tray icon's `set_menu`.
+
+### 3. New Tauri command `update_tray_menu`
+
+- Typed wrapper added in `src/lib/tauri.ts`.
+- Payload: recent connections (`{id, label}` array, already sliced to 3), localized "Don't Sleep" and "Exit" strings, current Don't Sleep enabled flag.
+- Backend stores the snapshot in `TrayState` and calls `rebuild_menu`.
+- Called by the frontend on: app startup, language change, and whenever the recent-connection list changes.
+
+### 4. Menu actions (Rust → frontend via Tauri events)
+
+- **Recent connection item** → backend emits `kkterm://tray-open-connection` with the connection id. An app-shell effect in `src/app/` listens, resolves the id against the connection tree, calls `openConnection` (which focuses an existing tab or opens a new one), and restores the window.
+- **"Don't Sleep"** → backend calls the existing `DontSleepManager`, rebuilds the menu with the new check state, and emits `kkterm://dont-sleep-changed`. `StatusBar.tsx`'s Don't Sleep button listens and updates its local state. The status-bar button's own toggle also emits `kkterm://dont-sleep-changed` so the tray menu stays in sync (the frontend re-pushes the snapshot via `update_tray_menu`).
+- **"Exit"** → `app.exit(0)`. Quits immediately, no confirmation — consistent with KKTerm keeping the close path native and unhooked.
+
+### 5. i18n
+
+New keys under the `app` namespace in `src/i18n/locales/en.json`:
+- `app.trayDontSleep` — "Don't Sleep"
+- `app.trayExit` — "Exit"
+
+Add matching `docs/localization_todo/app.trayDontSleep.md` and `docs/localization_todo/app.trayExit.md` stubs from `_TEMPLATE.md`. Recent-connection labels are connection names and are not translated.
+
+## Data flow
+
+```
+recent list / language change (frontend)
+   -> update_tray_menu command (typed wrapper)
+   -> TrayState snapshot updated -> rebuild_menu -> set_menu
+
+right-click tray -> menu
+   recent item -> emit kkterm://tray-open-connection {id}
+                  -> app-shell listener -> openConnection + restore window
+   Don't Sleep  -> DontSleepManager toggle -> rebuild_menu
+                  -> emit kkterm://dont-sleep-changed -> StatusBar syncs
+   Exit         -> app.exit(0)
+
+StatusBar Don't Sleep button toggle
+   -> set_dont_sleep_enabled + emit kkterm://dont-sleep-changed
+   -> frontend re-pushes update_tray_menu so tray check stays in sync
+```
+
+## Error handling
+
+- `update_tray_menu` is best-effort: a failure to rebuild the menu logs to stderr (matching the existing `app_tray::install` error path) and does not surface to the user.
+- The tray-open-connection listener silently no-ops if the id no longer resolves to a connection (it may have been deleted).
+- Non-Windows: Don't Sleep already errors gracefully via `DontSleepManager`; the tray menu still renders and the toggle surfaces the existing error path.
+
+## Testing
+
+- `cargo test` for any pure Rust helpers (e.g. snapshot construction).
+- Manual smoke test in the real Tauri runtime (`npm run tauri dev`), per AGENTS.md native-verification rule:
+  - Right-click tray shows recent connections, Don't Sleep (with correct check state), Exit.
+  - Clicking a recent connection restores the window and opens/focuses the session.
+  - Toggling Don't Sleep from the tray updates the Status Bar button, and vice versa.
+  - Exit quits the app completely.
+  - Fresh install defaults minimize-to-tray ON; existing settings unchanged.

--- a/src-tauri/src/app_tray.rs
+++ b/src-tauri/src/app_tray.rs
@@ -1,15 +1,41 @@
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+
+use serde::Deserialize;
+use tauri::menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem};
 use tauri::tray::{MouseButton, TrayIconBuilder, TrayIconEvent};
-use tauri::Manager;
+use tauri::{Emitter, Manager};
+
+const TRAY_ID: &str = "kkterm-main";
+const DONT_SLEEP_ITEM_ID: &str = "kkterm-tray-dont-sleep";
+const EXIT_ITEM_ID: &str = "kkterm-tray-exit";
+const RECENT_ITEM_PREFIX: &str = "kkterm-tray-recent:";
+
+#[derive(Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrayRecentConnection {
+    pub id: String,
+    pub label: String,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrayMenuSnapshot {
+    pub recent_connections: Vec<TrayRecentConnection>,
+    pub dont_sleep_label: String,
+    pub exit_label: String,
+}
 
 pub struct TrayState {
     minimize_to_tray: AtomicBool,
+    snapshot: Mutex<Option<TrayMenuSnapshot>>,
 }
 
 impl TrayState {
     pub fn new(minimize_to_tray: bool) -> Self {
         Self {
             minimize_to_tray: AtomicBool::new(minimize_to_tray),
+            snapshot: Mutex::new(None),
         }
     }
 
@@ -20,10 +46,16 @@ impl TrayState {
     pub fn set_minimize_to_tray(&self, enabled: bool) {
         self.minimize_to_tray.store(enabled, Ordering::Relaxed);
     }
+
+    pub fn set_snapshot(&self, snapshot: TrayMenuSnapshot) {
+        if let Ok(mut guard) = self.snapshot.lock() {
+            *guard = Some(snapshot);
+        }
+    }
 }
 
 pub fn install(app: &tauri::App, tooltip: &str) -> Result<(), String> {
-    let mut builder = TrayIconBuilder::with_id("kkterm-main").tooltip(tooltip);
+    let mut builder = TrayIconBuilder::with_id(TRAY_ID).tooltip(tooltip);
     if let Some(icon) = app.default_window_icon().cloned() {
         builder = builder.icon(icon);
     }
@@ -41,10 +73,122 @@ pub fn install(app: &tauri::App, tooltip: &str) -> Result<(), String> {
             } => restore_main_window(tray.app_handle()),
             _ => {}
         })
+        .on_menu_event(|app, event| handle_menu_event(app, event.id().as_ref()))
         .build(app)
         .map_err(|error| format!("failed to install tray icon: {error}"))?;
 
     Ok(())
+}
+
+/// Rebuilds the tray menu from the snapshot the frontend last pushed. Does nothing until the
+/// frontend has pushed a snapshot, since the menu labels are localized on the frontend. The
+/// Don't Sleep check state is read live from [`crate::power::DontSleepManager`], which owns it.
+pub fn rebuild_menu<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    tray_state: &TrayState,
+) -> Result<(), String> {
+    let guard = tray_state
+        .snapshot
+        .lock()
+        .map_err(|_| "tray menu snapshot is unavailable".to_string())?;
+    let Some(snapshot) = guard.as_ref() else {
+        return Ok(());
+    };
+    let dont_sleep_enabled = app
+        .try_state::<crate::power::DontSleepManager>()
+        .map(|power| power.is_enabled())
+        .unwrap_or(false);
+    let menu = build_menu(app, snapshot, dont_sleep_enabled)?;
+    let Some(tray) = app.tray_by_id(TRAY_ID) else {
+        return Err("tray icon is not installed".to_string());
+    };
+    tray.set_menu(Some(menu))
+        .map_err(|error| format!("failed to update tray menu: {error}"))
+}
+
+fn build_menu<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    snapshot: &TrayMenuSnapshot,
+    dont_sleep_enabled: bool,
+) -> Result<Menu<R>, String> {
+    let menu = Menu::new(app).map_err(|error| error.to_string())?;
+
+    for connection in &snapshot.recent_connections {
+        let item = MenuItem::with_id(
+            app,
+            format!("{RECENT_ITEM_PREFIX}{}", connection.id),
+            &connection.label,
+            true,
+            None::<&str>,
+        )
+        .map_err(|error| error.to_string())?;
+        menu.append(&item).map_err(|error| error.to_string())?;
+    }
+
+    if !snapshot.recent_connections.is_empty() {
+        menu.append(&PredefinedMenuItem::separator(app).map_err(|error| error.to_string())?)
+            .map_err(|error| error.to_string())?;
+    }
+
+    let dont_sleep = CheckMenuItem::with_id(
+        app,
+        DONT_SLEEP_ITEM_ID,
+        &snapshot.dont_sleep_label,
+        true,
+        dont_sleep_enabled,
+        None::<&str>,
+    )
+    .map_err(|error| error.to_string())?;
+    menu.append(&dont_sleep)
+        .map_err(|error| error.to_string())?;
+
+    menu.append(&PredefinedMenuItem::separator(app).map_err(|error| error.to_string())?)
+        .map_err(|error| error.to_string())?;
+
+    let exit = MenuItem::with_id(app, EXIT_ITEM_ID, &snapshot.exit_label, true, None::<&str>)
+        .map_err(|error| error.to_string())?;
+    menu.append(&exit).map_err(|error| error.to_string())?;
+
+    Ok(menu)
+}
+
+fn handle_menu_event<R: tauri::Runtime>(app: &tauri::AppHandle<R>, id: &str) {
+    if id == EXIT_ITEM_ID {
+        app.exit(0);
+        return;
+    }
+
+    if id == DONT_SLEEP_ITEM_ID {
+        toggle_dont_sleep(app);
+        return;
+    }
+
+    if let Some(connection_id) = id.strip_prefix(RECENT_ITEM_PREFIX) {
+        restore_main_window(app);
+        let _ = app.emit("kkterm://tray-open-connection", connection_id.to_string());
+    }
+}
+
+fn toggle_dont_sleep<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    let Some(power) = app.try_state::<crate::power::DontSleepManager>() else {
+        return;
+    };
+    let currently_enabled = power.is_enabled();
+
+    match power.set_enabled(!currently_enabled) {
+        Ok(enabled) => {
+            if let Some(tray_state) = app.try_state::<TrayState>() {
+                if let Err(error) = rebuild_menu(app, &tray_state) {
+                    eprintln!("failed to refresh tray menu after Don't Sleep toggle: {error}");
+                }
+            }
+            let _ = app.emit("kkterm://dont-sleep-changed", enabled);
+        }
+        Err(error) => {
+            eprintln!("failed to toggle Don't Sleep from tray: {error}");
+            let _ = app.emit("kkterm://dont-sleep-changed", currently_enabled);
+        }
+    }
 }
 
 pub fn restore_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -722,10 +722,26 @@ fn get_dont_sleep_enabled(power: tauri::State<'_, power::DontSleepManager>) -> b
 
 #[tauri::command]
 fn set_dont_sleep_enabled(
+    app: tauri::AppHandle,
     power: tauri::State<'_, power::DontSleepManager>,
+    tray_state: tauri::State<'_, app_tray::TrayState>,
     enabled: bool,
 ) -> Result<bool, String> {
-    power.set_enabled(enabled)
+    let saved = power.set_enabled(enabled)?;
+    if let Err(error) = app_tray::rebuild_menu(&app, &tray_state) {
+        eprintln!("failed to refresh tray menu after Don't Sleep change: {error}");
+    }
+    Ok(saved)
+}
+
+#[tauri::command]
+fn update_tray_menu(
+    app: tauri::AppHandle,
+    tray_state: tauri::State<'_, app_tray::TrayState>,
+    snapshot: app_tray::TrayMenuSnapshot,
+) -> Result<(), String> {
+    tray_state.set_snapshot(snapshot);
+    app_tray::rebuild_menu(&app, &tray_state)
 }
 
 #[tauri::command]
@@ -1935,6 +1951,7 @@ pub fn run() {
             create_diagnostics_bundle,
             get_dont_sleep_enabled,
             set_dont_sleep_enabled,
+            update_tray_menu,
             capture_screenshot_to_clipboard,
             capture_screenshot_for_assistant,
             capture_fullscreen_screenshot_for_assistant,

--- a/src/app-defaults.ts
+++ b/src/app-defaults.ts
@@ -26,7 +26,7 @@ export const defaultGeneralSettings: GeneralSettings = {
   showConnectedConnectionsInRail: true,
   pinnedConnectionIds: [],
   allowClipboardRead: true,
-  minimizeToTray: false,
+  minimizeToTray: true,
   lastBackupAt: null,
 };
 

--- a/src/app/trayMenu.ts
+++ b/src/app/trayMenu.ts
@@ -1,0 +1,32 @@
+import { invokeCommand, isTauriRuntime } from "../lib/tauri";
+import type { Connection } from "../types";
+
+const TRAY_RECENT_LIMIT = 3;
+
+/**
+ * Pushes the localized tray-menu snapshot to the backend. The Rust tray has no i18n, so the
+ * frontend owns every translated label. Best-effort: failures are swallowed so a missing tray
+ * never blocks the app.
+ */
+export async function pushTrayMenu(
+  recentConnections: Connection[],
+  labels: { dontSleep: string; exit: string },
+) {
+  if (!isTauriRuntime()) {
+    return;
+  }
+
+  try {
+    await invokeCommand("update_tray_menu", {
+      snapshot: {
+        recentConnections: recentConnections
+          .slice(0, TRAY_RECENT_LIMIT)
+          .map((connection) => ({ id: connection.id, label: connection.name })),
+        dontSleepLabel: labels.dontSleep,
+        exitLabel: labels.exit,
+      },
+    });
+  } catch {
+    // Tray menu is a convenience surface; ignore push failures.
+  }
+}

--- a/src/connections/ConnectionSidebar.tsx
+++ b/src/connections/ConnectionSidebar.tsx
@@ -12,6 +12,7 @@ import { RECENT_CONNECTION_LIMIT, createStoredSecretMask, loadCollapsedFolderIds
 import { collectConnectionFolderIds, countConnections, countFolders, filterConnectionTree, flattenConnections, flattenFolders, upsertRootConnection, withLiveConnectionStatuses } from "./treeUtils";
 import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, ChevronDown, ChevronRight, Folder, FolderPlus, KeyRound, LayoutDashboard, PanelRight, Pin, PinOff, Play, Plus, RotateCcw, Save, Search, X } from "lucide-react";
 import { AddComputer as IconParkAddComputer, CollapseTextInput as IconParkCollapseTextInput, Delete as IconParkDelete, Edit as IconParkEdit, ExpandTextInput as IconParkExpandTextInput, FolderPlus as IconParkFolderPlus, Setting as IconParkSetting } from "@icon-park/react";
+import { listen } from "@tauri-apps/api/event";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { FormEvent, MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from "react";
 import type { TFunction } from "i18next";
@@ -22,6 +23,7 @@ import { nativeMenuIcons } from "../lib/nativeMenuIcons";
 import { showNativeContextMenu, type NativeContextMenuItem } from "../lib/nativeContextMenu";
 import { confirmNativeDialog, invokeCommand, isTauriRuntime, selectAppLauncherFolder, selectKeyFile } from "../lib/tauri";
 import { connectionTree } from "../app-defaults";
+import { pushTrayMenu } from "../app/trayMenu";
 import { useWorkspaceStore } from "../store";
 import type { Connection, ConnectionFolder, ConnectionStatus, ConnectionTree, ConnectionType, CreateConnectionRequest, RdpSettings, SplitDirection, SshSettings, UpdateConnectionRequest, VncSettings } from "../types";
 
@@ -772,6 +774,31 @@ export function ConnectionSidebar({
       .filter((connection): connection is Connection => Boolean(connection))
       .slice(0, RECENT_CONNECTION_LIMIT);
   }, [recentConnectionIds, treeWithLiveStatuses]);
+
+  useEffect(() => {
+    void pushTrayMenu(recentConnections, {
+      dontSleep: t("app.trayDontSleep"),
+      exit: t("app.trayExit"),
+    });
+  }, [recentConnections, t]);
+
+  useEffect(() => {
+    if (!isTauriRuntime()) {
+      return;
+    }
+    const unlistenPromise = listen<string>("kkterm://tray-open-connection", (event) => {
+      const connection = flattenConnections(treeWithLiveStatuses).find(
+        (candidate) => candidate.id === event.payload,
+      );
+      if (connection) {
+        handleOpenConnection(connection);
+      }
+    });
+    return () => {
+      void unlistenPromise.then((unlisten) => unlisten());
+    };
+  }, [treeWithLiveStatuses]);
+
   const isTreeFiltered = query.trim().length > 0;
 
   function menuPositionFromElement(element: HTMLElement) {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -16,7 +16,9 @@
     "connectionRail": "Connection Rail",
     "connectedConnectionsRail": "Connected Connections",
     "openConnectedConnection": "Open {{name}}",
-    "openPinnedConnection": "Open pinned Connection {{name}}"
+    "openPinnedConnection": "Open pinned Connection {{name}}",
+    "trayDontSleep": "Don't Sleep",
+    "trayExit": "Exit"
   },
   "dashboard": {
     "title": "Dashboard",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -381,6 +381,17 @@ export interface TransferSshPublicKeyResult {
   publicKeyPath: string;
 }
 
+export interface TrayRecentConnection {
+  id: string;
+  label: string;
+}
+
+export interface TrayMenuSnapshot {
+  recentConnections: TrayRecentConnection[];
+  dontSleepLabel: string;
+  exitLabel: string;
+}
+
 export interface CommandProposalPlan {
   prompt: string;
   command: string;
@@ -929,6 +940,10 @@ type CommandMap = {
   set_dont_sleep_enabled: {
     args: { enabled: boolean };
     result: boolean;
+  };
+  update_tray_menu: {
+    args: { snapshot: TrayMenuSnapshot };
+    result: null;
   };
   capture_screenshot_to_clipboard: {
     args: { request: CaptureScreenshotRequest };

--- a/src/workspace/StatusBar.tsx
+++ b/src/workspace/StatusBar.tsx
@@ -1,3 +1,4 @@
+import { listen } from "@tauri-apps/api/event";
 import { ArrowDownToLine, ArrowUpFromLine, BedSingle, Coffee, Cpu, MemoryStick } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
@@ -92,6 +93,18 @@ function DontSleepStatusButton() {
 
     return () => {
       disposed = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isTauriRuntime()) {
+      return;
+    }
+    const unlistenPromise = listen<boolean>("kkterm://dont-sleep-changed", (event) => {
+      setEnabled(event.payload);
+    });
+    return () => {
+      void unlistenPromise.then((unlisten) => unlisten());
     };
   }, []);
 


### PR DESCRIPTION
## Summary

- Default `minimizeToTray` to **on** for new installs (existing saved settings untouched).
- Add a right-click menu to the tray icon: up to 3 most recent connections → a checkable **Don't Sleep** toggle → **Exit** (quits completely). Left-click still restores the window.

## What changed

- **`app_tray.rs`** — dynamic tray menu built from a frontend-pushed snapshot. Menu actions: recent item emits `kkterm://tray-open-connection`, "Don't Sleep" toggles `DontSleepManager` + emits `kkterm://dont-sleep-changed`, "Exit" calls `app.exit(0)`.
- **`lib.rs`** — new `update_tray_menu` command stores the snapshot and rebuilds the menu; `set_dont_sleep_enabled` now also rebuilds the tray so the status-bar toggle keeps the checkmark in sync.
- **`src/app/trayMenu.ts`** (new) — pushes the localized snapshot via the typed command.
- **`ConnectionSidebar.tsx`** — pushes the snapshot on recency/language change; listens for tray-open events and opens/focuses the connection.
- **`StatusBar.tsx`** — listens for `kkterm://dont-sleep-changed` so the Don't Sleep button reflects tray toggles.
- i18n: `app.trayDontSleep` / `app.trayExit` added to `en.json` with `docs/localization_todo/` stubs.

## Design notes for reviewers

- The Rust tray has no i18n layer, so the frontend owns all translated labels and pushes them in. The `t` function identity changes on language switch, so the push effect re-fires on both recency and language changes.
- The Don't Sleep check state is **not** carried in the snapshot — `rebuild_menu` reads it live from `DontSleepManager`, the single source of truth. Both toggle paths just call `rebuild_menu`, so the checkmark can't drift.
- Design doc: `docs/superpowers/specs/2026-05-14-tray-menu-design.md`.

## Test plan

- [x] `npm run check`
- [x] `npm run build`
- [x] `cargo check` / `cargo test` (206 passed)
- [ ] Manual smoke test in the real Tauri runtime (required per AGENTS.md for tray/OS integration): right-click menu contents, recent-connection open/focus, two-way Don't Sleep sync, Exit, fresh-install default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)