### PR TITLE
fix(terminal): 修正本地 PTY 中 Shift+Enter 被當作送出

### DIFF
--- a/src/terminal/TerminalWorkspace.tsx
+++ b/src/terminal/TerminalWorkspace.tsx
@@ -1110,6 +1110,27 @@ function TerminalPaneView({
     terminal.fit();
     focusTerminalUnlessExternalInputIsActive(terminal, paneRef.current);
     terminal.attachCustomKeyEventHandler((event) => {
+      // xterm.js emits a bare CR for Shift+Enter, indistinguishable from a
+      // plain Enter, so Node.js TUIs running inside local PowerShell/cmd/WSL
+      // (e.g. Claude Code) submit the line instead of inserting a newline.
+      // Translate Shift+Enter to LF here, matching Windows Terminal's
+      // behavior. Only for local connections; SSH uses the NativeSsh
+      // transport and its own remote PTY semantics.
+      if (
+        event.type === "keydown" &&
+        event.code === "Enter" &&
+        event.shiftKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !event.metaKey &&
+        !event.isComposing &&
+        connection.type === "local"
+      ) {
+        event.preventDefault();
+        writeInputToSession(encodeShiftEnterForLocalPty());
+        return false;
+      }
+
       if (event.type !== "keydown" || !event.ctrlKey) {
         return true;
       }
@@ -2180,6 +2201,16 @@ function formatByteCount(bytes: number) {
 
 function encodeTerminalInput(data: string) {
   return Array.from(terminalInputEncoder.encode(data));
+}
+
+// Node.js TUIs (Claude Code, etc.) read stdin as raw bytes and never call
+// ReadConsoleInputW, so the win32-input-mode KEY_EVENT_RECORD CSI sequences
+// that ConPTY translates for native Win32 console clients are invisible to
+// them. Both plain Enter and Shift+Enter arrive as bare CR ("\r"), which
+// readline treats as "submit". Send LF ("\n") instead so the TUI sees a
+// real newline, matching what Windows Terminal emits for Shift+Enter.
+function encodeShiftEnterForLocalPty(): string {
+  return "\n";
 }
 
 function terminalDimensionsEqual(left: TerminalDimensions, right: TerminalDimensions) {


### PR DESCRIPTION
## 問題

KKTerm 內本地 PowerShell / cmd / WSL 跑 Claude Code 之類 Node.js TUI 時，按 Shift+Enter 會送出（與 Enter 無異），無法插入換行。同情境在 Windows Terminal 內正常。

## 根因

xterm.js 預設對 Shift+Enter 輸出與 Enter 相同的 CR (`\r`)。Node.js TUI 透過 ConPTY pipe 讀 raw bytes，不走 `ReadConsoleInputW`，因此 ConPTY 的 `PSEUDOCONSOLE_WIN32_INPUT_MODE` KEY_EVENT_RECORD 翻譯對它透明——Shift 修飾位永遠看不到。

## 修法

`src/terminal/TerminalWorkspace.tsx` `attachCustomKeyEventHandler` 內攔截 Shift+Enter（local connection、無其他 modifier、非 IME composition），改送 LF (`\n`)，與 Windows Terminal 對 Shift+Enter 的行為一致。

SSH 連線走 NativeSsh transport，不受影響。

## 驗收

- [x] 本地 PowerShell + Claude Code 內 Shift+Enter 換行（不送出）
- [x] 純 Enter / Ctrl+C / Ctrl+V / Ctrl+Insert 行為不變
- [x] `npm run check` / `npm run build` / `cargo check` / `cargo test` 全綠