### PR TITLE
App Launcher: add "Show file extensions" setting and display logic

### DIFF
--- a/docs/localization_todo/appLauncher.showFileExtensions.md
+++ b/docs/localization_todo/appLauncher.showFileExtensions.md
@@ -1,0 +1,10 @@
+# appLauncher.showFileExtensions
+
+- **English value**: `Show file extensions`
+- **Namespace**: `app`
+- **File/component**: `src/modules/dashboard/edit/CustomizePopover.tsx`
+- **UI role**: `label`
+- **User flow**: `Shown in Dashboard widget customization under the Widget tab for App Launcher instances. Users toggle whether file shortcuts display their extension in the widget grid/list/details name column.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `App Launcher is a Dashboard widget; preserve "file extensions" as operating-system filename suffixes like .txt/.exe.`

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -368,6 +368,7 @@
     "railShortcutsLabel": "Pinned App Launcher shortcuts",
     "entriesLabel": "Pinned applications",
     "viewModeLabel": "App Launcher view mode",
+    "showFileExtensions": "Show file extensions",
     "iconView": "Icons",
     "listView": "List",
     "detailsView": "Details",

--- a/src/modules/dashboard/edit/CustomizePopover.tsx
+++ b/src/modules/dashboard/edit/CustomizePopover.tsx
@@ -35,6 +35,16 @@ type SectionKey = "common" | "widget" | "advanced";
 
 const POPOVER_MARGIN = 8;
 const POPOVER_WIDTH = 440;
+const APP_LAUNCHER_SETTINGS_SCHEMA: WidgetSettingsSchema = {
+  fields: [
+    {
+      key: "showFileExtensions",
+      type: "boolean",
+      label: "appLauncher.showFileExtensions",
+      defaultValue: false,
+    },
+  ],
+};
 
 export function CustomizePopover({ instance, anchorRect, onClose }: CustomizePopoverProps) {
   const { t } = useTranslation();
@@ -49,11 +59,16 @@ export function CustomizePopover({ instance, anchorRect, onClose }: CustomizePop
 
   const customSource =
     instance.kind !== "builtIn" ? customWidgets.find((c) => c.id === instance.sourceId) : undefined;
-  const settingsSchema = useMemo(
-    () => (customSource ? parseSettingsSchema(customSource.settingsSchemaJson) : null),
-    [customSource],
-  );
-  const hasWidgetSettings = Boolean(customSource);
+  const settingsSchema = useMemo(() => {
+    if (customSource) {
+      return parseSettingsSchema(customSource.settingsSchemaJson);
+    }
+    if (instance.kind === "builtIn" && instance.sourceId === "appLauncher") {
+      return APP_LAUNCHER_SETTINGS_SCHEMA;
+    }
+    return null;
+  }, [customSource, instance.kind, instance.sourceId]);
+  const hasWidgetSettings = settingsSchema !== null;
   const hasAdvanced = instance.kind !== "builtIn";
 
   const sections = useMemo(() => {

--- a/src/modules/dashboard/widgets/builtin/app-launcher/AppLauncherWidget.tsx
+++ b/src/modules/dashboard/widgets/builtin/app-launcher/AppLauncherWidget.tsx
@@ -745,6 +745,7 @@ export function AppLauncherWidget({ instance }: { instance: DashboardWidgetInsta
               onPointerUpEntry={finishPointerReorder}
               onRemove={removeEntry}
               prepared={preparedById[entry.id]}
+              showFileExtensions={settings.showFileExtensions}
               viewMode={settings.viewMode}
             />
           ))}
@@ -917,6 +918,7 @@ function AppLauncherTile({
   onPointerUpEntry,
   onRemove,
   prepared,
+  showFileExtensions,
   viewMode,
 }: {
   entry: AppLauncherEntry;
@@ -924,6 +926,7 @@ function AppLauncherTile({
   isDragging: boolean;
   reorderPlacement: ReorderPlacement | null;
   prepared?: PreparedAppLauncherEntry;
+  showFileExtensions: boolean;
   viewMode: AppLauncherViewMode;
   onLaunch: (entry: AppLauncherEntry, mode: AppLauncherLaunchMode) => Promise<void>;
   onMenu: (state: MenuState) => void;
@@ -990,6 +993,7 @@ function AppLauncherTile({
             entry={entry}
             iconDataUrl={iconDataUrl}
             prepared={prepared}
+            showFileExtensions={showFileExtensions}
             viewMode={viewMode}
           />
         </div>
@@ -1005,6 +1009,7 @@ function AppLauncherTile({
             entry={entry}
             iconDataUrl={iconDataUrl}
             prepared={prepared}
+            showFileExtensions={showFileExtensions}
             viewMode={viewMode}
           />
         </button>
@@ -1017,11 +1022,13 @@ function AppLauncherTileContent({
   entry,
   iconDataUrl,
   prepared,
+  showFileExtensions,
   viewMode,
 }: {
   entry: AppLauncherEntry;
   iconDataUrl: string | null | undefined;
   prepared?: PreparedAppLauncherEntry;
+  showFileExtensions: boolean;
   viewMode: AppLauncherViewMode;
 }) {
   const { t } = useTranslation();
@@ -1034,7 +1041,9 @@ function AppLauncherTileContent({
           <AppWindow size={20} />
         )}
       </span>
-      <span className="app-launcher-tile-label">{entry.name}</span>
+      <span className="app-launcher-tile-label">
+        {entryDisplayName(entry, prepared, showFileExtensions)}
+      </span>
       {viewMode === "details" ? (
         <>
           <span className="app-launcher-tile-type">{fileTypeLabel(t, entry, prepared)}</span>
@@ -1346,6 +1355,28 @@ function sortStringValue(
     return `${prepared?.fileKind ?? "missing"}:${prepared?.extension ?? ""}`;
   }
   return entry.name;
+}
+
+function entryDisplayName(
+  entry: AppLauncherEntry,
+  prepared: PreparedAppLauncherEntry | undefined,
+  showFileExtensions: boolean,
+) {
+  if (!showFileExtensions || prepared?.fileKind === "folder") {
+    return entry.name;
+  }
+  const filename = entry.path.trim().replace(/\\/g, "/").split("/").filter(Boolean).pop();
+  if (!filename || !filename.includes(".")) {
+    return entry.name;
+  }
+  const extension = extensionFromPath(entry.path);
+  if (!extension) {
+    return entry.name;
+  }
+  const filenameWithoutExtension = filename.slice(0, filename.length - (extension.length + 1));
+  return entry.name.localeCompare(filenameWithoutExtension, undefined, { sensitivity: "accent" }) === 0
+    ? filename
+    : entry.name;
 }
 
 function compareStrings(a: string, b: string) {

--- a/src/modules/dashboard/widgets/builtin/app-launcher/storage.ts
+++ b/src/modules/dashboard/widgets/builtin/app-launcher/storage.ts
@@ -141,6 +141,7 @@ function normalizeAppLauncherSettings(settings: Partial<AppLauncherSettings>): A
     viewMode: isAppLauncherViewMode(settings.viewMode) ? settings.viewMode : "icons",
     listSort: normalizeSortState(settings.listSort, DEFAULT_LIST_SORT),
     detailsSort: normalizeSortState(settings.detailsSort, DEFAULT_DETAILS_SORT),
+    showFileExtensions: settings.showFileExtensions === true,
   };
 }
 
@@ -197,6 +198,7 @@ function defaultAppLauncherSettings(): AppLauncherSettings {
     viewMode: "icons",
     listSort: DEFAULT_LIST_SORT,
     detailsSort: DEFAULT_DETAILS_SORT,
+    showFileExtensions: false,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -233,6 +233,7 @@ export interface AppLauncherSettings {
   viewMode: AppLauncherViewMode;
   listSort: AppLauncherSortState;
   detailsSort: AppLauncherSortState;
+  showFileExtensions: boolean;
 }
 
 export interface DashboardSettings {


### PR DESCRIPTION
### Motivation
- Provide a widget-level setting to toggle showing file name extensions for App Launcher entries so users can optionally see OS filename suffixes in the widget UI.

### Description
- Add a new localization key `appLauncher.showFileExtensions` and a `localization_todo` entry for translators with English value `Show file extensions`.
- Expose a built-in widget settings schema `APP_LAUNCHER_SETTINGS_SCHEMA` in `CustomizePopover` so the App Launcher builtin shows a `showFileExtensions` boolean in the widget customization UI via the `widget` section.
- Persist the setting in the App Launcher settings structure by adding `showFileExtensions` to `AppLauncherSettings`, normalizing it in `storage.ts`, and adding a default value in `defaultAppLauncherSettings`.
- Thread the setting through the UI by passing `showFileExtensions` into `AppLauncherTile` and `AppLauncherTileContent` and implement `entryDisplayName` to decide whether to render the filename with its extension based on the stored setting and entry metadata.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a156b318024832fbcc0982cd40385a3)