### PR TITLE
feat: per-widget canvas opacity with 70% default for App Launcher & Connection widgets

### DIFF
--- a/docs/localization_todo/dashboard.canvasOpacity.md
+++ b/docs/localization_todo/dashboard.canvasOpacity.md
@@ -1,0 +1,10 @@
+# dashboard.canvasOpacity
+
+- **English value**: `Canvas opacity`
+- **Namespace**: `dashboard`
+- **File/component**: `src/dashboard/edit/CustomizePopover.tsx`
+- **UI role**: `label`
+- **User flow**: Shown in the Dashboard widget "Customize" popover, Common tab, above a 0-100 slider that controls how opaque the widget body (canvas area, excluding the title bar) is rendered. Defaults to 70% for the built-in App Launcher and Connection widgets, 100% otherwise; the user can adjust to taste so the dashboard background shows through.
+- **Tone**: concise/neutral label, paired with a percentage suffix in parentheses, matches the surrounding Common-tab labels (`Frosted glass background`, `Hide title bar`).
+- **Placeholders**: none (the displayed percentage like "(70%)" is appended in JSX, not in the translation)
+- **Domain notes**: "Canvas" here means the widget body area, not a `<canvas>` element. Keep wording short to fit alongside the slider. The KKTerm domain terms (Dashboard, Widget) typically stay English.

--- a/docs/manual/10-dashboard.md
+++ b/docs/manual/10-dashboard.md
@@ -4,7 +4,7 @@
 
 - Keys: `dashboard.*` (full namespace)
 - Topics: Dashboard Views, Widget Instances, presets (panel / ambient / tile / hero / action), accents, icons, backgrounds, density, edit layout, catalog, custom widgets (content + script), AI-authored widgets, agent widget JSON
-- Synonyms: "homepage", "tiles", "cards", "widgets", "report", "background image", "wallpaper"
+- Synonyms: "homepage", "tiles", "cards", "widgets", "report", "background image", "wallpaper", "translucent widget", "see-through widget", "canvas opacity"
 
 > **Terms:** see `CONTEXT.md`. **Dashboard View** is a durable SQLite-backed tab; **Widget Instance** is a placed widget on a View with its own preset/accent/title/layout. **Dashboard Custom Widget** is an AI-authored widget definition (kinds `content` or `script`). Architecture details live in `docs/DASHBOARD.md`.
 
@@ -58,6 +58,7 @@ Fields:
 
 - **Preset**: `dashboard.presetLabel`. Options: `dashboard.preset.panel`, `dashboard.preset.ambient`, `dashboard.preset.tile`, `dashboard.preset.hero`, `dashboard.preset.action`. Ambient hides the title bar by default; `dashboard.hideTitle` is also offered for other presets. Action preset adds an `dashboard.actionDirection` axis with `dashboard.actionDirectionOptions.vertical` / `dashboard.actionDirectionOptions.horizontal`.
 - **Glass background**: `dashboard.glassBackground`.
+- **Canvas opacity**: `dashboard.canvasOpacity` — slider (0-100) that fades the Widget Instance body area only, leaving the title bar fully opaque. Default 70% for the built-in App Launcher and Connection widgets, 100% otherwise; visual effect is applied on the panel preset's `.dw-body`.
 - **Accent**: `dashboard.accent`, default `dashboard.accentDefault`.
 - **Icon**: `dashboard.icon`.
 - **Title**: `dashboard.titleLabel`, placeholder `dashboard.titlePlaceholder`. Untitled widgets show `dashboard.untitledWidget`.

--- a/src-tauri/src/dashboard_storage.rs
+++ b/src-tauri/src/dashboard_storage.rs
@@ -96,6 +96,7 @@ pub struct DashboardWidgetInstance {
     pub hide_title: bool,
     pub action_direction: Option<String>,
     pub settings_values_json: String,
+    pub body_opacity: Option<i64>,
     pub grid_x: i64,
     pub grid_y: i64,
     pub grid_w: i64,
@@ -144,6 +145,8 @@ pub struct InstancePatch {
     pub action_direction: Option<Option<String>>,
     #[serde(default)]
     pub settings_values_json: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_nullable_patch")]
+    pub body_opacity: Option<Option<i64>>,
     #[serde(default)]
     pub grid_x: Option<i64>,
     #[serde(default)]
@@ -284,7 +287,8 @@ pub fn load_state(conn: &SqliteConnection) -> Result<DashboardLoadState, Dashboa
 
     let mut inst_stmt = conn.prepare(
         "SELECT id, view_id, kind, source_id, preset, accent_name, icon_name, custom_title,
-                glass, hide_title, action_direction, settings_values_json, grid_x, grid_y, grid_w, grid_h, sort_order
+                glass, hide_title, action_direction, settings_values_json, body_opacity,
+                grid_x, grid_y, grid_w, grid_h, sort_order
          FROM dashboard_widget_instances
          ORDER BY view_id, sort_order"
     )?;
@@ -303,11 +307,12 @@ pub fn load_state(conn: &SqliteConnection) -> Result<DashboardLoadState, Dashboa
                 hide_title: row.get::<_, i64>(9)? != 0,
                 action_direction: row.get(10)?,
                 settings_values_json: row.get(11)?,
-                grid_x: row.get(12)?,
-                grid_y: row.get(13)?,
-                grid_w: row.get(14)?,
-                grid_h: row.get(15)?,
-                sort_order: row.get(16)?,
+                body_opacity: row.get(12)?,
+                grid_x: row.get(13)?,
+                grid_y: row.get(14)?,
+                grid_w: row.get(15)?,
+                grid_h: row.get(16)?,
+                sort_order: row.get(17)?,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
@@ -491,8 +496,9 @@ pub fn add_instance(
     conn.execute(
         "INSERT INTO dashboard_widget_instances
             (id, view_id, kind, source_id, preset, accent_name, icon_name, custom_title,
-             glass, hide_title, action_direction, settings_values_json, grid_x, grid_y, grid_w, grid_h, sort_order)
-         VALUES (?, ?, ?, ?, ?, ?, ?, NULL, 0, ?, NULL, '{}', ?, ?, ?, ?, ?)",
+             glass, hide_title, action_direction, settings_values_json, body_opacity,
+             grid_x, grid_y, grid_w, grid_h, sort_order)
+         VALUES (?, ?, ?, ?, ?, ?, ?, NULL, 0, ?, NULL, '{}', NULL, ?, ?, ?, ?, ?)",
         params![id, view_id, kind, source_id, preset, accent_name, icon_name, hide_title as i64, x, y, w, h, next_sort],
     )?;
     Ok(DashboardWidgetInstance {
@@ -508,6 +514,7 @@ pub fn add_instance(
         hide_title,
         action_direction: None,
         settings_values_json: "{}".to_string(),
+        body_opacity: None,
         grid_x: x,
         grid_y: y,
         grid_w: w,
@@ -532,7 +539,8 @@ pub fn update_instance(
     }
     let mut current: DashboardWidgetInstance = conn.query_row(
         "SELECT id, view_id, kind, source_id, preset, accent_name, icon_name, custom_title,
-                glass, hide_title, action_direction, settings_values_json, grid_x, grid_y, grid_w, grid_h, sort_order
+                glass, hide_title, action_direction, settings_values_json, body_opacity,
+                grid_x, grid_y, grid_w, grid_h, sort_order
          FROM dashboard_widget_instances WHERE id = ?",
         params![id],
         |row| Ok(DashboardWidgetInstance {
@@ -548,11 +556,12 @@ pub fn update_instance(
             hide_title: row.get::<_, i64>(9)? != 0,
             action_direction: row.get(10)?,
             settings_values_json: row.get(11)?,
-            grid_x: row.get(12)?,
-            grid_y: row.get(13)?,
-            grid_w: row.get(14)?,
-            grid_h: row.get(15)?,
-            sort_order: row.get(16)?,
+            body_opacity: row.get(12)?,
+            grid_x: row.get(13)?,
+            grid_y: row.get(14)?,
+            grid_w: row.get(15)?,
+            grid_h: row.get(16)?,
+            sort_order: row.get(17)?,
         }),
     ).map_err(|e| match e {
         rusqlite::Error::QueryReturnedNoRows => DashboardStorageError::NotFound,
@@ -586,6 +595,17 @@ pub fn update_instance(
     if let Some(values) = patch.settings_values_json.clone() {
         current.settings_values_json = values;
     }
+    if let Some(opacity) = patch.body_opacity {
+        if let Some(value) = opacity {
+            if !(0..=100).contains(&value) {
+                return Err(DashboardStorageError::validation_with_detail(
+                    ValidationError::InvalidBodyOpacity,
+                    Some(format!("body_opacity must be between 0 and 100; got {value}")),
+                ));
+            }
+        }
+        current.body_opacity = opacity;
+    }
     if let Some(x) = patch.grid_x {
         current.grid_x = x;
     }
@@ -611,7 +631,7 @@ pub fn update_instance(
         "UPDATE dashboard_widget_instances
             SET preset = ?, accent_name = ?, icon_name = ?, custom_title = ?,
                 glass = ?, hide_title = ?, action_direction = ?, settings_values_json = ?,
-                grid_x = ?, grid_y = ?, grid_w = ?, grid_h = ?
+                body_opacity = ?, grid_x = ?, grid_y = ?, grid_w = ?, grid_h = ?
             WHERE id = ?",
         params![
             current.preset,
@@ -622,6 +642,7 @@ pub fn update_instance(
             current.hide_title as i64,
             current.action_direction,
             current.settings_values_json,
+            current.body_opacity,
             current.grid_x,
             current.grid_y,
             current.grid_w,
@@ -860,7 +881,8 @@ pub fn widget_secret_owner_id_for_instance(
 ) -> Result<Option<String>, DashboardStorageError> {
     let instance: DashboardWidgetInstance = conn.query_row(
         "SELECT id, view_id, kind, source_id, preset, accent_name, icon_name, custom_title,
-                glass, hide_title, action_direction, settings_values_json, grid_x, grid_y, grid_w, grid_h, sort_order
+                glass, hide_title, action_direction, settings_values_json, body_opacity,
+                grid_x, grid_y, grid_w, grid_h, sort_order
          FROM dashboard_widget_instances WHERE id = ?",
         params![instance_id],
         |row| Ok(DashboardWidgetInstance {
@@ -876,11 +898,12 @@ pub fn widget_secret_owner_id_for_instance(
             hide_title: row.get::<_, i64>(9)? != 0,
             action_direction: row.get(10)?,
             settings_values_json: row.get(11)?,
-            grid_x: row.get(12)?,
-            grid_y: row.get(13)?,
-            grid_w: row.get(14)?,
-            grid_h: row.get(15)?,
-            sort_order: row.get(16)?,
+            body_opacity: row.get(12)?,
+            grid_x: row.get(13)?,
+            grid_y: row.get(14)?,
+            grid_w: row.get(15)?,
+            grid_h: row.get(16)?,
+            sort_order: row.get(17)?,
         }),
     ).map_err(|e| match e {
         rusqlite::Error::QueryReturnedNoRows => DashboardStorageError::NotFound,
@@ -995,6 +1018,7 @@ mod tests {
                 hide_title INTEGER NOT NULL DEFAULT 0,
                 action_direction TEXT,
                 settings_values_json TEXT NOT NULL DEFAULT '{}',
+                body_opacity INTEGER,
                 grid_x INTEGER NOT NULL, grid_y INTEGER NOT NULL,
                 grid_w INTEGER NOT NULL, grid_h INTEGER NOT NULL,
                 sort_order INTEGER NOT NULL
@@ -1058,6 +1082,7 @@ mod tests {
                 hide_title: None,
                 action_direction: None,
                 settings_values_json: None,
+                body_opacity: None,
                 grid_x: None,
                 grid_y: None,
                 grid_w: None,
@@ -1099,6 +1124,7 @@ mod tests {
                 action_direction: None,
                 hide_title: Some(true),
                 settings_values_json: None,
+                body_opacity: None,
                 grid_x: None,
                 grid_y: None,
                 grid_w: None,
@@ -1168,6 +1194,7 @@ mod tests {
                 action_direction: None,
                 hide_title: None,
                 settings_values_json: None,
+                body_opacity: None,
                 grid_x: None,
                 grid_y: None,
                 grid_w: None,
@@ -1270,6 +1297,7 @@ mod tests {
                 hide_title: None,
                 action_direction: None,
                 settings_values_json: Some(r#"{"apiKey":"plain-text"}"#.into()),
+                body_opacity: None,
                 grid_x: None,
                 grid_y: None,
                 grid_w: None,
@@ -1288,6 +1316,7 @@ mod tests {
             preset: None, accent_name: None, icon_name: None, custom_title: None,
             glass: None, hide_title: None, action_direction: None,
             settings_values_json: Some(r#"{"apiKey":{"type":"secretRef","ownerId":"dashboard-widget-secret:inst:apiKey","hasSecret":true}}"#.into()),
+            body_opacity: None,
             grid_x: None, grid_y: None, grid_w: None, grid_h: None,
         }).unwrap();
         assert!(updated.settings_values_json.contains("secretRef"));

--- a/src-tauri/src/dashboard_validation.rs
+++ b/src-tauri/src/dashboard_validation.rs
@@ -171,6 +171,7 @@ pub enum ValidationError {
     InvalidBackground,
     InvalidScriptSource,
     UnusedLibrary,
+    InvalidBodyOpacity,
 }
 
 pub fn validate_preset(value: &str) -> Result<(), ValidationError> {

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -190,6 +190,7 @@ CREATE TABLE IF NOT EXISTS dashboard_widget_instances (
     hide_title INTEGER NOT NULL DEFAULT 0,
     action_direction TEXT,
     settings_values_json TEXT NOT NULL DEFAULT '{}',
+    body_opacity INTEGER,
     grid_x INTEGER NOT NULL,
     grid_y INTEGER NOT NULL,
     grid_w INTEGER NOT NULL,
@@ -1721,6 +1722,12 @@ impl Storage {
             "dashboard_widget_instances",
             "hide_title",
             "INTEGER NOT NULL DEFAULT 0",
+        )?;
+        ensure_column(
+            &connection,
+            "dashboard_widget_instances",
+            "body_opacity",
+            "INTEGER",
         )?;
         ensure_column(&connection, "dashboard_views", "background_json", "TEXT")?;
         ensure_column(&connection, "dashboard_views", "tab_color", "TEXT")?;
@@ -5160,12 +5167,13 @@ mod tests {
             connection.execute(
                 "INSERT INTO dashboard_widget_instances
                     (id, view_id, kind, source_id, preset, accent_name, icon_name, custom_title,
-                     glass, action_direction, settings_values_json, grid_x, grid_y, grid_w, grid_h, sort_order)
+                     glass, action_direction, settings_values_json, body_opacity,
+                     grid_x, grid_y, grid_w, grid_h, sort_order)
                  VALUES
                     ('inst-1', 'view-1', 'script', 'cw-1', 'panel', 'blue', 'Key', NULL,
                      0, NULL,
                      '{\"apiKey\":{\"type\":\"secretRef\",\"ownerId\":\"dashboard-widget-secret:inst-1:apiKey\",\"hasSecret\":true}}',
-                     0, 0, 4, 3, 0)",
+                     NULL, 0, 0, 4, 3, 0)",
                 [],
             ).map_err(to_storage_error)?;
             Ok(())

--- a/src/dashboard/dashboard.css
+++ b/src/dashboard/dashboard.css
@@ -955,6 +955,28 @@ button.dashboard-pill-dot:focus-visible {
   line-height: 1.55;
 }
 
+/* Panel preset: the body owns its own surface so --w-body-opacity can fade
+   only the canvas, leaving the accent-colored head fully opaque. */
+.dw-preset-panel {
+  background: transparent;
+}
+
+.dw-preset-panel .dw-body {
+  position: relative;
+  z-index: 0;
+  background: transparent;
+}
+
+.dw-preset-panel .dw-body::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background: var(--surface);
+  opacity: calc(var(--w-body-opacity, 100) / 100);
+}
+
 .dw-custom-widget .dw-head {
   min-height: 38px;
   padding: 5px 6px;

--- a/src/dashboard/edit/CustomizePopover.tsx
+++ b/src/dashboard/edit/CustomizePopover.tsx
@@ -17,7 +17,13 @@ import type {
   AccentName, DashboardWidgetInstance, IconName,
   WidgetSettingsField, WidgetSettingsSchema,
 } from "../types";
-import { defaultWidgetPresentationForPreset, ICON_NAMES, WIDGET_PRESETS } from "../types";
+import {
+  defaultBodyOpacityForInstance,
+  defaultWidgetPresentationForPreset,
+  effectiveBodyOpacity,
+  ICON_NAMES,
+  WIDGET_PRESETS,
+} from "../types";
 
 export interface CustomizePopoverProps {
   instance: DashboardWidgetInstance;
@@ -193,6 +199,9 @@ function CommonSection({ instance }: { instance: DashboardWidgetInstance }) {
         </section>
       ) : null}
 
+      <CanvasOpacityField instance={instance} />
+
+
       <section>
         <h4>{t("dashboard.accent")}</h4>
         <div className="dw-accent-picker">
@@ -233,6 +242,36 @@ function CommonSection({ instance }: { instance: DashboardWidgetInstance }) {
         </div>
       </section>
     </>
+  );
+}
+
+function CanvasOpacityField({ instance }: { instance: DashboardWidgetInstance }) {
+  const { t } = useTranslation();
+  const updateInstance = useDashboardStore((s) => s.updateInstance);
+  const value = effectiveBodyOpacity(instance);
+  const fallback = defaultBodyOpacityForInstance(instance);
+
+  return (
+    <section>
+      <label className="dw-field">
+        <span>
+          {t("dashboard.canvasOpacity")} <span className="dw-muted">({value}%)</span>
+        </span>
+        <input
+          type="range"
+          min={0}
+          max={100}
+          step={1}
+          value={value}
+          onChange={(e) => {
+            const next = Number(e.currentTarget.value);
+            void updateInstance(instance.id, {
+              bodyOpacity: next === fallback ? null : next,
+            });
+          }}
+        />
+      </label>
+    </section>
   );
 }
 

--- a/src/dashboard/types.ts
+++ b/src/dashboard/types.ts
@@ -16,6 +16,26 @@ export function defaultWidgetPresentationForPreset<T extends WidgetPreset>(prese
   return DEFAULT_WIDGET_PRESENTATION_BY_PRESET[preset];
 }
 
+const TRANSLUCENT_BUILT_IN_WIDGET_IDS = new Set(["appLauncher", "connectionPane"]);
+
+export function defaultBodyOpacityForInstance(instance: {
+  kind: WidgetKind;
+  sourceId: string;
+}): number {
+  if (instance.kind === "builtIn" && TRANSLUCENT_BUILT_IN_WIDGET_IDS.has(instance.sourceId)) {
+    return 70;
+  }
+  return 100;
+}
+
+export function effectiveBodyOpacity(instance: {
+  kind: WidgetKind;
+  sourceId: string;
+  bodyOpacity?: number | null;
+}): number {
+  return instance.bodyOpacity ?? defaultBodyOpacityForInstance(instance);
+}
+
 export const ACCENT_NAMES = [
   "default", "blue", "indigo", "teal", "green", "amber", "red", "purple", "pink",
   "slate", "cyan", "orange", "rose", "emerald", "sky",
@@ -65,6 +85,7 @@ export interface DashboardWidgetInstance {
   customTitle: string | null;
   glass?: boolean;
   hideTitle?: boolean;
+  bodyOpacity?: number | null;
   settingsValuesJson: string;
   gridX: number;
   gridY: number;
@@ -98,6 +119,7 @@ export interface InstancePatch {
   customTitle?: string | null;
   glass?: boolean;
   hideTitle?: boolean;
+  bodyOpacity?: number | null;
   settingsValuesJson?: string;
   gridX?: number;
   gridY?: number;

--- a/src/dashboard/view/WidgetFrame.tsx
+++ b/src/dashboard/view/WidgetFrame.tsx
@@ -10,6 +10,7 @@ import { useDashboardStore } from "../state/dashboardStore";
 import { getBuiltInWidget } from "../registry/builtInRegistry";
 import { PRESET_RENDERERS } from "../registry/presetRegistry";
 import { resolveAccent } from "../registry/palette";
+import { effectiveBodyOpacity } from "../types";
 import type { DashboardWidgetInstance } from "../types";
 import { WidgetBody } from "./WidgetBody";
 
@@ -112,6 +113,7 @@ export function WidgetFrame({ instance, onCustomize }: WidgetFrameProps) {
     ["--w-accent" as unknown as string]: accent.color,
     ["--w-accent-soft" as unknown as string]: accent.soft,
     ["--w-title-text" as unknown as string]: accent.titleText,
+    ["--w-body-opacity" as unknown as string]: effectiveBodyOpacity(instance),
   } as CSSProperties;
 
   const className = [

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -59,6 +59,7 @@
     },
     "glassBackground": "Frosted glass background",
     "hideTitle": "Hide title bar",
+    "canvasOpacity": "Canvas opacity",
     "actionDirection": "Layout direction",
     "actionDirectionOptions": {
       "vertical": "Vertical",


### PR DESCRIPTION
## Summary

- Built-in **App Launcher** and **Connection** widgets now render their canvas (body area, excluding the title bar) at **70% opacity by default**, letting the Dashboard background show through.
- Every widget gets a new **Canvas opacity** slider (0–100%) in the Customize popover's *Common* tab. The per-widget default is computed on read, so changing a built-in's default later doesn't require a data migration — the column stays `NULL` until the user overrides.
- CSS-side: only `.dw-body` is faded via a `::before` overlay driven by `--w-body-opacity`. The accent-tinted `.dw-head` stays fully opaque, matching the user's "not including title bar" spec.

## What changed

- **SQLite**: nullable `body_opacity INTEGER` column on `dashboard_widget_instances`, added through the existing `ensure_column` migration path (no `SCHEMA_USER_VERSION` bump, no destructive table rebuild).
- **Rust** (`dashboard_storage.rs`, `dashboard_validation.rs`): `body_opacity: Option<i64>` on `DashboardWidgetInstance`; `Option<Option<i64>>` on `InstancePatch` with the existing `deserialize_nullable_patch` helper (missing → don't touch, `null` → clear, value → set). New `InvalidBodyOpacity` validation variant, range 0–100.
- **TypeScript** (`src/dashboard/types.ts`): `bodyOpacity?: number | null` on instance + patch; `defaultBodyOpacityForInstance` (70 for `appLauncher`/`connectionPane`, 100 otherwise) and `effectiveBodyOpacity` helpers used by both the renderer and the slider.
- **Slider** (`CustomizePopover.tsx`): added `CanvasOpacityField` in the Common section; writes `null` back to the patch when the value matches the per-widget default so the row stays "unspecified."
- **CSS** (`dashboard.css`): `.dw-preset-panel` becomes transparent at the parent level; `.dw-body::before` paints a `--surface`-colored overlay with `opacity: calc(var(--w-body-opacity, 100) / 100)`. Avoids `color-mix()` per `AGENTS.md`.
- **i18n**: new `dashboard.canvasOpacity` key + `docs/localization_todo/dashboard.canvasOpacity.md` per the per-key backlog rule.
- **Manual** (`docs/manual/10-dashboard.md`): documented the new Common-tab field and added grep hint synonyms.

## Notes for the reviewer

- Scope is intentionally focused on the **panel preset's body** (`.dw-body`), which covers both target widgets. The slider is visible on every widget and persists for all presets, but the visual effect on the ambient/hero presets is minimal in this change since their backgrounds are structured differently (ambient already has the `glass` option, hero uses a full-card gradient). Happy to extend hero/ambient in a follow-up if you want them visually parity.
- `body_opacity` is stored as `NULL` whenever the user lands on the computed default — this keeps existing rows untouched and means a future default change won't silently overwrite users' explicit choices.
- WebView2-safe: no `color-mix()`, no `backdrop-filter` additions; uses `::before` with `opacity` and a CSS var.

## Test plan

- [ ] `npm run check` ✅ (clean tsc)
- [ ] `npm run build` ✅
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml` ✅
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml` ✅ (297 passed)
- [ ] **Native verification** in `npm run tauri dev`:
  - [ ] Fresh-install / migrated DB: App Launcher and Connection widget bodies render at ~70% opacity over the dashboard background; their title bars stay fully opaque.
  - [ ] Customize popover → Common tab shows the *Canvas opacity* slider with the live percentage; dragging updates the widget in real-time.
  - [ ] Setting the slider back to the widget's default value clears the override (verified by reloading — the widget still uses the default).
  - [ ] Notes (ambient) and any hero-preset custom widget render unchanged at 100% by default; slider persists value across reloads.
  - [ ] No regression to head accent gradient, border radius, or panel shadow at any opacity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)