### PR TITLE
fix(ai-usage): real Claude quotas, brand icons, subscription badge

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4591,6 +4591,7 @@ checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ anyhow = "1.0.102"
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream", "form"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream", "form", "blocking"] }
 github-copilot-sdk = "1.0.0-beta.4"
 rand = "0.9"
 base64 = "0.22"

--- a/src-tauri/src/ai_coding_usage.rs
+++ b/src-tauri/src/ai_coding_usage.rs
@@ -65,6 +65,7 @@ pub struct AiCodingUsageProviderState {
     auth_state: String,
     account_label: Option<String>,
     account_email: Option<String>,
+    subscription_plan: Option<String>,
     five_hour: AiCodingUsageQuotaWindow,
     weekly: AiCodingUsageQuotaWindow,
     last_refresh_at: Option<String>,
@@ -157,6 +158,7 @@ pub async fn ai_coding_usage_disconnect(
 struct ProviderUpdate {
     account_label: Option<String>,
     account_email: Option<String>,
+    subscription_plan: Option<String>,
     auth_state: &'static str,
     snapshot: Option<ProviderSnapshot>,
     raw_provider_json: Option<Value>,
@@ -223,7 +225,7 @@ fn load_provider_state(
 ) -> Result<AiCodingUsageProviderState, String> {
     let row = connection
         .query_row(
-            "SELECT account_label, account_email, auth_state, last_refresh_at, last_error
+            "SELECT account_label, account_email, subscription_plan, auth_state, last_refresh_at, last_error
              FROM ai_coding_usage_accounts
              WHERE provider = ?1",
             params![provider.as_str()],
@@ -231,16 +233,25 @@ fn load_provider_state(
                 Ok((
                     row.get::<_, Option<String>>(0)?,
                     row.get::<_, Option<String>>(1)?,
-                    row.get::<_, String>(2)?,
-                    row.get::<_, Option<String>>(3)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, String>(3)?,
                     row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<String>>(5)?,
                 ))
             },
         )
         .optional()
         .map_err(|error| format!("failed to load usage account: {error}"))?;
 
-    let Some((account_label, account_email, auth_state, last_refresh_at, last_error)) = row else {
+    let Some((
+        account_label,
+        account_email,
+        subscription_plan,
+        auth_state,
+        last_refresh_at,
+        last_error,
+    )) = row
+    else {
         return Ok(disconnected_state(provider));
     };
 
@@ -272,6 +283,7 @@ fn load_provider_state(
         auth_state,
         account_label,
         account_email,
+        subscription_plan,
         five_hour: snapshot
             .as_ref()
             .map(|snapshot| snapshot.five_hour.clone())
@@ -291,6 +303,7 @@ fn disconnected_state(provider: AiCodingUsageProvider) -> AiCodingUsageProviderS
         auth_state: "disconnected".to_string(),
         account_label: None,
         account_email: None,
+        subscription_plan: None,
         five_hour: AiCodingUsageQuotaWindow::unknown(),
         weekly: AiCodingUsageQuotaWindow::unknown(),
         last_refresh_at: None,
@@ -308,11 +321,12 @@ fn save_provider_update(
     connection
         .execute(
             "INSERT INTO ai_coding_usage_accounts
-                (provider, account_label, account_email, auth_state, last_refresh_at, last_error, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                (provider, account_label, account_email, subscription_plan, auth_state, last_refresh_at, last_error, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
              ON CONFLICT(provider) DO UPDATE SET
                 account_label = excluded.account_label,
                 account_email = excluded.account_email,
+                subscription_plan = excluded.subscription_plan,
                 auth_state = excluded.auth_state,
                 last_refresh_at = excluded.last_refresh_at,
                 last_error = excluded.last_error,
@@ -321,6 +335,7 @@ fn save_provider_update(
                 provider.as_str(),
                 update.account_label,
                 update.account_email,
+                update.subscription_plan,
                 update.auth_state,
                 now,
                 last_error,
@@ -436,9 +451,10 @@ fn refresh_codex(cli_paths: &ProviderCliPaths) -> Result<ProviderUpdate, String>
     Ok(ProviderUpdate {
         account_label: email
             .clone()
-            .or(plan)
+            .or_else(|| plan.clone())
             .or_else(|| Some(AiCodingUsageProvider::Codex.label().to_string())),
         account_email: email,
+        subscription_plan: plan,
         auth_state: "connected",
         snapshot: Some(snapshot),
         raw_provider_json: Some(rate_limits),
@@ -462,27 +478,140 @@ fn refresh_claude(cli_paths: &ProviderCliPaths) -> Result<ProviderUpdate, String
         "claude",
         AiCodingUsageProvider::ClaudeCode,
     );
-    let output = run_command(&command, &["auth", "status"], Duration::from_secs(30))?;
-    let value =
+    let output = run_command(
+        &command,
+        &["auth", "status", "--json"],
+        Duration::from_secs(30),
+    )?;
+    let status_value =
         serde_json::from_str::<Value>(&output).unwrap_or_else(|_| json!({ "text": output }));
-    Ok(claude_update_from_status_value(value))
+
+    if status_value.get("loggedIn").and_then(Value::as_bool) == Some(false) {
+        return Err("Claude Code is not logged in.".to_string());
+    }
+
+    let mut update = claude_update_from_status_value(status_value);
+    match fetch_claude_oauth_usage() {
+        Ok(usage) => {
+            update.snapshot = Some(normalize_claude_oauth_usage(&usage));
+            update.raw_provider_json = Some(usage);
+        }
+        Err(error) => {
+            update.last_error = Some(error);
+        }
+    }
+    Ok(update)
 }
 
 fn claude_update_from_status_value(value: Value) -> ProviderUpdate {
     let email = find_string_key(&value, &["email", "accountEmail", "username"]);
     let label = email
         .clone()
+        .or_else(|| find_string_key(&value, &["orgName"]))
         .or_else(|| find_string_key(&value, &["account", "login", "name"]));
-    let snapshot = normalize_claude_rate_limits(&value);
+    let subscription_plan = find_string_key(&value, &["subscriptionType", "subscription_type"]);
     ProviderUpdate {
         account_label: label
             .or_else(|| Some(AiCodingUsageProvider::ClaudeCode.label().to_string())),
         account_email: email,
+        subscription_plan,
         auth_state: "connected",
-        snapshot: Some(snapshot),
+        snapshot: None,
         raw_provider_json: Some(value),
         last_error: None,
     }
+}
+
+const CLAUDE_OAUTH_USAGE_URL: &str = "https://api.anthropic.com/api/oauth/usage";
+const CLAUDE_OAUTH_BETA_HEADER: &str = "oauth-2025-04-20";
+
+fn fetch_claude_oauth_usage() -> Result<Value, String> {
+    let token = read_claude_oauth_token()?;
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(20))
+        .build()
+        .map_err(|error| format!("failed to build HTTP client: {error}"))?;
+    let response = client
+        .get(CLAUDE_OAUTH_USAGE_URL)
+        .bearer_auth(&token)
+        .header("anthropic-beta", CLAUDE_OAUTH_BETA_HEADER)
+        .send()
+        .map_err(|error| format!("Claude usage request failed: {error}"))?;
+    let status = response.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(
+            "Claude Code OAuth token rejected. Please sign in again with `claude auth login`."
+                .to_string(),
+        );
+    }
+    if !status.is_success() {
+        return Err(format!("Claude usage endpoint returned HTTP {status}."));
+    }
+    response
+        .json::<Value>()
+        .map_err(|error| format!("failed to parse Claude usage response: {error}"))
+}
+
+fn read_claude_oauth_token() -> Result<String, String> {
+    let path = claude_credentials_path().ok_or_else(|| {
+        "Claude credentials file is not available on this platform.".to_string()
+    })?;
+    let content = std::fs::read_to_string(&path).map_err(|error| {
+        format!(
+            "failed to read Claude credentials at {}: {error}",
+            path.display()
+        )
+    })?;
+    let value: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|error| format!("failed to parse Claude credentials: {error}"))?;
+    value
+        .pointer("/claudeAiOauth/accessToken")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| {
+            "Claude credentials do not contain an OAuth access token. Sign in with `claude auth login`."
+                .to_string()
+        })
+}
+
+fn claude_credentials_path() -> Option<PathBuf> {
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    {
+        let home = std::env::var_os("USERPROFILE").or_else(|| std::env::var_os("HOME"))?;
+        Some(PathBuf::from(home).join(".claude").join(".credentials.json"))
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+    {
+        None
+    }
+}
+
+fn normalize_claude_oauth_usage(value: &Value) -> ProviderSnapshot {
+    let five_hour = value
+        .pointer("/five_hour")
+        .and_then(oauth_usage_window_from_value)
+        .unwrap_or_else(AiCodingUsageQuotaWindow::unknown);
+    let weekly = value
+        .pointer("/seven_day")
+        .and_then(oauth_usage_window_from_value)
+        .unwrap_or_else(AiCodingUsageQuotaWindow::unknown);
+    ProviderSnapshot { five_hour, weekly }
+}
+
+fn oauth_usage_window_from_value(value: &Value) -> Option<AiCodingUsageQuotaWindow> {
+    let object = value.as_object()?;
+    let used_percent = object
+        .get("utilization")
+        .and_then(Value::as_f64)
+        .map(clamp_percent);
+    let resets_at = object
+        .get("resets_at")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    Some(AiCodingUsageQuotaWindow {
+        used_percent,
+        resets_at,
+    })
 }
 
 struct CodexRpcSession {
@@ -782,18 +911,6 @@ fn normalize_codex_rate_limits(value: &Value) -> ProviderSnapshot {
     ProviderSnapshot { five_hour, weekly }
 }
 
-fn normalize_claude_rate_limits(value: &Value) -> ProviderSnapshot {
-    let five_hour = value
-        .pointer("/rate_limits/five_hour")
-        .and_then(quota_window_from_value)
-        .unwrap_or_else(AiCodingUsageQuotaWindow::unknown);
-    let weekly = value
-        .pointer("/rate_limits/seven_day")
-        .and_then(quota_window_from_value)
-        .unwrap_or_else(AiCodingUsageQuotaWindow::unknown);
-    ProviderSnapshot { five_hour, weekly }
-}
-
 #[derive(Debug)]
 struct QuotaCandidate {
     used_percent: Option<f64>,
@@ -864,19 +981,6 @@ fn collect_quota_windows_inner(
     }
 }
 
-fn quota_window_from_value(value: &Value) -> Option<AiCodingUsageQuotaWindow> {
-    let object = value.as_object()?;
-    let used_percent = numeric_key(object, &["used_percentage", "usedPercent"]).map(clamp_percent);
-    let resets_at = object
-        .get("resets_at")
-        .or_else(|| object.get("resetsAt"))
-        .and_then(timestamp_to_rfc3339);
-    Some(AiCodingUsageQuotaWindow {
-        used_percent,
-        resets_at,
-    })
-}
-
 fn numeric_key(map: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<f64> {
     keys.iter()
         .find_map(|key| map.get(*key))
@@ -935,42 +1039,53 @@ mod tests {
     use super::*;
 
     #[test]
-    fn normalizes_claude_status_rate_limits() {
+    fn normalizes_claude_oauth_usage() {
         let value = serde_json::json!({
-            "rate_limits": {
-                "five_hour": { "used_percentage": 42.5, "resets_at": 1770000000 },
-                "seven_day": { "used_percentage": 12.0, "resets_at": 1770400000 }
-            }
+            "five_hour": { "utilization": 23.0, "resets_at": "2026-05-19T18:30:00+00:00" },
+            "seven_day": { "utilization": 18.0, "resets_at": "2026-05-25T14:00:00+00:00" },
+            "seven_day_opus": null,
+            "extra_usage": { "is_enabled": false }
         });
 
-        let snapshot = normalize_claude_rate_limits(&value);
+        let snapshot = normalize_claude_oauth_usage(&value);
 
-        assert_eq!(snapshot.five_hour.used_percent, Some(42.5));
-        assert_eq!(snapshot.weekly.used_percent, Some(12.0));
+        assert_eq!(snapshot.five_hour.used_percent, Some(23.0));
+        assert_eq!(snapshot.weekly.used_percent, Some(18.0));
         assert_eq!(
             snapshot.five_hour.resets_at.as_deref(),
-            Some("2026-02-02T02:40:00Z")
+            Some("2026-05-19T18:30:00+00:00")
         );
         assert_eq!(
             snapshot.weekly.resets_at.as_deref(),
-            Some("2026-02-06T17:46:40Z")
+            Some("2026-05-25T14:00:00+00:00")
         );
     }
 
     #[test]
-    fn claude_auth_status_without_rate_limits_is_not_an_error() {
+    fn missing_oauth_usage_window_falls_back_to_unknown() {
+        let snapshot = normalize_claude_oauth_usage(&serde_json::json!({}));
+        assert!(snapshot.five_hour.used_percent.is_none());
+        assert!(snapshot.weekly.used_percent.is_none());
+    }
+
+    #[test]
+    fn claude_auth_status_populates_account_without_snapshot() {
         let value = serde_json::json!({
             "loggedIn": true,
             "authMethod": "claude.ai",
             "email": "ryan@example.com",
+            "orgName": "Ryan's Org",
             "subscriptionType": "pro"
         });
 
         let update = claude_update_from_status_value(value);
 
         assert_eq!(update.auth_state, "connected");
+        assert_eq!(update.account_email.as_deref(), Some("ryan@example.com"));
+        assert_eq!(update.account_label.as_deref(), Some("ryan@example.com"));
+        assert_eq!(update.subscription_plan.as_deref(), Some("pro"));
         assert_eq!(update.last_error, None);
-        assert_eq!(update.snapshot.unwrap().five_hour.used_percent, None);
+        assert!(update.snapshot.is_none());
     }
 
     #[test]

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -240,6 +240,7 @@ CREATE TABLE IF NOT EXISTS ai_coding_usage_accounts (
     provider TEXT PRIMARY KEY CHECK (provider IN ('codex', 'claudeCode')),
     account_label TEXT,
     account_email TEXT,
+    subscription_plan TEXT,
     auth_state TEXT NOT NULL DEFAULT 'disconnected'
         CHECK (auth_state IN ('disconnected', 'connected', 'expired', 'error')),
     last_refresh_at TEXT,
@@ -1813,6 +1814,12 @@ impl Storage {
         )?;
         ensure_column(&connection, "dashboard_views", "background_json", "TEXT")?;
         ensure_column(&connection, "dashboard_views", "tab_color", "TEXT")?;
+        ensure_column(
+            &connection,
+            "ai_coding_usage_accounts",
+            "subscription_plan",
+            "TEXT",
+        )?;
         connection
             .execute(
                 "UPDATE dashboard_widget_instances

--- a/src/App.css
+++ b/src/App.css
@@ -10439,6 +10439,30 @@ fieldset.connection-specific-options > legend {
   white-space: nowrap;
 }
 
+.ai-coding-provider-name-row {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.ai-coding-provider-plan {
+  padding: 1px 6px;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--text-secondary, currentColor);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1.4;
+  text-transform: uppercase;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 9em;
+}
+
 .ai-coding-provider-account {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/ai-coding-usage/AiCodingUsageWidget.tsx
+++ b/src/ai-coding-usage/AiCodingUsageWidget.tsx
@@ -1,4 +1,5 @@
-import { Bot, Code2, ExternalLink, LogOut, Plus, RefreshCw, X } from "lucide-react";
+import { ExternalLink, LogOut, Plus, RefreshCw, X } from "lucide-react";
+import { ClaudeCodeColorIcon, CodexColorIcon } from "./providerIcons";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode, RefObject } from "react";
 import { createPortal } from "react-dom";
@@ -35,6 +36,7 @@ const EMPTY_STATE: AiCodingUsageState = {
     authState: "disconnected",
     accountLabel: null,
     accountEmail: null,
+    subscriptionPlan: null,
     fiveHour: {},
     weekly: {},
     lastRefreshAt: null,
@@ -316,7 +318,7 @@ function ProviderSlot({
   const label = t(`dashboard.aiCodingUsageProvider.${provider.provider}`);
   const connected = provider.authState === "connected";
   const displayError = providerDisplayError(provider);
-  const Icon = provider.provider === "codex" ? Code2 : Bot;
+  const Icon = provider.provider === "codex" ? CodexColorIcon : ClaudeCodeColorIcon;
 
   return (
     <section className="ai-coding-provider" data-state={provider.authState}>
@@ -326,7 +328,14 @@ function ProviderSlot({
             <Icon size={15} />
           </span>
           <span>
-            <span className="ai-coding-provider-name">{label}</span>
+            <span className="ai-coding-provider-name-row">
+              <span className="ai-coding-provider-name">{label}</span>
+              {provider.subscriptionPlan ? (
+                <span className="ai-coding-provider-plan" title={provider.subscriptionPlan}>
+                  {formatSubscriptionPlan(provider.subscriptionPlan)}
+                </span>
+              ) : null}
+            </span>
             <span className="ai-coding-provider-account">
               {provider.accountLabel || provider.accountEmail || t("dashboard.aiCodingUsageNotConnected")}
             </span>
@@ -450,7 +459,7 @@ function AiCodingUsageAddMenu({
     >
       {providers.map((provider) => (
         <MenuButton
-          icon={provider === "codex" ? <Code2 size={14} /> : <Bot size={14} />}
+          icon={provider === "codex" ? <CodexColorIcon size={14} /> : <ClaudeCodeColorIcon size={14} />}
           key={provider}
           label={t(`dashboard.aiCodingUsageProvider.${provider}`)}
           onClick={() => {
@@ -533,6 +542,15 @@ function replaceProvider(
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
+}
+
+function formatSubscriptionPlan(plan: string) {
+  const trimmed = plan.trim();
+  if (!trimmed) return "";
+  return trimmed
+    .split(/[\s_-]+/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
 }
 
 function formatDateTime(value: string) {

--- a/src/ai-coding-usage/providerIcons.tsx
+++ b/src/ai-coding-usage/providerIcons.tsx
@@ -1,0 +1,119 @@
+import { useId } from "react";
+import type { SVGProps } from "react";
+
+type ProviderIconProps = Omit<SVGProps<SVGSVGElement>, "viewBox" | "xmlns"> & {
+  size?: number | string;
+};
+
+// SVGs sourced from @lobehub/icons-static-svg (icon ids: `codex`, `claudecode`).
+// CDN: https://unpkg.com/@lobehub/icons-static-svg@latest/icons/<id>.svg
+//
+// Variants:
+//   CodexIcon          — mono (currentColor)
+//   CodexColorIcon     — brand (white card + blue/purple gradient)
+//   ClaudeCodeIcon     — mono (currentColor)
+//   ClaudeCodeColorIcon — brand (Anthropic terracotta #D97757)
+
+const CODEX_MONO_D =
+  "M8.086.457a6.105 6.105 0 013.046-.415c1.333.153 2.521.72 3.564 1.7a.117.117 0 00.107.029c1.408-.346 2.762-.224 4.061.366l.063.03.154.076c1.357.703 2.33 1.77 2.918 3.198.278.679.418 1.388.421 2.126a5.655 5.655 0 01-.18 1.631.167.167 0 00.04.155 5.982 5.982 0 011.578 2.891c.385 1.901-.01 3.615-1.183 5.14l-.182.22a6.063 6.063 0 01-2.934 1.851.162.162 0 00-.108.102c-.255.736-.511 1.364-.987 1.992-1.199 1.582-2.962 2.462-4.948 2.451-1.583-.008-2.986-.587-4.21-1.736a.145.145 0 00-.14-.032c-.518.167-1.04.191-1.604.185a5.924 5.924 0 01-2.595-.622 6.058 6.058 0 01-2.146-1.781c-.203-.269-.404-.522-.551-.821a7.74 7.74 0 01-.495-1.283 6.11 6.11 0 01-.017-3.064.166.166 0 00.008-.074.115.115 0 00-.037-.064 5.958 5.958 0 01-1.38-2.202 5.196 5.196 0 01-.333-1.589 6.915 6.915 0 01.188-2.132c.45-1.484 1.309-2.648 2.577-3.493.282-.188.55-.334.802-.438.286-.12.573-.22.861-.304a.129.129 0 00.087-.087A6.016 6.016 0 015.635 2.31C6.315 1.464 7.132.846 8.086.457zm-.804 7.85a.848.848 0 00-1.473.842l1.694 2.965-1.688 2.848a.849.849 0 001.46.864l1.94-3.272a.849.849 0 00.007-.854l-1.94-3.393zm5.446 6.24a.849.849 0 000 1.695h4.848a.849.849 0 000-1.696h-4.848z";
+
+const CODEX_COLOR_CARD_D =
+  "M19.503 0H4.496A4.496 4.496 0 000 4.496v15.007A4.496 4.496 0 004.496 24h15.007A4.496 4.496 0 0024 19.503V4.496A4.496 4.496 0 0019.503 0z";
+
+const CODEX_COLOR_MARK_D =
+  "M9.064 3.344a4.578 4.578 0 012.285-.312c1 .115 1.891.54 2.673 1.275.01.01.024.017.037.021a.09.09 0 00.043 0 4.55 4.55 0 013.046.275l.047.022.116.057a4.581 4.581 0 012.188 2.399c.209.51.313 1.041.315 1.595a4.24 4.24 0 01-.134 1.223.123.123 0 00.03.115c.594.607.988 1.33 1.183 2.17.289 1.425-.007 2.71-.887 3.854l-.136.166a4.548 4.548 0 01-2.201 1.388.123.123 0 00-.081.076c-.191.551-.383 1.023-.74 1.494-.9 1.187-2.222 1.846-3.711 1.838-1.187-.006-2.239-.44-3.157-1.302a.107.107 0 00-.105-.024c-.388.125-.78.143-1.204.138a4.441 4.441 0 01-1.945-.466 4.544 4.544 0 01-1.61-1.335c-.152-.202-.303-.392-.414-.617a5.81 5.81 0 01-.37-.961 4.582 4.582 0 01-.014-2.298.124.124 0 00.006-.056.085.085 0 00-.027-.048 4.467 4.467 0 01-1.034-1.651 3.896 3.896 0 01-.251-1.192 5.189 5.189 0 01.141-1.6c.337-1.112.982-1.985 1.933-2.618.212-.141.413-.251.601-.33.215-.089.43-.164.646-.227a.098.098 0 00.065-.066 4.51 4.51 0 01.829-1.615 4.535 4.535 0 011.837-1.388zm3.482 10.565a.637.637 0 000 1.272h3.636a.637.637 0 100-1.272h-3.636zM8.462 9.23a.637.637 0 00-1.106.631l1.272 2.224-1.266 2.136a.636.636 0 101.095.649l1.454-2.455a.636.636 0 00.005-.64L8.462 9.23z";
+
+const CLAUDE_CODE_MARK_D =
+  "M20.998 10.949H24v3.102h-3v3.028h-1.487V20H18v-2.921h-1.487V20H15v-2.921H9V20H7.488v-2.921H6V20H4.487v-2.921H3V14.05H0V10.95h3V5h17.998v5.949zM6 10.949h1.488V8.102H6v2.847zm10.51 0H18V8.102h-1.49v2.847z";
+
+export function CodexIcon({ size = 16, ...rest }: ProviderIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      fillRule="evenodd"
+      role="img"
+      aria-hidden="true"
+      style={{ flex: "none", lineHeight: 1 }}
+      {...rest}
+    >
+      <title>Codex</title>
+      <path clipRule="evenodd" d={CODEX_MONO_D} />
+    </svg>
+  );
+}
+
+export function CodexColorIcon({ size = 16, ...rest }: ProviderIconProps) {
+  const gradientId = useId();
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      role="img"
+      aria-hidden="true"
+      style={{ flex: "none", lineHeight: 1 }}
+      {...rest}
+    >
+      <title>Codex</title>
+      <path d={CODEX_COLOR_CARD_D} fill="#fff" />
+      <path d={CODEX_COLOR_MARK_D} fill={`url(#${gradientId})`} />
+      <defs>
+        <linearGradient
+          gradientUnits="userSpaceOnUse"
+          id={gradientId}
+          x1="12"
+          x2="12"
+          y1="3"
+          y2="21"
+        >
+          <stop stopColor="#B1A7FF" />
+          <stop offset=".5" stopColor="#7A9DFF" />
+          <stop offset="1" stopColor="#3941FF" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+}
+
+export function ClaudeCodeIcon({ size = 16, ...rest }: ProviderIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      fillRule="evenodd"
+      role="img"
+      aria-hidden="true"
+      style={{ flex: "none", lineHeight: 1 }}
+      {...rest}
+    >
+      <title>Claude Code</title>
+      <path clipRule="evenodd" d={CLAUDE_CODE_MARK_D} />
+    </svg>
+  );
+}
+
+export function ClaudeCodeColorIcon({ size = 16, ...rest }: ProviderIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      role="img"
+      aria-hidden="true"
+      style={{ flex: "none", lineHeight: 1 }}
+      {...rest}
+    >
+      <title>Claude Code</title>
+      <path clipRule="evenodd" fillRule="evenodd" d={CLAUDE_CODE_MARK_D} fill="#D97757" />
+    </svg>
+  );
+}

--- a/src/ai-coding-usage/types.ts
+++ b/src/ai-coding-usage/types.ts
@@ -11,6 +11,7 @@ export interface AiCodingUsageProviderState {
   authState: AiCodingUsageAuthState;
   accountLabel?: string | null;
   accountEmail?: string | null;
+  subscriptionPlan?: string | null;
   fiveHour: AiCodingUsageQuotaWindow;
   weekly: AiCodingUsageQuotaWindow;
   lastRefreshAt?: string | null;


### PR DESCRIPTION
## Summary

- **Fix:** Claude Code usage meters were always **Unknown** after OAuth. Root cause: the code parsed `claude auth status` looking for `rate_limits.five_hour.used_percentage` — a schema that only exists on Claude Code's statusline stdin channel, not on auth status. Auth half succeeded silently; quota half always returned `None`. Now fetched from `GET https://api.anthropic.com/api/oauth/usage` with the OAuth token from `~/.claude/.credentials.json` (Windows/Linux; macOS Keychain pending).
- **Feat:** Show a small uppercase **subscription plan** badge to the right of each provider title (Claude `subscriptionType`, Codex `planType` — both already in the API responses, previously discarded). Backed by a new `ai_coding_usage_accounts.subscription_plan` column with `ensure_column` migration.
- **Feat:** Replace the lucide `Bot`/`Code2` placeholders with product-specific **Codex** and **Claude Code** brand icons sourced from `@lobehub/icons-static-svg` (ids `codex`, `claudecode`), inlined as React components — avoids adding `@lobehub/ui` + `antd` as peer deps. Color variants used by default (Codex gradient, Anthropic terracotta `#D97757`); mono variants exported for future theme use. `<linearGradient>` ids generated via `useId()` so multi-instance renders don't collide.

## Why

- Auth status and statusline-stdin are two different IPC channels Claude Code uses. Anthropic [closed the request](https://github.com/anthropics/claude-code/issues/40395) for a dedicated `claude usage` CLI, so the OAuth usage endpoint is the only programmatic source for live quota numbers.
- Subscription plan was already retrievable from both providers; surfacing it gives users at-a-glance context for what the meters are measuring against.
- The lobe-icons set has actual product marks for Codex and Claude Code, distinct from their parent-company logos — more accurate for a coding-tool widget.

## Reviewer notes

- On **401** from the OAuth usage endpoint, we set `last_error` to a clear "sign in again with `claude auth login`" message; we don't attempt token refresh (deliberately scoped out — refresh-token plumbing is a separate change).
- macOS still shows "Unknown" because Claude Code stores its token in Keychain there, not in a file. Follow-up: shell out to `security find-generic-password -s claude-code -w`.
- Existing DB rows with the legacy "did not expose quota windows in auth status" error message stay hidden by the existing `isLegacyClaudeStatuslineNotice` filter; first successful refresh after upgrade clears them.
- `reqwest` gains the `blocking` feature so the existing `spawn_blocking` refresh path can call the HTTP endpoint synchronously without restructuring the async/sync boundary.

## Test plan

- [x] `cargo test --lib ai_coding_usage` — 7/7 pass (new: `normalizes_claude_oauth_usage`, `missing_oauth_usage_window_falls_back_to_unknown`, updated `claude_auth_status_populates_account_without_snapshot`)
- [x] `cargo build --lib` — no warnings
- [x] `npm run check` — clean
- [x] `node --test tests/ai-coding-usage-settings.test.mjs` — 2/2 pass
- [x] Verified `GET /api/oauth/usage` returns expected shape against a real local token
- [ ] Rebuild and click refresh on the AI Coding Usage widget — confirm meters populate and "PRO" badge renders next to "Claude Code"

🤖 Generated with [Claude Code](https://claude.com/claude-code)