### PR TITLE
feat(rdp): hint Ctrl+Alt+End hotkey and add Remote Resolution option

### DIFF
--- a/docs/localization_todo/remoteDesktop.sendCtrlAltDelHint.md
+++ b/docs/localization_todo/remoteDesktop.sendCtrlAltDelHint.md
@@ -1,0 +1,10 @@
+# remoteDesktop.sendCtrlAltDelHint
+
+- **English value**: `Press CTRL+ALT+END to Send CTRL+ALT+DEL`
+- **Namespace**: `remoteDesktop`
+- **File/component**: `src/remote-desktop/RemoteDesktopWorkspace.tsx`
+- **UI role**: `tooltip` (also shown as the single disabled item in a native context menu popped from the keyboard icon in the RDP toolbar)
+- **User flow**: Shown on the RDP workspace toolbar's keyboard icon. Hovering shows it as a tooltip; clicking opens a native menu containing this single, disabled hint. It explains that the user must press the local Ctrl+Alt+End hotkey to send Ctrl+Alt+Delete to the remote Windows desktop, because the embedded Microsoft RDP ActiveX control cannot reliably synthesize the SAS sequence.
+- **Tone**: short, imperative instruction; mirrors Microsoft mstsc conventions
+- **Placeholders**: none
+- **Domain notes**: `CTRL+ALT+END` and `CTRL+ALT+DEL` are Windows keyboard shortcuts and must stay in English/uppercase across all locales — they refer to physical keys. Do not translate the key names. The verb "Press"/"Send" may be localized.

--- a/docs/localization_todo/settings.rdpRemoteResolution.md
+++ b/docs/localization_todo/settings.rdpRemoteResolution.md
@@ -1,0 +1,10 @@
+# settings.rdpRemoteResolution
+
+- **English value**: `Remote resolution`
+- **Namespace**: `settings`
+- **File/component**: `src/settings/RdpSettings.tsx` (also reused in `src/connections/ConnectionSidebar.tsx` per-connection RDP options)
+- **UI role**: `label`
+- **User flow**: Label for the new RDP "Remote resolution" dropdown shown in Settings → RDP, and also in the Connection editor's per-connection RDP options panel when "Inherit defaults" is off.
+- **Tone**: concise/neutral, matches the existing RDP Settings labels ("Color depth", "Performance flags")
+- **Placeholders**: none
+- **Domain notes**: refers to the desktop resolution that KKTerm asks the remote Windows host to render at. "RDP" stays English. Pair with the three mode keys (`rdpRemoteResolutionAutomatic`, `rdpRemoteResolutionSmartSizing`, `rdpRemoteResolutionDpiZoom`) plus a list of fixed `WIDTHxHEIGHT` items that are not translated.

--- a/docs/localization_todo/settings.rdpRemoteResolutionAutomatic.md
+++ b/docs/localization_todo/settings.rdpRemoteResolutionAutomatic.md
@@ -1,0 +1,10 @@
+# settings.rdpRemoteResolutionAutomatic
+
+- **English value**: `Automatic`
+- **Namespace**: `settings`
+- **File/component**: `src/settings/RdpSettings.tsx` and `src/connections/ConnectionSidebar.tsx`
+- **UI role**: `label` (dropdown option)
+- **User flow**: Default value in the Remote resolution dropdown. With Automatic mode KKTerm asks the remote host for the pane's logical (DIP) size, so the remote UI stays readable on high-DPI displays.
+- **Tone**: short single word, dropdown label
+- **Placeholders**: none
+- **Domain notes**: same word as the resolution dropdown shown in Microsoft mstsc's Display tab — translators may match local Windows terminology if there is an established convention.

--- a/docs/localization_todo/settings.rdpRemoteResolutionDpiZoom.md
+++ b/docs/localization_todo/settings.rdpRemoteResolutionDpiZoom.md
@@ -1,0 +1,10 @@
+# settings.rdpRemoteResolutionDpiZoom
+
+- **English value**: `DPI Zoom`
+- **Namespace**: `settings`
+- **File/component**: `src/settings/RdpSettings.tsx` and `src/connections/ConnectionSidebar.tsx`
+- **UI role**: `label` (dropdown option)
+- **User flow**: Selected when the user wants the remote desktop to render at the pane's native physical pixel size and have the RDP ActiveX's `ZoomLevel` set to the host's DPI scale (e.g. 150 on a 150% display). The remote OS renders at native pixel density and the client zooms.
+- **Tone**: short two-word dropdown label
+- **Placeholders**: none
+- **Domain notes**: "DPI" is the universal abbreviation for dots per inch and stays English. "Zoom" may be localized using the same word Microsoft uses for the RDP zoom level menu in mstsc.

--- a/docs/localization_todo/settings.rdpRemoteResolutionSmartSizing.md
+++ b/docs/localization_todo/settings.rdpRemoteResolutionSmartSizing.md
@@ -1,0 +1,10 @@
+# settings.rdpRemoteResolutionSmartSizing
+
+- **English value**: `Smart Sizing`
+- **Namespace**: `settings`
+- **File/component**: `src/settings/RdpSettings.tsx` and `src/connections/ConnectionSidebar.tsx`
+- **UI role**: `label` (dropdown option)
+- **User flow**: Selected when the user wants KKTerm to enable the Microsoft RDP ActiveX `SmartSizing` property so the remote framebuffer is scaled to fit the pane. The remote desktop size is initially set to the pane's physical pixel size and then locked; subsequent pane resizes just rescale the existing framebuffer.
+- **Tone**: short two-word dropdown label
+- **Placeholders**: none
+- **Domain notes**: "Smart Sizing" is the verbatim Microsoft mstsc option name; keep it English unless a localized Windows translation is well-known (e.g. Microsoft's own "智能调整大小" in zh-CN). When in doubt, leave it English.

--- a/docs/manual/09-remote-desktop.md
+++ b/docs/manual/09-remote-desktop.md
@@ -2,9 +2,9 @@
 
 ## AI grep hints
 
-- Keys: `remoteDesktop.*` (full namespace), `connections.windowsRdp`, `connections.screenControl`
-- Topics: RDP via mstscax ActiveX, VNC via vnc-rs, Ctrl+Alt+Del, reconnect, framebuffer waiting, tutorial targets `remoteDesktop.toolbar`, `remoteDesktop.sendCtrlAltDel`, `remoteDesktop.reconnect`, `remoteDesktop.sendToAi`, `remoteDesktop.surface`
-- Synonyms: "remote desktop", "screen sharing", "mstsc", "VNC viewer", "send three-finger salute"
+- Keys: `remoteDesktop.*` (full namespace), `connections.windowsRdp`, `connections.screenControl`, `settings.rdpRemoteResolution*`
+- Topics: RDP via mstscax ActiveX, VNC via vnc-rs, Ctrl+Alt+Del, Ctrl+Alt+End hotkey hint, remote resolution (Automatic / Smart Sizing / DPI Zoom / fixed `WxH`), reconnect, framebuffer waiting, tutorial targets `remoteDesktop.toolbar`, `remoteDesktop.sendCtrlAltDel`, `remoteDesktop.reconnect`, `remoteDesktop.sendToAi`, `remoteDesktop.surface`, `settings.rdpRemoteResolution`
+- Synonyms: "remote desktop", "screen sharing", "mstsc", "VNC viewer", "send three-finger salute", "high DPI scaling", "smart sizing", "remote screen size"
 
 ## Connection kinds
 
@@ -34,7 +34,9 @@ Transport labels for status messages: `remoteDesktop.rdpActiveX`, `remoteDesktop
 
 ## Toolbar actions
 
-- `remoteDesktop.sendCtrlAltDel` — sends Ctrl+Alt+Del to the remote (RDP). Required for the Windows lock screen; the local OS intercepts the real key combo.
+- `remoteDesktop.sendCtrlAltDel` — keyboard icon in the toolbar.
+  - **RDP**: clicking opens a native context menu with the hint `remoteDesktop.sendCtrlAltDelHint` ("Press CTRL+ALT+END to Send CTRL+ALT+DEL"). The embedded Microsoft RDP ActiveX control cannot reliably synthesize the Secure Attention Sequence from outside its own keyboard hook, so the local Ctrl+Alt+End hotkey (set via `HotKeyCtrlAltDel = VK_END`) is the supported path.
+  - **VNC**: the same button still calls `send_vnc_ctrl_alt_delete` directly.
 - `remoteDesktop.reconnect` — explicit reconnect button.
 
 Tutorial targets: `remoteDesktop.toolbar`, `remoteDesktop.sendCtrlAltDel`, `remoteDesktop.reconnect`, `remoteDesktop.sendToAi`.
@@ -52,3 +54,12 @@ This behaviour is **RDP-only**. WebView2, VNC, terminal, and SFTP surfaces never
 ## RDP / VNC settings
 
 Per-kind defaults (resolution, colour depth, etc.) live in Settings → RDP (`settings.sectionRdp`) and Settings → VNC (`settings.sectionVnc`). See [15-settings.md](15-settings.md).
+
+### Remote resolution (`settings.rdpRemoteResolution`)
+
+Controls the desktop size and scaling KKTerm asks the RDP ActiveX control to apply. Available both as a global default (Settings → RDP) and as a per-connection override.
+
+- `settings.rdpRemoteResolutionAutomatic` (default) — push the pane's logical (DIP) size as `DesktopWidth`/`DesktopHeight`. Smart Sizing stays off. Best on high-DPI displays because it stops the remote UI from rendering at physical pixel density and looking too small.
+- `settings.rdpRemoteResolutionSmartSizing` — push the pane's physical pixel size once and enable the ActiveX `SmartSizing` property. The framebuffer is then stretched to fit subsequent pane resizes.
+- `settings.rdpRemoteResolutionDpiZoom` — push the pane's physical pixel size and set `ZoomLevel` to `round(scale_factor * 100)`. The remote OS renders at native DPI; the client scales the framebuffer.
+- Fixed resolutions (`1440x900` through `3840x2400`) — push the chosen size as `DesktopWidth`/`DesktopHeight` and enable `SmartSizing` so the framebuffer is letterboxed/scaled to fit the pane. Subsequent pane resizes do not change the remote desktop size.

--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -61,7 +61,7 @@ const TUTORIAL_TOOL_KNOWN_TARGETS: &str = concat!(
     "settings.defaultUser, settings.defaultPort, settings.defaultKey, settings.sshBufferLines with navigation page=settings settingsSectionId=ssh-settings; ",
     "settings.terminalFontFamily, settings.terminalFontSize, settings.defaultShell, settings.scrollbackLines with navigation page=settings settingsSectionId=terminal-settings; ",
     "settings.ignoreCertificateErrors, settings.urlSavedPasswords, settings.urlDataShards with navigation page=settings settingsSectionId=url-settings; ",
-    "settings.rdpColorDepth, settings.rdpPerformanceProfile with navigation page=settings settingsSectionId=rdp-settings; ",
+    "settings.rdpColorDepth, settings.rdpPerformanceProfile, settings.rdpRemoteResolution with navigation page=settings settingsSectionId=rdp-settings; ",
     "settings.vncViewOnly, settings.vncColorLevel with navigation page=settings settingsSectionId=vnc-settings; ",
     "settings.aboutVersion with navigation page=settings settingsSectionId=about-settings"
 );

--- a/src-tauri/src/rdp.rs
+++ b/src-tauri/src/rdp.rs
@@ -201,6 +201,78 @@ mod platform {
         bitmap_cache: bool,
         #[serde(default = "default_performance_profile")]
         performance_profile: String,
+        #[serde(default = "default_remote_resolution")]
+        remote_resolution: String,
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub enum RemoteResolutionMode {
+        Automatic,
+        SmartSizing,
+        DpiZoom,
+        Fixed { width: i32, height: i32 },
+    }
+
+    impl RemoteResolutionMode {
+        pub fn parse(value: &str) -> Self {
+            match value.trim() {
+                "automatic" | "" => Self::Automatic,
+                "smartSizing" => Self::SmartSizing,
+                "dpiZoom" => Self::DpiZoom,
+                other => other
+                    .split_once('x')
+                    .and_then(|(w, h)| {
+                        let width: i32 = w.parse().ok()?;
+                        let height: i32 = h.parse().ok()?;
+                        if width > 0 && height > 0 {
+                            Some(Self::Fixed { width, height })
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or(Self::Automatic),
+            }
+        }
+
+        pub fn smart_sizing(&self) -> bool {
+            matches!(self, Self::SmartSizing | Self::Fixed { .. })
+        }
+
+        pub fn zoom_level(&self, scale_factor: f64) -> Option<i32> {
+            if let Self::DpiZoom = self {
+                let raw = (scale_factor * 100.0).round() as i32;
+                Some(raw.clamp(100, 500))
+            } else {
+                None
+            }
+        }
+
+        pub fn tracks_pane_size(&self) -> bool {
+            matches!(self, Self::Automatic | Self::DpiZoom)
+        }
+
+        pub fn desktop_size(
+            &self,
+            logical_w: f64,
+            logical_h: f64,
+            physical_w: i32,
+            physical_h: i32,
+        ) -> (i32, i32) {
+            match self {
+                Self::Automatic => (
+                    desktop_width_for(logical_w.round() as i32),
+                    desktop_height_for(logical_h.round() as i32),
+                ),
+                Self::SmartSizing | Self::DpiZoom => (
+                    desktop_width_for(physical_w),
+                    desktop_height_for(physical_h),
+                ),
+                Self::Fixed { width, height } => (
+                    desktop_width_for(*width),
+                    desktop_height_for(*height),
+                ),
+            }
+        }
     }
 
     #[derive(Serialize)]
@@ -308,6 +380,7 @@ mod platform {
         dispatch: IDispatch,
         desktop_width: i32,
         desktop_height: i32,
+        resolution_mode: RemoteResolutionMode,
     }
 
     // These values are always created, used, and destroyed through closures
@@ -438,8 +511,12 @@ mod platform {
                     request.width,
                     request.height,
                 )?;
-                let desktop_width = desktop_width_for(rect.2);
-                let desktop_height = desktop_height_for(rect.3);
+                let (desktop_width, desktop_height) = session.resolution_mode.desktop_size(
+                    request.width,
+                    request.height,
+                    rect.2,
+                    rect.3,
+                );
                 let connection_state = get_property_i32(&session.dispatch, "Connected")?;
                 let connected = is_rdp_connected_state(connection_state);
                 let display_synced = is_rdp_displayable_state(connection_state)
@@ -731,15 +808,22 @@ mod platform {
         let initial_rect = staged_rect(size.2, size.3);
         let (hwnd, dispatch, control) = create_rdp_control(parent_hwnd, initial_rect)?;
 
+        let options = request.options.unwrap_or_default();
+        let resolution_mode = RemoteResolutionMode::parse(&options.remote_resolution);
+        let (desktop_width, desktop_height) =
+            resolution_mode.desktop_size(request.width, request.height, size.2, size.3);
+
         configure_rdp_control(
             &dispatch,
             &host,
             &user,
             port,
             request.password.as_deref(),
-            desktop_width_for(size.2),
-            desktop_height_for(size.3),
-            &request.options.unwrap_or_default(),
+            desktop_width,
+            desktop_height,
+            scale_factor,
+            resolution_mode,
+            &options,
         )?;
         invoke_method(&dispatch, "Connect")?;
 
@@ -756,6 +840,7 @@ mod platform {
                 // startup bounds pushes retry the real remote desktop resize.
                 desktop_width: 0,
                 desktop_height: 0,
+                resolution_mode,
             },
         );
 
@@ -841,6 +926,8 @@ mod platform {
         password: Option<&str>,
         desktop_width: i32,
         desktop_height: i32,
+        scale_factor: f64,
+        resolution_mode: RemoteResolutionMode,
         options: &RdpSessionOptions,
     ) -> Result<(), String> {
         let (domain, username) = split_windows_user(user);
@@ -885,7 +972,10 @@ mod platform {
             let _ = set_property_bool(&advanced, "RedirectSmartCards", false);
             let _ = set_property_i32(&advanced, "SasSequence", RDP_STANDARD_SAS_SEQUENCE);
             let _ = set_property_i32(&advanced, "HotKeyCtrlAltDel", VK_END_KEY as i32);
-            let _ = set_property_bool(&advanced, "SmartSizing", false);
+            let _ = set_property_bool(&advanced, "SmartSizing", resolution_mode.smart_sizing());
+            if let Some(zoom) = resolution_mode.zoom_level(scale_factor) {
+                let _ = set_property_i32(&advanced, "ZoomLevel", zoom);
+            }
             let _ = set_property_bool(&advanced, "BitmapPersistence", options.bitmap_cache);
             let _ = set_property_bool(&advanced, "CachePersistenceActive", options.bitmap_cache);
             let _ = set_property_i32(
@@ -909,8 +999,13 @@ mod platform {
                 redirect_drives: false,
                 bitmap_cache: true,
                 performance_profile: default_performance_profile(),
+                remote_resolution: default_remote_resolution(),
             }
         }
+    }
+
+    fn default_remote_resolution() -> String {
+        "automatic".to_string()
     }
 
     fn default_color_depth() -> u16 {
@@ -1545,8 +1640,11 @@ mod platform {
             width,
             height,
         )?;
-        let desktop_width = desktop_width_for(rect.2);
-        let desktop_height = desktop_height_for(rect.3);
+        if !session.resolution_mode.tracks_pane_size() {
+            return Ok(());
+        }
+        let (desktop_width, desktop_height) =
+            session.resolution_mode.desktop_size(width, height, rect.2, rect.3);
         let _ = sync_remote_desktop_size(session, desktop_width, desktop_height, false);
         Ok(())
     }
@@ -2036,6 +2134,8 @@ mod platform {
         pub redirect_drives: bool,
         pub bitmap_cache: bool,
         pub performance_profile: String,
+        #[serde(default)]
+        pub remote_resolution: String,
     }
 
     #[derive(Serialize)]

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -475,6 +475,8 @@ pub struct RdpSettings {
     bitmap_cache: bool,
     #[serde(default = "default_remote_desktop_performance_profile")]
     performance_profile: String,
+    #[serde(default = "default_remote_desktop_resolution")]
+    remote_resolution: String,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -902,6 +904,8 @@ pub struct RdpConnectionOptions {
     bitmap_cache: Option<bool>,
     #[serde(default)]
     performance_profile: Option<String>,
+    #[serde(default)]
+    remote_resolution: Option<String>,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -3939,6 +3943,7 @@ fn normalize_rdp_connection_options(
             redirect_drives: None,
             bitmap_cache: None,
             performance_profile: None,
+            remote_resolution: None,
         }));
     }
     if let Some(color_depth) = options.color_depth {
@@ -3946,6 +3951,9 @@ fn normalize_rdp_connection_options(
     }
     if let Some(profile) = options.performance_profile {
         options.performance_profile = Some(validate_remote_desktop_performance_profile(profile)?);
+    }
+    if let Some(resolution) = options.remote_resolution {
+        options.remote_resolution = Some(validate_remote_desktop_resolution(resolution)?);
     }
     Ok(Some(options))
 }
@@ -4241,7 +4249,12 @@ fn default_rdp_settings() -> RdpSettings {
         redirect_drives: false,
         bitmap_cache: true,
         performance_profile: default_remote_desktop_performance_profile(),
+        remote_resolution: default_remote_desktop_resolution(),
     }
+}
+
+fn default_remote_desktop_resolution() -> String {
+    "automatic".to_string()
 }
 
 fn default_rdp_color_depth() -> u16 {
@@ -4640,7 +4653,27 @@ fn validate_rdp_settings(mut settings: RdpSettings) -> Result<RdpSettings, Strin
     settings.color_depth = validate_rdp_color_depth(settings.color_depth)?;
     settings.performance_profile =
         validate_remote_desktop_performance_profile(settings.performance_profile)?;
+    settings.remote_resolution = validate_remote_desktop_resolution(settings.remote_resolution)?;
     Ok(settings)
+}
+
+fn validate_remote_desktop_resolution(value: String) -> Result<String, String> {
+    let trimmed = value.trim();
+    if matches!(trimmed, "automatic" | "smartSizing" | "dpiZoom") {
+        return Ok(trimmed.to_string());
+    }
+    if let Some((w, h)) = trimmed.split_once('x') {
+        let width: u32 = w
+            .parse()
+            .map_err(|_| format!("RDP remote resolution '{value}' is not recognized"))?;
+        let height: u32 = h
+            .parse()
+            .map_err(|_| format!("RDP remote resolution '{value}' is not recognized"))?;
+        if width >= 640 && height >= 480 && width <= 7680 && height <= 4320 {
+            return Ok(format!("{width}x{height}"));
+        }
+    }
+    Err(format!("RDP remote resolution '{value}' is not recognized"))
 }
 
 fn validate_vnc_settings(mut settings: VncSettings) -> Result<VncSettings, String> {
@@ -6567,6 +6600,7 @@ mod tests {
                 redirect_drives: true,
                 bitmap_cache: true,
                 performance_profile: "quality".to_string(),
+                remote_resolution: "automatic".to_string(),
             })
             .expect("RDP settings update");
 
@@ -6627,6 +6661,7 @@ mod tests {
                     redirect_drives: Some(true),
                     bitmap_cache: Some(true),
                     performance_profile: Some("quality".to_string()),
+                    remote_resolution: None,
                 }),
                 vnc_options: Some(VncConnectionOptions {
                     inherit_defaults: false,
@@ -6669,6 +6704,7 @@ mod tests {
                     redirect_drives: Some(true),
                     bitmap_cache: Some(true),
                     performance_profile: Some("quality".to_string()),
+                    remote_resolution: None,
                 }),
                 vnc_options: Some(VncConnectionOptions {
                     inherit_defaults: false,

--- a/src/app-defaults.ts
+++ b/src/app-defaults.ts
@@ -94,6 +94,7 @@ export const defaultRdpSettings: RdpSettings = {
   redirectDrives: false,
   bitmapCache: true,
   performanceProfile: "balanced",
+  remoteResolution: "automatic",
 };
 
 export const defaultVncSettings: VncSettings = {

--- a/src/app/tutorialNavigationModel.ts
+++ b/src/app/tutorialNavigationModel.ts
@@ -53,6 +53,7 @@ const SETTINGS_TUTORIAL_TARGET_SECTIONS: Record<string, SettingsSectionId> = {
   "settings.urlDataShards": "url-settings",
   "settings.rdpColorDepth": "rdp-settings",
   "settings.rdpPerformanceProfile": "rdp-settings",
+  "settings.rdpRemoteResolution": "rdp-settings",
   "settings.vncViewOnly": "vnc-settings",
   "settings.vncColorLevel": "vnc-settings",
   "settings.aboutVersion": "about-settings",

--- a/src/connections/ConnectionSidebar.tsx
+++ b/src/connections/ConnectionSidebar.tsx
@@ -28,6 +28,7 @@ import { DeleteConfirmationDialog } from "../app/DeleteConfirmationDialog";
 import { pushTrayMenu } from "../app/trayMenu";
 import { useWorkspaceStore } from "../store";
 import type { Connection, ConnectionFolder, ConnectionStatus, ConnectionTree, ConnectionType, CreateConnectionRequest, RdpSettings, SplitDirection, SshSettings, UpdateConnectionRequest, VncSettings } from "../types";
+import { RDP_REMOTE_RESOLUTION_FIXED } from "../types";
 
 type DraggedTreeItem =
   | { kind: "folder"; folderId: string }
@@ -2567,6 +2568,11 @@ function ConnectionDialog({
                   ? rdpSettings.performanceProfile
                   : form.get("rdpPerformanceProfile") ?? rdpSettings.performanceProfile,
               ) as RdpSettings["performanceProfile"],
+              remoteResolution: String(
+                inheritRdpDefaults
+                  ? rdpSettings.remoteResolution
+                  : form.get("rdpRemoteResolution") ?? rdpSettings.remoteResolution,
+              ) as RdpSettings["remoteResolution"],
             }
           : undefined,
       vncOptions:
@@ -3088,6 +3094,23 @@ function ConnectionDialog({
                         <option value="balanced">{t("settings.rdpPerformanceBalanced")}</option>
                         <option value="quality">{t("settings.rdpPerformanceQuality")}</option>
                         <option value="speed">{t("settings.rdpPerformanceSpeed")}</option>
+                      </select>
+                    </label>
+                    <label>
+                      <span>{t("settings.rdpRemoteResolution")}</span>
+                      <select
+                        disabled={rdpInheritsSettingsDefaults}
+                        name="rdpRemoteResolution"
+                        defaultValue={initialConnection?.rdpOptions?.remoteResolution ?? rdpSettings.remoteResolution}
+                      >
+                        <option value="automatic">{t("settings.rdpRemoteResolutionAutomatic")}</option>
+                        <option value="smartSizing">{t("settings.rdpRemoteResolutionSmartSizing")}</option>
+                        <option value="dpiZoom">{t("settings.rdpRemoteResolutionDpiZoom")}</option>
+                        {RDP_REMOTE_RESOLUTION_FIXED.map((value) => (
+                          <option key={value} value={value}>
+                            {value.replace("x", "×")}
+                          </option>
+                        ))}
                       </select>
                     </label>
                   </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -729,6 +729,10 @@
     "rdpPerformanceBalanced": "Balanced",
     "rdpPerformanceQuality": "Quality",
     "rdpPerformanceSpeed": "Speed",
+    "rdpRemoteResolution": "Remote resolution",
+    "rdpRemoteResolutionAutomatic": "Automatic",
+    "rdpRemoteResolutionSmartSizing": "Smart Sizing",
+    "rdpRemoteResolutionDpiZoom": "DPI Zoom",
     "rdpRedirectClipboard": "Clipboard redirection",
     "rdpRedirectClipboardHint": "Allow clipboard copy and paste between KKTerm and the remote desktop.",
     "rdpRedirectDrives": "Drive redirection",
@@ -1462,6 +1466,7 @@
   "remoteDesktop": {
     "typeLabel": "Remote desktop",
     "sendCtrlAltDel": "Send Ctrl+Alt+Delete",
+    "sendCtrlAltDelHint": "Press CTRL+ALT+END to Send CTRL+ALT+DEL",
     "reconnect": "Reconnect",
     "reconnecting": "Reconnecting",
     "connecting": "Connecting",

--- a/src/remote-desktop/RemoteDesktopWorkspace.tsx
+++ b/src/remote-desktop/RemoteDesktopWorkspace.tsx
@@ -2,6 +2,7 @@ import { connectionIconForType, connectionSubtitle, connectionToolbarTitle, conn
 import { ScreenshotMenu } from "../workspace/ScreenshotMenu";
 
 import { documentHasRdpBlockingOverlay } from "../workspace/nativeOverlay";
+import { showNativeContextMenu } from "../lib/nativeContextMenu";
 import { Bot, Keyboard, Monitor, RotateCcw } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { useEffect, useRef, useState } from "react";
@@ -601,13 +602,27 @@ export function RemoteDesktopWorkspace({
     setRdpStartKey((key) => key + 1);
   };
 
-  const handleSendCtrlAltDelete = () => {
+  const handleSendCtrlAltDelete = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (canStartRdp) {
+      const rect = event.currentTarget.getBoundingClientRect();
+      void showNativeContextMenu(
+        [
+          {
+            kind: "item",
+            label: t("remoteDesktop.sendCtrlAltDelHint"),
+            disabled: true,
+            action: () => {},
+          },
+        ],
+        { x: rect.left, y: rect.bottom },
+      );
+      return;
+    }
     const sessionId = sessionIdRef.current;
     if (!sessionId || !sessionStartedRef.current || !isTauriRuntime()) {
       return;
     }
-    const command = canStartVnc ? "send_vnc_ctrl_alt_delete" : "send_rdp_ctrl_alt_delete";
-    void invokeCommand(command, { request: { sessionId } }).catch((error) => {
+    void invokeCommand("send_vnc_ctrl_alt_delete", { request: { sessionId } }).catch((error) => {
       setRdpError(error instanceof Error ? error.message : String(error));
     });
   };
@@ -1231,9 +1246,9 @@ export function RemoteDesktopWorkspace({
               aria-label={`${t("remoteDesktop.sendCtrlAltDel")} ${typeLabel} ${t("remoteDesktop.session")}`}
               className="terminal-pane-action"
               data-tutorial-id="remoteDesktop.sendCtrlAltDel"
-              disabled={!isTauriRuntime() || !sessionStartedRef.current}
+              disabled={!isTauriRuntime() || (!canStartRdp && !sessionStartedRef.current)}
               onClick={handleSendCtrlAltDelete}
-              title={t("remoteDesktop.sendCtrlAltDel")}
+              title={canStartRdp ? t("remoteDesktop.sendCtrlAltDelHint") : t("remoteDesktop.sendCtrlAltDel")}
               type="button"
             >
               <Keyboard size={13} />
@@ -1387,6 +1402,7 @@ function resolveRdpOptions(
     redirectDrives: overrides.redirectDrives ?? defaults.redirectDrives,
     bitmapCache: overrides.bitmapCache ?? defaults.bitmapCache,
     performanceProfile: overrides.performanceProfile ?? defaults.performanceProfile,
+    remoteResolution: overrides.remoteResolution ?? defaults.remoteResolution,
   };
 }
 

--- a/src/settings/RdpSettings.tsx
+++ b/src/settings/RdpSettings.tsx
@@ -3,7 +3,12 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { invokeCommand, isTauriRuntime } from "../lib/tauri";
 import { useWorkspaceStore } from "../store";
-import type { RdpColorDepth, RdpPerformanceProfile } from "../types";
+import {
+  RDP_REMOTE_RESOLUTION_FIXED,
+  type RdpColorDepth,
+  type RdpPerformanceProfile,
+  type RdpRemoteResolution,
+} from "../types";
 import { SettingsSectionHeader } from "./shared";
 import { ToggleSwitch } from "./ToggleSwitch";
 
@@ -81,6 +86,28 @@ export function RdpSettings() {
               <option value="balanced">{t("settings.rdpPerformanceBalanced")}</option>
               <option value="quality">{t("settings.rdpPerformanceQuality")}</option>
               <option value="speed">{t("settings.rdpPerformanceSpeed")}</option>
+            </select>
+          </label>
+          <label data-tutorial-id="settings.rdpRemoteResolution">
+            <span>{t("settings.rdpRemoteResolution")}</span>
+            <select
+              value={draft.remoteResolution}
+              onChange={(event) => {
+                const remoteResolution = event.currentTarget.value as RdpRemoteResolution;
+                setDraft((settings) => ({
+                  ...settings,
+                  remoteResolution,
+                }));
+              }}
+            >
+              <option value="automatic">{t("settings.rdpRemoteResolutionAutomatic")}</option>
+              <option value="smartSizing">{t("settings.rdpRemoteResolutionSmartSizing")}</option>
+              <option value="dpiZoom">{t("settings.rdpRemoteResolutionDpiZoom")}</option>
+              {RDP_REMOTE_RESOLUTION_FIXED.map((value) => (
+                <option key={value} value={value}>
+                  {value.replace("x", "×")}
+                </option>
+              ))}
             </select>
           </label>
         </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -336,12 +336,46 @@ export interface UrlSettings {
 export type RdpPerformanceProfile = "balanced" | "quality" | "speed";
 export type RdpColorDepth = 15 | 16 | 24 | 32;
 
+export type RdpRemoteResolutionMode = "automatic" | "smartSizing" | "dpiZoom";
+export type RdpRemoteResolutionFixed =
+  | "1440x900"
+  | "1400x1050"
+  | "1600x1024"
+  | "1600x1200"
+  | "1600x1280"
+  | "1680x1050"
+  | "1900x1200"
+  | "1920x1080"
+  | "1920x1200"
+  | "2048x1536"
+  | "2560x2048"
+  | "3200x2400"
+  | "3840x2400";
+export type RdpRemoteResolution = RdpRemoteResolutionMode | RdpRemoteResolutionFixed;
+
+export const RDP_REMOTE_RESOLUTION_FIXED: readonly RdpRemoteResolutionFixed[] = [
+  "1440x900",
+  "1400x1050",
+  "1600x1024",
+  "1600x1200",
+  "1600x1280",
+  "1680x1050",
+  "1900x1200",
+  "1920x1080",
+  "1920x1200",
+  "2048x1536",
+  "2560x2048",
+  "3200x2400",
+  "3840x2400",
+] as const;
+
 export interface RdpSettings {
   colorDepth: RdpColorDepth;
   redirectClipboard: boolean;
   redirectDrives: boolean;
   bitmapCache: boolean;
   performanceProfile: RdpPerformanceProfile;
+  remoteResolution: RdpRemoteResolution;
 }
 
 export interface RdpConnectionOptions {
@@ -351,6 +385,7 @@ export interface RdpConnectionOptions {
   redirectDrives?: boolean;
   bitmapCache?: boolean;
   performanceProfile?: RdpPerformanceProfile;
+  remoteResolution?: RdpRemoteResolution;
 }
 
 export type VncColorLevel = "full" | "256" | "64" | "8";


### PR DESCRIPTION
## Summary

- **Replace the broken RDP \"Send Ctrl+Alt+Del\" button with a native menu hint.** The embedded Microsoft RDP ActiveX control silently no-ops `SendCtrlAltDel` when it doesn't own keyboard focus / isn't full-screen, so the toolbar button never worked for RDP. Clicking the keyboard icon now opens a Tauri native context menu containing one disabled item: *\"Press CTRL+ALT+END to Send CTRL+ALT+DEL\"* — the actual working path, since the backend already maps `HotKeyCtrlAltDel = VK_END`. VNC's button still calls `send_vnc_ctrl_alt_delete` directly.
- **Add a Remote Resolution dropdown** to Settings → RDP (global default) and the per-connection RDP options panel (override). Default `Automatic` fixes too-small remote UI on high-DPI displays by pushing logical (DIP) pane size as `DesktopWidth`/`DesktopHeight` instead of physical pixels. `Smart Sizing` and `DPI Zoom` modes are exposed for experimentation, plus a fixed-resolution list (1440×900 … 3840×2400) that uses SmartSizing to fit the pane.

## Mode behavior (\`src-tauri/src/rdp.rs\`)

| Mode | DesktopWidth/Height | SmartSizing | ZoomLevel | Tracks pane resize? |
| --- | --- | --- | --- | --- |
| Automatic (default) | logical pane size | off | default | yes |
| Smart Sizing | physical pane size (initial) | on | default | no (framebuffer rescales) |
| DPI Zoom | physical pane size | off | round(scale × 100) | yes |
| Fixed \`WxH\` | chosen value | on | default | no |

## Files

- New \`RemoteResolutionMode\` enum + per-session storage in [\`src-tauri/src/rdp.rs\`](src-tauri/src/rdp.rs); \`configure_rdp_control\` now honors the mode instead of hard-coding \`SmartSizing=false\`.
- New \`remoteResolution\` field on \`RdpSettings\` / \`RdpConnectionOptions\` in [\`src-tauri/src/storage.rs\`](src-tauri/src/storage.rs) and [\`src/types.ts\`](src/types.ts), with validation (whitelist of 3 modes + \`WIDTHxHEIGHT\` parser bounded to 640–7680 / 480–4320).
- UI in [\`src/settings/RdpSettings.tsx\`](src/settings/RdpSettings.tsx) and [\`src/connections/ConnectionSidebar.tsx\`](src/connections/ConnectionSidebar.tsx); tutorial / AI metadata updated for the new \`settings.rdpRemoteResolution\` anchor.
- New i18n keys in \`src/i18n/locales/en.json\` (\`remoteDesktop.sendCtrlAltDelHint\`, \`settings.rdpRemoteResolution{,Automatic,SmartSizing,DpiZoom}\`) plus matching \`docs/localization_todo/\` files.
- Operation manual chapter \`docs/manual/09-remote-desktop.md\` updated (new toolbar wording + Remote Resolution section).

## Test plan

- [x] \`npm run check\` (tutorial-target navigation cross-check + \`tsc --noEmit\`)
- [x] \`npm run build\`
- [x] \`cargo check\` (Windows MSVC)
- [x] \`cargo test\` — 395 passed, 0 failed
- [ ] **Native verification (reviewer):** run \`npm run tauri dev\`, open an RDP connection, then
  - click the keyboard icon — verify the native menu opens with the hint and that pressing Ctrl+Alt+End in-session triggers the remote SAS dialog;
  - switch Settings → RDP → Remote resolution between Automatic / Smart Sizing / DPI Zoom / a fixed resolution and reconnect; confirm text size is readable in Automatic on a high-DPI display, that Smart Sizing stretches the framebuffer on pane resize, and that fixed resolutions letterbox/scale to fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)