### PR TITLE
fix(dashboard): make dynamic backgrounds fill the full canvas

### DIFF
--- a/src/dashboard/dashboard.css
+++ b/src/dashboard/dashboard.css
@@ -329,11 +329,7 @@ main.dashboard-page.dashboard-page-hidden,
 }
 
 .dw-dynamic-bg-layer {
-  position: absolute;
-  inset: 0;
-  z-index: 0;
   overflow: hidden;
-  pointer-events: none;
 }
 
 .dw-dynamic-bg-layer > * {


### PR DESCRIPTION
## Summary
- Dashboard dynamic backgrounds (Aurora, Synthwave, Matrix, etc.) did not fill the entire view canvas like preset and image backgrounds — they stopped at the inner content rect, leaving the scroll-padding region uncovered.
- Root cause: `.dw-dynamic-bg-layer` in `src/dashboard/dashboard.css` re-declared `position: absolute; inset: 0;`. Since dynamic backgrounds carry both `dw-canvas-bg` and `dw-dynamic-bg-layer`, and the dynamic rule was defined later in the file with equal specificity, its `inset: 0` overrode the negative `top/right/bottom/left` offsets that `.dw-canvas-bg` uses to spill out across `--dw-canvas-padding-*`.
- Fix: reduce `.dw-dynamic-bg-layer` to only `overflow: hidden` (still required so aurora blobs at `top: -10%` etc. are clipped). Position, stacking, and pointer-events now come from the single source of truth in `.dw-canvas-bg`, matching the other background kinds. JSX is unchanged; the existing `dynamicBackgrounds.test.ts` invariant about the class name still holds.

## Test plan
- [x] `npm run check` (tsc --noEmit) passes
- [x] `npm run build` passes
- [ ] In `npm run tauri dev`, open a Dashboard view and cycle the background between a preset, an image, and a dynamic option (Aurora, Synthwave). Confirm all three now fill the same expanded rect, including the area under the scroll padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)