### PR TITLE
fix: prevent AI Assistant from stopping when navigating Settings -> Workspace

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,12 +88,13 @@ function App() {
       } ${aiPanelLayout.collapsed ? "ai-assist-collapsed" : ""}`}
     >
       <ActivityRail
+        key="activity-rail"
         activePage={activePage}
         connectionsCollapsed={connectionPanelLayout.collapsed}
         onConnectionsToggle={toggleConnectionPanel}
         onNavigate={navigateToPage}
       />
-      <div className="workspace-page" {...ariaHidden(activePage !== "workspace")}>
+      <div key="workspace-page" className="workspace-page" {...ariaHidden(activePage !== "workspace")}>
         <ConnectionSidebar
           collapsed={connectionPanelLayout.collapsed}
           onToggleCollapsed={toggleConnectionPanel}
@@ -114,6 +115,7 @@ function App() {
       </div>
       {activePage !== "settings" ? (
         <PanelResizeHandle
+          key="ai-resize-handle"
           ariaLabel={t("app.resizeAiAssistant")}
           side="right"
           collapsed={aiPanelLayout.collapsed}
@@ -123,6 +125,7 @@ function App() {
         />
       ) : null}
       <AssistantPanel
+        key="assistant-panel"
         collapsed={aiPanelLayout.collapsed}
         onOpenSettings={() => navigateToPage("settings")}
         onToggleCollapsed={toggleAiPanel}
@@ -130,17 +133,19 @@ function App() {
       />
       {activePage === "settings" ? (
         <SettingsPage
+          key="settings-page"
           onBack={() => setActivePage(previousNonSettingsPageRef.current)}
           onResetLayout={resetWorkspaceChromeLayout}
         />
       ) : null}
       {dashboardMounted ? (
         <DashboardPage
+          key="dashboard-page"
           dashboardActive={activePage === "dashboard"}
           onAssistantContextChange={setDashboardAssistantContext}
         />
       ) : null}
-      <StatusBar activePage={activePage} onOpenAssistant={openAssistantPanel} />
+      <StatusBar key="status-bar" activePage={activePage} onOpenAssistant={openAssistantPanel} />
     </div>
   );
 }


### PR DESCRIPTION
## Problem

When the AI Assistant is actively streaming a response, switching from the Workspace page to the Settings page and back causes the AI to appear to 'forcibly stop' — the streaming output vanishes and the send button reappears as if the request was aborted.

## Root Cause

In \src/App.tsx\, the app-shell div has 7 direct children with 3 conditionally rendered (\PanelResizeHandle\, \SettingsPage\, \DashboardPage\). No child had a \key\ prop. React's index-based reconciliation could unmount and remount \AssistantPanel\ when conditional siblings shift indices during navigation. The remount resets all state (\isSendingPrompt\, \messages\) and severs the \Channel.onmessage\ handler, while the Rust backend keeps streaming with no receiver.

## Fix

Add stable \key\ props to all 7 direct children of the app-shell div so React tracks components by key rather than fragile index position. With keys, \AssistantPanel\ stays mounted and the streaming channel is preserved across page navigation.

## Verification

- \
pm run check\ — TypeScript passes
- \
pm run build\ — Vite build succeeds
- \cargo check --manifest-path src-tauri/Cargo.toml\ — Rust compiles