### PR TITLE
Redesign connection widget as app launcher

### DIFF
--- a/docs/localization_todo/dashboard.connectionWidgetNoResults.md
+++ b/docs/localization_todo/dashboard.connectionWidgetNoResults.md
@@ -1,0 +1,15 @@
+# dashboard.connectionWidgetNoResults
+
+- **English value**: `No Connections match your search`
+- **Namespace**: `dashboard`
+- **File/component**: `src/dashboard/widgets/ConnectionWidgetBody.tsx`
+- **UI role**: `status`
+- **User flow**: The user opens the connection launcher overlay (by clicking Add or the connection name in the toolbar) and types a search query that matches no saved Connections.
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Domain notes**: "Connections" are saved connection profiles (SSH, local terminal, RDP, VNC, URL). The launcher is a searchable list overlay inside the dashboard Connection widget.
+
+<!--
+Filename: dashboard.connectionWidgetNoResults.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/src/dashboard/dashboard.css
+++ b/src/dashboard/dashboard.css
@@ -1924,7 +1924,127 @@ main.dashboard-page.dashboard-page-hidden,
   border-radius: 7px;
 }
 
-.dashboard-connection-widget,
+.dashboard-connection-widget {
+  position: relative;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr);
+  height: 100%;
+  min-height: 0;
+}
+
+.dashboard-connection-widget-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+.dashboard-connection-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 18px;
+  color: var(--text-muted);
+  background: var(--surface-muted);
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.dashboard-connection-add:hover {
+  color: var(--text);
+  background: var(--surface);
+  border-color: var(--w-accent);
+}
+
+.dashboard-connection-launcher {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--nav-toolbar-bg);
+  border: 1px solid var(--terminal-border);
+  border-radius: 9px;
+}
+
+.dashboard-connection-launcher-search {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex: 0 0 auto;
+  padding: 6px 8px;
+  color: var(--text-faint);
+  border-bottom: 1px solid var(--terminal-border);
+}
+
+.dashboard-connection-launcher-search input {
+  flex: 1 1 0;
+  min-width: 0;
+  padding: 0;
+  color: var(--text);
+  background: transparent;
+  border: none;
+  outline: none;
+  font-size: 13px;
+}
+
+.dashboard-connection-launcher-search input::placeholder {
+  color: var(--text-faint);
+}
+
+.dashboard-connection-launcher-list {
+  flex: 1 1 0;
+  overflow-y: auto;
+  padding: 4px;
+}
+
+.dashboard-connection-launcher-list button {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  padding: 6px 9px;
+  color: var(--text);
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 12.5px;
+  text-align: left;
+}
+
+.dashboard-connection-launcher-list button:hover {
+  background: color-mix(in srgb, var(--text) 6%, transparent);
+}
+
+.dashboard-connection-launcher-list button.active {
+  background: color-mix(in srgb, var(--w-accent, var(--accent)) 12%, transparent);
+}
+
+.dashboard-connection-launcher-name {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-connection-launcher-sub {
+  flex: 1 1 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-faint);
+  font-size: 11.5px;
+}
+
+.dashboard-connection-launcher-empty {
+  margin: 12px;
+  color: var(--text-faint);
+  font-size: 12px;
+}
+
 .dashboard-url-widget {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
@@ -1933,7 +2053,6 @@ main.dashboard-page.dashboard-page-hidden,
   min-height: 0;
 }
 
-.dashboard-connection-controls,
 .dashboard-url-controls {
   display: flex;
   align-items: end;
@@ -1941,47 +2060,8 @@ main.dashboard-page.dashboard-page-hidden,
   min-width: 0;
 }
 
-.dashboard-connection-select,
 .dashboard-url-field {
   flex: 1 1 220px;
-}
-
-.dashboard-connection-tabs {
-  display: flex;
-  gap: 5px;
-  min-width: 0;
-  overflow-x: auto;
-  padding-bottom: 1px;
-}
-
-.dashboard-connection-tabs button {
-  display: inline-flex;
-  align-items: center;
-  flex: 0 0 auto;
-  gap: 6px;
-  max-width: 220px;
-  min-height: 28px;
-  padding: 5px 8px;
-  color: var(--text-muted);
-  background: var(--surface-muted);
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  cursor: pointer;
-  font-size: 12px;
-}
-
-.dashboard-connection-tabs button.active {
-  color: var(--text);
-  background: var(--surface);
-  border-color: var(--w-accent);
-  font-weight: 650;
-}
-
-.dashboard-connection-tabs button > span:nth-child(2) {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .dashboard-connection-tab-remove {
@@ -2014,18 +2094,44 @@ main.dashboard-page.dashboard-page-hidden,
 .dashboard-connection-pane-toolbar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 8px;
   min-width: 0;
   min-height: 32px;
-  padding: 4px 6px 4px 10px;
+  padding: 4px 6px;
   color: var(--text-muted);
   background: var(--nav-toolbar-bg);
   border-bottom: 1px solid var(--terminal-border);
   font-size: 11.5px;
 }
 
+.dashboard-connection-pane-name {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 5px;
+  max-width: 160px;
+  padding: 2px 7px;
+  color: var(--text);
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--terminal-border) 70%, transparent);
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 11.5px;
+}
+
+.dashboard-connection-pane-name:hover {
+  background: color-mix(in srgb, var(--text) 7%, transparent);
+}
+
+.dashboard-connection-pane-name > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .dashboard-connection-pane-toolbar > span {
+  flex: 1 1 0;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/dashboard/widgets/ConnectionWidgetBody.tsx
+++ b/src/dashboard/widgets/ConnectionWidgetBody.tsx
@@ -1,5 +1,5 @@
-import { ExternalLink, Plus, X } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { ExternalLink, Plus, Search, X } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ConnectionIcon } from "../../connections/ConnectionIcon";
 import { connectionSubtitle, connectionTypeLabel } from "../../connections/utils";
@@ -123,7 +123,9 @@ export function ConnectionWidgetBody({ instance }: BuiltInWidgetBodyProps) {
   );
   const [tree, setTree] = useState<ConnectionTree>(emptyConnectionTree);
   const [loadError, setLoadError] = useState("");
-  const [draftConnectionId, setDraftConnectionId] = useState("");
+  const [showLauncher, setShowLauncher] = useState(false);
+  const [launcherSearch, setLauncherSearch] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
   const activeSessionCounts = useWorkspaceStore((state) => state.activeSessionCounts);
   const openConnection = useWorkspaceStore((state) => state.openConnection);
 
@@ -176,15 +178,23 @@ export function ConnectionWidgetBody({ instance }: BuiltInWidgetBodyProps) {
     return connection ? [connection] : [];
   });
   const activeConnection =
-    selectedConnections.find((connection) => connection.id === config.activeConnectionId)
-    ?? selectedConnections[0]
-    ?? null;
+    selectedConnections.find((connection) => connection.id === config.activeConnectionId) ??
+    selectedConnections[0] ??
+    null;
   const sessionConnection = activeConnection
-    ? sessionConnectionsById.get(activeConnection.id) ?? activeConnection
+    ? (sessionConnectionsById.get(activeConnection.id) ?? activeConnection)
     : null;
-  const availableConnections = allConnections.filter(
-    (connection) => !config.connectionIds.includes(connection.id),
-  );
+
+  const filteredConnections = useMemo(() => {
+    const q = launcherSearch.toLowerCase().trim();
+    if (!q) return allConnections;
+    return allConnections.filter(
+      (c) =>
+        c.name.toLowerCase().includes(q) ||
+        connectionSubtitle(c).toLowerCase().includes(q) ||
+        connectionTypeLabel(c.type).toLowerCase().includes(q),
+    );
+  }, [allConnections, launcherSearch]);
 
   function updateConfig(nextConfig: ConnectionWidgetConfig) {
     const knownIds = new Set(allConnections.map((connection) => connection.id));
@@ -196,115 +206,157 @@ export function ConnectionWidgetBody({ instance }: BuiltInWidgetBodyProps) {
     setConfig({ connectionIds, activeConnectionId });
   }
 
-  function addDraftConnection() {
-    if (!draftConnectionId || config.connectionIds.includes(draftConnectionId)) {
-      return;
-    }
-    updateConfig({
-      connectionIds: [...config.connectionIds, draftConnectionId],
-      activeConnectionId: draftConnectionId,
-    });
-    setDraftConnectionId("");
-  }
-
   function removeConnection(connectionId: string) {
     const nextIds = config.connectionIds.filter((id) => id !== connectionId);
     updateConfig({
       connectionIds: nextIds,
       activeConnectionId:
-        config.activeConnectionId === connectionId ? (nextIds[0] ?? null) : config.activeConnectionId,
+        config.activeConnectionId === connectionId
+          ? (nextIds[0] ?? null)
+          : config.activeConnectionId,
     });
+  }
+
+  function openLauncher() {
+    setShowLauncher(true);
+    setLauncherSearch("");
+    requestAnimationFrame(() => searchRef.current?.focus());
+  }
+
+  function closeLauncher() {
+    setShowLauncher(false);
+    setLauncherSearch("");
+  }
+
+  function selectFromLauncher(connectionId: string) {
+    if (!config.connectionIds.includes(connectionId)) {
+      updateConfig({
+        connectionIds: [...config.connectionIds, connectionId],
+        activeConnectionId: connectionId,
+      });
+    } else {
+      updateConfig({ ...config, activeConnectionId: connectionId });
+    }
+    closeLauncher();
+  }
+
+  const subtitle = activeConnection ? connectionSubtitle(activeConnection) : "";
+
+  if (showLauncher) {
+    return (
+      <div
+        className="dashboard-connection-widget"
+        onKeyDown={(e) => e.key === "Escape" && closeLauncher()}
+      >
+        <div className="dashboard-connection-launcher">
+          <div className="dashboard-connection-launcher-search">
+            <Search size={13} />
+            <input
+              ref={searchRef}
+              type="text"
+              value={launcherSearch}
+              onChange={(e) => setLauncherSearch(e.currentTarget.value)}
+              placeholder={t("common.search")}
+            />
+            <button className="dashboard-widget-icon-button" onClick={closeLauncher} type="button">
+              <X size={13} />
+            </button>
+          </div>
+          <div className="dashboard-connection-launcher-list">
+            {filteredConnections.map((connection) => (
+              <button
+                key={connection.id}
+                className={connection.id === activeConnection?.id ? "active" : ""}
+                onClick={() => selectFromLauncher(connection.id)}
+                type="button"
+              >
+                <ConnectionIcon
+                  localShell={connection.localShell}
+                  size={14}
+                  type={connection.type}
+                />
+                <span className="dashboard-connection-launcher-name">{connection.name}</span>
+                <span className="dashboard-connection-launcher-sub">
+                  {connectionSubtitle(connection)}
+                </span>
+                <span className={`status-dot ${connection.status}`} />
+                {config.connectionIds.includes(connection.id) ? (
+                  <span
+                    className="dashboard-connection-tab-remove"
+                    role="button"
+                    tabIndex={0}
+                    aria-label={t("dashboard.connectionWidgetRemove", { name: connection.name })}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      removeConnection(connection.id);
+                    }}
+                  >
+                    <X size={11} />
+                  </span>
+                ) : null}
+              </button>
+            ))}
+            {filteredConnections.length === 0 ? (
+              <p className="dashboard-connection-launcher-empty">
+                {t("dashboard.connectionWidgetNoResults")}
+              </p>
+            ) : null}
+          </div>
+          {loadError ? (
+            <p className="dashboard-widget-error">
+              {t("dashboard.connectionWidgetLoadError", { message: loadError })}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  if (!activeConnection) {
+    return (
+      <div className="dashboard-connection-widget dashboard-connection-widget-empty">
+        <button className="dashboard-connection-add" onClick={openLauncher} type="button">
+          <Plus size={15} />
+          {t("common.add")}
+        </button>
+      </div>
+    );
   }
 
   return (
     <div className="dashboard-connection-widget">
-      <div className="dashboard-connection-controls">
-        <label className="dw-field dashboard-connection-select">
-          <span>{t("dashboard.connectionWidgetSelect")}</span>
-          <select
-            value={draftConnectionId}
-            onChange={(event) => setDraftConnectionId(event.currentTarget.value)}
+      <div className="dashboard-connection-pane">
+        <div className="dashboard-connection-pane-toolbar">
+          <button
+            className="dashboard-connection-pane-name"
+            onClick={openLauncher}
+            type="button"
           >
-            <option value="">{t("dashboard.connectionWidgetSelectPlaceholder")}</option>
-            {availableConnections.map((connection) => (
-              <option key={connection.id} value={connection.id}>
-                {connection.name} · {connectionTypeLabel(connection.type)}
-              </option>
-            ))}
-          </select>
-        </label>
-        <button className="dashboard-widget-icon-button" onClick={addDraftConnection} type="button">
-          <Plus size={14} />
-          {t("common.add")}
-        </button>
+            <ConnectionIcon
+              localShell={activeConnection.localShell}
+              size={13}
+              type={activeConnection.type}
+            />
+            <span>{activeConnection.name}</span>
+          </button>
+          {subtitle ? <span>{subtitle}</span> : null}
+          <button
+            className="dashboard-widget-icon-button compact"
+            onClick={() => openConnection(activeConnection)}
+            type="button"
+          >
+            <ExternalLink size={13} />
+            {t("dashboard.connectionWidgetOpenWorkspace")}
+          </button>
+        </div>
+        {sessionConnection ? (
+          <ConnectionWidgetSession
+            connection={sessionConnection}
+            instanceId={instance.id}
+            key={sessionConnection.id}
+          />
+        ) : null}
       </div>
-
-      {loadError ? (
-        <p className="dashboard-widget-error">
-          {t("dashboard.connectionWidgetLoadError", { message: loadError })}
-        </p>
-      ) : null}
-
-      {allConnections.length === 0 ? (
-        <div className="dashboard-widget-empty-state">
-          <h4>{t("dashboard.connectionWidgetNoConnectionsTitle")}</h4>
-          <p>{t("dashboard.connectionWidgetNoConnectionsHint")}</p>
-        </div>
-      ) : selectedConnections.length === 0 ? (
-        <div className="dashboard-widget-empty-state">
-          <h4>{t("dashboard.connectionWidgetEmptyTitle")}</h4>
-          <p>{t("dashboard.connectionWidgetEmptyHint")}</p>
-        </div>
-      ) : (
-        <>
-          <div className="dashboard-connection-tabs" aria-label={t("dashboard.connectionWidgetActivePane")}>
-            {selectedConnections.map((connection) => (
-              <button
-                className={connection.id === activeConnection?.id ? "active" : ""}
-                key={connection.id}
-                onClick={() => updateConfig({ ...config, activeConnectionId: connection.id })}
-                type="button"
-              >
-                <ConnectionIcon localShell={connection.localShell} size={14} type={connection.type} />
-                <span>{connection.name}</span>
-                <span className={`status-dot ${connection.status}`} />
-                <span
-                  className="dashboard-connection-tab-remove"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    removeConnection(connection.id);
-                  }}
-                  role="button"
-                  tabIndex={0}
-                  aria-label={t("dashboard.connectionWidgetRemove", { name: connection.name })}
-                >
-                  <X size={12} />
-                </span>
-              </button>
-            ))}
-          </div>
-          {activeConnection && sessionConnection ? (
-            <div className="dashboard-connection-pane">
-              <div className="dashboard-connection-pane-toolbar">
-                <span>{connectionSubtitle(activeConnection)}</span>
-                <button
-                  className="dashboard-widget-icon-button compact"
-                  onClick={() => openConnection(activeConnection)}
-                  type="button"
-                >
-                  <ExternalLink size={13} />
-                  {t("dashboard.connectionWidgetOpenWorkspace")}
-                </button>
-              </div>
-              <ConnectionWidgetSession
-                connection={sessionConnection}
-                instanceId={instance.id}
-                key={sessionConnection.id}
-              />
-            </div>
-          ) : null}
-        </>
-      )}
     </div>
   );
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -190,6 +190,7 @@
     "connectionWidgetEmptyHint": "Add a saved Connection to show its live pane directly inside this widget.",
     "connectionWidgetActivePane": "Pinned Connection panes",
     "connectionWidgetRemove": "Remove {{name}} from this widget",
+    "connectionWidgetNoResults": "No Connections match your search",
     "connectionWidgetOpenWorkspace": "Open in Workspace",
     "urlViewerTitle": "URL Viewer",
     "urlViewerSummary": "Open a website with the native URL viewer and optional auto-reload.",


### PR DESCRIPTION
## What changed

- **Removed** the dropdown-select + "Add" controls row above the pane
- **Removed** the connection tabs strip above the pane
- **Empty state** is now a single centered dashed "+ Add" button — nothing else
- **Active state** is purely the connection pane: dark toolbar fills the top, workspace fills the rest, zero surrounding chrome
- **Launcher overlay**: clicking Add (empty state) or the connection name pill (toolbar) opens a full-widget searchable list with icons, names, subtitles, and status dots; Escape or the ✕ closes it; already-pinned connections show an ✕ to remove them
- Connection name in the toolbar is now a subtle pill button that doubles as the launcher trigger for switching/adding connections

## CSS

- `.dashboard-connection-widget` is now `position: relative` with a single `minmax(0,1fr)` row and no gap — the pane fills 100% of the widget cell
- Removed `.dashboard-connection-controls`, `.dashboard-connection-tabs`, `.dashboard-connection-select` rules
- Split `.dashboard-url-widget` into its own standalone rule (behavior unchanged)
- New: `.dashboard-connection-launcher`, `.dashboard-connection-launcher-search/list/name/sub/empty`, `.dashboard-connection-add`, `.dashboard-connection-pane-name`
- Toolbar `> span` (subtitle) now has `flex: 1 1 0` to fill the gap between the name pill and Open button

## i18n

- Added `dashboard.connectionWidgetNoResults` ("No Connections match your search") to `en.json`
- Added `docs/localization_todo/dashboard.connectionWidgetNoResults.md` — other locales pending

## Review notes

- Multi-connection support is preserved: the config still tracks `connectionIds[]`; the launcher marks already-pinned connections and lets you remove them inline
- The `sessionConnectionsById` stable-reference guard is untouched — no session flicker risk
- `npm run check` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)