### PR TITLE
feat: add divider above first AI coding provider and move Last Updated to header

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -10833,14 +10833,16 @@ fieldset.connection-specific-options > legend {
   border-top: 1px solid var(--border);
 }
 
-.ai-coding-provider:first-child {
-  padding-top: 0;
-  border-top: 0;
-}
-
 .ai-coding-provider-header {
   justify-content: space-between;
   gap: 8px;
+}
+
+.ai-coding-provider-header-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
 }
 
 .ai-coding-provider-identity {

--- a/src/ai-coding-usage/AiCodingUsageWidget.tsx
+++ b/src/ai-coding-usage/AiCodingUsageWidget.tsx
@@ -314,53 +314,64 @@ function ProviderSlot({
             </span>
           </span>
         </div>
-        {connected ? (
-          <div className="ai-coding-provider-actions">
-            <button
-              type="button"
-              className="dashboard-widget-icon-button"
-              onClick={onDisconnect}
-              disabled={busy}
-              aria-label={t("dashboard.aiCodingUsageDisconnectProvider", { provider: label })}
-              title={t("dashboard.aiCodingUsageDisconnectProvider", { provider: label })}
-            >
-              <LogOut size={13} />
-            </button>
-            <button
-              type="button"
-              className="dashboard-widget-icon-button"
-              onClick={onRemove}
-              disabled={busy}
-              aria-label={t("dashboard.aiCodingUsageRemoveProvider", { provider: label })}
-              title={t("dashboard.aiCodingUsageRemoveProvider", { provider: label })}
-            >
-              <X size={13} />
-            </button>
-          </div>
-        ) : (
-          <div className="ai-coding-provider-actions">
-            <button
-              type="button"
-              className="dashboard-widget-icon-button"
-              onClick={onRemove}
-              disabled={busy}
-              aria-label={t("dashboard.aiCodingUsageRemoveProvider", { provider: label })}
-              title={t("dashboard.aiCodingUsageRemoveProvider", { provider: label })}
-            >
-              <X size={13} />
-            </button>
-            <button
-              type="button"
-              className="ai-coding-connect"
-              onClick={onConnect}
-              disabled={busy}
-            >
-              {busy
-                ? t("dashboard.aiCodingUsageConnecting")
-                : t("dashboard.aiCodingUsageConnectProvider", { provider: label })}
-            </button>
-          </div>
-        )}
+        <div className="ai-coding-provider-header-right">
+          {connected ? (
+            <div className="ai-coding-provider-meta">
+              {provider.lastRefreshAt
+                ? t("dashboard.aiCodingUsageLastRefresh", {
+                    time: formatDateTime(provider.lastRefreshAt),
+                  })
+                : t("dashboard.aiCodingUsageNeverRefreshed")}
+            </div>
+          ) : null}
+          {connected ? (
+            <div className="ai-coding-provider-actions">
+              <button
+                type="button"
+                className="dashboard-widget-icon-button"
+                onClick={onDisconnect}
+                disabled={busy}
+                aria-label={t("dashboard.aiCodingUsageDisconnectProvider", { provider: label })}
+                title={t("dashboard.aiCodingUsageDisconnectProvider", { provider: label })}
+              >
+                <LogOut size={13} />
+              </button>
+              <button
+                type="button"
+                className="dashboard-widget-icon-button"
+                onClick={onRemove}
+                disabled={busy}
+                aria-label={t("dashboard.aiCodingUsageRemoveProvider", { provider: label })}
+                title={t("dashboard.aiCodingUsageRemoveProvider", { provider: label })}
+              >
+                <X size={13} />
+              </button>
+            </div>
+          ) : (
+            <div className="ai-coding-provider-actions">
+              <button
+                type="button"
+                className="dashboard-widget-icon-button"
+                onClick={onRemove}
+                disabled={busy}
+                aria-label={t("dashboard.aiCodingUsageRemoveProvider", { provider: label })}
+                title={t("dashboard.aiCodingUsageRemoveProvider", { provider: label })}
+              >
+                <X size={13} />
+              </button>
+              <button
+                type="button"
+                className="ai-coding-connect"
+                onClick={onConnect}
+                disabled={busy}
+              >
+                {busy
+                  ? t("dashboard.aiCodingUsageConnecting")
+                  : t("dashboard.aiCodingUsageConnectProvider", { provider: label })}
+              </button>
+            </div>
+          )}
+        </div>
       </div>
 
       {connected ? (
@@ -373,13 +384,6 @@ function ProviderSlot({
             label={t("dashboard.aiCodingUsageWeekly")}
             quota={provider.weekly}
           />
-          <div className="ai-coding-provider-meta">
-            {provider.lastRefreshAt
-              ? t("dashboard.aiCodingUsageLastRefresh", {
-                  time: formatDateTime(provider.lastRefreshAt),
-                })
-              : t("dashboard.aiCodingUsageNeverRefreshed")}
-          </div>
         </>
       ) : (
         <div className="ai-coding-provider-empty">


### PR DESCRIPTION
## Summary

- **Divider above first provider**: Removed the `.ai-coding-provider:first-child` CSS exception that was suppressing `border-top`, so all provider items (including Codex as the first entry) now show a top separator line.
- **Last Updated moved to header**: Relocated the `ai-coding-provider-meta` (Last Updated timestamp) from below the usage meters to the right side of the provider header row, beside the icon and subscription label. It now sits inline with the actions area via a new `ai-coding-provider-header-right` flex container.

## What changed

- `src/App.css`: Removed `:first-child` border suppression rule; added `.ai-coding-provider-header-right` flex container styles.
- `src/ai-coding-usage/AiCodingUsageWidget.tsx`: Wrapped action buttons and meta text in `ai-coding-provider-header-right`; removed meta div from the connected meters section.

## Reviewer notes

The meta text is always visible (no opacity rule), while action buttons still fade in on hover — wrapping them in the same container keeps them on the same row without conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)