### PR TITLE
chore: remove @icon-park/react and @lezer/markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,6 @@
         "@codemirror/state": "^6.6.0",
         "@codemirror/theme-one-dark": "^6.1.3",
         "@codemirror/view": "^6.42.0",
-        "@icon-park/react": "^1.4.2",
-        "@lezer/markdown": "^1.6.3",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-fs": "^2.5.1",
@@ -936,20 +934,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@icon-park/react": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@icon-park/react/-/react-1.4.2.tgz",
-      "integrity": "sha512-+MtQLjNiRuia3fC/NfpSCTIy5KH5b+NkMB9zYd7p3R4aAIK61AjK0OSraaICJdkKooU9jpzk8m0fY4g9A3JqhQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 8.0.0",
-        "npm": ">= 5.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9",
-        "react-dom": ">=16.9"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
     "@codemirror/state": "^6.6.0",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.42.0",
-    "@icon-park/react": "^1.4.2",
-    "@lezer/markdown": "^1.6.3",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-fs": "^2.5.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,6 @@ import { SettingsPage } from "./settings/SettingsPage";
 import { useWorkspaceStore } from "./store";
 import { StatusBar } from "./workspace/StatusBar";
 import { TabStrip, WorkspaceCanvas } from "./workspace/WorkspaceCanvas";
-import "@icon-park/react/styles/index.css";
 import "@xterm/xterm/css/xterm.css";
 import "./App.css";
 

--- a/src/connections/ConnectionSidebar.tsx
+++ b/src/connections/ConnectionSidebar.tsx
@@ -11,8 +11,7 @@ import {
 import { confirmTrustedSshHostKey, defaultPortForConnectionType, connectionTypeLabel, ftpPortForProtocolSelection, isRemoteDesktopConnectionType, localShellOptionsForPlatform, uniqueRuntimeId, type LocalShellOption } from "./utils";
 import { RECENT_CONNECTION_LIMIT, createStoredSecretMask, loadCollapsedFolderIds, loadRecentConnectionIds, notifyConnectionTreeInvalidated, saveCollapsedFolderIds, saveRecentConnectionIds } from "./connectionSidebarState";
 import { collectConnectionFolderIds, countConnections, countFolders, filterConnectionTree, flattenConnections, flattenFolders, upsertRootConnection, withLiveConnectionStatuses } from "./treeUtils";
-import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, ChevronDown, ChevronRight, Folder, FolderPlus, KeyRound, LayoutDashboard, PanelRight, Pin, PinOff, Play, Plus, RotateCcw, Save, Search, X } from "lucide-react";
-import { AddComputer as IconParkAddComputer, CollapseTextInput as IconParkCollapseTextInput, Delete as IconParkDelete, Edit as IconParkEdit, ExpandTextInput as IconParkExpandTextInput, FolderPlus as IconParkFolderPlus, Setting as IconParkSetting } from "@icon-park/react";
+import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, ChevronDown, ChevronRight, Folder, FolderPlus, KeyRound, LayoutDashboard, Maximize2, Minimize2, PanelRight, Pencil, Pin, PinOff, Play, Plus, RotateCcw, Save, Search, Settings, SquarePlus, Trash2, X } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { FormEvent, MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from "react";
@@ -1543,7 +1542,7 @@ export function ConnectionSidebar({
           title={t("connections.collapseAll")}
           type="button"
         >
-          <IconParkCollapseTextInput size={13} />
+          <Minimize2 size={13} />
         </button>
         <button
           aria-label={t("connections.expandAll")}
@@ -1552,7 +1551,7 @@ export function ConnectionSidebar({
           title={t("connections.expandAll")}
           type="button"
         >
-          <IconParkExpandTextInput size={13} />
+          <Maximize2 size={13} />
         </button>
       </div>
       {treeError ? <p className="form-error tree-error">{treeError}</p> : null}
@@ -2163,11 +2162,11 @@ function TreeContextMenu({
       {menu.kind === "tree" ? (
         <>
           <button onClick={onCreateConnection} role="menuitem" type="button">
-            <IconParkAddComputer className="menu-item-icon" size={15} />
+            <SquarePlus className="menu-item-icon" size={15} />
             <span>{t("connections.newConnection")}</span>
           </button>
           <button onClick={onCreateFolder} role="menuitem" type="button">
-            <IconParkFolderPlus className="menu-item-icon" size={15} />
+            <FolderPlus className="menu-item-icon" size={15} />
             <span>{t("connections.newFolder")}</span>
           </button>
         </>
@@ -2175,11 +2174,11 @@ function TreeContextMenu({
       {menu.kind !== "tree" ? (
         <>
           <button onClick={onRename} role="menuitem" type="button">
-            <IconParkEdit className="menu-item-icon" size={15} />
+            <Pencil className="menu-item-icon" size={15} />
             <span>{t("connections.rename")}</span>
           </button>
           <button onClick={onDelete} role="menuitem" type="button">
-            <IconParkDelete className="menu-item-icon" size={15} />
+            <Trash2 className="menu-item-icon" size={15} />
             <span>{t("connections.delete")}</span>
           </button>
         </>
@@ -2247,7 +2246,7 @@ function TreeContextMenu({
             </button>
           ) : null}
           <button onClick={onProperties} role="menuitem" type="button">
-            <IconParkSetting className="menu-item-icon" size={15} />
+            <Settings className="menu-item-icon" size={15} />
             <span>{t("connections.properties")}</span>
           </button>
         </>


### PR DESCRIPTION
## Summary

- **Remove `@icon-park/react`**: Only used in `ConnectionSidebar.tsx` (7 icons). All replaced with `lucide-react` equivalents — `FolderPlus` was already imported there, the other 6 map to `SquarePlus`, `Minimize2`, `Maximize2`, `Pencil`, `Trash2`, and `Settings`. The global CSS import in `App.tsx` is also removed.
- **Remove `@lezer/markdown`**: Had zero direct imports in source. It is a transitive dependency of `@codemirror/lang-markdown` and does not need an explicit pin in `package.json`.

## What changed

| File | Change |
|------|--------|
| `src/connections/ConnectionSidebar.tsx` | Drop icon-park import, add 6 lucide icons, update 7 JSX usages |
| `src/App.tsx` | Remove `@icon-park/react/styles/index.css` global import |
| `package.json` | Remove `@icon-park/react` and `@lezer/markdown` entries |
| `package-lock.json` | Lock file updated accordingly |

## Reviewer notes

- No behavioral or visual change is intended — lucide icons are size-matched (`size={13}` / `size={15}`) and carry the same `className` as before. `SquarePlus` replaces the old `AddComputer` icon for "New Connection" in the context menu, which pairs visually with the adjacent `FolderPlus` for "New Folder".
- TypeScript compiles clean (`npm run check` passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)