### PR TITLE
Refine widget header, App Launcher, and Customize popover labels

### DIFF
--- a/docs/localization_todo/dashboard.titleLabel.md
+++ b/docs/localization_todo/dashboard.titleLabel.md
@@ -1,0 +1,10 @@
+# dashboard.titleLabel
+
+- **English value**: `Title`
+- **Namespace**: `dashboard`
+- **File/component**: `src/dashboard/edit/CustomizePopover.tsx`
+- **UI role**: `heading`
+- **User flow**: Section heading in the widget Customize popover, above the input where the user types a custom title for a dashboard widget instance.
+- **Tone**: concise/neutral, single-word section label
+- **Placeholders**: none
+- **Domain notes**: Refers to the widget's display title (the `customTitle` field), not the "Dashboard" module itself. Distinct from `dashboard.title` ("Dashboard"), which names the module.

--- a/src/App.css
+++ b/src/App.css
@@ -1017,18 +1017,8 @@ button {
   display: flex;
   gap: 10px;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   min-width: 0;
-}
-
-.app-launcher-widget-toolbar > span {
-  min-width: 0;
-  overflow: hidden;
-  color: var(--text-muted);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 12px;
-  font-weight: 800;
 }
 
 .app-launcher-add {

--- a/src/app-launcher/AppLauncherWidget.tsx
+++ b/src/app-launcher/AppLauncherWidget.tsx
@@ -382,7 +382,6 @@ export function AppLauncherWidget() {
   return (
     <div className="dashboard-widget-body app-launcher-widget">
       <div className="app-launcher-widget-toolbar">
-        <span>{t("appLauncher.entriesLabel")}</span>
         <button
           className="secondary-button app-launcher-add"
           onClick={(event) => openAddMenuFromElement(event.currentTarget)}

--- a/src/dashboard/dashboard.css
+++ b/src/dashboard/dashboard.css
@@ -411,6 +411,7 @@ main.dashboard-page {
 
 .dw-title-group {
   display: grid;
+  position: relative;
   flex: 1 1 auto;
   min-width: 0;
   gap: 2px;
@@ -429,13 +430,21 @@ main.dashboard-page {
   letter-spacing: 0;
 }
 
-.dw-subtitle {
-  overflow: hidden;
-  color: var(--text-faint);
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.dw-subtitle-tip {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 20;
+  margin-top: 4px;
+  max-width: 240px;
+  padding: 6px 8px;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 0.18);
   font-size: 11px;
-  line-height: 1.25;
+  line-height: 1.3;
 }
 
 .dw-icon {
@@ -1325,16 +1334,8 @@ main.dashboard-page {
 .app-launcher-widget-toolbar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 10px;
-}
-
-.app-launcher-widget-toolbar > span {
-  color: var(--text-muted);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
 }
 
 .app-launcher-tile-grid {

--- a/src/dashboard/edit/CustomizePopover.tsx
+++ b/src/dashboard/edit/CustomizePopover.tsx
@@ -138,7 +138,7 @@ export function CustomizePopover({ instance, anchorRect, onClose }: CustomizePop
       </section>
 
       <section>
-        <h4>{t("dashboard.title")}</h4>
+        <h4>{t("dashboard.titleLabel")}</h4>
         <input
           defaultValue={instance.customTitle ?? ""}
           placeholder={t("dashboard.titlePlaceholder")}

--- a/src/dashboard/registry/presetRegistry.tsx
+++ b/src/dashboard/registry/presetRegistry.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import type { ReactElement, ReactNode } from "react";
 import type { WidgetPreset } from "../types";
 
@@ -12,15 +13,50 @@ export interface PresetChromeProps {
   actionDirection?: "vertical" | "horizontal";
 }
 
+function PanelTitle({ title, summary }: { title: string; summary?: string }) {
+  const [showTip, setShowTip] = useState(false);
+  const timer = useRef<number | null>(null);
+
+  function clearTimer() {
+    if (timer.current !== null) {
+      window.clearTimeout(timer.current);
+      timer.current = null;
+    }
+  }
+
+  useEffect(() => clearTimer, []);
+
+  function handleEnter() {
+    if (!summary) return;
+    clearTimer();
+    timer.current = window.setTimeout(() => setShowTip(true), 3000);
+  }
+
+  function handleLeave() {
+    clearTimer();
+    setShowTip(false);
+  }
+
+  return (
+    <div
+      className="dw-title-group"
+      onMouseEnter={handleEnter}
+      onMouseLeave={handleLeave}
+    >
+      <h3 className="dw-title">{title}</h3>
+      {showTip && summary ? (
+        <span className="dw-subtitle-tip" role="tooltip">{summary}</span>
+      ) : null}
+    </div>
+  );
+}
+
 function PanelChrome({ title, summary, icon, body, controls, editMode }: PresetChromeProps) {
   return (
     <div className="dw-preset dw-preset-panel">
       <div className={`dw-head${editMode ? " drag-handle" : ""}`}>
         <span className="dw-icon">{icon}</span>
-        <div className="dw-title-group">
-          <h3 className="dw-title">{title}</h3>
-          {summary ? <span className="dw-subtitle">{summary}</span> : null}
-        </div>
+        <PanelTitle title={title} summary={summary} />
         {controls}
       </div>
       <div className="dw-body">{body}</div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -63,6 +63,7 @@
     },
     "accent": "Accent",
     "icon": "Icon",
+    "titleLabel": "Title",
     "titlePlaceholder": "Custom title…",
     "advanced": "Advanced",
     "advancedNothing": "No advanced settings for built-in widgets.",


### PR DESCRIPTION
## Summary
- **Panel preset**: the subtitle is no longer shown inline. Hovering the widget title for 3 seconds surfaces the subtitle as a small popup (`role="tooltip"`). Implemented via a new `PanelTitle` component with an arm/clear `setTimeout` ref.
- **App Launcher**: removed the "Pinned applications" heading from the widget toolbar. Toolbar switched from `space-between` to `flex-end` so the "Add" button stays right-aligned, and the now-dead `> span` CSS rules were deleted.
- **Customize popover**: the widget-title section heading now reads "Title" instead of "Dashboard". `dashboard.title` is shared by the breadcrumb/ActivityRail, so a new `dashboard.titleLabel` key was added rather than repurposing it.

## Notes for reviewers
- Native `title` tooltips can't do a custom 3s delay, hence the small React timer component.
- New English-only i18n key `dashboard.titleLabel` ships with a `docs/localization_todo/dashboard.titleLabel.md` tracking file per the repo's i18n rules. The `appLauncher.entriesLabel` key is retained — still used as the tile grid `aria-label`.
- `tsc --noEmit` passes. Visual behaviors (popup timing, right-aligned Add button) were verified by code/typecheck only, not in a running browser.

## Test plan
- [ ] Hover a Panel-preset widget title for 3s — subtitle popup appears; leaving hides it
- [ ] App Launcher widget shows no "Pinned applications" heading; Add button right-aligned
- [ ] Widget Customize popover shows "TITLE" section label above the custom-title input

🤖 Generated with [Claude Code](https://claude.com/claude-code)