### PR TITLE
feat: beautify widget catalog cards

### DIFF
--- a/src/dashboard/dashboard.css
+++ b/src/dashboard/dashboard.css
@@ -1456,6 +1456,8 @@ main.dashboard-page.dashboard-page-hidden,
   flex-direction: column;
   gap: 9px;
   padding: 12px;
+  height: 220px;
+  overflow: hidden;
   text-align: left;
   background: var(--surface);
   border: 1px solid var(--border);
@@ -1485,45 +1487,64 @@ main.dashboard-page.dashboard-page-hidden,
   color: var(--text-muted);
   font-size: 12px;
   line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .dw-catalog-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
-  color: var(--text-faint);
-  font-size: 10.5px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  align-items: center;
+  gap: 5px;
+  margin-top: auto;
 }
 
 .dw-catalog-delete {
   position: absolute;
-  top: 6px;
+  bottom: 6px;
   right: 6px;
   display: flex;
   align-items: center;
   justify-content: center;
   width: 22px;
   height: 22px;
-  color: var(--text-muted);
+  color: var(--red);
   background: transparent;
   border: 1px solid transparent;
   border-radius: 6px;
   cursor: pointer;
   z-index: 1;
   transition:
-    color 100ms ease,
     background 100ms ease,
     border-color 100ms ease;
 }
 
 .dw-catalog-delete:hover,
 .dw-catalog-delete:focus-visible {
-  color: var(--red);
   background: color-mix(in srgb, var(--red) 12%, transparent);
   border-color: color-mix(in srgb, var(--red) 25%, transparent);
   outline: none;
+}
+
+.dw-catalog-tag {
+  padding: 2px 7px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.dw-catalog-tag--builtIn {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.dw-catalog-tag--custom {
+  color: #7c3aed;
+  background: rgba(124, 58, 237, 0.12);
 }
 
 .dw-badge {
@@ -1531,46 +1552,30 @@ main.dashboard-page.dashboard-page-hidden,
   color: var(--accent);
   background: var(--accent-soft);
   border-radius: 3px;
+  font-size: 10px;
   font-weight: 700;
 }
 
+.dw-badge--ai {
+  color: var(--amber);
+  background: var(--amber-soft);
+}
+
+.dw-badge--check {
+  color: var(--green);
+  background: var(--green-soft);
+}
+
 .dw-catalog-thumb {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
   height: 80px;
-  overflow: hidden;
-  background:
-    linear-gradient(180deg, var(--surface), var(--surface-muted)),
-    var(--surface-muted);
+  background: var(--w-accent-soft, var(--surface-muted));
   border: 1px solid var(--border);
   border-radius: 8px;
-}
-
-.dw-catalog-thumb[data-preset="ambient"] {
-  background:
-    radial-gradient(circle at 22% 36%, var(--w-accent) 0 3px, transparent 4px),
-    linear-gradient(90deg, transparent 0 20%, var(--text) 20% 46%, transparent 46%),
-    var(--surface-muted);
-  opacity: 0.7;
-}
-
-.dw-catalog-thumb[data-preset="tile"] {
-  background:
-    linear-gradient(90deg, var(--w-accent) 0 40%, transparent 40% 100%),
-    linear-gradient(180deg, var(--surface), var(--surface-muted));
-  background-size: 100% 6px, auto;
-  background-position: 0 54px, 0 0;
-  background-repeat: no-repeat;
-}
-
-.dw-catalog-thumb[data-preset="hero"] {
-  background: linear-gradient(135deg, var(--w-accent), color-mix(in srgb, var(--w-accent) 68%, black));
-}
-
-.dw-catalog-thumb[data-preset="action"] {
-  background:
-    linear-gradient(90deg, transparent 0 16px, var(--w-accent-soft, var(--accent-soft)) 16px 52px, transparent 52px),
-    var(--surface);
-  border-style: dashed;
+  color: var(--w-accent, var(--accent));
 }
 
 .dw-catalog-confirm-backdrop {

--- a/src/dashboard/edit/CatalogOverlay.tsx
+++ b/src/dashboard/edit/CatalogOverlay.tsx
@@ -1,3 +1,4 @@
+import * as Icons from "lucide-react";
 import { AlertTriangle, Trash2, X } from "lucide-react";
 import type { CSSProperties } from "react";
 import { useMemo, useState } from "react";
@@ -129,6 +130,7 @@ export function CatalogOverlay({ viewId, onClose }: CatalogOverlayProps) {
             const alreadyOnView = instances.some(
               (i) => i.viewId === viewId && i.sourceId === entry.id && i.kind === entry.kind,
             );
+            const IconCmp = (Icons as unknown as Record<string, React.ComponentType<{ width?: number; height?: number }>>)[entry.defaultIcon] ?? Icons.Hash;
             return (
               <button
                 key={entry.id}
@@ -157,16 +159,18 @@ export function CatalogOverlay({ viewId, onClose }: CatalogOverlayProps) {
                       }
                     }}
                   >
-                    <X width={12} height={12} />
+                    <Trash2 width={12} height={12} />
                   </span>
                 )}
-                <span className="dw-catalog-thumb" data-preset={entry.defaultPreset} />
+                <span className="dw-catalog-thumb">
+                  <IconCmp width={36} height={36} />
+                </span>
                 <h4>{entry.title}</h4>
                 <p>{entry.summary}</p>
                 <div className="dw-catalog-meta">
-                  <span>{groupLabel(getCatalogGroup(entry))}</span>
-                  {entry.createdBy === "agent" && <span className="dw-badge">AI</span>}
-                  {alreadyOnView && <span className="dw-badge">✓</span>}
+                  <span className={`dw-catalog-tag dw-catalog-tag--${getCatalogGroup(entry)}`}>{groupLabel(getCatalogGroup(entry))}</span>
+                  {entry.createdBy === "agent" && <span className="dw-badge dw-badge--ai">AI</span>}
+                  {alreadyOnView && <span className="dw-badge dw-badge--check">✓</span>}
                 </div>
               </button>
             );


### PR DESCRIPTION
## Summary

- **Icon thumbnails**: replaces the abstract CSS gradient placeholder with the widget's own Lucide icon (36×36) centered on an accent-soft tinted background — each card now reads at a glance
- **Fixed card size**: cards are a uniform 220 px tall with `overflow: hidden`; descriptions truncate at 3 lines via `-webkit-line-clamp`
- **Colored meta tags**: group label becomes a colored pill (builtIn → accent blue, custom → purple); AI badge → amber; already-added checkmark → green; all pushed to the card bottom via `margin-top: auto`
- **Delete button**: custom widget delete moved to bottom-right, icon swapped to red `Trash2` (always red, not reveal-on-hover), consistent with the Settings delete-button convention in AGENTS.md

## Files changed

- `src/dashboard/edit/CatalogOverlay.tsx` — icon lookup via `Icons[entry.defaultIcon]`, updated thumb markup, updated badge class names
- `src/dashboard/dashboard.css` — fixed height/clamp, meta layout, thumb restyle (removed 4 `data-preset` overrides), new `.dw-catalog-tag` + variant rules, `.dw-badge--ai` / `.dw-badge--check`

## Reviewer notes

The `--w-accent` / `--w-accent-soft` CSS variables are already set inline on each card by the existing `resolveAccent()` call, so the icon color and thumb background are automatically widget-specific with no extra prop changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)