### PR TITLE
fix(rdp): hide owned popups on close and use host DPI in Automatic mode

### DIFF
--- a/docs/manual/09-remote-desktop.md
+++ b/docs/manual/09-remote-desktop.md
@@ -59,7 +59,7 @@ Per-kind defaults (resolution, colour depth, etc.) live in Settings → RDP (`se
 
 Controls the desktop size and scaling KKTerm asks the RDP ActiveX control to apply. Available both as a global default (Settings → RDP) and as a per-connection override.
 
-- `settings.rdpRemoteResolutionAutomatic` (default) — push the pane's logical desktop size as `DesktopWidth`/`DesktopHeight` and enable Smart Sizing so the remote UI stays at a comfortable scale while stretching to fill the Pane.
+- `settings.rdpRemoteResolutionAutomatic` (default) — push the pane's physical pixel size as `DesktopWidth`/`DesktopHeight`, forward the host display scale factor as the RDP `DesktopScaleFactor` (so the remote OS re-renders UI at the host DPI, not just bitmap-stretched), and keep `SmartSizing` enabled as a fallback during resize transitions. On a 4K monitor at 150% scaling the remote desktop looks the same size as native host apps.
 - `settings.rdpRemoteResolutionSmartSizing` — push the pane's physical pixel size once and enable the ActiveX `SmartSizing` property. The framebuffer is then stretched to fit subsequent pane resizes.
 - `settings.rdpRemoteResolutionDpiZoom` — push the pane's physical pixel size and send the local display scale as the RDP desktop scale factor. The remote OS renders with DPI-aware scaling.
 - Fixed resolutions (`1440x900` through `3840x2400`) — push the chosen size as `DesktopWidth`/`DesktopHeight` and enable `SmartSizing` so the framebuffer scales to fill the Pane. Subsequent pane resizes do not change the remote desktop size.

--- a/src-tauri/src/app_tray.rs
+++ b/src-tauri/src/app_tray.rs
@@ -6,6 +6,12 @@ use tauri::menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem};
 use tauri::tray::{MouseButton, TrayIconBuilder, TrayIconEvent};
 use tauri::{Emitter, Manager};
 
+#[cfg(target_os = "windows")]
+use windows::Win32::{
+    Foundation::HWND,
+    UI::WindowsAndMessaging::ShowOwnedPopups,
+};
+
 const TRAY_ID: &str = "kkterm-main";
 const DONT_SLEEP_ITEM_ID: &str = "kkterm-tray-dont-sleep";
 const EXIT_ITEM_ID: &str = "kkterm-tray-exit";
@@ -218,6 +224,7 @@ pub fn restore_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
             "skipped"
         };
         let show_result = main_window.show().map(|_| "ok").unwrap_or("error");
+        set_owned_popups_visible(&main_window, true);
         let focus_result = main_window.set_focus().map(|_| "ok").unwrap_or("error");
         crate::debug_heartbeat::record_tray_event(format!(
             "restore:wasMinimized={was_minimized}:unminimize={unminimize_result}:show={show_result}:focus={focus_result}"
@@ -238,16 +245,24 @@ pub fn hide_minimized_window_if_enabled<R: tauri::Runtime>(window: &tauri::Windo
 
     crate::debug_heartbeat::record_window_event("hide-minimized-to-tray");
     let _ = window.hide();
+    set_owned_popups_visible(window, false);
 }
 
 /// Diverts the native title-bar close button to a hide-to-tray when minimize-to-tray is enabled.
 /// When disabled, the close request is left untouched so the window quits natively. The tray
 /// "Exit" item calls `app.exit(0)`, which never routes through `CloseRequested`, so quitting
 /// always remains possible.
+///
+/// In both branches we synchronously hide every owned popup HWND (e.g. the RDP ActiveX host
+/// window). Owned popups are not auto-hidden when their owner is hidden via `ShowWindow(SW_HIDE)`
+/// (only when the owner is minimized), so without this the RDP pane lingers on screen after the
+/// main window goes away.
 pub fn hide_window_on_close_if_enabled<R: tauri::Runtime>(
     window: &tauri::Window<R>,
     api: &tauri::CloseRequestApi,
 ) {
+    set_owned_popups_visible(window, false);
+
     let Some(tray_state) = window.try_state::<TrayState>() else {
         return;
     };
@@ -260,3 +275,16 @@ pub fn hide_window_on_close_if_enabled<R: tauri::Runtime>(
     crate::debug_heartbeat::record_window_event("hide-close-to-tray");
     let _ = window.hide();
 }
+
+#[cfg(target_os = "windows")]
+fn set_owned_popups_visible<R: tauri::Runtime>(window: &tauri::Window<R>, visible: bool) {
+    let Ok(handle) = window.hwnd() else { return };
+    let hwnd = HWND(handle.0);
+    // ShowOwnedPopups walks the owner's owned-window list and sets/clears WS_VISIBLE on each.
+    // It is purely a flag flip plus a paint message, so it is safe to call from the close-event
+    // handler on the main thread.
+    let _ = unsafe { ShowOwnedPopups(hwnd, visible) };
+}
+
+#[cfg(not(target_os = "windows"))]
+fn set_owned_popups_visible<R: tauri::Runtime>(_window: &tauri::Window<R>, _visible: bool) {}

--- a/src-tauri/src/rdp.rs
+++ b/src-tauri/src/rdp.rs
@@ -258,19 +258,24 @@ mod platform {
             matches!(self, Self::Automatic | Self::DpiZoom)
         }
 
+        fn applies_host_dpi(&self) -> bool {
+            matches!(self, Self::Automatic | Self::DpiZoom)
+        }
+
         pub fn desktop_size(
             &self,
-            logical_w: f64,
-            logical_h: f64,
+            _logical_w: f64,
+            _logical_h: f64,
             physical_w: i32,
             physical_h: i32,
         ) -> (i32, i32) {
             match self {
-                Self::Automatic => (
-                    desktop_width_for(logical_w.round() as i32),
-                    desktop_height_for(logical_h.round() as i32),
-                ),
-                Self::SmartSizing | Self::DpiZoom => (
+                // Automatic, SmartSizing, and DpiZoom all render at the pane's physical pixel
+                // resolution so the bitmap is 1:1 with the host surface. Automatic and DpiZoom
+                // additionally pass the host scale factor so the remote re-renders UI at the
+                // host's DPI (e.g. 150% on a 4K screen), instead of relying on the bitmap stretch
+                // which leaves text/icons tiny.
+                Self::Automatic | Self::SmartSizing | Self::DpiZoom => (
                     desktop_width_for(physical_w),
                     desktop_height_for(physical_h),
                 ),
@@ -320,16 +325,15 @@ mod platform {
         }
 
         fn desktop_scale_factor(&self, scale_factor: f64) -> i32 {
-            if let Self::DpiZoom = self {
-                let raw = (scale_factor * 100.0).round() as i32;
-                raw.clamp(100, 500)
-            } else {
-                RDP_DISPLAY_SCALE_FACTOR_PERCENT
+            if !self.applies_host_dpi() {
+                return RDP_DISPLAY_SCALE_FACTOR_PERCENT;
             }
+            let raw = (scale_factor * 100.0).round() as i32;
+            raw.clamp(100, 500)
         }
 
         fn device_scale_factor(&self, scale_factor: f64) -> i32 {
-            if !matches!(self, Self::DpiZoom) {
+            if !self.applies_host_dpi() {
                 return RDP_DISPLAY_SCALE_FACTOR_PERCENT;
             }
             let raw = (scale_factor * 100.0).round() as i32;
@@ -2210,24 +2214,36 @@ mod platform {
         }
 
         #[test]
-        fn automatic_resolution_uses_logical_desktop_with_smart_sizing() {
+        fn automatic_resolution_uses_physical_desktop_with_smart_sizing() {
             assert_eq!(
                 RemoteResolutionMode::Automatic.desktop_size(1200.0, 800.0, 1800, 1200),
-                (1200, 800)
+                (1800, 1200)
             );
             assert!(RemoteResolutionMode::Automatic.smart_sizing());
         }
 
         #[test]
-        fn automatic_display_settings_stretch_logical_desktop_with_smart_sizing() {
+        fn automatic_display_settings_apply_host_dpi_at_physical_size() {
             let settings =
                 RemoteResolutionMode::Automatic.display_settings(1200.0, 800.0, 1800, 1200, 1.5);
 
-            assert_eq!(settings.desktop_width, 1200);
-            assert_eq!(settings.desktop_height, 800);
-            assert_eq!(settings.physical_width, 1200);
-            assert_eq!(settings.physical_height, 800);
+            assert_eq!(settings.desktop_width, 1800);
+            assert_eq!(settings.desktop_height, 1200);
+            assert_eq!(settings.physical_width, 1800);
+            assert_eq!(settings.physical_height, 1200);
+            assert_eq!(settings.desktop_scale_factor, 150);
+            assert_eq!(settings.device_scale_factor, 140);
+        }
+
+        #[test]
+        fn automatic_display_settings_pass_through_native_dpi() {
+            let settings =
+                RemoteResolutionMode::Automatic.display_settings(1920.0, 1080.0, 1920, 1080, 1.0);
+
+            assert_eq!(settings.desktop_width, 1920);
+            assert_eq!(settings.desktop_height, 1080);
             assert_eq!(settings.desktop_scale_factor, 100);
+            assert_eq!(settings.device_scale_factor, 100);
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Two long-standing RDP bugs on Windows, both rooted in the fact that the RDP control lives in a `WS_POPUP` top-level window owned by KKTerm's main HWND.

### Bug 1 — RDP pane ghosts after closing the app window
`ShowWindow(SW_HIDE)` on an owner HWND does **not** propagate to its owned popups (only minimize does). When minimize-to-tray calls `window.hide()`, or Tauri's async close lets the main HWND linger, the RDP pane stayed visible on screen until the user clicked elsewhere.

**Fix:** Call Win32 `ShowOwnedPopups(main_hwnd, FALSE)` from the existing sync `hide_window_on_close_if_enabled` / `hide_minimized_window_if_enabled` handlers, and `ShowOwnedPopups(main_hwnd, TRUE)` from `restore_main_window` so a tray-restore brings the RDP pane back.

### Bug 2 — Tiny remote UI in Automatic mode on 4K @ 150% scaling
Automatic was pushing the pane's *logical* CSS pixel size as `DesktopWidth`/`DesktopHeight` and leaving `DesktopScaleFactor` at 100. SmartSizing is only a bitmap stretch — per [Microsoft's RDP docs](https://learn.microsoft.com/en-us/windows/win32/termserv/imsrdpclientadvancedsettings-interface) and the [Devolutions Smart Resizing post](https://blog.devolutions.net/2016/08/smart-resizing-and-high-dpi-issues-in-remote-desktop-manager/), it does **not** re-render the remote UI at higher DPI. Result: icons and text were tiny on a 4K @ 150% host.

**Fix:** Automatic now sends physical pixels for `DesktopWidth`/`Height` **and** forwards the host scale factor as `DesktopScaleFactor`/`DeviceScaleFactor` (same mechanism `DpiZoom` already used), while keeping `SmartSizing` on as a resize-transition fallback. Effectively Automatic = DpiZoom + SmartSizing.

## Files

- `src-tauri/src/app_tray.rs` — adds `set_owned_popups_visible` helper (Windows-only via cfg, no-op elsewhere) and wires it into the close/hide/restore paths.
- `src-tauri/src/rdp.rs` — `RemoteResolutionMode::Automatic` now uses physical pixels and applies host DPI; tests updated.
- `docs/manual/09-remote-desktop.md` — Automatic chapter line updated to describe the new behavior.

## Test plan

Automated:
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib rdp::` (16 passed, 0 failed; includes new `automatic_resolution_uses_physical_desktop_with_smart_sizing`, `automatic_display_settings_apply_host_dpi_at_physical_size`, `automatic_display_settings_pass_through_native_dpi`)
- [x] `npm run check`
- [x] `npm run build`

Manual (please verify on the real Tauri runtime per the project's Native Debug Verification rule):
- [ ] Close the main window with **minimize-to-tray ON** — RDP pane disappears immediately, no click needed.
- [ ] Close the main window with **minimize-to-tray OFF** — RDP pane disappears immediately before the window closes.
- [ ] Restore from tray — RDP pane returns at the correct geometry inside the workspace pane.
- [ ] On a 4K @ 150% host with resolution set to **Automatic**, remote desktop UI scale matches host apps (no longer tiny).
- [ ] Resize the pane while connected — bitmap stretches smoothly during the transition (SmartSizing fallback), then settles at a crisp physical-pixel render.
- [ ] `DpiZoom` and `Smart Sizing` modes still work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)