### PR TITLE
Harden AI agent loop and surface widget validation detail

### DIFF
--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -796,6 +796,8 @@ fn log_provider_request<T: Serialize>(
     endpoint: &str,
     body: &T,
 ) {
+    let body_value = serde_json::to_value(body).unwrap_or(Value::Null);
+    let item_summary = summarize_request_items(&body_value);
     ai_interaction_debug!(
         "provider.request",
         json!({
@@ -804,9 +806,52 @@ fn log_provider_request<T: Serialize>(
             "model": model,
             "turn": turn_index,
             "endpoint": endpoint,
-            "body": body,
+            "itemSummary": item_summary,
+            "body": body_value,
         })
     );
+}
+
+/// Per-boundary diagnostics: for each top-level item the harness sends to the
+/// provider, log `type`, `role`, and approximate size. This catches malformed
+/// items (e.g. an `output_text` content part leaked to the top level) before
+/// the provider rejects the request with an opaque enum-only 400.
+fn summarize_request_items(body: &Value) -> Vec<Value> {
+    let array = body
+        .get("input")
+        .or_else(|| body.get("messages"))
+        .and_then(Value::as_array);
+    let Some(items) = array else {
+        return Vec::new();
+    };
+    items
+        .iter()
+        .enumerate()
+        .map(|(index, item)| {
+            let type_str = item.get("type").and_then(Value::as_str);
+            let role = item.get("role").and_then(Value::as_str);
+            let content_parts: Vec<&str> = item
+                .get("content")
+                .and_then(Value::as_array)
+                .map(|parts| {
+                    parts
+                        .iter()
+                        .filter_map(|part| part.get("type").and_then(Value::as_str))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let approx_bytes = serde_json::to_string(item)
+                .map(|s| s.len())
+                .unwrap_or_default();
+            json!({
+                "index": index,
+                "type": type_str,
+                "role": role,
+                "contentParts": content_parts,
+                "approxBytes": approx_bytes,
+            })
+        })
+        .collect()
 }
 
 fn log_provider_response(
@@ -1678,6 +1723,7 @@ impl OpenAiCompatibleProvider {
             .map_err(|error| format!("failed to locate KKTerm app data: {error}"))?;
         let model = settings.model().to_string();
         let exhausted = true;
+        let mut tool_error_tracker = ConsecutiveToolErrorTracker::default();
 
         for turn_index in 0..10 {
             ai_debug!(
@@ -1817,6 +1863,8 @@ impl OpenAiCompatibleProvider {
                     result.len()
                 );
                 let tool_error = tool_result_error(&result);
+                let abort_message =
+                    tool_error_tracker.note(&tool_call.function.name, &tool_error);
                 messages.push(OpenAiCompatibleMessage {
                     role: "tool".to_string(),
                     content: OpenAiCompatibleContent::Text(result),
@@ -1832,6 +1880,16 @@ impl OpenAiCompatibleProvider {
                         error: tool_error,
                     },
                 )?;
+                if let Some(message) = abort_message {
+                    emit_stream(
+                        &channel,
+                        &AiStreamEvent::Done {
+                            model: model.clone(),
+                            provider_kind: self.provider_kind.to_string(),
+                        },
+                    )?;
+                    return finish_agent_response(self, &model, message, None);
+                }
             }
         }
 
@@ -1947,6 +2005,7 @@ impl OpenAiCompatibleProvider {
 
         let mut input = responses_input_from_messages(messages, request.files);
         let resp_tool_defs = self.responses_tool_definitions_for_provider(&tool_definitions);
+        let mut tool_error_tracker = ConsecutiveToolErrorTracker::default();
 
         for turn_index in 0..10 {
             let request_body = OpenAiResponsesRequest {
@@ -2002,7 +2061,11 @@ impl OpenAiCompatibleProvider {
                 stream_responses_completions(response, &channel).await?;
 
             if let Some(output) = &content {
-                input.push(json!({"type": "output_text", "output_text": output}));
+                input.push(json!({
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": output}],
+                }));
             }
 
             if tool_calls.is_empty() {
@@ -2041,6 +2104,8 @@ impl OpenAiCompatibleProvider {
                 let result =
                     run_ai_tool(&settings, &app_data_dir, &app, tool_call, Some(&channel)).await;
                 let tool_error = tool_result_error(&result);
+                let abort_message =
+                    tool_error_tracker.note(&tool_call.function.name, &tool_error);
                 input.push(json!({
                     "type": "function_call_output",
                     "call_id": tool_call.id,
@@ -2054,6 +2119,16 @@ impl OpenAiCompatibleProvider {
                         error: tool_error,
                     },
                 )?;
+                if let Some(message) = abort_message {
+                    emit_stream(
+                        &channel,
+                        &AiStreamEvent::Done {
+                            model: model.clone(),
+                            provider_kind: self.provider_kind.to_string(),
+                        },
+                    )?;
+                    return finish_agent_response(self, &model, message, None);
+                }
             }
         }
 
@@ -3489,7 +3564,7 @@ fn dashboard_tool(app: &tauri::AppHandle, name: &str, args: Value) -> String {
     let result: Result<Value, String> = storage.with_connection_infallible(|conn| match name {
         "dashboard_load_state" => ds::load_state(conn)
             .map(|v| serde_json::to_value(v).unwrap_or(Value::Null))
-            .map_err(|e| format!("{e:?}")),
+            .map_err(|e| e.to_string()),
         "dashboard_create_view" => {
             let title = arg_string(&args, "title");
             if title.is_empty() {
@@ -3502,7 +3577,7 @@ fn dashboard_tool(app: &tauri::AppHandle, name: &str, args: Value) -> String {
             let id = new_dashboard_id("view");
             ds::create_view(conn, &id, &title, grid_density.as_deref())
                 .map(|v| serde_json::to_value(v).unwrap_or(Value::Null))
-                .map_err(|e| format!("{e:?}"))
+                .map_err(|e| e.to_string())
         }
         "dashboard_update_view" => {
             let id = arg_string(&args, "id");
@@ -3514,7 +3589,7 @@ fn dashboard_tool(app: &tauri::AppHandle, name: &str, args: Value) -> String {
                     .map_err(|e| format!("invalid patch: {e}"))?;
             ds::update_view(conn, &id, &patch)
                 .map(|v| serde_json::to_value(v).unwrap_or(Value::Null))
-                .map_err(|e| format!("{e:?}"))
+                .map_err(|e| e.to_string())
         }
         "dashboard_remove_view" => {
             let id = arg_string(&args, "id");
@@ -3523,7 +3598,7 @@ fn dashboard_tool(app: &tauri::AppHandle, name: &str, args: Value) -> String {
             }
             ds::remove_view(conn, &id)
                 .map(|_| json!({"ok": true}))
-                .map_err(|e| format!("{e:?}"))
+                .map_err(|e| e.to_string())
         }
         "dashboard_reorder_views" => {
             let ordered_ids: Vec<String> = args
@@ -3538,7 +3613,7 @@ fn dashboard_tool(app: &tauri::AppHandle, name: &str, args: Value) -> String {
                 .unwrap_or_default();
             ds::reorder_views(conn, &ordered_ids)
                 .map(|_| json!({"ok": true}))
-                .map_err(|e| format!("{e:?}"))
+                .map_err(|e| e.to_string())
         }
         "dashboard_add_instance" => {
             let view_id = arg_string(&args, "viewId");
@@ -3576,7 +3651,7 @@ fn dashboard_tool(app: &tauri::AppHandle, name: &str, args: Value) -> String {
                 grid_h,
             )
             .map(|v| serde_json::to_value(v).unwrap_or(Value::Null))
-            .map_err(|e| format!("{e:?}"))
+            .map_err(|e| e.to_string())
         }
         "dashboard_update_instance" => {
             let id = arg_string(&args, "id");
@@ -3588,7 +3663,7 @@ fn dashboard_tool(app: &tauri::AppHandle, name: &str, args: Value) -> String {
                     .map_err(|e| format!("invalid patch: {e}"))?;
             ds::update_instance(conn, &id, &patch)
                 .map(|v| serde_json::to_value(v).unwrap_or(Value::Null))
-                .map_err(|e| format!("{e:?}"))
+                .map_err(|e| e.to_string())
         }
         "dashboard_remove_instance" => {
             let id = arg_string(&args, "id");
@@ -3597,7 +3672,7 @@ fn dashboard_tool(app: &tauri::AppHandle, name: &str, args: Value) -> String {
             }
             ds::remove_instance(conn, &id)
                 .map(|_| json!({"ok": true}))
-                .map_err(|e| format!("{e:?}"))
+                .map_err(|e| e.to_string())
         }
         "dashboard_apply_layout" => {
             let view_id = arg_string(&args, "viewId");
@@ -3610,7 +3685,7 @@ fn dashboard_tool(app: &tauri::AppHandle, name: &str, args: Value) -> String {
                 .unwrap_or_default();
             ds::apply_layout(conn, &view_id, &layout)
                 .map(|_| json!({"ok": true}))
-                .map_err(|e| format!("{e:?}"))
+                .map_err(|e| e.to_string())
         }
         "dashboard_create_widget" => {
             let view_id = arg_string(&args, "viewId");
@@ -3696,7 +3771,7 @@ fn dashboard_tool(app: &tauri::AppHandle, name: &str, args: Value) -> String {
                 settings_schema_json.as_deref(),
                 "agent",
             )
-            .map_err(|e| format!("{e:?}"))?;
+            .map_err(|e| e.to_string())?;
             ai_interaction_debug!(
                 "dashboard.create_widget.custom_created",
                 json!({
@@ -3767,7 +3842,7 @@ fn dashboard_tool(app: &tauri::AppHandle, name: &str, args: Value) -> String {
                 &created_by,
             )
             .map(|v| serde_json::to_value(v).unwrap_or(Value::Null))
-            .map_err(|e| format!("{e:?}"))
+            .map_err(|e| e.to_string())
         }
         "dashboard_update_custom_widget" => {
             let id = arg_string(&args, "id");
@@ -3781,7 +3856,7 @@ fn dashboard_tool(app: &tauri::AppHandle, name: &str, args: Value) -> String {
                 .map_err(|e| format!("invalid patch: {e}"))?;
             ds::update_custom_widget(conn, &id, &patch)
                 .map(|v| serde_json::to_value(v).unwrap_or(Value::Null))
-                .map_err(|e| format!("{e:?}"))
+                .map_err(|e| e.to_string())
         }
         "dashboard_remove_custom_widget" => {
             let id = arg_string(&args, "id");
@@ -3794,11 +3869,11 @@ fn dashboard_tool(app: &tauri::AppHandle, name: &str, args: Value) -> String {
                 .unwrap_or(false);
             ds::remove_custom_widget(conn, &id, force)
                 .map(|_| json!({"ok": true}))
-                .map_err(|e| format!("{e:?}"))
+                .map_err(|e| e.to_string())
         }
         "dashboard_reset" => ds::reset_dashboard(conn)
             .map(|_| json!({"ok": true}))
-            .map_err(|e| format!("{e:?}")),
+            .map_err(|e| e.to_string()),
         _ => Err(format!("unknown dashboard tool: {name}")),
     });
     if result.is_ok() && is_dashboard_mutating_tool(name) {
@@ -4135,6 +4210,47 @@ fn tool_result_error(result: &str) -> Option<String> {
         .and_then(|v| v.get("error").and_then(Value::as_str).map(str::to_string))
         .map(|e| e.trim().to_string())
         .filter(|e| !e.is_empty())
+}
+
+/// Maximum number of times the same `(tool, error)` pair may repeat
+/// consecutively before the agent loop aborts. Prevents pathological
+/// retry loops where the model regenerates the same broken tool call
+/// because the tool result gave it no actionable diagnostic.
+const MAX_CONSECUTIVE_TOOL_ERRORS: u8 = 3;
+
+#[derive(Default)]
+struct ConsecutiveToolErrorTracker {
+    signature: Option<String>,
+    count: u8,
+}
+
+impl ConsecutiveToolErrorTracker {
+    /// Update tracker after a tool call. If the same `(tool, error)` pair has
+    /// repeated `MAX_CONSECUTIVE_TOOL_ERRORS` times, return an explanatory
+    /// message the caller should surface to the user before bailing out.
+    fn note(&mut self, tool_name: &str, error: &Option<String>) -> Option<String> {
+        let Some(err) = error else {
+            self.signature = None;
+            self.count = 0;
+            return None;
+        };
+        let signature = format!("{tool_name}::{err}");
+        if self.signature.as_deref() == Some(signature.as_str()) {
+            self.count += 1;
+        } else {
+            self.count = 1;
+            self.signature = Some(signature);
+        }
+        if self.count >= MAX_CONSECUTIVE_TOOL_ERRORS {
+            Some(format!(
+                "Aborted tool loop: '{tool_name}' returned the same error {} times in a row. \
+Last error: {err}",
+                self.count
+            ))
+        } else {
+            None
+        }
+    }
 }
 
 fn is_destructive_command(command: &str) -> bool {
@@ -4555,6 +4671,7 @@ fn build_agent_messages(
         "TOOLS: When you need to search the web, fetch URLs, read files, check the current time, or run shell commands, you MUST use the provided function-calling mechanism. Always make the actual function call alongside your explanation. Do not describe what you plan to do with a tool without calling it — invoke the tool in the same response.".to_string(),
         "SESSION TOOLS: Use session_state to discover active Tabs, pane ids, remote desktop targets, and SFTP/FTP browser Sessions before using session_* interaction tools. Terminal, remote desktop, and file browser tools operate on live Sessions, not saved Connections. Prefer read tools before mutating tools. For RDP/VNC, use send_text for text, keypress for named keys, and mouse_click for remote surface coordinates. In Prompt permission mode, mutating tools return permissionRequired; explain that the user must switch AI Assistant tool permissions to Allow All if they want automatic execution.".to_string(),
         "DASHBOARD TOOLS: When the active page context is Dashboard and the user asks to create, customize, arrange, repair, or remove Dashboard widgets or views, use the dashboard_* tools. To create a new user-requested widget on the active view, use dashboard_create_widget so the widget is validated and placed on the selected view in one step. Do not use the separate two-step dashboard_create_custom_widget + dashboard_add_instance for user-visible widget creation. When the user reports an error in an existing AI-authored widget, use dashboard_load_state to read the current Dashboard custom widget source, then call dashboard_update_custom_widget with the matching custom widget id. Prefer patch.body for widget source edits; patch.body is structured JSON and avoids escaping mistakes. Do not ask the user to paste widget source that KKTerm can read through dashboard_load_state. Choose the preset, accent, icon, and grid size to fit the widget's job and KKTerm's quiet desktop style; do not pick decorative colors at random. Be boundary-aware: size simple timers/counters at least 4x3, forms or images at least 5x4, and list widgets tall enough for their expected rows so the initial widget does not show inner scrollbars. Games, canvas demos, and single-purpose interactive tools should start compact, normally 4-6 columns wide and 4-7 rows tall; do not make them full-width unless the user asks for a wide layout. Prefer schema/content widgets when possible, and keep generated script widget UI compact, app-like, readable, high-contrast, and free of full HTML documents or script tags. Use body.libraries for curated local script libraries such as mermaid and animejs; use permissions.network=true only for remote network access or CDN-loaded libraries. Use settingsSchema.fields for persistent per-instance custom options; KKTerm renders those settings and scripts can read non-secret values with KK.getSettings() and save via KK.setSetting(key, value). Passwords, API keys, tokens, and similar sensitive values must use settingsSchema field type secret with no defaultValue; SQLite stores only a secretRef, the value lives in OS keychain as widgetSecret, and scripts read it with await KK.getSecret('fieldKey') only when needed. After creating a widget with a secret field, call request_secret_entry using the returned widget instance id and the exact secret field key instead of asking the user to paste the secret in chat. When a widget embeds remote images, fetches remote data, or loads external libraries from a CDN, set script permissions.network=true. External website links should be http/https anchors or KK.openExternal(url); they open in the external browser, not inside the widget iframe.".to_string(),
+        "MCP IN WIDGETS: When a widget's source will call KK.callMcpTool('<server>', '<tool>', <args>), you MUST first discover the real tool list and parameter shape of that server before writing the widget. Use the mcp_list_tools tool (or read tool schemas from current page context) to look up the exact tool names, required argument keys, and response field names. Do not guess tool names like 'opendata-search_datasets' or invent arguments like 'agency' or 'normalised_only' and do not assume a response has fields like 'datasets[0].dataset_id' without verifying. Quote the tool's documented argument keys verbatim in the widget source, and parse the actual response shape returned by that tool. If a tool result does not match what the widget expects at runtime, fix the parser to match the real shape rather than retrying with the same guess. If the user names an MCP server (for example twinkle-hub) but no tool list is available, ask the user to confirm the server is connected before generating widget code that depends on it.".to_string(),
     ];
     if let Some(language) = normalize_output_language(output_language) {
         system_instructions.push(language);

--- a/src-tauri/src/dashboard_commands.rs
+++ b/src-tauri/src/dashboard_commands.rs
@@ -12,10 +12,18 @@ use crate::secrets;
 #[derive(Debug, Serialize)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum DashboardCommandError {
-    Validation { reason: String },
+    Validation {
+        reason: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+    },
     NotFound,
-    InstancesExist { instance_ids: Vec<String> },
-    Internal { message: String },
+    InstancesExist {
+        instance_ids: Vec<String>,
+    },
+    Internal {
+        message: String,
+    },
 }
 
 #[derive(Debug, Serialize)]
@@ -28,9 +36,12 @@ pub struct DashboardCreatedWidget {
 impl From<ds::DashboardStorageError> for DashboardCommandError {
     fn from(value: ds::DashboardStorageError) -> Self {
         match value {
-            ds::DashboardStorageError::Validation(v) => DashboardCommandError::Validation {
-                reason: format!("{:?}", v),
-            },
+            ds::DashboardStorageError::Validation { kind, detail } => {
+                DashboardCommandError::Validation {
+                    reason: format!("{:?}", kind),
+                    detail,
+                }
+            }
             ds::DashboardStorageError::NotFound => DashboardCommandError::NotFound,
             ds::DashboardStorageError::InstancesExist { instance_ids } => {
                 DashboardCommandError::InstancesExist { instance_ids }

--- a/src-tauri/src/dashboard_storage.rs
+++ b/src-tauri/src/dashboard_storage.rs
@@ -4,7 +4,7 @@ use rusqlite::{params, Connection as SqliteConnection, OptionalExtension};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::dashboard_validation::{
-    dashboard_widget_secret_owner_id, validate_accent, validate_custom_body_for_kind,
+    dashboard_widget_secret_owner_id, validate_accent, validate_custom_body_for_kind_detailed,
     validate_custom_widget_kind, validate_grid_bounds, validate_grid_density, validate_icon,
     validate_kind, validate_preset, validate_settings_schema_json,
     validate_settings_values_for_schema_json, validate_title, ValidationError,
@@ -65,7 +65,7 @@ fn background_to_json(
             bg.validate()?;
             serde_json::to_string(bg)
                 .map(Some)
-                .map_err(|_| DashboardStorageError::Validation(ValidationError::InvalidBackground))
+                .map_err(|_| DashboardStorageError::validation(ValidationError::InvalidBackground))
         }
     }
 }
@@ -198,10 +198,44 @@ pub struct LayoutEntry {
 
 #[derive(Debug)]
 pub enum DashboardStorageError {
-    Validation(ValidationError),
+    Validation {
+        kind: ValidationError,
+        detail: Option<String>,
+    },
     Sqlite(rusqlite::Error),
     NotFound,
-    InstancesExist { instance_ids: Vec<String> },
+    InstancesExist {
+        instance_ids: Vec<String>,
+    },
+}
+
+impl DashboardStorageError {
+    pub fn validation(kind: ValidationError) -> Self {
+        Self::Validation { kind, detail: None }
+    }
+
+    pub fn validation_with_detail(kind: ValidationError, detail: Option<String>) -> Self {
+        Self::Validation { kind, detail }
+    }
+}
+
+impl std::fmt::Display for DashboardStorageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Validation { kind, detail: None } => {
+                write!(f, "Validation({kind:?})")
+            }
+            Self::Validation {
+                kind,
+                detail: Some(reason),
+            } => write!(f, "Validation({kind:?}): {reason}"),
+            Self::NotFound => write!(f, "NotFound"),
+            Self::InstancesExist { instance_ids } => {
+                write!(f, "InstancesExist({instance_ids:?})")
+            }
+            Self::Sqlite(error) => write!(f, "Sqlite: {error}"),
+        }
+    }
 }
 
 impl From<rusqlite::Error> for DashboardStorageError {
@@ -212,7 +246,16 @@ impl From<rusqlite::Error> for DashboardStorageError {
 
 impl From<ValidationError> for DashboardStorageError {
     fn from(value: ValidationError) -> Self {
-        Self::Validation(value)
+        Self::Validation {
+            kind: value,
+            detail: None,
+        }
+    }
+}
+
+impl From<(ValidationError, Option<String>)> for DashboardStorageError {
+    fn from((kind, detail): (ValidationError, Option<String>)) -> Self {
+        Self::Validation { kind, detail }
     }
 }
 
@@ -646,12 +689,15 @@ pub fn create_custom_widget(
 ) -> Result<DashboardCustomWidget, DashboardStorageError> {
     validate_custom_widget_kind(kind)?;
     validate_title(title)?;
-    validate_custom_body_for_kind(kind, body_json)?;
+    validate_custom_body_for_kind_detailed(kind, body_json)?;
     let settings_schema_json = settings_schema_json.unwrap_or(r#"{"fields":[]}"#);
     validate_settings_schema_json(settings_schema_json)?;
     if !matches!(created_by, "user" | "agent") {
-        return Err(DashboardStorageError::Validation(
+        return Err(DashboardStorageError::validation_with_detail(
             ValidationError::InvalidContentData,
+            Some(format!(
+                "createdBy must be 'user' or 'agent'; got {created_by:?}"
+            )),
         ));
     }
     conn.execute(
@@ -720,7 +766,7 @@ pub fn update_custom_widget(
         current.category = c;
     }
     if let Some(b) = patch.body_json.clone() {
-        validate_custom_body_for_kind(&current.kind, &b)?;
+        validate_custom_body_for_kind_detailed(&current.kind, &b)?;
         current.body_json = b;
     }
     if let Some(schema) = patch.settings_schema_json.clone() {
@@ -828,7 +874,7 @@ pub fn widget_secret_owner_id_for_instance(
         &instance.id,
     )?;
     let schema: serde_json::Value = serde_json::from_str(&schema_json)
-        .map_err(|_| DashboardStorageError::Validation(ValidationError::InvalidSettingsSchema))?;
+        .map_err(|_| DashboardStorageError::validation(ValidationError::InvalidSettingsSchema))?;
     let secret_field_exists = schema
         .get("fields")
         .and_then(serde_json::Value::as_array)
@@ -842,7 +888,7 @@ pub fn widget_secret_owner_id_for_instance(
         return Ok(None);
     }
     let values: serde_json::Value = serde_json::from_str(&instance.settings_values_json)
-        .map_err(|_| DashboardStorageError::Validation(ValidationError::InvalidSettingsValues))?;
+        .map_err(|_| DashboardStorageError::validation(ValidationError::InvalidSettingsValues))?;
     let expected_owner_id = dashboard_widget_secret_owner_id(&instance.id, key);
     let has_ref = values
         .get(key)
@@ -1047,9 +1093,10 @@ mod tests {
         );
         assert!(matches!(
             err,
-            Err(DashboardStorageError::Validation(
-                ValidationError::InvalidGridBounds
-            ))
+            Err(DashboardStorageError::Validation {
+                kind: ValidationError::InvalidGridBounds,
+                ..
+            })
         ));
     }
 
@@ -1137,9 +1184,10 @@ mod tests {
         );
         assert!(matches!(
             err,
-            Err(DashboardStorageError::Validation(
-                ValidationError::InvalidSettingsValues
-            ))
+            Err(DashboardStorageError::Validation {
+                kind: ValidationError::InvalidSettingsValues,
+                ..
+            })
         ));
 
         let updated = update_instance(&conn, "inst", &InstancePatch {
@@ -1270,9 +1318,10 @@ mod tests {
         );
         assert!(matches!(
             err,
-            Err(DashboardStorageError::Validation(
-                ValidationError::InvalidBackground
-            ))
+            Err(DashboardStorageError::Validation {
+                kind: ValidationError::InvalidBackground,
+                ..
+            })
         ));
     }
 

--- a/src-tauri/src/dashboard_validation.rs
+++ b/src-tauri/src/dashboard_validation.rs
@@ -317,61 +317,151 @@ pub struct ScriptPermissions {
     pub poll_seconds: Option<u64>,
 }
 
+#[allow(dead_code)]
 pub fn validate_content_body_json(json: &str) -> Result<ContentBody, ValidationError> {
+    validate_content_body_json_detailed(json).map_err(|(kind, _)| kind)
+}
+
+pub fn validate_content_body_json_detailed(
+    json: &str,
+) -> Result<ContentBody, (ValidationError, Option<String>)> {
     if json.len() > MAX_CONTENT_BODY_BYTES {
-        return Err(ValidationError::ContentTooLarge);
+        return Err((
+            ValidationError::ContentTooLarge,
+            Some(format!(
+                "content bodyJson is {} bytes; max is {}",
+                json.len(),
+                MAX_CONTENT_BODY_BYTES
+            )),
+        ));
     }
-    let parsed: ContentBody =
-        serde_json::from_str(json).map_err(|_| ValidationError::InvalidContentShape)?;
+    let parsed: ContentBody = serde_json::from_str(json).map_err(|error| {
+        (
+            ValidationError::InvalidContentShape,
+            Some(format!("content bodyJson did not parse: {error}")),
+        )
+    })?;
     match &parsed {
         ContentBody::Markdown { data } => {
             if data.source.trim().is_empty() {
-                return Err(ValidationError::InvalidContentData);
+                return Err((
+                    ValidationError::InvalidContentData,
+                    Some("markdown content 'source' is empty".to_string()),
+                ));
             }
         }
         ContentBody::KvList { data } => {
-            if data.rows.is_empty() || data.rows.iter().any(|row| row.label.trim().is_empty()) {
-                return Err(ValidationError::InvalidContentData);
+            if data.rows.is_empty() {
+                return Err((
+                    ValidationError::InvalidContentData,
+                    Some("kvList content has no rows".to_string()),
+                ));
+            }
+            if data.rows.iter().any(|row| row.label.trim().is_empty()) {
+                return Err((
+                    ValidationError::InvalidContentData,
+                    Some("kvList row has empty label".to_string()),
+                ));
             }
         }
         ContentBody::Checklist { data } => {
-            if data.items.is_empty() || data.items.iter().any(|item| item.label.trim().is_empty()) {
-                return Err(ValidationError::InvalidContentData);
+            if data.items.is_empty() {
+                return Err((
+                    ValidationError::InvalidContentData,
+                    Some("checklist has no items".to_string()),
+                ));
+            }
+            if data.items.iter().any(|item| item.label.trim().is_empty()) {
+                return Err((
+                    ValidationError::InvalidContentData,
+                    Some("checklist item has empty label".to_string()),
+                ));
             }
         }
         ContentBody::Stat { data } => {
             if data.value.trim().is_empty() {
-                return Err(ValidationError::InvalidContentData);
+                return Err((
+                    ValidationError::InvalidContentData,
+                    Some("stat 'value' is empty".to_string()),
+                ));
             }
         }
     }
     Ok(parsed)
 }
 
+#[allow(dead_code)]
 pub fn validate_script_body_json(json: &str) -> Result<ScriptBody, ValidationError> {
+    validate_script_body_json_detailed(json).map_err(|(kind, _)| kind)
+}
+
+/// Same as `validate_script_body_json`, but also surfaces a human-readable
+/// detail string explaining which check failed. The detail is passed back to
+/// agents/clients so they can correct widget source without re-guessing.
+pub fn validate_script_body_json_detailed(
+    json: &str,
+) -> Result<ScriptBody, (ValidationError, Option<String>)> {
     if json.len() > MAX_SCRIPT_SOURCE_BYTES + 4096 {
-        return Err(ValidationError::ScriptTooLarge);
+        return Err((
+            ValidationError::ScriptTooLarge,
+            Some(format!(
+                "script bodyJson is {} bytes; envelope limit is {} bytes",
+                json.len(),
+                MAX_SCRIPT_SOURCE_BYTES + 4096
+            )),
+        ));
     }
-    let parsed: ScriptBody =
-        serde_json::from_str(json).map_err(|_| ValidationError::InvalidScriptBody)?;
+    let parsed: ScriptBody = serde_json::from_str(json).map_err(|error| {
+        (
+            ValidationError::InvalidScriptBody,
+            Some(format!("script bodyJson did not parse: {error}")),
+        )
+    })?;
     if parsed.source.trim().is_empty() {
-        return Err(ValidationError::InvalidScriptBody);
+        return Err((
+            ValidationError::InvalidScriptBody,
+            Some("script body 'source' is empty after trimming".to_string()),
+        ));
     }
     if parsed.source.len() > MAX_SCRIPT_SOURCE_BYTES {
-        return Err(ValidationError::ScriptTooLarge);
+        return Err((
+            ValidationError::ScriptTooLarge,
+            Some(format!(
+                "script source is {} bytes; max is {}",
+                parsed.source.len(),
+                MAX_SCRIPT_SOURCE_BYTES
+            )),
+        ));
     }
     if let Some(secs) = parsed.permissions.poll_seconds {
         if secs < MIN_POLL_SECONDS {
-            return Err(ValidationError::InvalidPollSeconds);
+            return Err((
+                ValidationError::InvalidPollSeconds,
+                Some(format!(
+                    "permissions.pollSeconds is {secs}; minimum is {MIN_POLL_SECONDS}"
+                )),
+            ));
         }
     }
     if let Some(libs) = &parsed.libraries {
         if libs.len() > MAX_WIDGET_LIBRARIES {
-            return Err(ValidationError::InvalidLibraries);
+            return Err((
+                ValidationError::InvalidLibraries,
+                Some(format!(
+                    "{} libraries listed; max is {}",
+                    libs.len(),
+                    MAX_WIDGET_LIBRARIES
+                )),
+            ));
         }
         for entry in libs {
             if !is_valid_library_key(entry) {
-                return Err(ValidationError::InvalidLibraries);
+                return Err((
+                    ValidationError::InvalidLibraries,
+                    Some(format!(
+                        "invalid library key {entry:?}; expected lowercase ASCII id"
+                    )),
+                ));
             }
         }
     }
@@ -390,17 +480,30 @@ fn is_valid_library_key(value: &str) -> bool {
     chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
 }
 
+#[allow(dead_code)]
 pub fn validate_custom_body_for_kind(kind: &str, body_json: &str) -> Result<(), ValidationError> {
+    validate_custom_body_for_kind_detailed(kind, body_json).map_err(|(kind, _)| kind)
+}
+
+pub fn validate_custom_body_for_kind_detailed(
+    kind: &str,
+    body_json: &str,
+) -> Result<(), (ValidationError, Option<String>)> {
     match kind {
         "content" => {
-            validate_content_body_json(body_json)?;
+            validate_content_body_json_detailed(body_json)?;
             Ok(())
         }
         "script" => {
-            validate_script_body_json(body_json)?;
+            validate_script_body_json_detailed(body_json)?;
             Ok(())
         }
-        _ => Err(ValidationError::InvalidCustomWidgetKind),
+        _ => Err((
+            ValidationError::InvalidCustomWidgetKind,
+            Some(format!(
+                "custom widget kind {kind:?} is not one of: content, script"
+            )),
+        )),
     }
 }
 


### PR DESCRIPTION
## Summary

Diagnosed and fixed five compounding failures in the AI Assistant widget creation flow, traced from `logs/aiassistant.debug.log` (twinke-hub population widget that loaded with `找不到人口資料集` and ultimately surfaced as an OpenAI HTTP 400 on `input[12]`).

## Root causes (per layer)

| # | Layer | Failure |
|---|---|---|
| 1 | Agent harness | Conversation-history serializer emitted assistant `output_text` as a top-level item; OpenAI Responses API requires it to be nested in a `message` envelope. |
| 2 | Validator UX | `Validation(InvalidScriptBody)` enum dump leaked back to the model with no reason — three blind retries followed. |
| 3 | LLM prompting | Widget author guessed MCP tool names and response shape instead of discovering them. |
| 4 | Agent harness | Tool loop never stopped retrying identical `(tool, error)` pairs. |
| 5 | Diagnostics | `provider.request` log lacked per-item type/role info; the malformed item was invisible until the provider rejected it. |

## Changes

- **`src-tauri/src/ai.rs` — Responses-API serializer wrap.** `output_text` content parts now go inside `{type:"message", role:"assistant", content:[…]}` items when echoing prior assistant turns.
- **`src-tauri/src/dashboard_validation.rs` + `dashboard_storage.rs` + `dashboard_commands.rs` + `ai.rs`.** New `_detailed` validators capture serde parse errors and per-check reasons. `DashboardStorageError::Validation { kind, detail }` and `DashboardCommandError::Validation { reason, detail }` carry the reason through to the AI tool result envelope; a `Display` impl replaces the old opaque `{e:?}` formatter.
- **`src-tauri/src/ai.rs` — MCP discovery system instruction.** New rule: when a widget will call `KK.callMcpTool('<server>', …)`, the agent must first call `mcp_list_tools` (or read the live page tool list) and quote the real arg keys/response shape, not invent them.
- **`src-tauri/src/ai.rs` — `ConsecutiveToolErrorTracker`.** Cap = 3 identical `(tool, error)` pairs in both Responses and Chat-Completions paths. On cap-hit the loop emits `Done` and returns an explanatory message instead of firing another LLM turn.
- **`src-tauri/src/ai.rs` — `summarize_request_items`.** `log_provider_request` now emits `itemSummary` with `{index, type, role, contentParts[], approxBytes}` for each top-level item — would have made the original bug visible before the round trip.

## Test plan

- [x] `cargo check` clean (no warnings)
- [x] `cargo test --lib` — 254 passed, 0 failed, 1 ignored
- [x] `npm run check` (tsc) clean
- [ ] Manual: create twinke-hub population widget, confirm widget error string includes detail, confirm a 3rd identical `InvalidScriptBody` aborts the loop cleanly instead of producing an OpenAI 400
- [ ] Manual: inspect `aiassistant.debug.log` for new `itemSummary` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)