### PR TITLE
docs: align script-widget hardening docs with oxc parser pipeline

### DIFF
--- a/docs/ADR/0006-dashboard-script-widget-hardening.md
+++ b/docs/ADR/0006-dashboard-script-widget-hardening.md
@@ -35,59 +35,200 @@ The freeze was not a single bug. It was the absence of layered defenses.
 
 ## Decision
 
-Add five layers of defense, applied at the layer closest to where each class
-of mistake originates.
+Add layered defenses, applied at the layer closest to where each class of
+mistake originates.
 
 ### 1. Validate script source before SQLite write
 
-`dashboard_validation::validate_script_source_inner` runs on every
-script-widget write and rejects:
+`validate_script_body_json_detailed` in `dashboard_validation.rs` runs every
+script-widget write through a two-stage source check.
 
-- null bytes,
+**Stage 1a — semantic prefilter (`validate_script_source_inner`).** A cheap
+textual scan against a "code-only" view of the source (strings, template
+literals, and comments blanked out by `strip_strings_and_comments`) that
+rejects:
+
+- null bytes (filesystem / WebView2 hazard),
 - raw `while(true)`, `while(1)`, `for(;;)` infinite loops *in code* (not in
-  strings or comments),
-- unbalanced `()` `{}` `[]` delimiters *outside* string and comment regions.
+  strings or comments).
 
-The check operates on a "code-only" view of the source produced by a single
-pass through `strip_strings_and_comments`. The pass:
+This stage exists to enforce runtime-safety rules that a real JS parser will
+not catch — a well-formed `while(true) {}` is valid JavaScript that we still
+forbid for widgets. The string-stripper counts consecutive backslashes so
+`'\\'` closes the string but `'\\''` does not (regression-tested explicitly),
+and preserves newlines so any future diagnostic that maps to line/col works
+unchanged.
 
-- Treats single-quoted, double-quoted, and template literal strings as opaque
-  (so `'while(true) is forbidden'` does not trigger the infinite-loop check).
-- Counts consecutive backslashes inside strings so `'\\'` closes the string
-  but `'\\''` does not (regression-tested explicitly).
-- Treats line and block comments as opaque.
-- Does *not* track regex literals or `${expr}` interpolation inside template
-  literals. These are accepted heuristic limitations: regex literals are rare
-  in widget scripts, and the cap + visibility throttle bound the blast radius
-  of anything that slips through.
+**Stage 1b — AST parse (`parse_script_source_ast`).** Source is wrapped in
+the same synchronous IIFE the runtime host uses (`(function(){ source })()`)
+and parsed with `oxc_parser` using `SourceType::cjs()`. The wrapper makes a
+top-level `return` legal — matching what the iframe actually executes — so
+the validator does not false-reject the `if (!root) return;` early-exit
+pattern that AI generators emit. On failure, the validator returns the first
+parser diagnostic with its line/column mapped back to widget-source
+coordinates (the wrapper line is subtracted) so the assistant can self-
+correct on the next tool round.
+
+Stage 1b is the source of truth for syntactic correctness. It catches every
+class of grammar error the previous text-based delimiter scan could not:
+
+- `const x = ;` (delimiter-balanced, missing operand),
+- `let x x = 5;` (unexpected token after declaration),
+- regex literals with literally unbalanced inner delimiters such as
+  `/^foo\(/` — formerly false-rejected by the text scan, now correctly
+  recognized as regex tokens.
+
+Delimiter balance is no longer tracked in the heuristic; oxc reports any
+unmatched paren, brace, or bracket through the same parse-error path as
+every other grammar violation.
+
+**Heuristic limitation that remains.** Stage 1a treats `${expr}` interpolation
+inside template literals as part of the opaque string, so a `while(true)`
+written *inside* an interpolation expression slips through the infinite-loop
+scan. The active-widget cap (§6) and visibility throttle (§7) bound the
+blast radius if anything slips through. Stage 1b does walk into interpolation
+expressions for the unused-library cross-reference (§2), so a library
+referenced *only* inside `${...}` still counts as used.
 
 ### 2. Cross-check declared libraries against the code
 
-For each entry in `body.libraries` that maps to a known global in
-`KNOWN_LIBRARY_GLOBALS`, the validator requires the global to appear as a
-whole-word token in the code-only view. Substring matching is not enough —
-short globals like `L` (Leaflet) would otherwise pass through any identifier
-containing the letter `L`. References that exist only in comments or strings
-do not count.
+The AST parse in §1b returns the set of every
+`IdentifierReference.name` collected by an `oxc_ast_visit::Visit` walk
+(`IdentifierCollector`). That set is the source of truth for the unused-
+library check: for each entry in `body.libraries` that maps to a known
+global in `KNOWN_LIBRARY_GLOBALS`, the validator requires the global to
+appear in the identifier set. References that exist only in comments or
+strings do not count, because the AST does not surface them as identifier
+references. References inside template-literal `${...}` interpolations *do*
+count, because oxc walks into interpolation expressions like any other
+expression position.
 
-This list must stay in lockstep with `src/dashboard/script/widgetLibraries.ts`.
-A new bundled library that is not added to `KNOWN_LIBRARY_GLOBALS` silently
-skips this check — soft degradation, but reviewers must remember to update
-both files in the same change.
+The AST set is exact: no string/comment false-positives, and no false-
+negatives from template-literal interpolation. This replaces the previous
+text-based word-boundary scan (`source_references_identifier`), which short
+globals like `L` (Leaflet) forced into a brittle whole-token match against
+the stripped code view.
+
+`KNOWN_LIBRARY_GLOBALS` must stay in lockstep with
+`src/dashboard/script/widgetLibraries.ts`. A new bundled library that is
+not added to `KNOWN_LIBRARY_GLOBALS` silently skips this check — soft
+degradation, but reviewers must remember to update both files in the same
+change.
 
 Assistant-created widget bodies have one narrow repair path before this
 validator runs: `dashboard_create_widget` and structured
 `dashboard_update_custom_widget.patch.body` call
 `drop_unused_script_libraries` to remove declared libraries whose documented
-globals are not referenced in source. This exists because models often list a
-plausible helper such as `dayjs` and then implement the widget with native
-`Date`; failing the whole user-visible creation in that case is noisy but does
-not protect the renderer. Do not weaken the storage validator to accept unused
+globals are not referenced in source. The sanitizer uses the same AST parse
+as the validator, and falls through (no mutation) for unparseable source so
+the storage validator's structured parse-error message remains the canonical
+feedback to the assistant. This exists because models often list a plausible
+helper such as `dayjs` and then implement the widget with native `Date`;
+failing the whole user-visible creation in that case is noisy but does not
+protect the renderer. Do not weaken the storage validator to accept unused
 libraries generally, and do not add broad prompt-only fixes for this class of
 error. Keep the repair at the assistant tool boundary, then let normal
 validation remain the final authority.
 
-### 3. Active-widget cap with eviction notification
+### 3. Validate `htmlShim` before SQLite write
+
+`validate_html_shim` runs on every non-empty `body.htmlShim` value and
+rejects:
+
+- shims larger than `MAX_HTML_SHIM_BYTES` (128 KB) — generous enough for
+  realistic mount-point fragments and prebuilt layout scaffolds, narrow
+  enough to refuse multi-MB document dumps,
+- null bytes,
+- forbidden tags via a case-insensitive, token-boundary scan
+  (`html_shim_contains_tag_open`) against `HTML_SHIM_FORBIDDEN_TAGS`:
+  `script`, `iframe`, `object`, `embed`, `html`, `head`, `body`, `meta`,
+  `title`, `link`. The token-boundary check requires the byte after the tag
+  name to be non-alphanumeric, so `<scripty-x>` does not match `<script`.
+
+The runtime CSP already blocks `<script>`, `<iframe>`, `<object>`, and
+`<embed>` execution; this validator does not replace that defense. It
+exists so the assistant gets a clean structured error (`forbidden tag
+<script>; the shim must be a small mount-point fragment ...`) to self-
+correct against, rather than shipping a dead `<script>` tag through
+storage and then seeing a silent no-op at render time. Document-shell
+tags (`html`, `head`, `body`, `meta`, `title`, `link`) are rejected because
+the shim is meant to be a fragment dropped into the host document's
+`<body>`; a second document inside the shim breaks layout in undefined ways.
+
+To keep room for a 128 KB shim alongside a 64 KB source, the envelope
+size check in `validate_script_body_json_detailed` is
+`MAX_SCRIPT_SOURCE_BYTES + MAX_HTML_SHIM_BYTES + 4096` rather than the
+old `MAX_SCRIPT_SOURCE_BYTES + 4096`. Without this bump a maxed-out shim
+trips the outer envelope check before reaching the shim-specific
+validator, which gives the assistant the wrong error to react to.
+
+### 4. Declared lifecycle and motion watchdog
+
+`ScriptBody` carries an optional `lifecycle: { kind, minTickMs? }` field
+(`ScriptLifecycle` in Rust, mirrored in `src/dashboard/types.ts` and
+`src/dashboard/schema.ts`). `kind` is one of `static`, `periodic`,
+`animation`, `realtime`. Absent or null lifecycle is treated as `static`
+so legacy widgets without the field continue to deserialize cleanly.
+`minTickMs` is informational, clamped to `16..=60_000` at the storage
+boundary; the iframe host still clamps animation rAF callbacks to 33 ms
+regardless.
+
+The lifecycle kind turns the *prompt-only* contract for animation widgets
+into a *mechanically checked* invariant. The iframe's centralized
+`runKkRafPump` emits a throttled `{ kk: true, type: 'motionTick', ticks }`
+message every ~500 ms while rAF callbacks are firing
+(`KK_MOTION_TICK_MIN_MS`). `ScriptWidgetHost` records the last-tick
+timestamp in `motionTickRef` and runs a polling watchdog
+(`SCRIPT_WIDGET_MOTION_POLL_MS`, 3 s) only for instances whose
+`parsed.lifecycle.kind === "animation"`. If the iframe is visible and no
+tick has arrived for `SCRIPT_WIDGET_MOTION_STALL_MS` (8 s), the host flips
+the instance's `WidgetHealth` to `stalled`. A later tick after a stall
+transitions the health back to `ready`, so a widget that resumed after a
+resize-driven rAF re-arm shows correctly on the next AI context payload.
+
+The 8 s threshold is intentionally generous: a single GC pause or a big
+synchronous chunk should not false-positive. The real signal is "rAF
+stopped firing entirely", which produces an unbounded gap, not a 5–6 s one.
+The watchdog catches "exception in update callback that got swallowed"; it
+does **not** catch "rAF still running, scene visually frozen" — that needs
+a pixel-hash watchdog and is deferred.
+
+`realtime` and `periodic` are accepted but currently have no host-side
+invariant. They are reserved for future data-freshness / heartbeat checks.
+
+### 5. Smoke test + runtime health bubbling
+
+`ScriptWidgetHost` registers each mounting script instance in the
+`dashboardStore.widgetHealth` map as `{ state: "pending", since }` and
+arms a `SCRIPT_WIDGET_SMOKE_TEST_MS` (2 s) watchdog. The iframe sandbox
+posts two new messages the host listens for:
+
+- `{ kk: true, type: "ready" }` — emitted from the source-injection
+  `then()` after `injectScript` resolves. The widget reached its
+  top-level evaluation without a synchronous throw. Host transitions to
+  `ready`.
+- `{ kk: true, type: "runtimeError", error: <serialized> }` — emitted
+  from `showError` (the iframe's unhandled-error renderer). Host
+  transitions to `error` and stores the serialized error string. A
+  `runtimeError` *after* a previous `ready` is accepted, so post-mount
+  regressions are still observable.
+
+If neither message arrives within 2 s, the smoke watchdog flips the
+state to `timeout` so a silently-broken widget still shows up as
+unhealthy. Unmount clears the health entry.
+
+`DashboardPage` projects the union of all `non-ready / non-pending`
+widget healths into the `unhealthyInstances` field of the AI assistant
+context payload (`id`, `kind`, `sourceId`, `state`, and `error` when
+present). The assistant receives this on the next turn and can offer to
+fix the widget it just authored without waiting for the user to scroll
+over and report a blank or broken card.
+
+Health state is **in-memory only**. It is not persisted in SQLite — the
+2 s smoke window and the live iframe both restart on every app launch
+or reload anyway, so the only meaningful state is the current one.
+
+### 6. Active-widget cap with eviction notification
 
 `ScriptWidgetHost` tracks active script widgets in a module-level
 `Map<id, setCapped>`. When a new widget tries to mount past the cap it is
@@ -129,7 +270,7 @@ Bumping the upper bound requires changing both files, the
 `validate_dashboard_settings` clamp, and the localization_todo hint copy
 in `docs/localization_todo/settings.dashboardMaxActiveScriptWidgetsHint.md`.
 
-### 4. Visibility-aware throttling via IntersectionObserver
+### 7. Visibility-aware throttling via IntersectionObserver
 
 The host posts `{ kk: true, type: "setVisible", visible: bool }` to each
 iframe whenever the iframe scrolls off-screen or back on-screen. The iframe
@@ -139,10 +280,10 @@ Widgets that opt in can short-circuit expensive work — typically by checking
 their rAF callback.
 
 This is cooperative throttling, not enforcement: a widget that ignores
-`KK.isVisible()` keeps burning frames. The AI prompt change in §6 nudges
+`KK.isVisible()` keeps burning frames. The AI prompt change in §9 nudges
 toward the cooperative path.
 
-### 5. Mutex poison recovery with defensive rollback
+### 8. Mutex poison recovery with defensive rollback
 
 `storage::Storage::with_connection_infallible` recovers from poisoned mutexes
 by calling `poison.into_inner()` and issuing a best-effort `ROLLBACK` on the
@@ -160,7 +301,7 @@ trade favors keeping the app responsive. The dashboard tables are
 recoverable from settings export; the connections table is the only critical
 data, and panicking dashboard commands cannot reach it.
 
-### 6. AI prompt guardrails
+### 9. AI prompt guardrails
 
 The `dashboard_create_widget` tool description now contains explicit
 guidance:
@@ -182,24 +323,47 @@ the prompt missed.
 
 - Validation runs at the layer where the AI's mistake is cheapest to reject
   (before SQLite write). Bad widgets never reach the renderer.
+- Source validation uses a real JavaScript parser (oxc). Parser diagnostics
+  carry line and column coordinates the assistant can act on, so a malformed
+  source produces a structured error rather than a vague "delimiter
+  imbalance".
 - The cap bounds the worst case: at most the configured number of script
   widget iframes can run at once, regardless of how many widgets exist on
   the Dashboard.
+- Runtime health (`kk.ready`, `kk.runtimeError`, animation `kk.motionTick`)
+  bubbles up into the AI assistant context payload as `unhealthyInstances`.
+  The assistant notices a widget it just authored has failed to mount,
+  thrown at runtime, or stalled its animation loop within one user turn
+  rather than waiting for the user to scroll over and report it.
 - A poisoned mutex no longer cascades into an app-wide crash.
 - Dynamic backgrounds (e.g., Matrix) still run alongside the capped script
   widgets, but they are app-owned and well-bounded.
 
 **Negative**
 
-- The validator is a heuristic. Regex literals containing unbalanced
-  delimiters trigger false rejections. Template-literal interpolation can
-  hide a `while(true)` from the check. Both are accepted limitations.
+- The semantic prefilter is a heuristic. `${expr}` interpolation inside
+  template literals is treated as part of the string, so a `while(true)`
+  hidden there slips past the infinite-loop scan. The cap (§6) and
+  visibility throttle (§7) bound the blast radius. Note that AST-based
+  identifier collection (§2) *does* walk into interpolation expressions,
+  so this limitation is specific to the infinite-loop pattern check.
 - `KNOWN_LIBRARY_GLOBALS` must be kept in sync with the TypeScript catalog.
 - The active-widget cap is module-global, so it is shared across all
   Dashboards in one process. This is intentional for now (one WebView2
   renderer to protect), but multi-Dashboard users will eventually notice.
 - Cooperative visibility throttling does nothing for widgets that don't call
   `KK.isVisible()`. The cap is the hard backstop.
+- `widgetHealth` is in-memory only. Restarting the app loses any prior
+  health record. Acceptable because the 2 s smoke test and live iframe
+  both re-arm on every mount anyway.
+- The animation stall watchdog catches "rAF callback exception swallowed";
+  it does **not** catch "rAF still firing but the scene is visually
+  frozen" — that needs a pixel-hash watchdog and is deferred.
+- The htmlShim forbidden-tag scan is a token-boundary text match, not a
+  full HTML parse. Pathological strings could in principle smuggle a
+  forbidden tag past the scan, but the runtime CSP still blocks execution
+  for `<script>`, `<iframe>`, `<object>`, and `<embed>`, so the scan is a
+  feedback channel rather than the load-bearing defense.
 
 **Neutral**
 
@@ -243,9 +407,44 @@ the prompt missed.
   instead of hand-rolling collision, gravity, or rigid-body integration.
   The same unused-library validation still applies: declaring `matter`
   without referencing `Matter` is rejected before persistence.
-- Tightening the validator: add cases to the `validate_script_source_inner`
-  / `strip_strings_and_comments` test groups in `dashboard_validation.rs`.
-  Each new rejection rule must come with both a positive and a negative test.
+- Tightening the validator: source validation is now two-stage, so new
+  tests live in two test groups inside `dashboard_validation.rs`:
+  - **Semantic prefilter rules** (null bytes, infinite-loop tokens) belong
+    next to the `validate_script_source_inner` / `strip_strings_and_comments`
+    tests.
+  - **Grammar and identifier-reference rules** belong next to the AST tests
+    (`ast_rejects_*`, `ast_accepts_*`, `ast_detects_identifier_reference_*`).
+    Use whole-body JSON through `validate_script_body_json_detailed` so the
+    test exercises the same IIFE-wrap and error-path coordinates that the
+    real assistant sees.
+  - Every new rejection rule must come with both a positive and a negative
+    test.
+- Adjusting the AST wrap: source is wrapped in `(function(){ source })()`
+  before parsing so a top-level `return` is legal — matching what the
+  iframe actually executes via `injectScript('(function(){' + source +
+  '\n})();', ...)` in `permissions.ts`. If the runtime wrapper changes
+  shape, the validator's wrapper and the line-offset correction in
+  `map_offset_to_line_col` must change in lockstep, or assistant-facing
+  parse errors will point one line off.
+- Tuning the motion watchdog: `SCRIPT_WIDGET_MOTION_STALL_MS` (8 s),
+  `SCRIPT_WIDGET_MOTION_POLL_MS` (3 s), and the iframe-side
+  `KK_MOTION_TICK_MIN_MS` (500 ms) in `ScriptWidgetHost.tsx` /
+  `permissions.ts` together set the false-positive vs. detection-latency
+  trade-off. Lower stall threshold = faster detection but more false
+  positives during GC pauses; lower tick interval = lower latency but
+  more bridge traffic per frame loop. Change them together.
+- Adding a new lifecycle kind: extend `ScriptLifecycleKind` (Rust),
+  `ScriptLifecycleKind` (TypeScript in `src/dashboard/types.ts`), and the
+  schema check in `src/dashboard/schema.ts::validateScriptWidgetBody`.
+  A kind without a host-side invariant is allowed (current behavior for
+  `realtime` and `periodic`), but document the intended invariant in this
+  ADR and in the `ScriptLifecycle` Rust doc comment before users start
+  declaring it.
+- Adding or relaxing an htmlShim forbidden tag: edit
+  `HTML_SHIM_FORBIDDEN_TAGS` in `dashboard_validation.rs`. Removing a tag
+  weakens the structured-error feedback to the assistant; the CSP defense
+  remains, so the user-visible effect is "the AI gets a confusing silent
+  no-op at render time" rather than a clean parse error.
 - Adjusting the active-widget cap: the user-facing knob is Settings →
   Dashboard → Performance → Active script widgets cap. Changing the
   default value or hard ceiling requires editing both

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -197,7 +197,7 @@ The catalog overlay is a separate modal with search + two source-group tabs: Bui
 `ScriptWidgetHost.tsx` renders an `<iframe srcdoc="...">` per script instance, with:
 
 - A `<style>` block carrying compact KKTerm-like text, form-control, button, stack, row, and result defaults so simple generated DOM starts from the app's desktop UI grammar.
-- An optional `htmlShim` body markup (default: a single `<div id="root">`).
+- An optional `htmlShim` body markup (default: a single `<div id="root">`). The shim is capped at 128 KB (`MAX_HTML_SHIM_BYTES`) and a token-boundary tag scan rejects `<script>`, `<iframe>`, `<object>`, `<embed>`, and document-shell tags (`<html>`, `<head>`, `<body>`, `<meta>`, `<title>`, `<link>`) at validation time. Runtime CSP remains the real defense; the storage check exists so the AI gets a clean structured error rather than a silent no-op at render time.
 - A small host `<script>` that loads the stored source as data. The generated source is never pasted directly into the host script text, because generated snippets commonly contain HTML/script literals such as `</script>` that would prematurely close the host script and render broken JavaScript as widget body text.
 - Renderer guardrails inside the iframe: `requestAnimationFrame` callbacks are capped to about 30 fps, tiny `setInterval` delays are clamped, and timer/animation work pauses while the host marks the widget invisible. Scripts can read the current state with `KK.isVisible()` and subscribe with `KK.onVisibilityChange(callback)` to restart paused animation when visibility returns. This protects the shared WebView2 renderer from a single AI-authored widget with an overly aggressive loop.
 - A per-instance settings snapshot loaded through `KK.getSettings()`. Scripts can persist small non-secret user options with `KK.setSetting(key, value)` or replace the object with `KK.setSettings(nextSettings)`.
@@ -228,7 +228,9 @@ Curated local libraries are registered in `src/dashboard/script/widgetLibraries.
 
 Matter.js is the default 2D physics building block for script widgets. It is registered under the `matter` library key, exposes the `Matter` global, and should be used for widget-sized games, physics toys, collision, gravity, rigid bodies, and constraints instead of custom per-widget physics loops. Matter.js widgets should size their canvas from `KK.getViewport()`, update renderer bounds and static wall/floor bodies on `KK.onViewportResize`, keep all bodies bounded to the widget arena, and stop runners or animation loops when gameplay is paused, finished, or otherwise inactive.
 
-Unused library declarations are invalid at storage validation time: a key in `body.libraries` must correspond to a referenced documented global in the script source. The AI tool boundary may sanitize structured assistant submissions by dropping unused declarations before validation, because a model can over-declare helpers such as `dayjs` while using native APIs. Keep that sanitizer narrow to `dashboard_create_widget` / structured `dashboard_update_custom_widget.patch.body`; do not relax the Rust storage validator or paper over the failure with UI error boundaries.
+Unused library declarations are invalid at storage validation time: a key in `body.libraries` must correspond to a referenced documented global in the script source. The "referenced" check is an AST identifier scan (`oxc_parser` + `IdentifierCollector`), not a text match — so a library referenced only inside a template-literal `${...}` interpolation still counts as used, and a string or comment that names the global does not. The AI tool boundary may sanitize structured assistant submissions by dropping unused declarations before validation, because a model can over-declare helpers such as `dayjs` while using native APIs. Keep that sanitizer narrow to `dashboard_create_widget` / structured `dashboard_update_custom_widget.patch.body`; do not relax the Rust storage validator or paper over the failure with UI error boundaries.
+
+Script bodies may also declare an optional `lifecycle: { kind, minTickMs? }` field, where `kind` is one of `static`, `periodic`, `animation`, `realtime`. Absent or null is treated as `static` so legacy widgets keep working. Today only `animation` carries a host-side invariant: the iframe's rAF pump emits a throttled `kk.motionTick` heartbeat (~2 Hz), and `ScriptWidgetHost` flips the widget's runtime health to `stalled` if 8 s pass without a tick while the widget is visible. The other kinds are accepted but reserved for future invariants. See `docs/ADR/0006-dashboard-script-widget-hardening.md` §4 for the threshold rationale.
 
 When adding or renaming a script-widget library:
 
@@ -265,10 +267,13 @@ When the Dashboard page is active, `onAssistantContextChange` includes a compact
   activeView: { id, title, gridDensity },
   instances: [{ id, kind, sourceId, customTitle, preset, x, y, w, h }],
   customWidgets: [{ id, title }],
+  unhealthyInstances: [{ id, kind, sourceId, state, error? }],
 }
 ```
 
-The AI sees the current dashboard without an extra tool call. Validation errors from Rust come back as structured `{ ok: false, reason, details }` shapes so the AI can self-correct on retry.
+The AI sees the current dashboard without an extra tool call. `unhealthyInstances` carries any script widget whose runtime `state` is `error`, `timeout`, or `stalled` — surfaced by `ScriptWidgetHost`'s smoke-test + motion-watchdog signals (`kk.ready`, `kk.runtimeError`, `kk.motionTick`). This closes the feedback loop: the assistant notices a widget it just authored has silently failed to mount, thrown at runtime, or stalled its animation, and can offer to fix it inside the same turn rather than waiting for the user to scroll over.
+
+Validation errors from Rust come back as structured `{ ok: false, reason, details }` shapes so the AI can self-correct on retry. For script bodies, syntactic errors include the parser's line and column mapped back to widget-source coordinates (the synthetic `(function(){ ... })()` wrapper line is subtracted).
 
 AI Assistant UX polish around widget authorship (prompt tuning, suggestion affordances, preview-before-commit, conversational diffs) is a follow-up and not part of this architecture.
 


### PR DESCRIPTION
## Summary

Doc-only change. `ADR-0006` and `DASHBOARD.md` still described the pre-#116 regex/state-machine validator: `validate_script_source_inner` as the script-source authority, a `source_references_identifier` whole-word scan for the unused-library check, and no mention of `htmlShim` caps, the `lifecycle` field, or runtime health bubbling. This PR brings both docs into line with the validator that actually runs on `main` after PR #116.

## What changed

**`docs/ADR/0006-dashboard-script-widget-hardening.md`**

- **§1 rewritten as a two-stage check.**
  - **1a** — heuristic prefilter (`validate_script_source_inner`) covers null bytes and `while(true)`/`for(;;)` patterns, which are runtime-safety rules oxc happily accepts as valid JS.
  - **1b** — `parse_script_source_ast` AST parse via `oxc_parser` with `SourceType::cjs()` against the same `(function(){ source })()` wrapper the runtime uses, so top-level `return` is legal and parser errors carry widget-source-relative line/col.
- **§2 rewritten** around the `IdentifierCollector` `oxc_ast_visit::Visit` walk. The old `source_references_identifier` text scan is gone. References inside template-literal `${...}` interpolations now count as used; comments/strings do not.
- **§3 (new)** — `validate_html_shim`: 128 KB `MAX_HTML_SHIM_BYTES` cap, null-byte rejection, token-boundary scan against `HTML_SHIM_FORBIDDEN_TAGS` (`script`, `iframe`, `object`, `embed`, `html`, `head`, `body`, `meta`, `title`, `link`), and the envelope-cap bump to `MAX_SCRIPT_SOURCE_BYTES + MAX_HTML_SHIM_BYTES + 4096`.
- **§4 (new)** — optional `lifecycle: { kind, minTickMs? }` field and the animation stall watchdog: 8 s `SCRIPT_WIDGET_MOTION_STALL_MS` against the iframe's throttled `kk.motionTick` heartbeat, 3 s host poll, ~500 ms iframe-side throttle.
- **§5 (new)** — smoke test + health bubbling: `kk.ready` and `kk.runtimeError` iframe→host signals, 2 s `SCRIPT_WIDGET_SMOKE_TEST_MS` watchdog, in-memory `widgetHealth` store, and the `unhealthyInstances` projection into the AI assistant context payload.
- Active-widget cap / visibility throttle / mutex poison recovery / AI prompt guardrails **renumbered §6–§9** (no body changes other than one cross-reference fix from "§6" → "§9").
- **Consequences** — removed the now-false "regex literals trigger false rejections" negative. Clarified that the `${expr}` `while(true)` heuristic limitation remains in 1a but does **not** affect 1b's identifier walk. Added positives for AST parse-error diagnostics and runtime health bubbling.
- **Operational notes** — added guidance for tuning the AST wrap (`map_offset_to_line_col` line-offset must move with the runtime wrapper), the stall/poll/tick-throttle triple, and adding a new lifecycle kind or htmlShim forbidden tag.

**`docs/DASHBOARD.md`** (light touch)

- `htmlShim` line now mentions the 128 KB cap and the forbidden-tag list, with a note that CSP remains the real defense and the storage check is feedback-channel.
- Unused-library paragraph clarifies the check is now an AST identifier scan, and adds a paragraph on the `lifecycle` field + motion watchdog.
- AI context snapshot example now includes `unhealthyInstances`, with one paragraph on how the assistant uses it to self-correct, plus a note that script-body parse errors carry line/col mapped past the synthetic IIFE wrapper.

## Why

Commit 8444960 (in PR #116) replaced the regex/state-machine source validator with `oxc_parser` and added htmlShim hardening, declared lifecycle + motion watchdog, and the runtime-health bubbling pipeline. The validator code moved; the docs that described it did not. Future readers comparing the doc to `dashboard_validation.rs` would hit immediate contradictions (`source_references_identifier` doesn't exist in `main`, `validate_script_source_inner` no longer owns delimiter balance, `MAX_HTML_SHIM_BYTES` is undocumented, etc.). This PR closes the gap.

## Reviewer notes

- **Doc-only.** No Rust, TypeScript, or test edits. `cargo` / `tsc` / `node --test` are not affected by this change.
- This branch was cut from v0.1.26 *before* PR #116 merged, so the local `src-tauri/src/dashboard_validation.rs` here is the pre-oxc version. The docs describe `main`'s code, not this branch's tree. After merge, docs and code align on `main`.
- Section numbers shifted by 3 in `ADR-0006`. If you have downstream notes that reference "ADR-0006 §3" (the old active-widget cap), it is now **§6**.

## Test plan

- [ ] Read through `docs/ADR/0006-dashboard-script-widget-hardening.md` §1–§5 and confirm each claim against `src-tauri/src/dashboard_validation.rs` on `main` (specifically: `validate_script_source_inner`, `parse_script_source_ast`, `IdentifierCollector`, `validate_html_shim`, `HTML_SHIM_FORBIDDEN_TAGS`, `MAX_HTML_SHIM_BYTES`).
- [ ] Read §4 against `src/dashboard/script/ScriptWidgetHost.tsx` motion watchdog (`SCRIPT_WIDGET_MOTION_STALL_MS`, `SCRIPT_WIDGET_MOTION_POLL_MS`) and `src/dashboard/script/permissions.ts` (`KK_MOTION_TICK_MIN_MS`).
- [ ] Read §5 against `dashboardStore.ts::widgetHealth` and `DashboardPage.tsx::unhealthyInstances`.
- [ ] Confirm the renumbered §6–§9 bodies were not touched (only the heading numbers and one cross-reference at "§6 → §9" should differ).
- [ ] Skim `docs/DASHBOARD.md` Script Widget Host + AI Assistant Integration sections for tone match with surrounding prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)