### PR TITLE
Add anime.js to AI widget library catalog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "alasql": "^4.17.2",
+        "animejs": "^3.2.2",
         "ansi-to-html": "^0.7.2",
         "chart.js": "^4.5.1",
         "chroma-js": "^3.2.0",
@@ -3735,6 +3736,12 @@
       "optionalDependencies": {
         "react-native-fs": "^2.20.0"
       }
+    },
+    "node_modules/animejs": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/animejs/-/animejs-3.2.2.tgz",
+      "integrity": "sha512-Ao95qWLpDPXXM+WrmwcKbl6uNlC5tjnowlaRYtuVDHHoygjtIPfDUoK9NthrlZsQSKjZXlmji2TrBUAVbiH0LQ==",
+      "license": "MIT"
     },
     "node_modules/anser": {
       "version": "1.4.10",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "alasql": "^4.17.2",
+    "animejs": "^3.2.2",
     "ansi-to-html": "^0.7.2",
     "chart.js": "^4.5.1",
     "chroma-js": "^3.2.0",

--- a/src/dashboard/script/widgetLibraries.ts
+++ b/src/dashboard/script/widgetLibraries.ts
@@ -219,6 +219,13 @@ export const WIDGET_LIBRARIES: Record<string, WidgetLibrary> = {
     description: "Markdown to HTML renderer (already in the app bundle).",
     load: loadMarked,
   },
+  animejs: {
+    key: "animejs",
+    global: "anime",
+    description:
+      "DOM/SVG/CSS property animation (number countup, SVG path draw, attribute tweens, timelines). Use for data-driven transitions, not decorative entrance effects.",
+    load: () => rawDefault(() => import("widget-lib:animejs?global=anime")),
+  },
 };
 
 const sourceCache = new Map<string, Promise<string>>();


### PR DESCRIPTION
## Summary

- Adds `anime.js` v3 to the AI-authored script widget library catalog in [`src/dashboard/script/widgetLibraries.ts`](src/dashboard/script/widgetLibraries.ts).
- AI-authored script widgets can now request `"libraries": ["animejs"]` and use `window.anime(...)` inside their sandboxed iframe.

## Why

Every existing animation-capable widget library (`three`, `pixijs`, `konva`, `matter`) targets a canvas or WebGL surface. There was no first-class option for **DOM / SVG / CSS property** animation — things like animating a stat number counting up, drawing an SVG path, or tweening attributes on a dynamically rendered list. Anime.js fills that gap at ~17 KB minified.

## Notes for reviewers

- **Pinned to v3 (`^3.2.2`) on purpose.** Anime.js v4 is ESM-only and renamed the API surface (e.g. `anime.timeline()` → `createTimeline()`), which would (a) break the `require()`-based `widget-lib:` esbuild bundler in [`scripts/vite-widget-lib-bundle.ts`](scripts/vite-widget-lib-bundle.ts) and (b) invalidate the LLM prior on anime.js usage. v3 is what years of training data knows.
- **Description is deliberately opinionated** — `libraryCatalogForAi()` feeds the description string directly into the AI's prompt, so it acts as steering. The wording nudges the model toward data-driven transitions (countup, SVG path draw, attribute tweens) rather than decorative entrance effects, matching [`docs/DASHBOARD.md`](docs/DASHBOARD.md)'s "quiet, dense, desktop-oriented" rule.
- Bundle is a separate lazy chunk (`_widget-lib_animejs_global_anime-*.js`); only loaded when a widget actually requests it.

## Test plan

- [x] `npm run check` (tsc --noEmit) passes
- [x] `npm run build` succeeds and emits the `_widget-lib_animejs_global_anime-*.js` chunk
- [ ] Manual: ask the AI assistant in `tauri dev` to create a stat widget with an animated countup; confirm `window.anime` resolves and the tween runs inside the sandbox iframe
- [ ] Manual: confirm the new library shows up in the AI catalog briefing (via `libraryCatalogForAi()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)