### PR TITLE
[codex] Embed elevated Quick Connect local terminals

### DIFF
--- a/docs/manual/03-connections.md
+++ b/docs/manual/03-connections.md
@@ -66,6 +66,12 @@ Both are app-owned DOM dialogs (not browser-native `prompt`).
 - Permission tier toggle: `connections.normal` / `connections.admin`
 - Recently used Connections list, empty state `connections.noRecent`
 
+For local Command Prompt and PowerShell Quick Connect entries, `connections.admin`
+checks whether the KKTerm process is already elevated. When it is elevated,
+KKTerm opens an embedded local terminal Session and labels the draft shell with
+the admin tier. When it is not elevated, KKTerm keeps the Windows UAC path and
+opens the shell through an external elevated window.
+
 **Add Connection** uses the same form shape but persists to SQLite. The Type selector label is `connections.type`.
 
 For saved Connections, the properties/Add Connection header includes Connection icon presentation controls. `connections.editIcon` changes the icon image. `connections.editIconBackground` opens the circular icon background picker; `connections.iconBackground` labels the picker, `connections.transparentIconBackground` clears the color back to the default transparent state, and `connections.selectIconBackground` applies a palette color. The chosen background is shown behind Connection icons in the Connection Tree and on pinned/connected Activity Rail Connection shortcuts. Workspace Tab rename stores a separate `tabTitle` on the Connection, leaving `name` as the Connection Tree label.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1804,6 +1804,11 @@ fn launch_elevated_terminal(
     sessions::launch_elevated_terminal(request)
 }
 
+#[tauri::command]
+fn is_app_elevated() -> bool {
+    sessions::is_app_elevated()
+}
+
 async fn run_blocking_command<T, F>(label: &'static str, job: F) -> Result<T, String>
 where
     T: Send + 'static,
@@ -2729,6 +2734,7 @@ pub fn run() {
             list_remote_loopback_ports,
             start_ssh_port_forward,
             close_ssh_port_forward,
+            is_app_elevated,
             launch_elevated_terminal,
             start_sftp_session,
             list_sftp_directory,

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -1205,6 +1205,22 @@ pub fn launch_elevated_terminal(request: LaunchElevatedTerminalRequest) -> Resul
     launch_elevated_terminal_impl(normalize_elevated_shell(&request.shell)?)
 }
 
+pub fn is_app_elevated() -> bool {
+    is_app_elevated_impl()
+}
+
+#[cfg(target_os = "windows")]
+fn is_app_elevated_impl() -> bool {
+    use windows_sys::Win32::UI::Shell::IsUserAnAdmin;
+
+    unsafe { IsUserAnAdmin() != 0 }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn is_app_elevated_impl() -> bool {
+    false
+}
+
 fn normalize_elevated_shell(shell: &str) -> Result<&'static str, String> {
     match shell.trim().to_lowercase().as_str() {
         "cmd.exe" => Ok("cmd.exe"),

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1444,6 +1444,10 @@ type CommandMap = {
     args: { request: { forwardId: string } };
     result: null;
   };
+  is_app_elevated: {
+    args: undefined;
+    result: boolean;
+  };
   launch_elevated_terminal: {
     args: { request: { shell: string } };
     result: null;

--- a/src/modules/workspace/connections/ConnectionSidebar.tsx
+++ b/src/modules/workspace/connections/ConnectionSidebar.tsx
@@ -129,6 +129,7 @@ export function ConnectionSidebar({
   const activeSessionCounts = useWorkspaceStore((state) => state.activeSessionCounts);
   const generalSettings = useWorkspaceStore((state) => state.generalSettings);
   const setGeneralSettings = useWorkspaceStore((state) => state.setGeneralSettings);
+  const openElevatedLocalTerminal = useWorkspaceStore((state) => state.openElevatedLocalTerminal);
   const sshSettings = useWorkspaceStore((state) => state.sshSettings);
   const rdpSettings = useWorkspaceStore((state) => state.rdpSettings);
   const vncSettings = useWorkspaceStore((state) => state.vncSettings);
@@ -430,11 +431,7 @@ export function ConnectionSidebar({
     setTreeError("");
     setQuickConnectMenuOpen(false);
     try {
-      await invokeCommand("launch_elevated_terminal", {
-        request: {
-          shell: option.value,
-        },
-      });
+      await openElevatedLocalTerminal(option);
     } catch (error) {
       setTreeError(error instanceof Error ? error.message : String(error));
     }

--- a/src/modules/workspace/connections/quickConnectMenuModel.test.ts
+++ b/src/modules/workspace/connections/quickConnectMenuModel.test.ts
@@ -1,4 +1,7 @@
-import { truncateQuickConnectRecentLabel } from "./quickConnectMenuModel";
+import {
+  elevatedLocalShellAction,
+  truncateQuickConnectRecentLabel,
+} from "./quickConnectMenuModel";
 
 const exactForty = "1234567890123456789012345678901234567890";
 const longerThanForty = "12345678901234567890123456789012345678901";
@@ -9,4 +12,28 @@ if (truncateQuickConnectRecentLabel(exactForty) !== exactForty) {
 
 if (truncateQuickConnectRecentLabel(longerThanForty) !== "1234567890123456789012345678901234567...") {
   throw new Error("Quick Connect recent labels longer than 40 characters should be truncated with ...");
+}
+
+const elevatedPowerShell = elevatedLocalShellAction({
+  adminLabel: "Admin",
+  isAppElevated: true,
+  option: { label: "PowerShell", value: "powershell.exe" },
+});
+
+if (elevatedPowerShell.mode !== "embedded") {
+  throw new Error("Quick Connect Admin should embed the shell when KKTerm is already elevated");
+}
+
+if (elevatedPowerShell.name !== "PowerShell (Admin)") {
+  throw new Error("Embedded elevated local shells should be labelled as elevated");
+}
+
+const unelevatedPowerShell = elevatedLocalShellAction({
+  adminLabel: "Admin",
+  isAppElevated: false,
+  option: { label: "PowerShell", value: "powershell.exe" },
+});
+
+if (unelevatedPowerShell.mode !== "external") {
+  throw new Error("Quick Connect Admin should keep external UAC launch when KKTerm is not elevated");
 }

--- a/src/modules/workspace/connections/quickConnectMenuModel.ts
+++ b/src/modules/workspace/connections/quickConnectMenuModel.ts
@@ -1,5 +1,5 @@
 import type { Connection } from "../../../types";
-import { connectionSubtitle } from "./ConnectionGlyph";
+import { connectionSubtitle, type LocalShellOption } from "./utils";
 
 export const QUICK_CONNECT_RECENT_LABEL_MAX_LENGTH = 40;
 
@@ -12,4 +12,29 @@ export function truncateQuickConnectRecentLabel(label: string): string {
 
 export function quickConnectRecentLabel(connection: Connection): string {
   return truncateQuickConnectRecentLabel(`${connection.name} - ${connectionSubtitle(connection)}`);
+}
+
+export type ElevatedLocalShellAction =
+  | { mode: "embedded"; name: string; shell: string }
+  | { mode: "external"; shell: string };
+
+export function elevatedLocalShellAction({
+  adminLabel,
+  isAppElevated,
+  option,
+}: {
+  adminLabel: string;
+  isAppElevated: boolean;
+  option: LocalShellOption;
+}): ElevatedLocalShellAction {
+  const shell = option.value ?? "powershell.exe";
+  if (!isAppElevated) {
+    return { mode: "external", shell };
+  }
+
+  return {
+    mode: "embedded",
+    name: `${option.label} (${adminLabel})`,
+    shell,
+  };
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -46,6 +46,8 @@ import type {
 } from "./types";
 import i18next from "./i18n/config";
 import { invokeCommand } from "./lib/tauri";
+import { elevatedLocalShellAction } from "./modules/workspace/connections/quickConnectMenuModel";
+import type { LocalShellOption } from "./modules/workspace/connections/utils";
 
 const LAYOUT_STORAGE_PREFIX = "kkterm.layout.";
 const TMUX_SESSION_STORAGE_PREFIX = "kkterm.tmuxSessions.";
@@ -664,7 +666,8 @@ interface WorkspaceState {
   openSftpBrowser: (connection: Connection) => void;
   openFtpBrowser: (connection: Connection) => void;
   openTerminalHere: (connection: Connection, remotePath: string) => void;
-  openLocalTerminal: () => void;
+  openLocalTerminal: (options?: { name?: string; shell?: string }) => void;
+  openElevatedLocalTerminal: (option: LocalShellOption) => Promise<void>;
   splitTerminalPane: (tabId: string) => void;
   splitTerminalPaneDirected: (tabId: string, direction: SplitDirection) => void;
   addConnectionToTerminalPane: (
@@ -1154,17 +1157,34 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       activeTabId: tab.id,
     }));
   },
-  openLocalTerminal: () => {
+  openLocalTerminal: (options) => {
     const id = `local-${Date.now()}`;
-    const shell = get().terminalSettings.defaultShell;
+    const shell = options?.shell ?? get().terminalSettings.defaultShell;
     get().openConnection({
       id,
-      name: shell,
+      name: options?.name ?? shell,
       host: "localhost",
       user: "local",
       localShell: shell,
       type: "local",
       status: "idle",
+    });
+  },
+  openElevatedLocalTerminal: async (option) => {
+    const isAppElevated = await invokeCommand("is_app_elevated", undefined).catch(() => false);
+    const action = elevatedLocalShellAction({
+      adminLabel: i18next.t("connections.admin"),
+      isAppElevated,
+      option,
+    });
+
+    if (action.mode === "embedded") {
+      get().openLocalTerminal({ name: action.name, shell: action.shell });
+      return;
+    }
+
+    await invokeCommand("launch_elevated_terminal", {
+      request: { shell: action.shell },
     });
   },
   splitTerminalPane: (tabId) => {


### PR DESCRIPTION
## Summary
- add a typed Tauri command that reports whether the KKTerm process is elevated on Windows
- route Quick Connect Admin local shells through embedded terminal Sessions when KKTerm is already elevated
- keep the existing external UAC window fallback when KKTerm is not elevated
- document the Quick Connect Admin behavior and add focused model coverage

## Validation
- npx tsc --noEmit --pretty false
- cargo check --manifest-path src-tauri\Cargo.toml

## Notes
Manual runtime acceptance should still verify Quick Connect -> Admin for Command Prompt and PowerShell in both normal and elevated KKTerm desktop launches.
