### PR TITLE
Render committed demo.gif in all READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -106,21 +106,11 @@ Wir haben es noch nicht geschafft, eine echte Tüte Kuai Kuai mit dem Installer 
 
 ## In Aktion sehen
 
-<!--
-  TODO: Replace this placeholder with a real demo GIF.
-  Recommended:
-    - 5-10 seconds, looped
-    - Show: open a Connection -> split a pane -> SFTP upload -> AI proposes a command
-    - Target ~5 MB so GitHub renders it inline without lazy-loading
-  Suggested path: docs/assets/demo.gif
-  Then change the <img src=...> below to: src="docs/assets/demo.gif"
--->
-
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
     <img
-      src="https://placehold.co/1280x720/0d1117/8b949e?text=Drop+demo.gif+here%0A%E2%86%92+docs%2Fassets%2Fdemo.gif&font=source-code-pro"
-      alt="KKTerm demo placeholder — replace with docs/assets/demo.gif"
+      src="docs/assets/demo.gif"
+      alt="KKTerm demo"
       width="720"
     />
   </a>

--- a/README.es-MX.md
+++ b/README.es-MX.md
@@ -123,8 +123,8 @@ Todavía no hemos podido incluir una bolsa real de Kuai Kuai con el instalador. 
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
     <img
-      src="https://placehold.co/1280x720/0d1117/8b949e?text=Drop+demo.gif+here%0A%E2%86%92+docs%2Fassets%2Fdemo.gif&font=source-code-pro"
-      alt="KKTerm demo placeholder — replace with docs/assets/demo.gif"
+      src="docs/assets/demo.gif"
+      alt="KKTerm demo"
       width="720"
     />
   </a>

--- a/README.es.md
+++ b/README.es.md
@@ -106,21 +106,11 @@ Todavía no hemos podido incluir una bolsa real de Kuai Kuai en el instalador. E
 
 ## Véelo en acción
 
-<!--
-  TODO: Replace this placeholder with a real demo GIF.
-  Recommended:
-    - 5-10 seconds, looped
-    - Show: open a Connection -> split a pane -> SFTP upload -> AI proposes a command
-    - Target ~5 MB so GitHub renders it inline without lazy-loading
-  Suggested path: docs/assets/demo.gif
-  Then change the <img src=...> below to: src="docs/assets/demo.gif"
--->
-
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
     <img
-      src="https://placehold.co/1280x720/0d1117/8b949e?text=Drop+demo.gif+here%0A%E2%86%92+docs%2Fassets%2Fdemo.gif&font=source-code-pro"
-      alt="KKTerm demo placeholder — replace with docs/assets/demo.gif"
+      src="docs/assets/demo.gif"
+      alt="KKTerm demo"
       width="720"
     />
   </a>

--- a/README.fr.md
+++ b/README.fr.md
@@ -106,21 +106,11 @@ On n'a pas encore réussi à livrer un vrai sachet de Kuai Kuai avec l'installat
 
 ## Voir ça en action
 
-<!--
-  TODO: Replace this placeholder with a real demo GIF.
-  Recommended:
-    - 5-10 seconds, looped
-    - Show: open a Connection -> split a pane -> SFTP upload -> AI proposes a command
-    - Target ~5 MB so GitHub renders it inline without lazy-loading
-  Suggested path: docs/assets/demo.gif
-  Then change the <img src=...> below to: src="docs/assets/demo.gif"
--->
-
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
     <img
-      src="https://placehold.co/1280x720/0d1117/8b949e?text=Drop+demo.gif+here%0A%E2%86%92+docs%2Fassets%2Fdemo.gif&font=source-code-pro"
-      alt="KKTerm demo placeholder — replace with docs/assets/demo.gif"
+      src="docs/assets/demo.gif"
+      alt="KKTerm demo"
       width="720"
     />
   </a>

--- a/README.id.md
+++ b/README.id.md
@@ -119,8 +119,8 @@ Kami belum berhasil menyertakan kantong Kuai Kuai sungguhan dengan installer. It
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
     <img
-      src="https://placehold.co/1280x720/0d1117/8b949e?text=Drop+demo.gif+here%0A%E2%86%92+docs%2Fassets%2Fdemo.gif&font=source-code-pro"
-      alt="KKTerm demo placeholder — replace with docs/assets/demo.gif"
+      src="docs/assets/demo.gif"
+      alt="KKTerm demo"
       width="720"
     />
   </a>

--- a/README.it.md
+++ b/README.it.md
@@ -106,21 +106,11 @@ Non siamo ancora riusciti a includere un vero sacchetto di Kuai Kuai nell'instal
 
 ## Guardalo in Azione
 
-<!--
-  TODO: Replace this placeholder with a real demo GIF.
-  Recommended:
-    - 5-10 seconds, looped
-    - Show: open a Connection -> split a pane -> SFTP upload -> AI proposes a command
-    - Target ~5 MB so GitHub renders it inline without lazy-loading
-  Suggested path: docs/assets/demo.gif
-  Then change the <img src=...> below to: src="docs/assets/demo.gif"
--->
-
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
     <img
-      src="https://placehold.co/1280x720/0d1117/8b949e?text=Drop+demo.gif+here%0A%E2%86%92+docs%2Fassets%2Fdemo.gif&font=source-code-pro"
-      alt="KKTerm demo placeholder — replace with docs/assets/demo.gif"
+      src="docs/assets/demo.gif"
+      alt="KKTerm demo"
       width="720"
     />
   </a>

--- a/README.ja.md
+++ b/README.ja.md
@@ -106,21 +106,11 @@
 
 ## 動いている様子を見る
 
-<!--
-  TODO: Replace this placeholder with a real demo GIF.
-  Recommended:
-    - 5-10 seconds, looped
-    - Show: open a Connection -> split a pane -> SFTP upload -> AI proposes a command
-    - Target ~5 MB so GitHub renders it inline without lazy-loading
-  Suggested path: docs/assets/demo.gif
-  Then change the <img src=...> below to: src="docs/assets/demo.gif"
--->
-
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
     <img
-      src="https://placehold.co/1280x720/0d1117/8b949e?text=Drop+demo.gif+here%0A%E2%86%92+docs%2Fassets%2Fdemo.gif&font=source-code-pro"
-      alt="KKTerm demo placeholder — replace with docs/assets/demo.gif"
+      src="docs/assets/demo.gif"
+      alt="KKTerm demo"
       width="720"
     />
   </a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -109,21 +109,11 @@
 
 ## 실제로 움직이는 모습
 
-<!--
-  TODO: Replace this placeholder with a real demo GIF.
-  Recommended:
-    - 5-10 seconds, looped
-    - Show: open a Connection -> split a pane -> SFTP upload -> AI proposes a command
-    - Target ~5 MB so GitHub renders it inline without lazy-loading
-  Suggested path: docs/assets/demo.gif
-  Then change the <img src=...> below to: src="docs/assets/demo.gif"
--->
-
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
     <img
-      src="https://placehold.co/1280x720/0d1117/8b949e?text=Drop+demo.gif+here%0A%E2%86%92+docs%2Fassets%2Fdemo.gif&font=source-code-pro"
-      alt="KKTerm demo placeholder — replace with docs/assets/demo.gif"
+      src="docs/assets/demo.gif"
+      alt="KKTerm demo"
       width="720"
     />
   </a>

--- a/README.md
+++ b/README.md
@@ -106,21 +106,11 @@ We have not yet been able to ship an actual bag of Kuai Kuai with the installer.
 
 ## See It Move
 
-<!--
-  TODO: Replace this placeholder with a real demo GIF.
-  Recommended:
-    - 5-10 seconds, looped
-    - Show: open a Connection -> split a pane -> SFTP upload -> AI proposes a command
-    - Target ~5 MB so GitHub renders it inline without lazy-loading
-  Suggested path: docs/assets/demo.gif
-  Then change the <img src=...> below to: src="docs/assets/demo.gif"
--->
-
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
     <img
-      src="https://placehold.co/1280x720/0d1117/8b949e?text=Drop+demo.gif+here%0A%E2%86%92+docs%2Fassets%2Fdemo.gif&font=source-code-pro"
-      alt="KKTerm demo placeholder — replace with docs/assets/demo.gif"
+      src="docs/assets/demo.gif"
+      alt="KKTerm demo"
       width="720"
     />
   </a>

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -119,8 +119,8 @@ Ainda não conseguimos incluir um saquinho de Kuai Kuai de verdade com o instala
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
     <img
-      src="https://placehold.co/1280x720/0d1117/8b949e?text=Drop+demo.gif+here%0A%E2%86%92+docs%2Fassets%2Fdemo.gif&font=source-code-pro"
-      alt="KKTerm demo placeholder — replace with docs/assets/demo.gif"
+      src="docs/assets/demo.gif"
+      alt="KKTerm demo"
       width="720"
     />
   </a>

--- a/README.th.md
+++ b/README.th.md
@@ -106,21 +106,11 @@
 
 ## ดูมันขยับ
 
-<!--
-  TODO: Replace this placeholder with a real demo GIF.
-  Recommended:
-    - 5-10 seconds, looped
-    - Show: open a Connection -> split a pane -> SFTP upload -> AI proposes a command
-    - Target ~5 MB so GitHub renders it inline without lazy-loading
-  Suggested path: docs/assets/demo.gif
-  Then change the <img src=...> below to: src="docs/assets/demo.gif"
--->
-
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
     <img
-      src="https://placehold.co/1280x720/0d1117/8b949e?text=Drop+demo.gif+here%0A%E2%86%92+docs%2Fassets%2Fdemo.gif&font=source-code-pro"
-      alt="KKTerm demo placeholder — replace with docs/assets/demo.gif"
+      src="docs/assets/demo.gif"
+      alt="KKTerm demo"
       width="720"
     />
   </a>

--- a/README.vi.md
+++ b/README.vi.md
@@ -106,21 +106,11 @@ Chúng tôi chưa thể đính kèm một gói Kuai Kuai thật vào installer. 
 
 ## Xem nó chạy
 
-<!--
-  TODO: Replace this placeholder with a real demo GIF.
-  Recommended:
-    - 5-10 seconds, looped
-    - Show: open a Connection -> split a pane -> SFTP upload -> AI proposes a command
-    - Target ~5 MB so GitHub renders it inline without lazy-loading
-  Suggested path: docs/assets/demo.gif
-  Then change the <img src=...> below to: src="docs/assets/demo.gif"
--->
-
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
     <img
-      src="https://placehold.co/1280x720/0d1117/8b949e?text=Drop+demo.gif+here%0A%E2%86%92+docs%2Fassets%2Fdemo.gif&font=source-code-pro"
-      alt="KKTerm demo placeholder — replace with docs/assets/demo.gif"
+      src="docs/assets/demo.gif"
+      alt="KKTerm demo"
       width="720"
     />
   </a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -106,21 +106,11 @@
 
 ## 看它动起来
 
-<!--
-  TODO: Replace this placeholder with a real demo GIF.
-  Recommended:
-    - 5-10 seconds, looped
-    - Show: open a Connection -> split a pane -> SFTP upload -> AI proposes a command
-    - Target ~5 MB so GitHub renders it inline without lazy-loading
-  Suggested path: docs/assets/demo.gif
-  Then change the <img src=...> below to: src="docs/assets/demo.gif"
--->
-
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
     <img
-      src="https://placehold.co/1280x720/0d1117/8b949e?text=Drop+demo.gif+here%0A%E2%86%92+docs%2Fassets%2Fdemo.gif&font=source-code-pro"
-      alt="KKTerm demo placeholder — replace with docs/assets/demo.gif"
+      src="docs/assets/demo.gif"
+      alt="KKTerm demo"
       width="720"
     />
   </a>

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -106,21 +106,11 @@
 
 ## 親眼看看
 
-<!--
-  TODO: Replace this placeholder with a real demo GIF.
-  Recommended:
-    - 5-10 seconds, looped
-    - Show: open a Connection -> split a pane -> SFTP upload -> AI proposes a command
-    - Target ~5 MB so GitHub renders it inline without lazy-loading
-  Suggested path: docs/assets/demo.gif
-  Then change the <img src=...> below to: src="docs/assets/demo.gif"
--->
-
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
     <img
-      src="https://placehold.co/1280x720/0d1117/8b949e?text=Drop+demo.gif+here%0A%E2%86%92+docs%2Fassets%2Fdemo.gif&font=source-code-pro"
-      alt="KKTerm demo placeholder — replace with docs/assets/demo.gif"
+      src="docs/assets/demo.gif"
+      alt="KKTerm demo"
       width="720"
     />
   </a>


### PR DESCRIPTION
## Summary
- The demo GIF was committed at `docs/assets/demo.gif` in 21599b1, but every README still pointed its `<img src>` at the placehold.co placeholder, so GitHub kept rendering the placeholder.
- Updated `<img src>` to `docs/assets/demo.gif` (relative path — works on github.com, forks, and offline clones) and removed the now-stale `<!-- TODO -->` comment block across all 14 language variants.

## Notes for reviewer
- 3 localized files (`es-MX`, `id`, `pt-BR`) never had the TODO comment block to begin with — only the `<img>` line changed there. The others lose both the TODO block and have the `<img>` rewritten. Net: -138 / +28 lines.
- GitHub proxies README images through `camo.githubusercontent.com` and caches aggressively. If the GIF ever needs to be replaced at the same path, bust the cache with `?v=2` or rename the file.

## Test plan
- [ ] After merge, confirm the demo GIF renders in the main README on github.com
- [ ] Spot-check one or two localized READMEs (e.g. `README.ja.md`, `README.zh-CN.md`) to confirm the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)