### PR TITLE
Preserve AI chat draft across Settings navigation

### DIFF
--- a/src/ai/AssistantPanel.tsx
+++ b/src/ai/AssistantPanel.tsx
@@ -646,7 +646,7 @@ export function AssistantPanel({
   const aiProviderSettings = useWorkspaceStore((state) => state.aiProviderSettings);
   const setAiProviderSettings = useWorkspaceStore((state) => state.setAiProviderSettings);
   const aiProviderHasApiKey = useWorkspaceStore((state) => state.aiProviderHasApiKey);
-  const [prompt, setPrompt] = useState("");
+  const [prompt, setPrompt] = useState(() => sessionStorage.getItem("ai-chat-draft") ?? "");
   const [messages, setMessages] = useState<AssistantChatMessage[]>([]);
   const [currentThreadId, setCurrentThreadId] = useState(createAssistantChatThreadId);
   const [currentThreadTitle, setCurrentThreadTitle] = useState<string | undefined>();
@@ -771,6 +771,14 @@ export function AssistantPanel({
       setImagePasteRejected(false);
     }
   }, [currentModelSupportsImageInput]);
+
+  useEffect(() => {
+    if (prompt) {
+      sessionStorage.setItem("ai-chat-draft", prompt);
+    } else {
+      sessionStorage.removeItem("ai-chat-draft");
+    }
+  }, [prompt]);
 
   useEffect(() => {
     if (!isTauriRuntime()) {


### PR DESCRIPTION
## What changed

When the user opens Settings, `AssistantPanel` is unmounted (it's conditionally rendered with `activePage !== "settings"`). Any text typed in the chat input was lost because React destroys all local state on unmount.

## Fix

Persist the `prompt` draft in `sessionStorage` with two small changes to `AssistantPanel.tsx`:

1. **Lazy `useState` initializer** — reads the saved draft from `sessionStorage` on mount, so text is restored when the panel remounts after leaving Settings.
2. **`useEffect` sync** — keeps `sessionStorage` up-to-date on every keystroke; removes the key when the prompt is cleared (e.g. after sending a message).

No changes to `App.tsx`, the Zustand store, or any other files. The fix is fully self-contained in `AssistantPanel`.

## Why sessionStorage

`sessionStorage` is tab-scoped and clears when the tab closes, which is the right lifetime for an unsent chat draft — it shouldn't persist across restarts.

## Testing

1. Type something in the AI chat input.
2. Click the Settings button (or navigate to Settings via the activity rail).
3. Click Back.
4. Confirm the typed text is still present in the chat input.
5. Send a message and confirm the input clears normally.