### PR TITLE
[codex] Fix dashboard tab color picker

### DIFF
--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -25,7 +25,7 @@ It does not own:
 
 ## Domain Concepts
 
-**Dashboard View** — a tab in the Dashboard topbar. A user may have many views; the first one is named "Default" and is created on first run. Each view carries its own `grid_density` (`compact` / `default` / `roomy`) and optional `tab_color` gradient preset id, edited from the topbar's edit-mode controls.
+**Dashboard View** — a tab in the Dashboard topbar. A user may have many views; the first one is named "Default" and is created on first run. Each view carries its own `grid_density` (`compact` / `default` / `roomy`) and optional `tab_color` preset id, edited from the topbar's edit-mode controls.
 
 **Dashboard Widget Instance** — one placed widget on a view. Carries display state (preset, accent, icon, custom title), layout state (`x`, `y`, `w`, `h` on the 12-column grid), per-instance custom settings values, a `kind` of `builtIn` / `script`, and a `source_id` that resolves either to a built-in registry entry or a `DashboardCustomWidget` row.
 
@@ -104,7 +104,7 @@ SQLite holds three Dashboard tables, defined in `src-tauri/src/storage.rs` under
 
 | Table | Purpose |
 | --- | --- |
-| `dashboard_views` | One row per view. Holds `title`, `sort_order`, `grid_density`, and optional `tab_color` gradient preset id. |
+| `dashboard_views` | One row per view. Holds `title`, `sort_order`, `grid_density`, and optional `tab_color` preset id. |
 | `dashboard_widget_instances` | One row per placed widget. Holds `kind`, `source_id`, presentation fields (`preset`, `accent_name`, `icon_name`, `custom_title`), per-instance `settings_values_json`, and layout (`grid_x`, `grid_y`, `grid_w`, `grid_h`). Secret fields store only `secretRef` metadata here. |
 | `dashboard_custom_widgets` | One row per AI Created script-widget definition. Holds `body_json`, validated against the script body schema, plus optional app-rendered `settings_schema_json`. It does not carry a widget kind because all AI Created Widgets are script widgets. |
 

--- a/docs/manual/10-dashboard.md
+++ b/docs/manual/10-dashboard.md
@@ -20,7 +20,7 @@ A View is a Dashboard tab. The first View is named `dashboard.defaultView` and s
 - Add: `dashboard.addView`. New-View dialog `dashboard.newViewPrompt`, field `dashboard.newViewName`.
 - Rename: `dashboard.renameView`.
 - Remove: `dashboard.removeView`. Confirmation body `dashboard.deleteViewBody`.
-- Tab gradient styling: `dashboard.viewTabGradient`, clear `dashboard.clearViewTabGradient`.
+- Tab color styling: `dashboard.viewTabGradient`, theme/default swatch `dashboard.clearViewTabGradient`.
 
 Each View has its own `grid_density` (`dashboard.density.compact`, `dashboard.density.default`, `dashboard.density.roomy`) and its own background.
 Previously opened Views remain mounted while hidden so switching between View tabs preserves Widget Instance state and keeps embedded Connection panes responsive; hidden Connection panes are marked inactive instead of being closed.

--- a/src-tauri/src/dashboard_validation.rs
+++ b/src-tauri/src/dashboard_validation.rs
@@ -102,7 +102,15 @@ pub const BACKGROUND_PRESET_IDS: &[&str] = &[
     "g-nocturne",
 ];
 
-pub const DASHBOARD_TAB_GRADIENT_IDS: &[&str] = &[
+pub const DASHBOARD_TAB_COLOR_IDS: &[&str] = &[
+    "mist",
+    "sand",
+    "sage",
+    "sky",
+    "blush",
+    "lavender",
+    "graphite",
+    "midnight",
     "g-dawn",
     "g-fog",
     "g-meadow",
@@ -301,7 +309,7 @@ pub fn validate_dynamic_background(dynamic: &str) -> Result<(), ValidationError>
 }
 
 pub fn validate_dashboard_tab_color(color: &str) -> Result<(), ValidationError> {
-    if DASHBOARD_TAB_GRADIENT_IDS.contains(&color) {
+    if DASHBOARD_TAB_COLOR_IDS.contains(&color) {
         Ok(())
     } else {
         Err(ValidationError::InvalidBackground)
@@ -1337,20 +1345,22 @@ mod tests {
     }
 
     #[test]
-    fn dashboard_tab_color_accepts_gradient_presets() {
+    fn dashboard_tab_color_accepts_tab_color_presets() {
+        assert!(validate_dashboard_tab_color("mist").is_ok());
+        assert!(validate_dashboard_tab_color("midnight").is_ok());
         assert!(validate_dashboard_tab_color("g-dawn").is_ok());
         assert!(validate_dashboard_tab_color("g-twilight").is_ok());
         assert!(validate_dashboard_tab_color("g-nocturne").is_ok());
     }
 
     #[test]
-    fn dashboard_tab_color_rejects_custom_or_solid_colors() {
+    fn dashboard_tab_color_rejects_custom_or_unlisted_solid_colors() {
         assert_eq!(
             validate_dashboard_tab_color("#2563eb"),
             Err(ValidationError::InvalidBackground),
         );
         assert_eq!(
-            validate_dashboard_tab_color("mist"),
+            validate_dashboard_tab_color("pine"),
             Err(ValidationError::InvalidBackground),
         );
         assert_eq!(

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -40,8 +40,8 @@
     "newViewPrompt": "View name",
     "renameView": "Rename view",
     "removeView": "Remove view",
-    "viewTabGradient": "View tab gradient for {{view}}",
-    "clearViewTabGradient": "Clear view tab gradient for {{view}}",
+    "viewTabGradient": "View tab color for {{view}}",
+    "clearViewTabGradient": "Use theme tab color for {{view}}",
     "editLayout": "Edit Layout",
     "editDone": "Done",
     "density": {

--- a/src/modules/dashboard/DashboardPage.tsx
+++ b/src/modules/dashboard/DashboardPage.tsx
@@ -10,9 +10,9 @@ import { BackgroundPopover } from "./edit/BackgroundPopover";
 import { CatalogOverlay } from "./edit/CatalogOverlay";
 import { CustomizePopover } from "./edit/CustomizePopover";
 import {
-  DASHBOARD_TAB_GRADIENT_PRESETS,
+  DASHBOARD_TAB_COLOR_PRESETS,
   isDarkBackgroundPresetId,
-  resolveDashboardTabGradientPreset,
+  resolveDashboardTabColorPreset,
 } from "./registry/backgroundPresets";
 import { BUILT_IN_WIDGETS } from "./registry/builtInRegistry";
 import { compactLibraryCatalogForAi } from "./script/widgetLibraries";
@@ -375,23 +375,6 @@ export function DashboardPage({
                     ×
                   </button>
                 )}
-                {editMode && (
-                  <>
-                    {v.tabColor && (
-                      <button
-                        aria-label={t("dashboard.clearViewTabGradient", { view: v.title })}
-                        className="dashboard-pill-color-clear"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          void setViewTabColor(v.id, null);
-                        }}
-                        type="button"
-                      >
-                        ×
-                      </button>
-                    )}
-                  </>
-                )}
               </div>
             );
           })}
@@ -473,6 +456,7 @@ export function DashboardPage({
         <TabGradientPopover
           anchorRect={tabGradientPicker.rect}
           activeGradientId={views.find((view) => view.id === tabGradientPicker.viewId)?.tabColor ?? null}
+          viewTitle={views.find((view) => view.id === tabGradientPicker.viewId)?.title ?? ""}
           onClose={() => setTabGradientPicker(null)}
           onSelect={(gradientId) => {
             void setViewTabColor(tabGradientPicker.viewId, gradientId);
@@ -512,7 +496,7 @@ export function DashboardPage({
 
 function dashboardTabColorStyle(tabColor: string | null): CSSProperties | undefined {
   if (!tabColor) return undefined;
-  const preset = resolveDashboardTabGradientPreset(tabColor);
+  const preset = resolveDashboardTabColorPreset(tabColor);
   const textColor = isDarkBackgroundPresetId(tabColor) ? "#ffffff" : "#0f172a";
   return {
     "--dashboard-pill-bg": preset.css,
@@ -523,7 +507,7 @@ function dashboardTabColorStyle(tabColor: string | null): CSSProperties | undefi
 
 function dashboardTabDotStyle(tabColor: string | null): CSSProperties | undefined {
   if (!tabColor) return undefined;
-  return { background: resolveDashboardTabGradientPreset(tabColor).css };
+  return { background: resolveDashboardTabColorPreset(tabColor).css };
 }
 
 function TabGradientPopover({
@@ -531,11 +515,13 @@ function TabGradientPopover({
   anchorRect,
   onClose,
   onSelect,
+  viewTitle,
 }: {
   activeGradientId: string | null;
   anchorRect: DOMRect;
   onClose: () => void;
-  onSelect: (gradientId: string) => void;
+  onSelect: (gradientId: string | null) => void;
+  viewTitle: string;
 }) {
   const { t } = useTranslation();
   const ref = useRef<HTMLDivElement | null>(null);
@@ -557,12 +543,18 @@ function TabGradientPopover({
 
   const style = {
     top: anchorRect.bottom + 6,
-    left: Math.min(anchorRect.left, window.innerWidth - 214),
+    left: Math.min(anchorRect.left, window.innerWidth - 168),
   } as CSSProperties;
 
   return (
     <div ref={ref} className="dashboard-tab-gradient-popover" style={style}>
-      {DASHBOARD_TAB_GRADIENT_PRESETS.map((preset) => (
+      <button
+        aria-label={t("dashboard.clearViewTabGradient", { view: viewTitle })}
+        className={`dashboard-tab-gradient-none${activeGradientId === null ? " active" : ""}`}
+        onClick={() => onSelect(null)}
+        type="button"
+      />
+      {DASHBOARD_TAB_COLOR_PRESETS.map((preset) => (
         <button
           key={preset.id}
           aria-label={t(preset.labelKey)}

--- a/src/modules/dashboard/dashboard.css
+++ b/src/modules/dashboard/dashboard.css
@@ -704,43 +704,21 @@ button.dashboard-pill-dot:focus-visible {
   background: var(--surface-muted);
 }
 
-.dashboard-pill.has-tab-color .dashboard-pill-close,
-.dashboard-pill.has-tab-color .dashboard-pill-color-clear {
+.dashboard-pill.has-tab-color .dashboard-pill-close {
   color: var(--dashboard-pill-muted);
 }
 
-.dashboard-pill.has-tab-color .dashboard-pill-close:hover,
-.dashboard-pill.has-tab-color .dashboard-pill-color-clear:hover {
+.dashboard-pill.has-tab-color .dashboard-pill-close:hover {
   color: var(--dashboard-pill-text);
   background: rgb(255 255 255 / 20%);
-}
-
-.dashboard-pill-color-clear {
-  flex: 0 0 auto;
-  width: 16px;
-  height: 16px;
-}
-
-.dashboard-pill-color-clear {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  color: var(--text-faint);
-  background: transparent;
-  border: 0;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 13px;
-  line-height: 1;
 }
 
 .dashboard-tab-gradient-popover {
   position: fixed;
   z-index: 210;
   display: grid;
-  grid-template-columns: repeat(4, 42px);
-  gap: 7px;
+  grid-template-columns: repeat(5, 24px);
+  gap: 6px;
   width: max-content;
   padding: 8px;
   background: var(--surface);
@@ -750,10 +728,30 @@ button.dashboard-pill-dot:focus-visible {
 }
 
 .dashboard-tab-gradient-popover button {
-  height: 28px;
+  width: 24px;
+  height: 24px;
+  padding: 0;
   border: 1px solid var(--border);
-  border-radius: 7px;
+  border-radius: 5px;
   cursor: pointer;
+}
+
+.dashboard-tab-gradient-popover .dashboard-tab-gradient-none {
+  position: relative;
+  overflow: hidden;
+  background: #ffffff;
+}
+
+.dashboard-tab-gradient-popover .dashboard-tab-gradient-none::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: -4px;
+  width: 34px;
+  height: 2px;
+  background: #dc2626;
+  transform: rotate(-45deg);
+  transform-origin: center;
 }
 
 .dashboard-tab-gradient-popover button:hover,

--- a/src/modules/dashboard/registry/backgroundPresets.test.ts
+++ b/src/modules/dashboard/registry/backgroundPresets.test.ts
@@ -1,10 +1,10 @@
 import {
   BACKGROUND_PRESETS,
-  DASHBOARD_TAB_GRADIENT_PRESETS,
+  DASHBOARD_TAB_COLOR_PRESETS,
   isBackgroundPresetId,
-  isDashboardTabGradientPresetId,
+  isDashboardTabColorPresetId,
   resolveBackgroundPreset,
-  resolveDashboardTabGradientPreset,
+  resolveDashboardTabColorPreset,
 } from "./backgroundPresets";
 
 // There must be exactly 32 presets (16 solid + 16 gradient), matching the Rust whitelist.
@@ -22,18 +22,22 @@ if (isBackgroundPresetId(maybeId)) {
   void known;
 }
 
-if (!DASHBOARD_TAB_GRADIENT_PRESETS.every((preset) => preset.id.startsWith("g-"))) {
-  throw new Error("Dashboard View tab presets should only expose gradients.");
+if (DASHBOARD_TAB_COLOR_PRESETS.length !== 24) {
+  throw new Error("Dashboard View tab presets should expose 16 gradients and 8 flat colors.");
 }
 
-if (!isDashboardTabGradientPresetId("g-dawn")) {
-  throw new Error("Dashboard View tab gradient ids should accept known gradients.");
+if (!isDashboardTabColorPresetId("g-dawn")) {
+  throw new Error("Dashboard View tab color ids should accept known gradients.");
 }
 
-if (isDashboardTabGradientPresetId("mist")) {
-  throw new Error("Dashboard View tab gradient ids should reject solid color presets.");
+if (!isDashboardTabColorPresetId("mist")) {
+  throw new Error("Dashboard View tab color ids should accept known flat colors.");
 }
 
-if (resolveDashboardTabGradientPreset("does-not-exist").id !== "g-dawn") {
-  throw new Error("Dashboard View tab gradient fallback should be stable.");
+if (isDashboardTabColorPresetId("pine")) {
+  throw new Error("Dashboard View tab color ids should reject flat colors outside the tab palette.");
+}
+
+if (resolveDashboardTabColorPreset("does-not-exist").id !== "mist") {
+  throw new Error("Dashboard View tab color fallback should be stable.");
 }

--- a/src/modules/dashboard/registry/backgroundPresets.ts
+++ b/src/modules/dashboard/registry/backgroundPresets.ts
@@ -72,15 +72,26 @@ export function isDarkBackgroundPresetId(value: string): boolean {
   return DARK_BACKGROUND_PRESET_IDS.has(value);
 }
 
-export const DASHBOARD_TAB_GRADIENT_PRESETS = BACKGROUND_PRESETS.filter((preset) => (
-  preset.id.startsWith("g-")
+const DASHBOARD_TAB_FLAT_COLOR_IDS = new Set([
+  "mist",
+  "sand",
+  "sage",
+  "sky",
+  "blush",
+  "lavender",
+  "graphite",
+  "midnight",
+]);
+
+export const DASHBOARD_TAB_COLOR_PRESETS = BACKGROUND_PRESETS.filter((preset) => (
+  preset.id.startsWith("g-") || DASHBOARD_TAB_FLAT_COLOR_IDS.has(preset.id)
 ));
 
-export function resolveDashboardTabGradientPreset(id: string): BackgroundPresetDefinition {
-  return DASHBOARD_TAB_GRADIENT_PRESETS.find((preset) => preset.id === id)
-    ?? DASHBOARD_TAB_GRADIENT_PRESETS[0];
+export function resolveDashboardTabColorPreset(id: string): BackgroundPresetDefinition {
+  return DASHBOARD_TAB_COLOR_PRESETS.find((preset) => preset.id === id)
+    ?? DASHBOARD_TAB_COLOR_PRESETS[0];
 }
 
-export function isDashboardTabGradientPresetId(value: string): value is (typeof DASHBOARD_TAB_GRADIENT_PRESETS)[number]["id"] {
-  return DASHBOARD_TAB_GRADIENT_PRESETS.some((preset) => preset.id === value);
+export function isDashboardTabColorPresetId(value: string): value is (typeof DASHBOARD_TAB_COLOR_PRESETS)[number]["id"] {
+  return DASHBOARD_TAB_COLOR_PRESETS.some((preset) => preset.id === value);
 }


### PR DESCRIPTION
## Summary

- remove the duplicate edit-mode clear button from Dashboard View pills
- add a compact default/theme swatch to the tab color picker
- add 8 flat tab color presets and update Rust validation/docs for the broader tab color palette

## Root cause

Colored Dashboard View pills showed both the remove-View button and a separate clear-color button, each rendered as `×`, so edit mode displayed two indistinguishable close-style controls. The reset action now lives in the picker itself.

## Validation

- `npm run i18n:check`
- `./node_modules/.bin/tsc.cmd --noEmit`
- `cargo test --manifest-path src-tauri/Cargo.toml dashboard_tab_color`
- `git diff --check`