### PR TITLE
Dashboard: redesign widget Customize popover (left-nav, no-clip, toggles)

### DIFF
--- a/docs/localization_todo/dashboard.customize.sectionCommon.md
+++ b/docs/localization_todo/dashboard.customize.sectionCommon.md
@@ -1,0 +1,10 @@
+# dashboard.customize.sectionCommon
+
+- **English value**: `Common`
+- **Namespace**: `dashboard`
+- **File/component**: `src/dashboard/edit/CustomizePopover.tsx`
+- **UI role**: `label`
+- **User flow**: Left-nav label in the widget Customize popover. Selects the section containing TITLE, STYLE PRESET, ACCENT, ICON, and preset-conditional layout options.
+- **Tone**: concise/neutral, one word
+- **Placeholders**: none
+- **Domain notes**: "Common" here means "settings shared by every widget" — translate as the generic-settings tab name, not "ordinary".

--- a/docs/localization_todo/dashboard.customize.sectionWidget.md
+++ b/docs/localization_todo/dashboard.customize.sectionWidget.md
@@ -1,0 +1,10 @@
+# dashboard.customize.sectionWidget
+
+- **English value**: `Widget`
+- **Namespace**: `dashboard`
+- **File/component**: `src/dashboard/edit/CustomizePopover.tsx`
+- **UI role**: `label`
+- **User flow**: Left-nav label in the widget Customize popover. Selects the section containing widget-author-defined settings (text, number, toggle, select, secret fields) for custom widgets.
+- **Tone**: concise/neutral, one word
+- **Placeholders**: none
+- **Domain notes**: "Widget" is the KKTerm dashboard widget concept (a tile on the Dashboard). Keep "widget" terminology consistent with `dashboard.untitledWidget`, `dashboard.removeWidget`, etc.

--- a/src/dashboard/dashboard.css
+++ b/src/dashboard/dashboard.css
@@ -966,8 +966,8 @@ main.dashboard-page {
 .dw-customize {
   position: fixed;
   z-index: 160;
-  width: 280px;
-  padding: 14px;
+  display: grid;
+  grid-template-columns: 124px 1fr;
   color: var(--text);
   background: var(--surface);
   border: 1px solid var(--border);
@@ -976,19 +976,71 @@ main.dashboard-page {
     0 16px 48px -12px rgb(0 0 0 / 28%),
     inset 0 0 0 1px rgb(255 255 255 / 5%);
   font-size: 12.5px;
+  overflow: hidden;
 }
 
-.dw-customize section + section {
+.dw-customize-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 6px;
+  background: var(--surface-muted);
+  border-right: 1px solid var(--border);
+}
+
+.dw-customize-nav-item {
+  display: block;
+  padding: 7px 10px;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-align: left;
+  text-transform: uppercase;
+}
+
+.dw-customize-nav-item:hover {
+  color: var(--text);
+}
+
+.dw-customize-nav-item.active {
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+
+.dw-customize-pane {
+  max-height: min(560px, 80vh);
+  padding: 14px;
+  overflow-y: auto;
+}
+
+.dw-customize-pane section + section {
   margin-top: 12px;
 }
 
-.dw-customize h4 {
+.dw-customize-pane h4 {
   margin: 0 0 10px;
   color: var(--text-muted);
   font-size: 12px;
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
+}
+
+.dw-field-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.dw-field-row > span {
+  flex: 1 1 auto;
 }
 
 .dw-preset-picker,
@@ -1048,22 +1100,6 @@ main.dashboard-page {
 .dw-accent-picker button.active {
   border-color: var(--text);
   box-shadow: inset 0 0 0 2px var(--surface);
-}
-
-.dw-advanced-toggle {
-  padding: 0;
-  color: var(--text-muted);
-  background: transparent;
-  border: 0;
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 650;
-}
-
-.dw-advanced {
-  display: grid;
-  gap: 8px;
-  margin-top: 8px;
 }
 
 .dw-source-view {

--- a/src/dashboard/dashboard.css
+++ b/src/dashboard/dashboard.css
@@ -573,8 +573,8 @@ main.dashboard-page {
 
 .dw-controls {
   position: absolute;
-  top: 6px;
-  right: 6px;
+  top: 10px;
+  right: 10px;
   z-index: 2;
   display: inline-flex;
   gap: 2px;

--- a/src/dashboard/dashboard.css
+++ b/src/dashboard/dashboard.css
@@ -485,14 +485,6 @@ main.dashboard-page {
   border-bottom-color: color-mix(in srgb, var(--w-accent) 60%, transparent);
 }
 
-.dw-title-group {
-  display: grid;
-  position: relative;
-  flex: 1 1 auto;
-  min-width: 0;
-  gap: 2px;
-}
-
 .dw-title,
 .dw-action-title,
 .dw-hero-title {
@@ -509,23 +501,6 @@ main.dashboard-page {
 .dw-preset-panel .dw-title {
   color: var(--w-title-text);
   text-shadow: 0 1px 1px rgb(0 0 0 / 22%);
-}
-
-.dw-subtitle-tip {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  z-index: 20;
-  margin-top: 4px;
-  max-width: 240px;
-  padding: 6px 8px;
-  color: var(--text);
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  box-shadow: 0 4px 12px rgb(0 0 0 / 0.18);
-  font-size: 11px;
-  line-height: 1.3;
 }
 
 .dw-icon {

--- a/src/dashboard/edit/CustomizePopover.tsx
+++ b/src/dashboard/edit/CustomizePopover.tsx
@@ -46,9 +46,7 @@ export function CustomizePopover({ instance, anchorRect, onClose }: CustomizePop
     () => (customSource ? parseSettingsSchema(customSource.settingsSchemaJson) : null),
     [customSource],
   );
-  const hasWidgetSettings = Boolean(
-    customSource && settingsSchema && settingsSchema.fields.length > 0,
-  );
+  const hasWidgetSettings = Boolean(customSource);
   const hasAdvanced = instance.kind !== "builtIn";
 
   const sections = useMemo(() => {
@@ -125,7 +123,7 @@ export function CustomizePopover({ instance, anchorRect, onClose }: CustomizePop
       </nav>
       <div className="dw-customize-pane">
         {section === "common" ? <CommonSection instance={instance} /> : null}
-        {section === "widget" && settingsSchema ? (
+        {section === "widget" ? (
           <WidgetSection schema={settingsSchema} instance={instance} />
         ) : null}
         {section === "advanced" ? <AdvancedSection instance={instance} /> : null}
@@ -243,28 +241,41 @@ function WidgetSection({
   schema,
   instance,
 }: {
-  schema: WidgetSettingsSchema;
+  schema: WidgetSettingsSchema | null;
   instance: DashboardWidgetInstance;
 }) {
   const { t } = useTranslation();
   const updateInstance = useDashboardStore((s) => s.updateInstance);
   const settingsValues = useMemo(
-    () => parseSettingsValues(schema, instance.settingsValuesJson),
+    () => (schema ? parseSettingsValues(schema, instance.settingsValuesJson) : {}),
     [schema, instance.settingsValuesJson],
   );
+
+  if (!schema) {
+    return (
+      <section>
+        <h4>{t("dashboard.widgetSettings")}</h4>
+        <p className="dw-muted">{t("dashboard.widgetSettingsInvalid")}</p>
+      </section>
+    );
+  }
 
   return (
     <section>
       <h4>{t("dashboard.widgetSettings")}</h4>
-      <WidgetSettingsFields
-        schema={schema}
-        values={settingsValues}
-        instanceId={instance.id}
-        onChange={(key, value) => {
-          const next = { ...settingsValues, [key]: value };
-          void updateInstance(instance.id, { settingsValuesJson: JSON.stringify(next) });
-        }}
-      />
+      {schema.fields.length > 0 ? (
+        <WidgetSettingsFields
+          schema={schema}
+          values={settingsValues}
+          instanceId={instance.id}
+          onChange={(key, value) => {
+            const next = { ...settingsValues, [key]: value };
+            void updateInstance(instance.id, { settingsValuesJson: JSON.stringify(next) });
+          }}
+        />
+      ) : (
+        <p className="dw-muted">{t("dashboard.widgetSettingsEmpty")}</p>
+      )}
     </section>
   );
 }

--- a/src/dashboard/edit/CustomizePopover.tsx
+++ b/src/dashboard/edit/CustomizePopover.tsx
@@ -1,7 +1,8 @@
 import * as Icons from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { invokeCommand, isTauriRuntime } from "../../lib/tauri";
+import { ToggleSwitch } from "../../settings/ToggleSwitch";
 import { useDashboardStore } from "../state/dashboardStore";
 import { ACCENT_PALETTE } from "../registry/palette";
 import {
@@ -23,17 +24,59 @@ export interface CustomizePopoverProps {
   onClose: () => void;
 }
 
+type SectionKey = "common" | "widget" | "advanced";
+
+const POPOVER_MARGIN = 8;
+const POPOVER_WIDTH = 440;
+
 export function CustomizePopover({ instance, anchorRect, onClose }: CustomizePopoverProps) {
   const { t } = useTranslation();
-  const updateInstance = useDashboardStore((s) => s.updateInstance);
   const customWidgets = useDashboardStore((s) => s.customWidgets);
-  const updateCustomWidget = useDashboardStore((s) => s.updateCustomWidget);
   const ref = useRef<HTMLDivElement | null>(null);
-  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [position, setPosition] = useState<{ top: number; left: number; visible: boolean }>({
+    top: anchorRect.bottom + 6,
+    left: anchorRect.left,
+    visible: false,
+  });
+  const [section, setSection] = useState<SectionKey>("common");
+
+  const customSource =
+    instance.kind !== "builtIn" ? customWidgets.find((c) => c.id === instance.sourceId) : undefined;
+  const settingsSchema = useMemo(
+    () => (customSource ? parseSettingsSchema(customSource.settingsSchemaJson) : null),
+    [customSource],
+  );
+  const hasWidgetSettings = Boolean(
+    customSource && settingsSchema && settingsSchema.fields.length > 0,
+  );
+  const hasAdvanced = instance.kind !== "builtIn";
+
+  const sections = useMemo(() => {
+    const list: { key: SectionKey; label: string }[] = [
+      { key: "common", label: t("dashboard.customize.sectionCommon") },
+    ];
+    if (hasWidgetSettings) {
+      list.push({ key: "widget", label: t("dashboard.customize.sectionWidget") });
+    }
+    if (hasAdvanced) {
+      list.push({ key: "advanced", label: t("dashboard.advanced") });
+    }
+    return list;
+  }, [hasWidgetSettings, hasAdvanced, t]);
 
   useEffect(() => {
-    function onDoc(e: MouseEvent) { if (ref.current && !ref.current.contains(e.target as Node)) onClose(); }
-    function onKey(e: KeyboardEvent) { if (e.key === "Escape") onClose(); }
+    if (!sections.some((s) => s.key === section)) {
+      setSection("common");
+    }
+  }, [section, sections]);
+
+  useEffect(() => {
+    function onDoc(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
     document.addEventListener("mousedown", onDoc);
     document.addEventListener("keydown", onKey);
     return () => {
@@ -42,19 +85,73 @@ export function CustomizePopover({ instance, anchorRect, onClose }: CustomizePop
     };
   }, [onClose]);
 
-  const top = anchorRect.bottom + 6;
-  const left = Math.min(anchorRect.left, window.innerWidth - 320);
-  const customSource =
-    instance.kind !== "builtIn" ? customWidgets.find((c) => c.id === instance.sourceId) : undefined;
-  const settingsSchema = customSource
-    ? parseSettingsSchema(customSource.settingsSchemaJson)
-    : null;
-  const settingsValues = settingsSchema
-    ? parseSettingsValues(settingsSchema, instance.settingsValuesJson)
-    : {};
+  useLayoutEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const rect = node.getBoundingClientRect();
+    const height = rect.height;
+    const width = rect.width;
+    const below = anchorRect.bottom + 6;
+    const above = anchorRect.top - height - 6;
+    const fitsBelow = below + height + POPOVER_MARGIN <= window.innerHeight;
+    const top = fitsBelow ? below : Math.max(POPOVER_MARGIN, above);
+    let left = Math.min(anchorRect.left, window.innerWidth - width - POPOVER_MARGIN);
+    left = Math.max(POPOVER_MARGIN, left);
+    setPosition({ top, left, visible: true });
+  }, [anchorRect, section]);
 
   return (
-    <div ref={ref} className="dw-customize" style={{ top, left }}>
+    <div
+      ref={ref}
+      className="dw-customize"
+      style={{
+        top: position.top,
+        left: position.left,
+        width: POPOVER_WIDTH,
+        visibility: position.visible ? "visible" : "hidden",
+      }}
+    >
+      <nav className="dw-customize-nav">
+        {sections.map((s) => (
+          <button
+            key={s.key}
+            type="button"
+            className={`dw-customize-nav-item${section === s.key ? " active" : ""}`}
+            onClick={() => setSection(s.key)}
+          >
+            {s.label}
+          </button>
+        ))}
+      </nav>
+      <div className="dw-customize-pane">
+        {section === "common" ? <CommonSection instance={instance} /> : null}
+        {section === "widget" && settingsSchema ? (
+          <WidgetSection schema={settingsSchema} instance={instance} />
+        ) : null}
+        {section === "advanced" ? <AdvancedSection instance={instance} /> : null}
+      </div>
+    </div>
+  );
+}
+
+function CommonSection({ instance }: { instance: DashboardWidgetInstance }) {
+  const { t } = useTranslation();
+  const updateInstance = useDashboardStore((s) => s.updateInstance);
+
+  return (
+    <>
+      <section>
+        <h4>{t("dashboard.titleLabel")}</h4>
+        <input
+          defaultValue={instance.customTitle ?? ""}
+          placeholder={t("dashboard.titlePlaceholder")}
+          onBlur={(e) => {
+            const value = e.target.value.trim();
+            updateInstance(instance.id, { customTitle: value.length === 0 ? null : value });
+          }}
+        />
+      </section>
+
       <section>
         <h4>{t("dashboard.presetLabel")}</h4>
         <div className="dw-preset-picker">
@@ -70,20 +167,19 @@ export function CustomizePopover({ instance, anchorRect, onClose }: CustomizePop
         </div>
       </section>
 
-      {instance.preset === "ambient" && (
+      {instance.preset === "ambient" ? (
         <section>
-          <label className="dw-field">
-            <input
-              type="checkbox"
-              checked={instance.glass === true}
-              onChange={(e) => updateInstance(instance.id, { glass: e.target.checked })}
-            />
+          <label className="dw-field dw-field-row">
             <span>{t("dashboard.glassBackground")}</span>
+            <ToggleSwitch
+              checked={instance.glass === true}
+              onChange={(checked) => updateInstance(instance.id, { glass: checked })}
+            />
           </label>
         </section>
-      )}
+      ) : null}
 
-      {instance.preset === "action" && (
+      {instance.preset === "action" ? (
         <section>
           <h4>{t("dashboard.actionDirection")}</h4>
           <div className="dw-preset-picker">
@@ -98,7 +194,7 @@ export function CustomizePopover({ instance, anchorRect, onClose }: CustomizePop
             ))}
           </div>
         </section>
-      )}
+      ) : null}
 
       <section>
         <h4>{t("dashboard.accent")}</h4>
@@ -139,65 +235,60 @@ export function CustomizePopover({ instance, anchorRect, onClose }: CustomizePop
           })}
         </div>
       </section>
-
-      <section>
-        <h4>{t("dashboard.titleLabel")}</h4>
-        <input
-          defaultValue={instance.customTitle ?? ""}
-          placeholder={t("dashboard.titlePlaceholder")}
-          onBlur={(e) => {
-            const value = e.target.value.trim();
-            updateInstance(instance.id, { customTitle: value.length === 0 ? null : value });
-          }}
-        />
-      </section>
-
-      {customSource ? (
-        <section>
-          <h4>{t("dashboard.widgetSettings")}</h4>
-          {settingsSchema ? (
-            settingsSchema.fields.length > 0 ? (
-              <WidgetSettingsFields
-                schema={settingsSchema}
-                values={settingsValues}
-                instanceId={instance.id}
-                onChange={(key, value) => {
-                  const next = { ...settingsValues, [key]: value };
-                  void updateInstance(instance.id, { settingsValuesJson: JSON.stringify(next) });
-                }}
-              />
-            ) : (
-              <p className="dw-muted">{t("dashboard.widgetSettingsEmpty")}</p>
-            )
-          ) : (
-            <p className="dw-muted">{t("dashboard.widgetSettingsInvalid")}</p>
-          )}
-        </section>
-      ) : null}
-
-      <section>
-        <button className="dw-advanced-toggle" onClick={() => setShowAdvanced((v) => !v)}>
-          {showAdvanced ? "▾ " : "▸ "}{t("dashboard.advanced")}
-        </button>
-        {showAdvanced && (
-          <div className="dw-advanced">
-            {instance.kind === "script" && customSource && (
-              <ScriptAdvanced
-                bodyJson={customSource.bodyJson}
-                onUpdate={(next) => updateCustomWidget(customSource.id, { bodyJson: next })}
-              />
-            )}
-            {instance.kind === "content" && customSource && (
-              <pre className="dw-source-view">{customSource.bodyJson}</pre>
-            )}
-            {instance.kind === "builtIn" && (
-              <p className="dw-muted">{t("dashboard.advancedNothing")}</p>
-            )}
-          </div>
-        )}
-      </section>
-    </div>
+    </>
   );
+}
+
+function WidgetSection({
+  schema,
+  instance,
+}: {
+  schema: WidgetSettingsSchema;
+  instance: DashboardWidgetInstance;
+}) {
+  const { t } = useTranslation();
+  const updateInstance = useDashboardStore((s) => s.updateInstance);
+  const settingsValues = useMemo(
+    () => parseSettingsValues(schema, instance.settingsValuesJson),
+    [schema, instance.settingsValuesJson],
+  );
+
+  return (
+    <section>
+      <h4>{t("dashboard.widgetSettings")}</h4>
+      <WidgetSettingsFields
+        schema={schema}
+        values={settingsValues}
+        instanceId={instance.id}
+        onChange={(key, value) => {
+          const next = { ...settingsValues, [key]: value };
+          void updateInstance(instance.id, { settingsValuesJson: JSON.stringify(next) });
+        }}
+      />
+    </section>
+  );
+}
+
+function AdvancedSection({ instance }: { instance: DashboardWidgetInstance }) {
+  const customWidgets = useDashboardStore((s) => s.customWidgets);
+  const updateCustomWidget = useDashboardStore((s) => s.updateCustomWidget);
+  const customSource =
+    instance.kind !== "builtIn" ? customWidgets.find((c) => c.id === instance.sourceId) : undefined;
+
+  if (!customSource) return null;
+
+  if (instance.kind === "script") {
+    return (
+      <ScriptAdvanced
+        bodyJson={customSource.bodyJson}
+        onUpdate={(next) => updateCustomWidget(customSource.id, { bodyJson: next })}
+      />
+    );
+  }
+  if (instance.kind === "content") {
+    return <pre className="dw-source-view">{customSource.bodyJson}</pre>;
+  }
+  return null;
 }
 
 function parseSettingsSchema(settingsSchemaJson: string): WidgetSettingsSchema | null {
@@ -256,13 +347,12 @@ function WidgetSettingsFieldControl({
 
   if (field.type === "boolean") {
     return (
-      <label className="dw-field">
-        <input
-          type="checkbox"
-          checked={value === true}
-          onChange={(event) => onChange(event.target.checked)}
-        />
+      <label className="dw-field dw-field-row">
         <span>{field.label}</span>
+        <ToggleSwitch
+          checked={value === true}
+          onChange={(checked) => onChange(checked)}
+        />
       </label>
     );
   }
@@ -387,16 +477,15 @@ function ScriptAdvanced({ bodyJson, onUpdate }: { bodyJson: string; onUpdate: (n
   }
   return (
     <div className="dw-stack-fields">
-      <label className="dw-field">
-        <input
-          type="checkbox"
+      <label className="dw-field dw-field-row">
+        <span>{t("dashboard.scriptNetwork")}</span>
+        <ToggleSwitch
           checked={parsed.permissions.network}
-          onChange={(e) => {
-            const next = { ...parsed, permissions: { ...parsed.permissions, network: e.target.checked } };
+          onChange={(checked) => {
+            const next = { ...parsed, permissions: { ...parsed.permissions, network: checked } };
             onUpdate(JSON.stringify(next));
           }}
         />
-        <span>{t("dashboard.scriptNetwork")}</span>
       </label>
       <label className="dw-field">
         <span>{t("dashboard.scriptPollSeconds")}</span>

--- a/src/dashboard/registry/presetRegistry.tsx
+++ b/src/dashboard/registry/presetRegistry.tsx
@@ -1,10 +1,8 @@
-import { useEffect, useRef, useState } from "react";
 import type { ReactElement, ReactNode } from "react";
 import type { WidgetPreset } from "../types";
 
 export interface PresetChromeProps {
   title: string;
-  summary?: string;
   icon: ReactNode;
   body: ReactNode;
   controls?: ReactNode;
@@ -13,50 +11,12 @@ export interface PresetChromeProps {
   actionDirection?: "vertical" | "horizontal";
 }
 
-function PanelTitle({ title, summary }: { title: string; summary?: string }) {
-  const [showTip, setShowTip] = useState(false);
-  const timer = useRef<number | null>(null);
-
-  function clearTimer() {
-    if (timer.current !== null) {
-      window.clearTimeout(timer.current);
-      timer.current = null;
-    }
-  }
-
-  useEffect(() => clearTimer, []);
-
-  function handleEnter() {
-    if (!summary) return;
-    clearTimer();
-    timer.current = window.setTimeout(() => setShowTip(true), 3000);
-  }
-
-  function handleLeave() {
-    clearTimer();
-    setShowTip(false);
-  }
-
-  return (
-    <div
-      className="dw-title-group"
-      onMouseEnter={handleEnter}
-      onMouseLeave={handleLeave}
-    >
-      <h3 className="dw-title">{title}</h3>
-      {showTip && summary ? (
-        <span className="dw-subtitle-tip" role="tooltip">{summary}</span>
-      ) : null}
-    </div>
-  );
-}
-
-function PanelChrome({ title, summary, icon, body, controls, editMode }: PresetChromeProps) {
+function PanelChrome({ title, icon, body, controls, editMode }: PresetChromeProps) {
   return (
     <div className="dw-preset dw-preset-panel">
       <div className={`dw-head${editMode ? " drag-handle" : ""}`}>
         <span className="dw-icon">{icon}</span>
-        <PanelTitle title={title} summary={summary} />
+        <h3 className="dw-title">{title}</h3>
         {controls}
       </div>
       <div className="dw-body">{body}</div>

--- a/src/dashboard/view/WidgetFrame.tsx
+++ b/src/dashboard/view/WidgetFrame.tsx
@@ -35,8 +35,6 @@ export function WidgetFrame({ instance, onCustomize }: WidgetFrameProps) {
     ?? (builtIn ? t(builtIn.titleKey) : undefined)
     ?? customSource?.title
     ?? t("dashboard.untitledWidget");
-  const fallbackSummary =
-    builtIn ? t(builtIn.summaryKey) : customSource?.summary;
 
   const IconCmp = (Icons as unknown as Record<string, React.ComponentType<{ width?: number; height?: number }>>)[instance.iconName] ?? Icons.Hash;
 
@@ -108,7 +106,6 @@ export function WidgetFrame({ instance, onCustomize }: WidgetFrameProps) {
     <div className={className} style={style}>
       <Render
         title={fallbackTitle}
-        summary={fallbackSummary}
         icon={<IconCmp width={14} height={14} />}
         body={<WidgetBody instance={instance} />}
         controls={controls}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -759,7 +759,6 @@
         "addWidget": "{{name}} hinzufügen",
         "addWidgetLabel": "Widget hinzufügen",
         "advanced": "Erweitert",
-        "advancedNothing": "Keine erweiterten Einstellungen für integrierte Widgets.",
         "agentWidgetBuiltInId": "Verwenden Sie eine andere Widget-ID; diese ID gehört zu einem integrierten Widget.",
         "agentWidgetDialogHint": "Fügen Sie einen überprüften Widget-JSON-Block vom KI-Assistenten oder einem Coding-Agenten ein. KKTerm speichert ihn lokal und führt keinen Code aus.",
         "agentWidgetDialogTitle": "Agenten-erstelltes Widget hinzufügen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -66,7 +66,10 @@
     "titleLabel": "Title",
     "titlePlaceholder": "Custom title…",
     "advanced": "Advanced",
-    "advancedNothing": "No advanced settings for built-in widgets.",
+    "customize": {
+      "sectionCommon": "Common",
+      "sectionWidget": "Widget"
+    },
     "changeBackground": "Change Background…",
     "backgroundModeDefault": "Theme Default",
     "backgroundModePreset": "Color & Gradient",

--- a/src/i18n/locales/es-MX.json
+++ b/src/i18n/locales/es-MX.json
@@ -758,7 +758,6 @@
         "addWidget": "Agregar {{name}}",
         "addWidgetLabel": "Agregar widget",
         "advanced": "Avanzado",
-        "advancedNothing": "Sin ajustes avanzados para widgets integrados.",
         "agentWidgetBuiltInId": "Usa un id de widget diferente; ese id pertenece a un widget integrado.",
         "agentWidgetDialogHint": "Pega un bloque JSON de widget revisado desde el Asistente IA o un agente de codificación. KKTerm lo guarda localmente y no ejecuta código.",
         "agentWidgetDialogTitle": "Agregar widget creado por agente",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -758,7 +758,6 @@
         "addWidget": "Añadir {{name}}",
         "addWidgetLabel": "Añadir widget",
         "advanced": "Avanzado",
-        "advancedNothing": "Sin ajustes avanzados para widgets integrados.",
         "agentWidgetBuiltInId": "Use un id de widget diferente; ese id pertenece a un widget integrado.",
         "agentWidgetDialogHint": "Pegue un bloque JSON de widget revisado desde el Asistente IA o un agente de codificación. KKTerm lo guarda localmente y no ejecuta código.",
         "agentWidgetDialogTitle": "Añadir widget creado por agente",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -759,7 +759,6 @@
         "addWidget": "Ajouter {{name}}",
         "addWidgetLabel": "Ajouter un widget",
         "advanced": "Avancé",
-        "advancedNothing": "Aucun paramètre avancé pour les widgets intégrés.",
         "agentWidgetBuiltInId": "Utilisez un ID de widget différent ; cet ID appartient à un widget intégré.",
         "agentWidgetDialogHint": "Collez un bloc JSON de widget révisé depuis l'Assistant IA ou un agent de codage. KKTerm l'enregistre localement et n'exécute pas de code.",
         "agentWidgetDialogTitle": "Ajouter un widget créé par agent",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -758,7 +758,6 @@
         "addWidget": "Tambah {{name}}",
         "addWidgetLabel": "Tambah Widget",
         "advanced": "Lanjutan",
-        "advancedNothing": "Tidak ada pengaturan lanjutan untuk widget bawaan.",
         "agentWidgetBuiltInId": "Gunakan id widget yang berbeda; id tersebut milik widget bawaan.",
         "agentWidgetDialogHint": "Tempel blok JSON widget yang telah ditinjau dari AI Assistant atau agen koding. KKTerm menyimpannya secara lokal dan tidak menjalankan kode.",
         "agentWidgetDialogTitle": "Tambah widget buatan agen",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -759,7 +759,6 @@
         "addWidget": "Aggiungi {{name}}",
         "addWidgetLabel": "Aggiungi widget",
         "advanced": "Avanzate",
-        "advancedNothing": "Nessuna impostazione avanzata per i widget integrati.",
         "agentWidgetBuiltInId": "Usa un ID widget diverso; quell'ID appartiene a un widget integrato.",
         "agentWidgetDialogHint": "Incolla un blocco JSON di widget revisionato dall'Assistente IA o da un agente di codifica. KKTerm lo salva localmente e non esegue codice.",
         "agentWidgetDialogTitle": "Aggiungi widget creato da agente",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -759,7 +759,6 @@
         "addWidget": "{{name}} を追加",
         "addWidgetLabel": "ウィジェットを追加",
         "advanced": "詳細",
-        "advancedNothing": "組み込みウィジェットには詳細設定はありません。",
         "agentWidgetBuiltInId": "別のウィジェット ID を使用してください。その ID は組み込みウィジェットに属しています。",
         "agentWidgetDialogHint": "AI アシスタントまたはコーディングエージェントからレビュー済みのウィジェット JSON ブロックを貼り付けます。KKTerm はローカルに保存し、コードは実行しません。",
         "agentWidgetDialogTitle": "エージェント作成ウィジェットを追加",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -758,7 +758,6 @@
         "addWidget": "{{name}} 추가",
         "addWidgetLabel": "위젯 추가",
         "advanced": "고급",
-        "advancedNothing": "내장 위젯에는 고급 설정이 없습니다.",
         "agentWidgetBuiltInId": "다른 위젯 ID를 사용하세요. 해당 ID는 내장 위젯에 속합니다.",
         "agentWidgetDialogHint": "AI 어시스턴트 또는 코딩 에이전트에서 검토된 위젯 JSON 블록을 붙여넣으세요. KKTerm은 로컬에 저장하며 코드를 실행하지 않습니다.",
         "agentWidgetDialogTitle": "에이전트 작성 위젯 추가",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -758,7 +758,6 @@
         "addWidget": "Adicionar {{name}}",
         "addWidgetLabel": "Adicionar widget",
         "advanced": "Avançado",
-        "advancedNothing": "Sem configurações avançadas para widgets integrados.",
         "agentWidgetBuiltInId": "Use um id de widget diferente; esse id pertence a um widget integrado.",
         "agentWidgetDialogHint": "Cole um bloco JSON de widget revisado do Assistente IA ou de um agente de codificação. O KKTerm salva localmente e não executa código.",
         "agentWidgetDialogTitle": "Adicionar widget criado por agente",

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -758,7 +758,6 @@
         "addWidget": "เพิ่ม {{name}}",
         "addWidgetLabel": "เพิ่มวิดเจ็ต",
         "advanced": "ขั้นสูง",
-        "advancedNothing": "ไม่มีค่าขั้นสูงสำหรับวิดเจ็ตในตัว",
         "agentWidgetBuiltInId": "ใช้ ID วิดเจ็ตอื่น ID นั้นเป็นของวิดเจ็ตในตัว",
         "agentWidgetDialogHint": "วางบล็อก JSON วิดเจ็ตที่ตรวจสอบแล้วจากผู้ช่วย AI หรือเอเจนต์เขียนโค้ด KKTerm บันทึกในเครื่องและไม่เรียกใช้โค้ด",
         "agentWidgetDialogTitle": "เพิ่มวิดเจ็ตที่เอเจนต์เขียน",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -758,7 +758,6 @@
         "addWidget": "Thêm {{name}}",
         "addWidgetLabel": "Thêm Tiện ích",
         "advanced": "Nâng cao",
-        "advancedNothing": "Không có cài đặt nâng cao cho tiện ích tích hợp.",
         "agentWidgetBuiltInId": "Hãy dùng id tiện ích khác; id đó thuộc về tiện ích tích hợp sẵn.",
         "agentWidgetDialogHint": "Dán khối JSON tiện ích đã được đánh giá từ AI Assistant hoặc tác nhân viết mã. KKTerm lưu cục bộ và không chạy mã.",
         "agentWidgetDialogTitle": "Thêm tiện ích do tác nhân soạn",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -759,7 +759,6 @@
         "addWidget": "添加 {{name}}",
         "addWidgetLabel": "添加小部件",
         "advanced": "高级",
-        "advancedNothing": "内置小部件无高级设置。",
         "agentWidgetBuiltInId": "请使用不同的小部件 ID；该 ID 属于内置小部件。",
         "agentWidgetDialogHint": "从 AI 助手或编码代理粘贴已审核的小部件 JSON 块。KKTerm 将其保存在本地，不执行代码。",
         "agentWidgetDialogTitle": "添加代理编写的小部件",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -759,7 +759,6 @@
         "addWidget": "新增 {{name}}",
         "addWidgetLabel": "新增小工具",
         "advanced": "進階",
-        "advancedNothing": "內建小工具無進階設定。",
         "agentWidgetBuiltInId": "請使用不同的小工具 ID；該 ID 屬於內建小工具。",
         "agentWidgetDialogHint": "從 AI 助理或編碼代理貼上已審核的小工具 JSON 區塊。KKTerm 將其儲存在本機，不執行程式碼。",
         "agentWidgetDialogTitle": "新增代理撰寫的小工具",


### PR DESCRIPTION
## Summary

Restructures the Dashboard widget Customize popover into a left-nav + right-pane layout with three sections (Common / Widget / Advanced), prevents the popover from being clipped near the bottom of the viewport, replaces inline checkboxes with the shared `ToggleSwitch`, bumps the per-widget gear icon margin, and removes the dead summary-tooltip from live widget chrome.

## What changed

- **Left-nav layout** — popover is now `~440px` wide with a 124px sidebar of uppercase section labels (COMMON / WIDGET / ADVANCED) and a scrolling right pane. Active item uses the existing preset-button active styling (accent fill + border).
- **No-clip positioning** — popover measures itself via `useLayoutEffect` and flips above the gear icon when there isn't enough room below; horizontal clamp now uses the measured width instead of a hard-coded 320px. First render uses `visibility: hidden` so there's no positional flash.
- **Section visibility** — built-in widgets see only COMMON; custom widgets with empty schemas hide WIDGET; ADVANCED is hidden for built-ins. Reactive state guards against the active section disappearing.
- **Toggle switches** — three checkboxes (ambient "Frosted glass background", schema-defined booleans, script "Allow network") now render with the shared `ToggleSwitch` from `src/settings/ToggleSwitch.tsx`.
- **Gear icon margin** — `.dw-controls` moves from `top/right: 6px` to `10px` for a small breathing-room win.
- **Dead-code cleanup** — `PanelTitle`'s 3-second hover tooltip showing `summary` on live widgets is removed (summary remains in the data model and is still surfaced in the Add Widget catalog).
- **i18n housekeeping** — adds `dashboard.customize.sectionCommon` / `sectionWidget` (with per-key files under `docs/localization_todo/`); retires `dashboard.advancedNothing` from `en.json` and all 13 translated locales per AGENTS.md i18n Rule 5.

## Why

The original popover was a single scrolling column anchored under the gear with `top = anchorRect.bottom + 6` — its bottom got clipped for any widget placed near the lower edge of the viewport. The all-caps `<h4>` headings (STYLE PRESET, ACCENT, ICON, TITLE…) sat next to a sentence-case "Advanced" toggle, which read as inconsistent; raw `<input type="checkbox">` looked out of place next to the toggle-switch idiom used in Settings. Splitting the popover into three named sections also helps users find widget-specific knobs (custom-widget secrets, polling permissions) which previously sat below a long scroll.

## Reviewer notes

- The `summary` field stays on `DashboardCustomWidget` and `BuiltInWidget` — only the live-widget tooltip surface is removed. `src/dashboard/edit/CatalogOverlay.tsx` still reads it for the Add Widget UI.
- No new fields on `DashboardWidgetInstance` (no per-instance summary override).
- The shared `ToggleSwitch` is rendered as a `<div role="switch">` — it slots into a new `.dw-field-row` flex layout, side-stepping the existing `.dw-customize input { width: 100% }` rule.
- Design and plan docs live under `docs/superpowers/` (gitignored — local working notes).

## Test plan

Automated (all green locally):

- [x] `npm run check`
- [x] `npm run build`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` (233 passed)

Manual (real Tauri runtime — `npm run tauri dev`):

- [ ] Widget near the top of the viewport: popover renders below the gear, fully visible.
- [ ] Widget near the bottom: popover flips above the gear, fully visible.
- [ ] Built-in widget (e.g. App Launcher): left nav shows only **COMMON**.
- [ ] Custom script widget: left nav shows **COMMON / WIDGET / ADVANCED**; "Allow network" is a toggle switch; schema booleans are toggle switches.
- [ ] Custom widget with empty `settingsSchemaJson`: left nav shows only **COMMON / ADVANCED**.
- [ ] Gear icon visibly inset ~10px from the widget's top-right corner.
- [ ] Hovering a widget title no longer triggers a tooltip after 3 seconds.
- [ ] Add Widget catalog still shows widget summaries (no regression).