### PR TITLE
docs: align README background list and CONTEXT.md Connection kinds with code

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,7 +18,7 @@ A top-level section of the locale JSON mapping to a frontend module: `app`, `set
 
 
 **Connection**:
-A durable openable resource stored in SQLite. The supported kinds are local terminal, SSH terminal, Telnet terminal, Serial terminal, URL (an embedded WebView2 browser surface targeting a single http(s) origin), RDP, and VNC. SFTP is opened from an SSH Connection and is not stored as a standalone Connection.
+A durable openable resource stored in SQLite. The supported kinds are local terminal, SSH terminal, Telnet terminal, Serial terminal, URL (an embedded WebView2 browser surface targeting a single http(s) origin), RDP, VNC, and FTP/FTPS. SFTP is opened from an SSH Connection and is not stored as a standalone Connection.
 _Avoid_: Profile, saved session, host entry
 
 SSH Connections may persist non-secret tmux launch preferences, including whether KKTerm should start terminal Panes inside named tmux sessions. The remote tmux process itself remains live Session/runtime state and is not the durable Connection.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Plus a few things you didn't know you wanted:
 
 - A **Dashboard** where you tell an AI *"build me a widget that pings my router every 30 seconds"* and it appears, sandboxed, on your grid.
 - **SSH panes that auto-attach to named tmux sessions** so your remote `claude` / `codex` / `aider` session survives every Wi-Fi tantrum your laptop throws.
-- Nine **animated canvas backgrounds** (yes, including `matrix`) for the dashboard, because we are not above it.
+- Twenty-one **animated canvas backgrounds** (yes, including `matrix`) for the dashboard, because we are not above it.
 
 Oh, and the AI assistant can turn a sentence into a tiny dashboard tool you actually keep using.
 
@@ -209,15 +209,15 @@ Every widget you keep is yours. They persist in SQLite next to your **Connection
 
 #### Animated dashboard backgrounds (because we wanted to)
 
-The dashboard has nine canvas-animated backgrounds you can pick per **Dashboard View**:
+The dashboard has twenty-one canvas-animated backgrounds you can pick per **Dashboard View**:
 
 | Mood | Backgrounds |
 | --- | --- |
-| Calm | `aurora`, `raindrops` |
+| Calm | `aurora`, `clouds`, `ocean`, `raindrops`, `snow`, `sakura`, `fireflies`, `bubbles`, `ricefield`, `lanterns` |
 | Spacey | `starfield`, `nebula` |
 | Warm | `embers`, `lava` |
-| Geeky | `matrix`, `synthwave` |
-| Erratic | `confetti` |
+| Geeky | `matrix`, `topo`, `synthwave` |
+| Erratic | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti` |
 
 They run on a single shared `requestAnimationFrame` and respect window focus, so they cost roughly nothing when you're elsewhere. Pair `matrix` with your AI assistant for a vibe that says "I am extremely productive and also possibly in a Wachowski film." Or pick `mist` and look like a serious person. We do not judge either choice.
 


### PR DESCRIPTION
## Summary

Documentation-only fixes surfaced during a code review pass. Two pieces of docs had drifted from the code:

- **README** still advertised "nine animated canvas backgrounds" and a five-row mood table covering only nine of them. The dashboard registry in `src/dashboard/registry/dynamicBackgrounds.tsx` now ships twenty-one. Both the headline count and the mood table are updated to match the registry exactly (calm: 10, spacey: 2, warm: 2, geeky: 3, erratic: 4).
- **CONTEXT.md** Connection kinds list omitted FTP/FTPS, even though `src/types.ts` exposes `"ftp"` as a `ConnectionType` and `src-tauri/src/ftp.rs` implements the backend. Added FTP/FTPS to the canonical list so the domain dictionary matches the code.

## Why

Per `AGENTS.md`, CONTEXT.md is the authoritative source for product terminology and `docs/manual/` references i18n keys (not English labels) to keep the manual locale-stable. README is the public-facing landing surface — under-counting features there means contributors and users get an incomplete picture of what's shipped. The recent additions (Ricefield, Lanterns, Taipei 101, etc., in commit 0694290 and the broader background expansion) added the registry entries and locale keys without bumping the README copy.

## What a reviewer should know

- No code changes. Diff is two markdown files, six insertions, six deletions.
- During the review I also flagged ping/scan unbounded-collector concerns — those turned out to be **already bounded** (`MAX_COUNT = 256` in `src-tauri/src/net/ping.rs:19`, `MAX_PORTS_PER_SCAN = 1024` in `src-tauri/src/net/scan.rs:18`), so no Rust changes were made.
- The mood groupings in the new table come directly from the `mood` field on each entry in `dynamicBackgrounds.tsx:2000-2020`, so this should stay correct as new backgrounds are added if the registry stays the source of truth.

## Test plan

- [ ] Render the README on GitHub and confirm the mood table renders cleanly with the longer Calm row.
- [ ] Confirm `npm run i18n:check` still passes (not run here — no locale files touched).
- [ ] Spot-check that every background id in the README table exists in `src/dashboard/registry/dynamicBackgrounds.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)