### PR TITLE
Fix Check for Updates and show Last Checked time

### DIFF
--- a/docs/localization_todo/settings.lastCheckedAt.md
+++ b/docs/localization_todo/settings.lastCheckedAt.md
@@ -1,0 +1,10 @@
+# settings.lastCheckedAt
+
+- **English value**: `Last checked {{time}}`
+- **Namespace**: `settings`
+- **File/component**: `src/settings/AboutSettings.tsx`
+- **UI role**: `status`
+- **User flow**: Shown beside the "Check for Updates" button in Settings → About to indicate when the app last contacted GitHub for a release check. Updates after every manual or startup check, regardless of outcome.
+- **Tone**: concise, neutral, status-line tone (similar in feel to "Last synced …" labels).
+- **Placeholders**: `{{time}}` — a fully formatted localized date+time string (already produced by `Date.toLocaleString` with the active locale).
+- **Domain notes**: Refers to the app's GitHub-release update check, not any remote-host connection check. Keep "Last checked" short — it sits inline next to a button.

--- a/docs/localization_todo/settings.lastCheckedNever.md
+++ b/docs/localization_todo/settings.lastCheckedNever.md
@@ -1,0 +1,10 @@
+# settings.lastCheckedNever
+
+- **English value**: `Never checked`
+- **Namespace**: `settings`
+- **File/component**: `src/settings/AboutSettings.tsx`
+- **UI role**: `status`
+- **User flow**: Shown beside the "Check for Updates" button in Settings → About when no update check has ever been recorded on this machine (clean install, cleared storage, or runtime that disables checks). Replaced by `settings.lastCheckedAt` once a check completes.
+- **Tone**: concise, neutral, status-line tone.
+- **Placeholders**: none
+- **Domain notes**: Refers to the app's GitHub-release update check, not any remote-host connection check.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { AssistantPanel } from "./ai/AssistantPanel";
 import type { AssistantPageContext } from "./ai/AssistantPanel";
 import { ActivityRail } from "./app/ActivityRail";
 import type { ActivePage } from "./app/ActivityRail";
+import { AppUpdatePrompt } from "./app/AppUpdatePrompt";
 import {
   useAppShellAppearance,
   useFrontendLaunchTimestamp,
@@ -70,7 +71,7 @@ function App() {
     toggleConnectionPanel,
   } = useWorkspaceChromeLayout(resetAllLayouts);
 
-  useBootstrapSettings();
+  const { generalSettingsReady } = useBootstrapSettings();
   useDashboardBackendInvalidation();
   useFrontendLaunchTimestamp();
   useHostUsagePolling();
@@ -150,6 +151,7 @@ function App() {
         />
       ) : null}
       <StatusBar key="status-bar" activePage={activePage} onOpenAssistant={openAssistantPanel} />
+      <AppUpdatePrompt key="app-update-prompt" settingsReady={generalSettingsReady} />
     </div>
   );
 }

--- a/src/app/AppUpdatePrompt.tsx
+++ b/src/app/AppUpdatePrompt.tsx
@@ -8,6 +8,7 @@ import {
   type AppUpdate,
 } from "../lib/appUpdates";
 import { shouldRunStartupUpdateCheck } from "../lib/appUpdatesModel";
+import { recordUpdateCheckedNow } from "../lib/lastUpdateCheck";
 import { isTauriRuntime } from "../lib/tauri";
 import { useWorkspaceStore } from "../store";
 
@@ -66,6 +67,7 @@ export function AppUpdatePrompt({
         });
       }
     } finally {
+      recordUpdateCheckedNow();
       setChecking(false);
     }
   }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -706,6 +706,8 @@
     "github": "GitHub",
     "softwareUpdates": "Software updates",
     "checkForUpdates": "Check for Updates",
+    "lastCheckedAt": "Last checked {{time}}",
+    "lastCheckedNever": "Never checked",
     "checkingForUpdates": "Checking for updates...",
     "updateNoUpdates": "KKTerm is up to date.",
     "updateAvailableTitle": "Update available",

--- a/src/lib/lastUpdateCheck.ts
+++ b/src/lib/lastUpdateCheck.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "kkterm:lastUpdateCheckAt";
+const CHANGE_EVENT = "kkterm:last-update-check-changed";
+
+export function readLastUpdateCheckAt(): number | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function recordUpdateCheckedNow(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  const timestamp = Date.now();
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(timestamp));
+  } catch {
+    // localStorage may be unavailable (private mode, quota); the in-memory
+    // notification below still lets the current session reflect the check.
+  }
+  window.dispatchEvent(new CustomEvent(CHANGE_EVENT, { detail: timestamp }));
+}
+
+export function useLastUpdateCheckAt(): number | null {
+  const [timestamp, setTimestamp] = useState<number | null>(() =>
+    readLastUpdateCheckAt(),
+  );
+
+  useEffect(() => {
+    const handleChange = () => setTimestamp(readLastUpdateCheckAt());
+    window.addEventListener(CHANGE_EVENT, handleChange);
+    // Sync across windows/tabs that share localStorage.
+    window.addEventListener("storage", handleChange);
+    return () => {
+      window.removeEventListener(CHANGE_EVENT, handleChange);
+      window.removeEventListener("storage", handleChange);
+    };
+  }, []);
+
+  return timestamp;
+}

--- a/src/settings/AboutSettings.tsx
+++ b/src/settings/AboutSettings.tsx
@@ -1,17 +1,32 @@
 import { ExternalLink, PackageOpen, RefreshCw } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { CHECK_FOR_APP_UPDATES_EVENT } from "../app/AppUpdatePrompt";
+import { useLastUpdateCheckAt } from "../lib/lastUpdateCheck";
 import { ABOUT_PRODUCT } from "./aboutData";
 import { SettingsSectionHeader, SettingsSummary } from "./shared";
 
 export function AboutSettings() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const lastCheckedAt = useLastUpdateCheckAt();
+  const lastCheckedLabel = lastCheckedAt
+    ? t("settings.lastCheckedAt", {
+        time: new Date(lastCheckedAt).toLocaleString(i18n.language),
+      })
+    : t("settings.lastCheckedNever");
 
   return (
     <section className="settings-card settings-section">
       <SettingsSectionHeader
         actions={
           <>
+            <span
+              className="field-hint"
+              title={
+                lastCheckedAt ? new Date(lastCheckedAt).toISOString() : undefined
+              }
+            >
+              {lastCheckedLabel}
+            </span>
             <button
               className="toolbar-button"
               onClick={() =>


### PR DESCRIPTION
## Summary

- **Fix:** the "Check for Updates" button in Settings → About was a no-op. `AppUpdatePrompt` (the component that listens for `kkterm:check-for-updates` and runs the GitHub release check) was exported but never mounted anywhere in the app tree, so dispatches had no subscriber. Mount it in `App.tsx`, gated on `generalSettingsReady` so the startup check waits for hydrated settings.
- **Feature:** show "Last checked &lt;time&gt;" left of the Check for Updates button. The timestamp is persisted in `localStorage` and updated after every manual or startup check (success or failure), so users get immediate feedback even when there is no newer release. A small custom event keeps the label reactive without coupling `AboutSettings` to `AppUpdatePrompt`'s lifecycle.

## Why

Before this PR, clicking the button silently did nothing — no network call, no status bar message, no dialog — making it impossible to tell whether the app was up to date or whether the check had failed. The added "Last checked" label gives a persistent breadcrumb that survives across launches.

## Notes for reviewers

- New i18n keys `settings.lastCheckedAt` and `settings.lastCheckedNever` are added to `en.json` only, with matching `docs/localization_todo/` entries per `AGENTS.md` §i18n rule 2–4. `npm run i18n:check` flags them as expected pending translations.
- Timestamp display uses `Date.toLocaleString(i18n.language)` so it respects the active locale; an ISO-8601 tooltip is provided for unambiguous reading.
- The recording call sits in `finally`, so failed checks still refresh the label — users can distinguish outcome via the existing status-bar tone.
- No backend / Rust changes; `localStorage` is the right tier for a per-device UI breadcrumb that doesn't belong in the settings schema.

## Test plan

- [ ] `npm run tauri dev`, open Settings → About, click **Check for Updates** — expect either an update dialog (if a newer non-draft, non-prerelease tag exists) or "KKTerm is up to date." in the status bar.
- [ ] The "Last checked" label updates immediately after the check completes; reloading the app preserves the timestamp.
- [ ] Block network and click the button — status bar shows the failure, "Last checked" still updates to "just now".
- [ ] Startup check still runs once per launch when `autoUpdateChecksEnabled` is true and not a debug build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)