### PR TITLE
Make App Launcher drop target cover full widget body

### DIFF
--- a/docs/manual/11-app-launcher.md
+++ b/docs/manual/11-app-launcher.md
@@ -43,6 +43,8 @@ File-name labels may wrap to two lines in the launcher surface so longer local a
 
 List and Details headers are clickable sort controls. List sort and Details sort are stored separately; switching view modes restores that mode's last sort. Icon view remains separate and keeps the manual drag order stored in the entry list.
 
+For desktop file/folder drag import, the browser-preview drop target highlight now covers the entire App Launcher widget body (not only populated icon rows), so drops can land anywhere inside the widget surface.
+
 Details values come from live local file metadata when available:
 
 - Type values use `appLauncher.folderType`, `appLauncher.fileType`, `appLauncher.fileTypeWithExtension`, or `appLauncher.unknownFileType`.

--- a/src/dashboard/dashboard.css
+++ b/src/dashboard/dashboard.css
@@ -2317,7 +2317,10 @@ button.dashboard-pill-dot:focus-visible {
 
 .app-launcher-widget {
   position: relative;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
   gap: 10px;
+  height: 100%;
   border-radius: 8px;
   transition:
     background-color 120ms ease,


### PR DESCRIPTION
### Motivation
- Ensure desktop file/folder drag-and-drop highlights the entire App Launcher widget surface so users can drop anywhere inside the widget, not only over populated icon rows.

### Description
- Update CSS for the App Launcher widget in `src/dashboard/dashboard.css` to make the widget a two-row grid and fill available height by adding `display: grid`, `grid-template-rows: auto minmax(0, 1fr)`, and `height: 100%`, which causes the `.app-launcher-widget.is-drop-target` style to cover the full body area.
- Update documentation `docs/manual/11-app-launcher.md` to note that the browser-preview drop target highlight now covers the entire widget body for desktop file/folder drag import.

### Testing
- Ran `npm run check`, which failed in this environment with `TypeError: source.matchAll.flatMap is not a function` from `tests/tutorial-target-navigation.test.mjs` (environment/runtime limitation).
- Ran `npm run build`, which completed successfully.
- Ran `cargo check --manifest-path src-tauri/Cargo.toml` and `cargo test --manifest-path src-tauri/Cargo.toml`, which failed in this environment due to a missing system `glib-2.0` pkg-config dependency required by `glib-sys`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1158dd80548330ba4703623063b883)