### PR TITLE
feat: multi-provider web search + improved web fetch with scraper readability

### DIFF
--- a/docs/localization_todo/settings.braveSearchApiKey.md
+++ b/docs/localization_todo/settings.braveSearchApiKey.md
@@ -1,0 +1,10 @@
+# settings.braveSearchApiKey
+
+- **English value**: `Brave Search API key`
+- **Namespace**: `settings`
+- **File/component**: `src/settings/AiSettings.tsx`
+- **UI role**: label
+- **User flow**: Shown as an API key input label when Brave Search is selected as the search provider. The key is stored in the OS keychain.
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Domain notes**: "Brave Search" is a product/brand name. "API key" is a technical term that typically stays in English or uses a well-known localized equivalent.

--- a/docs/localization_todo/settings.searchProvider.md
+++ b/docs/localization_todo/settings.searchProvider.md
@@ -1,0 +1,10 @@
+# settings.searchProvider
+
+- **English value**: `Search provider`
+- **Namespace**: `settings`
+- **File/component**: `src/settings/AiSettings.tsx`
+- **UI role**: label
+- **User flow**: Shown in AI Assistant Settings under the Web Search tool toggle when web search is enabled. Labels the dropdown selector that picks which search backend to use.
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Domain notes**: "Search provider" refers to the backend engine that performs web searches (DuckDuckGo via built-in scraping, Brave Search API, Tavily API, or self-hosted SearXNG).

--- a/docs/localization_todo/settings.searchProviderBrave.md
+++ b/docs/localization_todo/settings.searchProviderBrave.md
@@ -1,0 +1,10 @@
+# settings.searchProviderBrave
+
+- **English value**: `Brave Search`
+- **Namespace**: `settings`
+- **File/component**: `src/settings/AiSettings.tsx`
+- **UI role**: label
+- **User flow**: Dropdown option in the Search Provider selector for the Brave Search API backend.
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Domain notes**: "Brave Search" is a product/brand name and should typically stay in English.

--- a/docs/localization_todo/settings.searchProviderScraper.md
+++ b/docs/localization_todo/settings.searchProviderScraper.md
@@ -1,0 +1,10 @@
+# settings.searchProviderScraper
+
+- **English value**: `Built-in (DuckDuckGo)`
+- **Namespace**: `settings`
+- **File/component**: `src/settings/AiSettings.tsx`
+- **UI role**: label
+- **User flow**: Dropdown option in the Search Provider selector. This is the default, free option that uses the built-in DuckDuckGo search via HTML parsing.
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Domain notes**: "DuckDuckGo" is a search engine brand name and should stay in English.

--- a/docs/localization_todo/settings.searchProviderSearxng.md
+++ b/docs/localization_todo/settings.searchProviderSearxng.md
@@ -1,0 +1,10 @@
+# settings.searchProviderSearxng
+
+- **English value**: `SearXNG`
+- **Namespace**: `settings`
+- **File/component**: `src/settings/AiSettings.tsx`
+- **UI role**: label
+- **User flow**: Dropdown option in the Search Provider selector for a self-hosted SearXNG meta-search instance.
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Domain notes**: "SearXNG" is a product/brand name and should typically stay in English.

--- a/docs/localization_todo/settings.searchProviderTavily.md
+++ b/docs/localization_todo/settings.searchProviderTavily.md
@@ -1,0 +1,10 @@
+# settings.searchProviderTavily
+
+- **English value**: `Tavily`
+- **Namespace**: `settings`
+- **File/component**: `src/settings/AiSettings.tsx`
+- **UI role**: label
+- **User flow**: Dropdown option in the Search Provider selector for the Tavily Search API backend (AI-optimized search).
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Domain notes**: "Tavily" is a product/brand name and should typically stay in English.

--- a/docs/localization_todo/settings.searxngUrl.md
+++ b/docs/localization_todo/settings.searxngUrl.md
@@ -1,0 +1,10 @@
+# settings.searxngUrl
+
+- **English value**: `SearXNG instance URL`
+- **Namespace**: `settings`
+- **File/component**: `src/settings/AiSettings.tsx`
+- **UI role**: label
+- **User flow**: Shown as a URL input label when SearXNG is selected as the search provider. Users enter their self-hosted SearXNG instance URL here.
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Domain notes**: "SearXNG" is a product/brand name. "URL" is a technical term that typically stays in English.

--- a/docs/localization_todo/settings.tavilySearchApiKey.md
+++ b/docs/localization_todo/settings.tavilySearchApiKey.md
@@ -1,0 +1,10 @@
+# settings.tavilySearchApiKey
+
+- **English value**: `Tavily API key`
+- **Namespace**: `settings`
+- **File/component**: `src/settings/AiSettings.tsx`
+- **UI role**: label
+- **User flow**: Shown as an API key input label when Tavily is selected as the search provider. The key is stored in the OS keychain.
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Domain notes**: "Tavily" is a product/brand name. "API key" is a technical term that typically stays in English or uses a well-known localized equivalent.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -959,6 +959,19 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.11.3",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
@@ -1167,6 +1180,17 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
@@ -1284,12 +1308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
- "cssparser",
+ "cssparser 0.36.0",
  "foldhash 0.2.0",
- "html5ever",
+ "html5ever 0.38.0",
  "precomputed-hash",
- "selectors",
- "tendril",
+ "selectors 0.36.1",
+ "tendril 0.5.0",
 ]
 
 [[package]]
@@ -1389,6 +1413,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "ego-tree"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "elliptic-curve"
@@ -1670,6 +1700,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,6 +1808,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1888,6 +1937,15 @@ dependencies = [
  "generic-array 0.14.7",
  "rustversion",
  "typenum",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -2196,12 +2254,24 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.14.1",
+ "match_token",
+]
+
+[[package]]
+name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
- "markup5ever",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]
@@ -2817,6 +2887,7 @@ dependencies = [
  "rusqlite",
  "russh",
  "russh-sftp",
+ "scraper",
  "serde",
  "serde_json",
  "serial2",
@@ -3010,14 +3081,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+dependencies = [
+ "log",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+ "tendril 0.4.3",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
- "tendril",
+ "tendril 0.5.0",
  "web_atoms",
+]
+
+[[package]]
+name = "match_token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3791,6 +3893,16 @@ dependencies = [
  "phf_macros 0.13.1",
  "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -4930,6 +5042,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc3d051b884f40e309de6c149734eab57aa8cc1347992710dc80bcc1c2194c15"
+dependencies = [
+ "cssparser 0.34.0",
+ "ego-tree",
+ "getopts",
+ "html5ever 0.29.1",
+ "precomputed-hash",
+ "selectors 0.26.0",
+ "tendril 0.4.3",
+]
+
+[[package]]
 name = "scrypt"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4980,17 +5107,36 @@ dependencies = [
 
 [[package]]
 name = "selectors"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
+dependencies = [
+ "bitflags 2.11.1",
+ "cssparser 0.34.0",
+ "derive_more 0.99.20",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
+name = "selectors"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
  "bitflags 2.11.1",
- "cssparser",
- "derive_more",
+ "cssparser 0.36.0",
+ "derive_more 2.1.1",
  "log",
  "new_debug_unreachable",
  "phf 0.13.1",
- "phf_codegen",
+ "phf_codegen 0.13.1",
  "precomputed-hash",
  "rustc-hash",
  "servo_arc",
@@ -5454,6 +5600,19 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
@@ -5462,6 +5621,18 @@ dependencies = [
  "parking_lot",
  "phf_shared 0.13.1",
  "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -6006,6 +6177,17 @@ dependencies = [
 
 [[package]]
 name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
+]
+
+[[package]]
+name = "tendril"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
@@ -6477,6 +6659,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6797,9 +6985,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
 dependencies = [
  "phf 0.13.1",
- "phf_codegen",
- "string_cache",
- "string_cache_codegen",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ async-native-tls = { version = "0.5", default-features = false }
 serial2 = "0.2.36"
 tokio = { version = "1.48.0", features = ["io-util", "net", "rt-multi-thread", "sync", "time"] }
 url = "2"
+scraper = "0.22"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 vnc = { package = "vnc-rs", version = "0.5.3" }

--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -1,4 +1,5 @@
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use scraper::{Html, Selector};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
@@ -2396,7 +2397,7 @@ async fn run_ai_tool(
     match call.function.name.as_str() {
         "request_secret_entry" => request_secret_entry_tool(args, stream_channel),
         "current_time" if tool_settings.current_time() => current_time_tool(),
-        "web_search" if tool_settings.web_search() => web_search_tool(args).await,
+        "web_search" if tool_settings.web_search() => web_search_tool(settings, args).await,
         "web_fetch" if tool_settings.web_fetch() => web_fetch_tool(args).await,
         "app_data_file_search" if tool_settings.app_data_file_search() => {
             app_data_file_search_tool(app_data_dir, args)
@@ -2861,18 +2862,33 @@ fn current_time_tool() -> String {
         })
 }
 
-async fn web_search_tool(args: Value) -> String {
+async fn web_search_tool(settings: &AiProviderSettings, args: Value) -> String {
     let query = arg_string(&args, "query");
     if query.is_empty() {
         return "web_search requires query.".to_string();
     }
-    let url = format!("https://duckduckgo.com/html/?q={}", url_encode(&query));
-    match reqwest::get(url).await {
-        Ok(response) => match response.text().await {
-            Ok(text) => strip_html(&text).chars().take(4000).collect(),
-            Err(error) => format!("Failed to read search response: {error}"),
+    let provider = settings.search_provider();
+    let allow_insecure = settings.allow_insecure_tls();
+
+    match provider {
+        "scraper" | "" => web_search_scraper(&query, allow_insecure).await,
+        "brave" => match settings.search_provider_api_key() {
+            Some(key) => web_search_brave(&query, key, allow_insecure).await,
+            None => "Brave Search API key is not configured.".to_string(),
         },
-        Err(error) => format!("Web search failed: {error}"),
+        "tavily" => match settings.search_provider_api_key() {
+            Some(key) => web_search_tavily(&query, key, allow_insecure).await,
+            None => "Tavily Search API key is not configured.".to_string(),
+        },
+        "searxng" => {
+            let instance_url = settings.searxng_url();
+            if instance_url.is_empty() {
+                "SearXNG instance URL is not configured.".to_string()
+            } else {
+                web_search_searxng(&query, instance_url, allow_insecure).await
+            }
+        }
+        _ => "Unknown search provider configured.".to_string(),
     }
 }
 
@@ -2881,11 +2897,27 @@ async fn web_fetch_tool(args: Value) -> String {
     if !(url.starts_with("https://") || url.starts_with("http://")) {
         return "web_fetch only accepts http:// or https:// URLs.".to_string();
     }
-    match reqwest::get(url).await {
-        Ok(response) => match response.text().await {
-            Ok(text) => strip_html(&text).chars().take(8000).collect(),
-            Err(error) => format!("Failed to read page: {error}"),
-        },
+    let client = match reqwest::Client::builder().build() {
+        Ok(client) => client,
+        Err(error) => return format!("Failed to create HTTP client: {error}"),
+    };
+    match client.get(&url).send().await {
+        Ok(response) => {
+            let content_type = response
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            if !content_type.contains("text/html") && !content_type.contains("text/plain") {
+                return format!(
+                    "Cannot fetch content type: {content_type}. Only text/html and text/plain are supported."
+                );
+            }
+            match response.text().await {
+                Ok(html) => extract_readable_text(&html),
+                Err(error) => format!("Failed to read page: {error}"),
+            }
+        }
         Err(error) => format!("Fetch failed: {error}"),
     }
 }
@@ -3070,6 +3102,318 @@ fn url_encode(value: &str) -> String {
             _ => format!("%{byte:02X}"),
         })
         .collect()
+}
+
+fn clean_text(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut prev_was_whitespace = true;
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            if !prev_was_whitespace {
+                result.push(' ');
+            }
+            prev_was_whitespace = true;
+        } else {
+            result.push(ch);
+            prev_was_whitespace = false;
+        }
+    }
+    result.trim().to_string()
+}
+
+fn extract_readable_text(html: &str) -> String {
+    let document = Html::parse_document(html);
+
+    for selector_str in [
+        "article",
+        "main",
+        "[role=\"main\"]",
+        ".post-content",
+        ".article-content",
+        ".entry-content",
+        "#content",
+    ] {
+        if let Ok(selector) = Selector::parse(selector_str) {
+            let combined: String = document
+                .select(&selector)
+                .flat_map(|el| el.text())
+                .collect::<Vec<_>>()
+                .join(" ");
+            let cleaned = clean_text(&combined);
+            if cleaned.len() > 200 {
+                return cleaned.chars().take(8000).collect();
+            }
+        }
+    }
+
+    if let Ok(selector) = Selector::parse("body") {
+        if let Some(body) = document.select(&selector).next() {
+            let combined: String =
+                body.text().collect::<Vec<_>>().join(" ");
+            return clean_text(&combined).chars().take(8000).collect();
+        }
+    }
+
+    clean_text(&strip_html(html)).chars().take(8000).collect()
+}
+
+fn build_web_client(allow_insecure_tls: bool) -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .danger_accept_invalid_certs(allow_insecure_tls)
+        .build()
+        .map_err(|e| format!("failed to create HTTP client: {e}"))
+}
+
+async fn web_search_scraper(query: &str, allow_insecure_tls: bool) -> String {
+    let client = match build_web_client(allow_insecure_tls) {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+
+    let json_url = format!(
+        "https://api.duckduckgo.com/?q={}&format=json&no_html=1&skip_disambig=1",
+        url_encode(query)
+    );
+
+    match client.get(&json_url).send().await {
+        Ok(response) => match response.json::<DdgInstantAnswer>().await {
+            Ok(answer) => {
+                let mut result = String::new();
+                if !answer.abstract_text.is_empty() {
+                    result.push_str("Instant answer: ");
+                    result.push_str(&answer.abstract_text);
+                    if !answer.abstract_url.is_empty() {
+                        result.push_str(&format!("\nSource: {}", answer.abstract_url));
+                    }
+                }
+                let mut has_related = false;
+                for topic in &answer.related_topics {
+                    if let Some(text) = &topic.text {
+                        if !has_related {
+                            if !result.is_empty() {
+                                result.push_str("\n\n");
+                            }
+                            result.push_str("Related topics:\n");
+                            has_related = true;
+                        }
+                        result.push_str(&format!("- {}\n", text));
+                    }
+                }
+                if !result.is_empty() {
+                    return result.chars().take(4000).collect();
+                }
+            }
+            Err(_) => {}
+        },
+        Err(_) => {}
+    }
+
+    let html_url = format!(
+        "https://html.duckduckgo.com/html/?q={}",
+        url_encode(query)
+    );
+    match client.get(&html_url).send().await {
+        Ok(response) => match response.text().await {
+            Ok(html) => {
+                let document = Html::parse_document(&html);
+                let mut result = String::new();
+                if let Ok(sel) = Selector::parse(".result__body") {
+                    for (i, el) in document.select(&sel).enumerate() {
+                        if i >= 6 {
+                            break;
+                        }
+                        let snippet: String =
+                            el.text().collect::<Vec<_>>().join(" ");
+                        let cleaned = clean_text(&snippet);
+                        if !cleaned.is_empty() {
+                            result.push_str(&cleaned);
+                            result.push('\n');
+                        }
+                    }
+                }
+                if result.is_empty() {
+                    clean_text(&strip_html(&html))
+                        .chars()
+                        .take(4000)
+                        .collect()
+                } else {
+                    result.chars().take(4000).collect()
+                }
+            }
+            Err(error) => format!("Web search failed: {error}"),
+        },
+        Err(error) => format!("Web search failed: {error}"),
+    }
+}
+
+async fn web_search_brave(query: &str, api_key: &str, allow_insecure_tls: bool) -> String {
+    let client = match build_web_client(allow_insecure_tls) {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+    let url = format!(
+        "https://api.search.brave.com/res/v1/web/search?q={}&count=5",
+        url_encode(query)
+    );
+    match client
+        .get(&url)
+        .header("Accept", "application/json")
+        .header("Accept-Encoding", "gzip")
+        .header("X-Subscription-Token", api_key)
+        .send()
+        .await
+    {
+        Ok(response) => match response.json::<BraveSearchResponse>().await {
+            Ok(data) => {
+                if let Some(web) = data.web {
+                    let mut result = String::new();
+                    for (i, r) in web.results.iter().enumerate() {
+                        result.push_str(&format!("{}. {}\n", i + 1, r.title));
+                        result.push_str(&format!("   {}\n", r.url));
+                        result.push_str(&format!("   {}\n", r.description));
+                    }
+                    result.chars().take(4000).collect()
+                } else {
+                    "Brave Search returned no web results.".to_string()
+                }
+            }
+            Err(error) => format!("Failed to parse Brave Search response: {error}"),
+        },
+        Err(error) => format!("Brave Search request failed: {error}"),
+    }
+}
+
+async fn web_search_tavily(query: &str, api_key: &str, allow_insecure_tls: bool) -> String {
+    let client = match build_web_client(allow_insecure_tls) {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+    let body = serde_json::json!({
+        "api_key": api_key,
+        "query": query,
+        "search_depth": "basic",
+        "include_answer": true,
+        "max_results": 5,
+    });
+    match client
+        .post("https://api.tavily.com/search")
+        .json(&body)
+        .send()
+        .await
+    {
+        Ok(response) => match response.json::<TavilySearchResponse>().await {
+            Ok(data) => {
+                let mut result = String::new();
+                if let Some(answer) = &data.answer {
+                    if !answer.is_empty() {
+                        result.push_str("Answer: ");
+                        result.push_str(answer);
+                        result.push_str("\n\n");
+                    }
+                }
+                for (i, r) in data.results.iter().enumerate() {
+                    result.push_str(&format!("{}. {}\n", i + 1, r.title));
+                    result.push_str(&format!("   {}\n", r.url));
+                    result.push_str(&format!("   {}\n", r.content));
+                }
+                result.chars().take(4000).collect()
+            }
+            Err(error) => format!("Failed to parse Tavily response: {error}"),
+        },
+        Err(error) => format!("Tavily request failed: {error}"),
+    }
+}
+
+async fn web_search_searxng(
+    query: &str,
+    instance_url: &str,
+    allow_insecure_tls: bool,
+) -> String {
+    let client = match build_web_client(allow_insecure_tls) {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+    let base = instance_url.trim_end_matches('/');
+    let url = format!("{}/search?q={}&format=json", base, url_encode(query));
+    match client.get(&url).send().await {
+        Ok(response) => match response.json::<SearxngSearchResponse>().await {
+            Ok(data) => {
+                let mut result = String::new();
+                for (i, r) in data.results.iter().enumerate().take(6) {
+                    result.push_str(&format!("{}. {}\n", i + 1, r.title));
+                    result.push_str(&format!("   {}\n", r.url));
+                    if let Some(content) = &r.content {
+                        result.push_str(&format!("   {}\n", content));
+                    }
+                }
+                if result.is_empty() {
+                    "SearXNG returned no results.".to_string()
+                } else {
+                    result.chars().take(4000).collect()
+                }
+            }
+            Err(error) => format!("Failed to parse SearXNG response: {error}"),
+        },
+        Err(error) => format!("SearXNG request failed: {error}"),
+    }
+}
+
+#[derive(Deserialize)]
+struct DdgInstantAnswer {
+    #[serde(rename = "AbstractText")]
+    abstract_text: String,
+    #[serde(rename = "AbstractURL")]
+    abstract_url: String,
+    #[serde(rename = "RelatedTopics")]
+    related_topics: Vec<DdgRelatedTopic>,
+}
+
+#[derive(Deserialize)]
+struct DdgRelatedTopic {
+    #[serde(rename = "Text")]
+    text: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct BraveSearchResponse {
+    web: Option<BraveWeb>,
+}
+
+#[derive(Deserialize)]
+struct BraveWeb {
+    results: Vec<BraveResult>,
+}
+
+#[derive(Deserialize)]
+struct BraveResult {
+    title: String,
+    url: String,
+    description: String,
+}
+
+#[derive(Deserialize)]
+struct TavilySearchResponse {
+    answer: Option<String>,
+    results: Vec<TavilyResult>,
+}
+
+#[derive(Deserialize)]
+struct TavilyResult {
+    title: String,
+    url: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct SearxngSearchResponse {
+    results: Vec<SearxngResult>,
+}
+
+#[derive(Deserialize)]
+struct SearxngResult {
+    title: String,
+    url: String,
+    content: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -848,10 +848,11 @@ async fn run_ai_agent(
     secrets: tauri::State<'_, secrets::Secrets>,
     request: ai::AgentRunRequest,
 ) -> Result<ai::AgentRunResponse, String> {
-    let settings = storage.ai_provider_settings()?;
+    let mut settings = storage.ai_provider_settings()?;
     let api_key = secrets
         .read_ai_api_key("openai-compatible-provider".to_string())
         .map_err(|error| format!("failed to read AI API key: {error}"))?;
+    inject_search_api_key(&secrets, &mut settings)?;
     ai::run_agent(app, settings, api_key, request).await
 }
 
@@ -863,11 +864,29 @@ async fn run_ai_agent_streaming(
     channel: tauri::ipc::Channel<serde_json::Value>,
     request: ai::AgentRunRequest,
 ) -> Result<ai::AgentRunResponse, String> {
-    let settings = storage.ai_provider_settings()?;
+    let mut settings = storage.ai_provider_settings()?;
     let api_key = secrets
         .read_ai_api_key("openai-compatible-provider".to_string())
         .map_err(|error| format!("failed to read AI API key: {error}"))?;
+    inject_search_api_key(&secrets, &mut settings)?;
     ai::run_agent_streaming(app, settings, api_key, request, channel).await
+}
+
+fn inject_search_api_key(
+    secrets: &secrets::Secrets,
+    settings: &mut storage::AiProviderSettings,
+) -> Result<(), String> {
+    let key = match settings.search_provider() {
+        "brave" => secrets
+            .read_brave_search_api_key("brave-search".to_string())
+            .map_err(|e| format!("failed to read Brave Search API key: {e}"))?,
+        "tavily" => secrets
+            .read_tavily_search_api_key("tavily-search".to_string())
+            .map_err(|e| format!("failed to read Tavily Search API key: {e}"))?,
+        _ => None,
+    };
+    settings.set_search_provider_api_key(key);
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -61,6 +61,20 @@ impl SecretReferenceRequest {
             owner_id,
         }
     }
+
+    pub(crate) fn brave_search_api_key(owner_id: String) -> Self {
+        Self {
+            kind: SecretKind::BraveSearchApiKey,
+            owner_id,
+        }
+    }
+
+    pub(crate) fn tavily_search_api_key(owner_id: String) -> Self {
+        Self {
+            kind: SecretKind::TavilySearchApiKey,
+            owner_id,
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -82,6 +96,8 @@ enum SecretKind {
     ConnectionPassphrase,
     UrlPassword,
     AiApiKey,
+    BraveSearchApiKey,
+    TavilySearchApiKey,
     WidgetSecret,
 }
 
@@ -187,6 +203,20 @@ impl Secrets {
         })
     }
 
+    pub(crate) fn read_brave_search_api_key(
+        &self,
+        owner_id: String,
+    ) -> Result<Option<String>, String> {
+        self.read_secret(SecretReferenceRequest::brave_search_api_key(owner_id))
+    }
+
+    pub(crate) fn read_tavily_search_api_key(
+        &self,
+        owner_id: String,
+    ) -> Result<Option<String>, String> {
+        self.read_secret(SecretReferenceRequest::tavily_search_api_key(owner_id))
+    }
+
     pub(crate) fn read_widget_secret(&self, owner_id: String) -> Result<Option<String>, String> {
         self.read_secret(SecretReferenceRequest::widget_secret(owner_id))
     }
@@ -252,6 +282,8 @@ impl SecretKind {
             Self::ConnectionPassphrase => "connection-passphrase",
             Self::UrlPassword => "url-password",
             Self::AiApiKey => "ai-api-key",
+            Self::BraveSearchApiKey => "brave-search-api-key",
+            Self::TavilySearchApiKey => "tavily-search-api-key",
             Self::WidgetSecret => "widget-secret",
         }
     }

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -480,6 +480,12 @@ pub struct AiProviderSettings {
     codex_cli_path: Option<String>,
     #[serde(default = "default_ai_assistant_tool_settings")]
     tools: AiAssistantToolSettings,
+    #[serde(default = "default_search_provider")]
+    search_provider: String,
+    #[serde(default)]
+    searxng_url: String,
+    #[serde(skip)]
+    search_provider_api_key: Option<String>,
 }
 
 impl AiProviderSettings {
@@ -509,6 +515,22 @@ impl AiProviderSettings {
 
     pub(crate) fn tool_permission_mode(&self) -> &str {
         &self.tool_permission_mode
+    }
+
+    pub(crate) fn search_provider(&self) -> &str {
+        &self.search_provider
+    }
+
+    pub(crate) fn searxng_url(&self) -> &str {
+        &self.searxng_url
+    }
+
+    pub(crate) fn search_provider_api_key(&self) -> Option<&str> {
+        self.search_provider_api_key.as_deref()
+    }
+
+    pub(crate) fn set_search_provider_api_key(&mut self, key: Option<String>) {
+        self.search_provider_api_key = key;
     }
 }
 
@@ -3782,6 +3804,9 @@ fn default_ai_provider_settings() -> AiProviderSettings {
         claude_cli_path: None,
         codex_cli_path: None,
         tools: default_ai_assistant_tool_settings(),
+        search_provider: default_search_provider(),
+        searxng_url: String::new(),
+        search_provider_api_key: None,
     }
 }
 
@@ -3813,6 +3838,10 @@ fn default_ai_connections_tool_enabled() -> bool {
 
 fn default_ai_sessions_tool_enabled() -> bool {
     true
+}
+
+fn default_search_provider() -> String {
+    "scraper".to_string()
 }
 
 fn default_ai_provider_kind() -> String {
@@ -4096,6 +4125,34 @@ fn validate_ai_provider_settings(
 
     if settings.model.chars().any(char::is_whitespace) {
         return Err("AI model cannot contain whitespace".to_string());
+    }
+
+    settings.search_provider = match settings
+        .search_provider
+        .trim()
+        .to_lowercase()
+        .replace(['-', '_', ' '], "")
+        .as_str()
+    {
+        "" | "scraper" => "scraper".to_string(),
+        "brave" => "brave".to_string(),
+        "tavily" => "tavily".to_string(),
+        "searxng" => "searxng".to_string(),
+        _ => return Err("Search provider must be scraper, brave, tavily, or searxng".to_string()),
+    };
+
+    settings.searxng_url = settings.searxng_url.trim().to_string();
+    if !settings.searxng_url.is_empty() {
+        if !(settings.searxng_url.starts_with("https://")
+            || settings.searxng_url.starts_with("http://"))
+        {
+            return Err(
+                "SearXNG instance URL must start with https:// or http://".to_string(),
+            );
+        }
+        if settings.searxng_url.chars().any(char::is_whitespace) {
+            return Err("SearXNG instance URL cannot contain whitespace".to_string());
+        }
     }
 
     Ok(settings)
@@ -5776,6 +5833,9 @@ mod tests {
                 claude_cli_path: Some("  C:\\Tools\\claude.exe  ".to_string()),
                 codex_cli_path: Some("  codex  ".to_string()),
                 tools: default_ai_assistant_tool_settings(),
+                search_provider: default_search_provider(),
+                searxng_url: String::new(),
+                search_provider_api_key: None,
             })
             .expect("AI provider settings update");
 
@@ -5822,6 +5882,9 @@ mod tests {
                 claude_cli_path: None,
                 codex_cli_path: None,
                 tools: default_ai_assistant_tool_settings(),
+                search_provider: default_search_provider(),
+                searxng_url: String::new(),
+                search_provider_api_key: None,
             })
             .expect_err("unknown tool permission mode is rejected");
 
@@ -5849,6 +5912,9 @@ mod tests {
                 claude_cli_path: None,
                 codex_cli_path: None,
                 tools: default_ai_assistant_tool_settings(),
+                search_provider: default_search_provider(),
+                searxng_url: String::new(),
+                search_provider_api_key: None,
             })
             .expect_err("scheme-less endpoint is rejected");
 
@@ -5877,6 +5943,9 @@ mod tests {
                 claude_cli_path: None,
                 codex_cli_path: None,
                 tools: default_ai_assistant_tool_settings(),
+                search_provider: default_search_provider(),
+                searxng_url: String::new(),
+                search_provider_api_key: None,
             })
             .expect_err("blank model is rejected");
 
@@ -5901,6 +5970,9 @@ mod tests {
                 claude_cli_path: Some("claude".to_string()),
                 codex_cli_path: Some("codex".to_string()),
                 tools: default_ai_assistant_tool_settings(),
+                search_provider: default_search_provider(),
+                searxng_url: String::new(),
+                search_provider_api_key: None,
             })
             .expect_err("auto-execution policy is rejected");
 

--- a/src/App.css
+++ b/src/App.css
@@ -8443,6 +8443,34 @@ fieldset.connection-specific-options > legend {
   font-weight: 800;
 }
 
+.search-provider-subsection {
+  display: grid;
+  gap: 8px;
+  margin: 4px 0 0 44px;
+  padding: 8px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+}
+
+.search-provider-subsection label {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 3px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.search-provider-subsection label input,
+.search-provider-subsection label select {
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface-muted);
+  color: var(--text);
+  font-size: 13px;
+}
+
 .settings-help-text {
   margin: 0;
   color: var(--text-muted);

--- a/src/ai/providers.ts
+++ b/src/ai/providers.ts
@@ -1,6 +1,6 @@
 import i18next from "../i18n/config";
 import { AI_PROVIDER_DEFINITIONS } from "./providerRegistry";
-import type { AiAssistantToolSettings, AiProviderKind, AiProviderSettings, AiReasoningEffort } from "../types";
+import type { AiAssistantToolSettings, AiProviderKind, AiProviderSettings, AiReasoningEffort, SearchProvider } from "../types";
 export { AI_PROVIDER_DEFINITIONS, modelSupportsImageInput } from "./providerRegistry";
 export type {
   AiModelOption,
@@ -42,6 +42,8 @@ export function providerDefaultsFor(kind: AiProviderKind): AiProviderSettings {
     claudeCliPath: "",
     codexCliPath: "",
     tools: DEFAULT_AI_ASSISTANT_TOOLS,
+    searchProvider: "scraper",
+    searxngUrl: "",
   };
 }
 
@@ -74,7 +76,22 @@ export function normalizeAiProviderDraft(draft: AiProviderSettings): AiProviderS
     claudeCliPath: draft.claudeCliPath?.trim() ?? "",
     codexCliPath: draft.codexCliPath?.trim() ?? "",
     tools: { ...DEFAULT_AI_ASSISTANT_TOOLS, ...(draft.tools ?? {}) },
+    searchProvider: normalizeSearchProvider(draft.searchProvider),
+    searxngUrl: draft.searxngUrl?.trim() ?? "",
   };
+}
+
+function normalizeSearchProvider(value: string | undefined): SearchProvider {
+  switch (value) {
+    case "brave":
+      return "brave";
+    case "tavily":
+      return "tavily";
+    case "searxng":
+      return "searxng";
+    default:
+      return "scraper";
+  }
 }
 
 export function providerNeedsApiKey(settings: AiProviderSettings) {

--- a/src/app-defaults.ts
+++ b/src/app-defaults.ts
@@ -111,6 +111,8 @@ export const defaultAiProviderSettings: AiProviderSettings = {
   claudeCliPath: "",
   codexCliPath: "",
   tools: defaultAiAssistantToolSettings,
+  searchProvider: "scraper",
+  searxngUrl: "",
 };
 
 export type AiSuggestion = {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -714,6 +714,14 @@
         "description": "Read visible session context and interact with active terminal, remote desktop, and file browser Sessions."
       }
     },
+    "searchProvider": "Search provider",
+    "searchProviderScraper": "Built-in (DuckDuckGo)",
+    "searchProviderBrave": "Brave Search",
+    "searchProviderTavily": "Tavily",
+    "searchProviderSearxng": "SearXNG",
+    "braveSearchApiKey": "Brave Search API key",
+    "tavilySearchApiKey": "Tavily API key",
+    "searxngUrl": "SearXNG instance URL",
     "connectedConnectionsRail": "Show connected Connections",
     "connectedConnectionsRailHint": "Adds connected Connection icons to the Activity Rail.",
     "connectedConnectionsRailSaved": "Show Connection in Left Rail setting saved."

--- a/src/settings/AiSettings.tsx
+++ b/src/settings/AiSettings.tsx
@@ -18,6 +18,7 @@ import type {
   AiProviderKind,
   AiProviderSettings as AiProviderSettingsType,
   AiReasoningEffort,
+  SearchProvider,
 } from "../types";
 import { SettingsSectionHeader, SettingsSummary } from "./shared";
 import { ToggleSwitch } from "./ToggleSwitch";
@@ -217,12 +218,111 @@ const AI_ASSISTANT_TOOL_IDS: AiAssistantToolId[] = [
   "sessions",
 ];
 
-function AiAssistantToolsControl({
+const SEARCH_PROVIDER_OPTIONS: { value: SearchProvider; labelKey: string }[] = [
+  { value: "scraper", labelKey: "settings.searchProviderScraper" },
+  { value: "brave", labelKey: "settings.searchProviderBrave" },
+  { value: "tavily", labelKey: "settings.searchProviderTavily" },
+  { value: "searxng", labelKey: "settings.searchProviderSearxng" },
+];
+
+const BRAVE_SEARCH_OWNER_ID = "brave-search";
+const TAVILY_SEARCH_OWNER_ID = "tavily-search";
+
+function SearchProviderControl({
   draft,
+  searchApiKeyDraft,
+  searchApiKeyStoredMask,
+  hasSearchApiKey,
   onDraftChange,
+  onSearchApiKeyDraftChange,
 }: {
   draft: AiProviderSettingsType;
+  searchApiKeyDraft: string;
+  searchApiKeyStoredMask: string;
+  hasSearchApiKey: boolean;
   onDraftChange: (patch: Partial<AiProviderSettingsType>) => void;
+  onSearchApiKeyDraftChange: (value: string) => void;
+}) {
+  const { t } = useTranslation();
+  const [isSearchApiKeyFocused, setIsSearchApiKeyFocused] = useState(false);
+  const shouldShowStoredApiKeyMask =
+    hasSearchApiKey && !isSearchApiKeyFocused && searchApiKeyDraft.length === 0;
+
+  return (
+    <div className="search-provider-subsection">
+      <label>
+        <span>{t("settings.searchProvider")}</span>
+        <select
+          onChange={(event) =>
+            onDraftChange({
+              searchProvider: event.currentTarget.value as SearchProvider,
+            })
+          }
+          value={draft.searchProvider}
+        >
+          {SEARCH_PROVIDER_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {t(option.labelKey)}
+            </option>
+          ))}
+        </select>
+      </label>
+      {draft.searchProvider === "brave" ? (
+        <label>
+          <span>{t("settings.braveSearchApiKey")}</span>
+          <input
+            autoComplete="off"
+            onBlur={() => setIsSearchApiKeyFocused(false)}
+            onChange={(event) => onSearchApiKeyDraftChange(event.currentTarget.value)}
+            onFocus={() => setIsSearchApiKeyFocused(true)}
+            placeholder={t("settings.braveSearchApiKey")}
+            type="password"
+            value={shouldShowStoredApiKeyMask ? searchApiKeyStoredMask : searchApiKeyDraft}
+          />
+        </label>
+      ) : draft.searchProvider === "tavily" ? (
+        <label>
+          <span>{t("settings.tavilySearchApiKey")}</span>
+          <input
+            autoComplete="off"
+            onBlur={() => setIsSearchApiKeyFocused(false)}
+            onChange={(event) => onSearchApiKeyDraftChange(event.currentTarget.value)}
+            onFocus={() => setIsSearchApiKeyFocused(true)}
+            placeholder={t("settings.tavilySearchApiKey")}
+            type="password"
+            value={shouldShowStoredApiKeyMask ? searchApiKeyStoredMask : searchApiKeyDraft}
+          />
+        </label>
+      ) : draft.searchProvider === "searxng" ? (
+        <label>
+          <span>{t("settings.searxngUrl")}</span>
+          <input
+            onChange={(event) =>
+              onDraftChange({ searxngUrl: event.currentTarget.value })
+            }
+            placeholder="https://searxng.example.com"
+            value={draft.searxngUrl}
+          />
+        </label>
+      ) : null}
+    </div>
+  );
+}
+
+function AiAssistantToolsControl({
+  draft,
+  searchApiKeyDraft,
+  searchApiKeyStoredMask,
+  hasSearchApiKey,
+  onDraftChange,
+  onSearchApiKeyDraftChange,
+}: {
+  draft: AiProviderSettingsType;
+  searchApiKeyDraft: string;
+  searchApiKeyStoredMask: string;
+  hasSearchApiKey: boolean;
+  onDraftChange: (patch: Partial<AiProviderSettingsType>) => void;
+  onSearchApiKeyDraftChange: (value: string) => void;
 }) {
   const { t } = useTranslation();
 
@@ -232,23 +332,35 @@ function AiAssistantToolsControl({
       <p className="settings-help-text">{t("settings.aiToolsDescription")}</p>
       <div className="settings-toggle-list">
         {AI_ASSISTANT_TOOL_IDS.map((toolId) => (
-          <label className="settings-toggle-row" key={toolId}>
-            <ToggleSwitch
-              checked={Boolean(draft.tools?.[toolId])}
-              onChange={(checked) =>
-                onDraftChange({
-                  tools: {
-                    ...draft.tools,
-                    [toolId]: checked,
-                  },
-                })
-              }
-            />
-            <span>
-              <strong>{t(`settings.aiTools.${toolId}.label`)}</strong>
-              <small>{t(`settings.aiTools.${toolId}.description`)}</small>
-            </span>
-          </label>
+          <div key={toolId}>
+            <label className="settings-toggle-row">
+              <ToggleSwitch
+                checked={Boolean(draft.tools?.[toolId])}
+                onChange={(checked) =>
+                  onDraftChange({
+                    tools: {
+                      ...draft.tools,
+                      [toolId]: checked,
+                    },
+                  })
+                }
+              />
+              <span>
+                <strong>{t(`settings.aiTools.${toolId}.label`)}</strong>
+                <small>{t(`settings.aiTools.${toolId}.description`)}</small>
+              </span>
+            </label>
+            {toolId === "webSearch" && draft.tools?.webSearch ? (
+              <SearchProviderControl
+                draft={draft}
+                hasSearchApiKey={hasSearchApiKey}
+                onDraftChange={onDraftChange}
+                onSearchApiKeyDraftChange={onSearchApiKeyDraftChange}
+                searchApiKeyDraft={searchApiKeyDraft}
+                searchApiKeyStoredMask={searchApiKeyStoredMask}
+              />
+            ) : null}
+          </div>
         ))}
       </div>
       <p className="settings-help-text">{t("settings.aiToolsSafety")}</p>
@@ -266,13 +378,47 @@ export function AiSettings() {
   const [draft, setDraft] = useState(aiProviderSettings);
   const [apiKeyDraft, setApiKeyDraft] = useState("");
   const [apiKeyStoredMask, setApiKeyStoredMask] = useState(createStoredApiKeyMask);
+  const [searchApiKeyDraft, setSearchApiKeyDraft] = useState("");
+  const [searchApiKeyStoredMask, setSearchApiKeyStoredMask] = useState(createStoredApiKeyMask);
+  const [hasSearchApiKey, setHasSearchApiKey] = useState(false);
   const hasChanges =
-    JSON.stringify(draft) !== JSON.stringify(aiProviderSettings) || apiKeyDraft.trim().length > 0;
+    JSON.stringify(draft) !== JSON.stringify(aiProviderSettings) ||
+    apiKeyDraft.trim().length > 0 ||
+    searchApiKeyDraft.trim().length > 0;
   const aiProviderDefinition = getAiProviderDefinition(draft.providerKind);
 
   useEffect(() => {
     setDraft(aiProviderSettings);
   }, [aiProviderSettings]);
+
+  useEffect(() => {
+    if (!isTauriRuntime()) return;
+    let disposed = false;
+    const ownerId =
+      draft.searchProvider === "brave"
+        ? BRAVE_SEARCH_OWNER_ID
+        : draft.searchProvider === "tavily"
+          ? TAVILY_SEARCH_OWNER_ID
+          : null;
+    if (!ownerId) {
+      setHasSearchApiKey(false);
+      return;
+    }
+    void invokeCommand("secret_exists", {
+      request: {
+        kind:
+          draft.searchProvider === "brave"
+            ? ("braveSearchApiKey" as const)
+            : ("tavilySearchApiKey" as const),
+        ownerId,
+      },
+    }).then((presence) => {
+      if (!disposed) setHasSearchApiKey(presence.exists);
+    });
+    return () => {
+      disposed = true;
+    };
+  }, [draft.searchProvider]);
 
   async function handleSave() {
     try {
@@ -291,6 +437,23 @@ export function AiSettings() {
         setAiProviderHasApiKey(true);
         setApiKeyDraft("");
         setApiKeyStoredMask(createStoredApiKeyMask());
+      }
+
+      if (searchApiKeyDraft.trim()) {
+        const isBrave = nextSettings.searchProvider === "brave";
+        const isTavily = nextSettings.searchProvider === "tavily";
+        if ((isBrave || isTavily) && isTauriRuntime()) {
+          await invokeCommand("store_secret", {
+            request: {
+              kind: isBrave ? ("braveSearchApiKey" as const) : ("tavilySearchApiKey" as const),
+              ownerId: isBrave ? BRAVE_SEARCH_OWNER_ID : TAVILY_SEARCH_OWNER_ID,
+              secret: searchApiKeyDraft.trim(),
+            },
+          });
+          setHasSearchApiKey(true);
+          setSearchApiKeyDraft("");
+          setSearchApiKeyStoredMask(createStoredApiKeyMask());
+        }
       }
 
       const saved = isTauriRuntime()
@@ -417,12 +580,16 @@ export function AiSettings() {
 
       <AiAssistantToolsControl
         draft={draft}
+        hasSearchApiKey={hasSearchApiKey}
         onDraftChange={(patch) =>
           setDraft((settings) => ({
             ...settings,
             ...patch,
           }))
         }
+        onSearchApiKeyDraftChange={setSearchApiKeyDraft}
+        searchApiKeyDraft={searchApiKeyDraft}
+        searchApiKeyStoredMask={searchApiKeyStoredMask}
       />
 
       <div className="settings-summary-grid compact">

--- a/src/types.ts
+++ b/src/types.ts
@@ -383,6 +383,8 @@ export type AiAssistantToolId =
 
 export type AiAssistantToolSettings = Record<AiAssistantToolId, boolean>;
 
+export type SearchProvider = "scraper" | "brave" | "tavily" | "searxng";
+
 export interface AiProviderSettings {
   providerKind: AiProviderKind;
   baseUrl: string;
@@ -395,6 +397,8 @@ export interface AiProviderSettings {
   claudeCliPath?: string;
   codexCliPath?: string;
   tools: AiAssistantToolSettings;
+  searchProvider: SearchProvider;
+  searxngUrl: string;
 }
 
 export interface WorkspaceTab {
@@ -484,6 +488,8 @@ export type SecretKind =
   | "connectionPassphrase"
   | "urlPassword"
   | "aiApiKey"
+  | "braveSearchApiKey"
+  | "tavilySearchApiKey"
   | "widgetSecret";
 
 export interface KeychainStatus {


### PR DESCRIPTION
## Summary
- Add `scraper` crate for proper HTML parsing with CSS selectors
- Rewrite `web_search_tool` with pluggable search providers: built-in DDG (Instant Answer API + scraper fallback), Brave Search API, Tavily, and SearXNG
- Rewrite `web_fetch_tool` with content-type filtering and readability extraction (article > main > role=main > body > raw)
- Add Search Provider selector in AI Assistant Settings under Web Search toggle
- Store Brave/Tavily API keys in OS keychain; SearXNG URL in settings

## Details

### Web Search Providers
| Provider | Auth | Notes |
|---|---|---|
| Built-in (DuckDuckGo) | None | Uses DDG Instant Answer API (JSON) primary, HTML scraper fallback |
| Brave Search | API key (keychain) | 2,000 free queries/month |
| Tavily | API key (keychain) | 1,000 free/month, AI-optimized results |
| SearXNG | Instance URL (settings) | Self-hosted meta-search engine |

### Web Fetch Improvements
- CSS selector-based readability extraction (prefers `<article>`, `<main>`, `role=main`)
- Content-Type guard (only text/html and text/plain)
- Smarter whitespace normalization and truncation

### Settings UI
- Search provider dropdown appears under Web Search toggle when enabled
- Conditional API key/URL inputs based on provider selection
- API keys use masked password input and OS keychain (same pattern as AI API key)