### PR TITLE
fix: remove connection pane toolbar and fix launcher text colors

### DIFF
--- a/src/dashboard/dashboard.css
+++ b/src/dashboard/dashboard.css
@@ -1973,7 +1973,7 @@ main.dashboard-page.dashboard-page-hidden,
   gap: 7px;
   flex: 0 0 auto;
   padding: 6px 8px;
-  color: var(--text-faint);
+  color: color-mix(in srgb, var(--nav-toolbar-text) 50%, transparent);
   border-bottom: 1px solid var(--terminal-border);
 }
 
@@ -1981,7 +1981,7 @@ main.dashboard-page.dashboard-page-hidden,
   flex: 1 1 0;
   min-width: 0;
   padding: 0;
-  color: var(--text);
+  color: var(--nav-toolbar-text);
   background: transparent;
   border: none;
   outline: none;
@@ -1989,7 +1989,7 @@ main.dashboard-page.dashboard-page-hidden,
 }
 
 .dashboard-connection-launcher-search input::placeholder {
-  color: var(--text-faint);
+  color: color-mix(in srgb, var(--nav-toolbar-text) 40%, transparent);
 }
 
 .dashboard-connection-launcher-list {
@@ -2004,7 +2004,7 @@ main.dashboard-page.dashboard-page-hidden,
   gap: 7px;
   width: 100%;
   padding: 6px 9px;
-  color: var(--text);
+  color: var(--nav-toolbar-text);
   background: transparent;
   border: none;
   border-radius: 6px;
@@ -2014,7 +2014,7 @@ main.dashboard-page.dashboard-page-hidden,
 }
 
 .dashboard-connection-launcher-list button:hover {
-  background: color-mix(in srgb, var(--text) 6%, transparent);
+  background: color-mix(in srgb, var(--nav-toolbar-text) 10%, transparent);
 }
 
 .dashboard-connection-launcher-list button.active {
@@ -2022,7 +2022,7 @@ main.dashboard-page.dashboard-page-hidden,
 }
 
 .dashboard-connection-launcher-name {
-  flex: 0 1 auto;
+  flex: 1 1 0;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2041,7 +2041,7 @@ main.dashboard-page.dashboard-page-hidden,
 
 .dashboard-connection-launcher-empty {
   margin: 12px;
-  color: var(--text-faint);
+  color: color-mix(in srgb, var(--nav-toolbar-text) 50%, transparent);
   font-size: 12px;
 }
 
@@ -2070,7 +2070,7 @@ main.dashboard-page.dashboard-page-hidden,
   justify-content: center;
   width: 18px;
   height: 18px;
-  color: var(--text-faint);
+  color: color-mix(in srgb, var(--nav-toolbar-text) 45%, transparent);
   border-radius: 5px;
 }
 
@@ -2083,7 +2083,7 @@ main.dashboard-page.dashboard-page-hidden,
 
 .dashboard-connection-pane {
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
   min-height: 0;
   overflow: hidden;
   background: var(--terminal);

--- a/src/dashboard/widgets/ConnectionWidgetBody.tsx
+++ b/src/dashboard/widgets/ConnectionWidgetBody.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, Plus, Search, X } from "lucide-react";
+import { Plus, Search, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ConnectionIcon } from "../../connections/ConnectionIcon";
@@ -127,7 +127,6 @@ export function ConnectionWidgetBody({ instance }: BuiltInWidgetBodyProps) {
   const [launcherSearch, setLauncherSearch] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
   const activeSessionCounts = useWorkspaceStore((state) => state.activeSessionCounts);
-  const openConnection = useWorkspaceStore((state) => state.openConnection);
 
   useEffect(() => {
     let disposed = false;
@@ -240,8 +239,6 @@ export function ConnectionWidgetBody({ instance }: BuiltInWidgetBodyProps) {
     closeLauncher();
   }
 
-  const subtitle = activeConnection ? connectionSubtitle(activeConnection) : "";
-
   if (showLauncher) {
     return (
       <div
@@ -276,9 +273,6 @@ export function ConnectionWidgetBody({ instance }: BuiltInWidgetBodyProps) {
                   type={connection.type}
                 />
                 <span className="dashboard-connection-launcher-name">{connection.name}</span>
-                <span className="dashboard-connection-launcher-sub">
-                  {connectionSubtitle(connection)}
-                </span>
                 <span className={`status-dot ${connection.status}`} />
                 {config.connectionIds.includes(connection.id) ? (
                   <span
@@ -326,29 +320,6 @@ export function ConnectionWidgetBody({ instance }: BuiltInWidgetBodyProps) {
   return (
     <div className="dashboard-connection-widget">
       <div className="dashboard-connection-pane">
-        <div className="dashboard-connection-pane-toolbar">
-          <button
-            className="dashboard-connection-pane-name"
-            onClick={openLauncher}
-            type="button"
-          >
-            <ConnectionIcon
-              localShell={activeConnection.localShell}
-              size={13}
-              type={activeConnection.type}
-            />
-            <span>{activeConnection.name}</span>
-          </button>
-          {subtitle ? <span>{subtitle}</span> : null}
-          <button
-            className="dashboard-widget-icon-button compact"
-            onClick={() => openConnection(activeConnection)}
-            type="button"
-          >
-            <ExternalLink size={13} />
-            {t("dashboard.connectionWidgetOpenWorkspace")}
-          </button>
-        </div>
         {sessionConnection ? (
           <ConnectionWidgetSession
             connection={sessionConnection}


### PR DESCRIPTION
## Summary

- **Remove toolbar frame from connection pane widget**: The toolbar bar showing the connection name, subtitle, and "在工作區開啓" (open in workspace) button has been removed. The session content (terminal, webview, remote desktop) now fills the full widget area without any enclosing frame.
- **Launcher list shows name only**: Removed the subtitle line from each connection entry in the add-connection launcher, leaving just the icon, name, and status dot.
- **Fix dark-on-dark text in launcher**: Replaced `var(--text)` / `var(--text-faint)` throughout the launcher UI with `var(--nav-toolbar-text)` and `color-mix` variants. The launcher background is `var(--nav-toolbar-bg)` (dark in most themes), while `var(--text)` is designed for the app body background — mixing them caused dark text on a dark background in lighter themes.

## Files changed

- `src/dashboard/widgets/ConnectionWidgetBody.tsx` — removed toolbar JSX, unused `ExternalLink` import, `openConnection` selector, and subtitle span from launcher list
- `src/dashboard/dashboard.css` — updated launcher text colors to use `--nav-toolbar-text`, simplified connection pane grid to single row, expanded name span to fill available flex space

## Reviewer notes

The `connectionSubtitle()` call is still present in the search filter (`filteredConnections`) so subtitle text remains searchable even though it is no longer displayed.