### PR TITLE
feat: expose Operation Manual as AI assistant tools (manual_search / manual_read_chapter)

### DIFF
--- a/docs/localization_todo/settings.aiTools.manual.description.md
+++ b/docs/localization_todo/settings.aiTools.manual.description.md
@@ -1,0 +1,10 @@
+# settings.aiTools.manual.description
+
+- **English value**: `Search and read the bundled KKTerm Operation Manual to answer how-to questions about app features.`
+- **Namespace**: `settings`
+- **File/component**: `src/settings/AiSettings.tsx`
+- **UI role**: `fragment`
+- **User flow**: `Shown under the Operation Manual tool toggle in AI Assistant settings, explaining what the tool does.`
+- **Tone**: `concise setup guidance`
+- **Domain notes**: `"Operation Manual" refers to the bundled docs/manual/ chapters; keep capitalization consistent with app.manual. "KKTerm" is the product name and stays English.`
+- **Placeholders**: `none`

--- a/docs/localization_todo/settings.aiTools.manual.label.md
+++ b/docs/localization_todo/settings.aiTools.manual.label.md
@@ -1,0 +1,10 @@
+# settings.aiTools.manual.label
+
+- **English value**: `Operation Manual`
+- **Namespace**: `settings`
+- **File/component**: `src/settings/AiSettings.tsx`
+- **UI role**: `label`
+- **User flow**: `Shown in Settings -> AI Assistant -> Assistant tools as the toggle label for the bundled Operation Manual search/read tool.`
+- **Tone**: `concise/neutral`
+- **Domain notes**: `"Operation Manual" is the proper noun for the bundled KKTerm end-user manual shipped under docs/manual/. Keep capitalized as a product surface name, matching app.manual.`
+- **Placeholders**: `none`

--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -3017,6 +3017,18 @@ fn ai_tool_definitions(settings: &AiAssistantToolSettings) -> Vec<OpenAiToolDefi
     if settings.shell_command() {
         tools.push(tool_definition("shell_command", "Run a non-destructive PowerShell or batch command from KKTerm app data only. Destructive commands are blocked.", json!({"type":"object","properties":{"command":{"type":"string"},"shell":{"type":"string","enum":["powershell","batch"]}},"required":["command"]})));
     }
+    if settings.manual() {
+        tools.push(tool_definition(
+            "manual_search",
+            "Search the KKTerm Operation Manual by keyword. Returns matching chapter slugs, titles, and matched hint lines. Call this first when the user asks how to use a KKTerm feature. Then call manual_read_chapter with the best slug to get the full instructions.",
+            json!({"type":"object","properties":{"query":{"type":"string","description":"Feature name, action, or synonym to search for (e.g. \"RDP\", \"add connection\", \"screenshot\")"}},"required":["query"]}),
+        ));
+        tools.push(tool_definition(
+            "manual_read_chapter",
+            "Read a full KKTerm Operation Manual chapter by its slug. Use after manual_search to get the complete instructions for a feature.",
+            json!({"type":"object","properties":{"slug":{"type":"string","description":"Chapter slug returned by manual_search (e.g. \"remote-desktop\", \"connections\")"}},"required":["slug"]}),
+        ));
+    }
     if settings.email() {
         tools.push(tool_definition(
             "send_email",
@@ -3514,6 +3526,14 @@ async fn run_ai_tool(
             app_data_file_read_tool(app_data_dir, args)
         }
         "shell_command" if tool_settings.shell_command() => shell_command_tool(app_data_dir, args),
+        "manual_search" if tool_settings.manual() => {
+            let query = arg_string(&args, "query");
+            crate::manual::ai_search_manual(app, &query)
+        }
+        "manual_read_chapter" if tool_settings.manual() => {
+            let slug = arg_string(&args, "slug");
+            crate::manual::ai_read_manual_chapter(app, &slug)
+        }
         "send_email" if tool_settings.email() => send_email_tool(settings, args).await,
         "performance_counters" if tool_settings.performance_counters() => {
             performance_counters_tool(app)

--- a/src-tauri/src/manual.rs
+++ b/src-tauri/src/manual.rs
@@ -42,6 +42,54 @@ fn resolve_chapter_path(
         .map_err(|error| format!("failed to resolve manual resource path: {error}"))
 }
 
+/// Search chapter titles and AI grep hints for a keyword. Returns a compact JSON summary.
+pub fn ai_search_manual(app: &AppHandle, query: &str) -> String {
+    let query_lower = query.to_ascii_lowercase();
+    let mut results: Vec<serde_json::Value> = Vec::new();
+    for chapter in CHAPTERS {
+        let Ok(path) = resolve_chapter_path(app, chapter.filename) else {
+            continue;
+        };
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let matched_hints: Vec<&str> = content
+            .lines()
+            .take(60)
+            .filter(|line| line.to_ascii_lowercase().contains(&query_lower))
+            .collect();
+        let title_match = chapter.title.to_ascii_lowercase().contains(&query_lower);
+        if title_match || !matched_hints.is_empty() {
+            results.push(serde_json::json!({
+                "slug": chapter.slug,
+                "title": chapter.title,
+                "matchedLines": matched_hints,
+            }));
+        }
+    }
+    if results.is_empty() {
+        format!("No manual chapters matched \"{query}\". Available chapter slugs: {}",
+            CHAPTERS.iter().map(|c| c.slug).collect::<Vec<_>>().join(", "))
+    } else {
+        serde_json::to_string(&results).unwrap_or_default()
+    }
+}
+
+/// Read a manual chapter by slug and return its Markdown content.
+pub fn ai_read_manual_chapter(app: &AppHandle, slug: &str) -> String {
+    let Some(chapter) = CHAPTERS.iter().find(|c| c.slug == slug) else {
+        let slugs: Vec<&str> = CHAPTERS.iter().map(|c| c.slug).collect();
+        return format!("Unknown chapter slug \"{slug}\". Valid slugs: {}", slugs.join(", "));
+    };
+    let Ok(path) = resolve_chapter_path(app, chapter.filename) else {
+        return format!("Failed to locate chapter file for \"{}\".", chapter.slug);
+    };
+    match fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(error) => format!("Failed to read chapter \"{}\": {error}", chapter.slug),
+    }
+}
+
 #[tauri::command]
 pub fn list_manual_chapters() -> Vec<ManualChapter> {
     CHAPTERS.to_vec()

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -443,6 +443,8 @@ pub struct AiAssistantToolSettings {
     sessions: bool,
     #[serde(default)]
     email: bool,
+    #[serde(default = "default_ai_manual_tool_enabled")]
+    manual: bool,
 }
 
 impl AiAssistantToolSettings {
@@ -479,6 +481,9 @@ impl AiAssistantToolSettings {
     pub(crate) fn email(&self) -> bool {
         self.email
     }
+    pub(crate) fn manual(&self) -> bool {
+        self.manual
+    }
     pub(crate) fn any_enabled(&self) -> bool {
         self.web_search
             || self.web_fetch
@@ -491,6 +496,7 @@ impl AiAssistantToolSettings {
             || self.connections
             || self.sessions
             || self.email
+            || self.manual
     }
 }
 
@@ -4042,6 +4048,7 @@ fn default_ai_assistant_tool_settings() -> AiAssistantToolSettings {
         connections: default_ai_connections_tool_enabled(),
         sessions: default_ai_sessions_tool_enabled(),
         email: false,
+        manual: default_ai_manual_tool_enabled(),
     }
 }
 
@@ -4062,6 +4069,10 @@ fn default_ai_connections_tool_enabled() -> bool {
 }
 
 fn default_ai_sessions_tool_enabled() -> bool {
+    true
+}
+
+fn default_ai_manual_tool_enabled() -> bool {
     true
 }
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -827,6 +827,10 @@
       "sessions": {
         "label": "Live Sessions",
         "description": "Read visible session context and interact with active terminal, remote desktop, and file browser Sessions."
+      },
+      "manual": {
+        "label": "Operation Manual",
+        "description": "Search and read the bundled KKTerm Operation Manual to answer how-to questions about app features."
       }
     },
     "searchProvider": "Search provider",

--- a/src/settings/AiSettings.tsx
+++ b/src/settings/AiSettings.tsx
@@ -388,6 +388,7 @@ const AI_ASSISTANT_TOOL_IDS: AiAssistantToolId[] = [
   "dashboard",
   "connections",
   "sessions",
+  "manual",
 ];
 
 const SEARCH_PROVIDER_OPTIONS: { value: SearchProvider; labelKey: string }[] = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -389,7 +389,8 @@ export type AiAssistantToolId =
   | "email"
   | "dashboard"
   | "connections"
-  | "sessions";
+  | "sessions"
+  | "manual";
 
 export type AiAssistantToolSettings = Record<AiAssistantToolId, boolean>;
 


### PR DESCRIPTION
## Summary

- Adds two new AI assistant tools so the in-app AI can answer KKTerm-specific how-to questions from the bundled Operation Manual, instead of relying on generic training-data knowledge.
- **`manual_search`** — keyword-scans chapter titles and the `## AI grep hints` blocks (first 60 lines of each file, where synonyms and i18n keys are already tagged) across all 18 chapters, returning matched slugs and lines as compact JSON.
- **`manual_read_chapter`** — reads a full chapter by slug when the AI needs the complete instructions.
- The `manual` tool group is **on by default** (same as `dashboard`, `connections`, `sessions`) and can be toggled in Settings → AI Assistant → Assistant tools.

## What changed

| File | Change |
|---|---|
| `src-tauri/src/manual.rs` | `ai_search_manual` + `ai_read_manual_chapter` public functions |
| `src-tauri/src/storage.rs` | `manual: bool` field in `AiAssistantToolSettings`, default `true` |
| `src-tauri/src/ai.rs` | Tool definitions + dispatch arms in `run_ai_tool` |
| `src/types.ts` | `"manual"` added to `AiAssistantToolId` union |
| `src/settings/AiSettings.tsx` | `"manual"` added to `AI_ASSISTANT_TOOL_IDS` |
| `src/i18n/locales/en.json` | Label + description for the manual tool toggle |

## How it works at runtime

1. User asks: *"how do I add an RDP connection?"*
2. AI calls `manual_search("RDP")` → returns `remote-desktop` chapter match with matched hint lines
3. AI calls `manual_read_chapter("remote-desktop")` → gets the full Markdown chapter
4. AI answers from actual KKTerm docs, including app-specific UI flows and terminology

The tool description instructs the model to call `manual_search` first on how-to questions, making it self-activating without any deterministic keyword routing.

## Reviewer notes

- No new Tauri commands — the two new functions are plain Rust called directly from `run_ai_tool`, not exposed to the frontend.
- The 60-line scan limit for `manual_search` covers all `## AI grep hints` sections (which appear at the top of every chapter) without loading full chapter text unnecessarily.
- Existing users' stored settings (which have no `manual` key) will get the tool enabled on next load via the `serde(default)` attribute — no migration needed.

## Test plan

- [ ] Build and run; ask the AI assistant "how do I add an RDP connection?" — verify it calls `manual_search` then `manual_read_chapter` in the tool call log
- [ ] Verify Settings → AI Assistant → Assistant tools shows "Operation Manual" toggle
- [ ] Toggle the tool off and confirm `manual_search` / `manual_read_chapter` are not offered to the model
- [ ] Ask about a feature not in the manual and verify a graceful "no chapters matched" response

🤖 Generated with [Claude Code](https://claude.com/claude-code)