### PR TITLE
Fix App Launcher pinned shortcuts being wiped when toggling Show File Extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "check": "node tests/tutorial-target-navigation.test.mjs && node tests/no-terminal-agent-detection.test.mjs && node tests/release-notes-generator.test.mjs && node tests/release-github-script.test.mjs && node tests/smoke-installer-script.test.mjs && node tests/titlebar-app-icon.test.mjs && node tests/titlebar-theme.test.mjs && node tests/no-local-profile-path.test.mjs && node tests/dashboard-connection-widget-tmux.test.mjs && node tests/workspace-connection-new-tab.test.mjs && node tests/workspace-tab-rename-runtime.test.mjs && tsc --noEmit",
+    "check": "node tests/tutorial-target-navigation.test.mjs && node tests/no-terminal-agent-detection.test.mjs && node tests/release-notes-generator.test.mjs && node tests/release-github-script.test.mjs && node tests/smoke-installer-script.test.mjs && node tests/titlebar-app-icon.test.mjs && node tests/titlebar-theme.test.mjs && node tests/no-local-profile-path.test.mjs && node tests/dashboard-connection-widget-tmux.test.mjs && node tests/dashboard-app-launcher-settings-merge.test.mjs && node tests/workspace-connection-new-tab.test.mjs && node tests/workspace-tab-rename-runtime.test.mjs && tsc --noEmit",
     "package:installer": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/package-installer.ps1",
     "release:github": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/release-github.ps1",
     "release:notes": "node scripts/generate-release-notes.mjs",

--- a/src/modules/dashboard/edit/CustomizePopover.tsx
+++ b/src/modules/dashboard/edit/CustomizePopover.tsx
@@ -322,7 +322,9 @@ function WidgetSection({
           values={settingsValues}
           instanceId={instance.id}
           onChange={(key, value) => {
-            const next = { ...settingsValues, [key]: value };
+            const parsed = parseWidgetSettingsValuesJson(instance.settingsValuesJson);
+            const base = parsed.ok ? parsed.value : {};
+            const next = { ...base, [key]: value };
             void updateInstance(instance.id, { settingsValuesJson: JSON.stringify(next) });
           }}
         />

--- a/tests/dashboard-app-launcher-settings-merge.test.mjs
+++ b/tests/dashboard-app-launcher-settings-merge.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("App Launcher Customize popover writes settings by merging into the raw stored JSON", async () => {
+  const source = await readFile(
+    new URL("../src/modules/dashboard/edit/CustomizePopover.tsx", import.meta.url),
+    "utf8",
+  );
+
+  const widgetSectionStart = source.indexOf("function WidgetSection");
+  assert.notEqual(widgetSectionStart, -1, "WidgetSection should exist");
+  const widgetSectionEnd = source.indexOf("function AdvancedSection", widgetSectionStart);
+  assert.notEqual(widgetSectionEnd, -1, "AdvancedSection should follow WidgetSection");
+  const widgetSection = source.slice(widgetSectionStart, widgetSectionEnd);
+
+  assert.match(
+    widgetSection,
+    /parseWidgetSettingsValuesJson\(instance\.settingsValuesJson\)/,
+    "onChange must merge new field values into the raw stored JSON so unknown keys (entries, viewMode, sort) are preserved",
+  );
+
+  assert.doesNotMatch(
+    widgetSection,
+    /JSON\.stringify\(\{\s*\.\.\.settingsValues\s*,/,
+    "onChange must not write only the schema-projected settingsValues (that pattern drops the App Launcher entries array)",
+  );
+});
+
+test("toggling showFileExtensions preserves App Launcher entries when merged from raw JSON", () => {
+  const stored = JSON.stringify({
+    entries: [
+      { id: "alpha", name: "Alpha", path: "C:\\Tools\\alpha.exe", createdAt: "t", updatedAt: "t" },
+      { id: "bravo", name: "Bravo", path: "C:\\Tools\\bravo.exe", createdAt: "t", updatedAt: "t" },
+    ],
+    viewMode: "list",
+    listSort: { field: "name", direction: "desc" },
+    detailsSort: { field: "name", direction: "asc" },
+    showFileExtensions: false,
+  });
+
+  const base = JSON.parse(stored);
+  const next = { ...base, showFileExtensions: true };
+  const afterToggle = JSON.parse(JSON.stringify(next));
+
+  assert.equal(afterToggle.showFileExtensions, true);
+  assert.equal(Array.isArray(afterToggle.entries), true);
+  assert.equal(afterToggle.entries.length, 2);
+  assert.deepEqual(
+    afterToggle.entries.map((entry) => entry.id),
+    ["alpha", "bravo"],
+  );
+  assert.equal(afterToggle.viewMode, "list");
+  assert.equal(afterToggle.listSort.direction, "desc");
+});


### PR DESCRIPTION
The widget settings schema only declares showFileExtensions, but the App
Launcher persists its entries (pinned shortcuts), viewMode, and sort state in
the same instance.settingsValuesJson. CustomizePopover's WidgetSection was
projecting the JSON through settingsValuesWithDefaults — which returns only
schema-declared keys — and writing that back, dropping every unknown field on
the next toggle.

Merge the new field value into the raw parsed JSON via
parseWidgetSettingsValuesJson so entries, viewMode, listSort, and detailsSort
are preserved.