### PR TITLE
fix(terminal): Ctrl+V 重複貼上兩次

### DIFF
--- a/src/terminal/TerminalWorkspace.tsx
+++ b/src/terminal/TerminalWorkspace.tsx
@@ -1127,6 +1127,9 @@ function TerminalPaneView({
       }
 
       if (key === "v") {
+        // Prevent the browser's native paste event from also reaching xterm's
+        // hidden textarea — otherwise the clipboard text is written twice.
+        event.preventDefault();
         void handlePasteIntoTerminal();
         return false;
       }


### PR DESCRIPTION
## 問題

在終端機按 `Ctrl + V` 貼上時，剪貼簿內容會被寫入兩次。
例如剪貼簿是 `KKTerm`，貼上後終端機顯示 `KKTermKKTerm`。

## 根因

`src/terminal/TerminalWorkspace.tsx` 的 `attachCustomKeyEventHandler` 中，`Ctrl + V` 分支呼叫 `handlePasteIntoTerminal()` 後 `return false`。

但 xterm.js 的 `attachCustomKeyEventHandler` 回傳 `false` 只會讓 xterm **跳過自己的鍵盤處理**，並不會呼叫 `event.preventDefault()`。瀏覽器原生的 `paste` 事件因此仍會打到 xterm 的隱藏 textarea，再透過 `onData` 寫入 session 一次。

結果：
1. custom handler → `handlePasteIntoTerminal()` → 寫入（第 1 次）
2. 瀏覽器 native paste → xterm `onData` → 寫入（第 2 次）

## 修復

在 `Ctrl + V` 分支補上 `event.preventDefault()`，阻擋瀏覽器原生 paste 事件，只保留 `handlePasteIntoTerminal()` 那一條寫入路徑。

```diff
       if (key === "v") {
+        event.preventDefault();
         void handlePasteIntoTerminal();
         return false;
       }
```

`Ctrl + Shift + C` 複製分支不受影響（無對應的 native 衝突事件）。

## 驗證

`npm run tauri dev` 開起來後：
- 複製 `KKTerm` → 終端機 `Ctrl + V` → 應只出現 `KKTerm` 一次
- 右鍵選單「貼上」仍正常（同條 path）
- 多行貼上確認 dialog 仍只跳一次
