### PR TITLE
Keep Dashboard dynamic and video backgrounds playing when other OS windows take focus

### DIFF
--- a/docs/manual/10-dashboard.md
+++ b/docs/manual/10-dashboard.md
@@ -76,6 +76,8 @@ Presets are CSS wrappers that read the Instance's `--w-accent` / `--w-accent-sof
 - `dashboard.backgroundModeMedia` — video / animated source. Filter `dashboard.backgroundMediaFilter`. Hint `dashboard.backgroundMediaHint`. Source attribution `dashboard.backgroundMediaSourcePrefix` + link `dashboard.backgroundMediaSourceLink`.
 - `dashboard.backgroundModeDynamic` (`dashboard.backgroundDynamicHint`) — script-rendered animated backgrounds: `aurora`, `clouds`, `ocean`, `raindrops`, `snow`, `sakura`, `fireflies`, `bubbles`, `ricefield`, `lanterns`, `starfield`, `nebula`, `embers`, `lava`, `matrix`, `topo`, `synthwave`, `cyberpunk`, `taipei101`, `thunderstorm`, `confetti` (keys under `dashboard.dynamicBackgrounds.*`).
 
+Dynamic and video backgrounds keep playing on the active View while the Dashboard Module is selected and any portion of the background is on screen, even when another OS window has focus on top of KKTerm. Playback pauses when the app is minimized (the document becomes hidden), when the user switches to another Module (Workspace or Settings), when a different Dashboard View becomes active, or when the background host is fully off-screen.
+
 ## Built-in widgets
 
 Each built-in widget is a Body component under `src/modules/dashboard/widgets/`, registered in `src/modules/dashboard/registry/builtInRegistry.ts`. The current built-in widgets are:

--- a/src/modules/dashboard/registry/dynamicBackgrounds.tsx
+++ b/src/modules/dashboard/registry/dynamicBackgrounds.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useRef, type ComponentType } from "react";
-import { DashboardAnimationGate, useDashboardAnimationActive } from "../view/animationGating";
+import {
+  DashboardAnimationGate,
+  useDashboardAnimationActive,
+  useElementOnScreen,
+} from "../view/animationGating";
 
 interface CanvasAnimLifecycle {
   onResize?: (width: number, height: number, ctx: CanvasRenderingContext2D) => void;
@@ -2232,11 +2236,13 @@ export function getDashboardDynamicBackgroundHostClassName() {
 }
 
 export function DashboardDynamicBackground({ id, active }: { id: string; active: boolean }) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const onScreen = useElementOnScreen(hostRef);
   if (!isDynamicBackgroundId(id)) return null;
   const Component = DYNAMIC_BACKGROUND_COMPONENTS[id];
   return (
-    <div className={getDashboardDynamicBackgroundHostClassName()} aria-hidden="true">
-      <DashboardAnimationGate active={active}>
+    <div ref={hostRef} className={getDashboardDynamicBackgroundHostClassName()} aria-hidden="true">
+      <DashboardAnimationGate active={active && onScreen}>
         <Component />
       </DashboardAnimationGate>
     </div>

--- a/src/modules/dashboard/view/DashboardBackgroundHost.tsx
+++ b/src/modules/dashboard/view/DashboardBackgroundHost.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { useDashboardStore } from "../state/dashboardStore";
 import type { BackgroundFit, DashboardView } from "../types";
+import { useElementOnScreen, useEnvironmentVisible } from "./animationGating";
 import { syncBackgroundVideoPlayback } from "./backgroundVideo";
 
 function videoFitStyle(fit: BackgroundFit): CSSProperties {
@@ -41,6 +42,10 @@ export function DashboardBackgroundHost({
   const backgroundImages = useDashboardStore((s) => s.backgroundImages);
   const loadBackgroundImage = useDashboardStore((s) => s.loadBackgroundImage);
   const videoRefs = useRef<Record<string, HTMLVideoElement | null>>({});
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const environmentVisible = useEnvironmentVisible();
+  const hostOnScreen = useElementOnScreen(hostRef);
+  const playbackEnabled = dashboardActive && environmentVisible && hostOnScreen;
   const [cachedVideoKeys, setCachedVideoKeys] = useState<string[]>([]);
 
   const activeVideo =
@@ -85,15 +90,15 @@ export function DashboardBackgroundHost({
     for (const entry of entries) {
       syncBackgroundVideoPlayback(
         videoRefs.current[entry.key] ?? null,
-        dashboardActive && entry.key === activeVideoKey,
+        playbackEnabled && entry.key === activeVideoKey,
       );
     }
-  }, [activeVideoKey, dashboardActive, entries]);
+  }, [activeVideoKey, playbackEnabled, entries]);
 
   return (
-    <div className={getDashboardBackgroundHostClassName()} aria-hidden="true">
+    <div ref={hostRef} className={getDashboardBackgroundHostClassName()} aria-hidden="true">
       {entries.map((entry) => {
-        const active = dashboardActive && entry.key === activeVideoKey;
+        const active = playbackEnabled && entry.key === activeVideoKey;
         return (
           <div
             key={entry.key}

--- a/src/modules/dashboard/view/animationGating.tsx
+++ b/src/modules/dashboard/view/animationGating.tsx
@@ -1,4 +1,11 @@
-import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from "react";
 
 const DashboardAnimationActiveContext = createContext(true);
 
@@ -11,29 +18,48 @@ function isDocumentVisible(): boolean {
   return !document.hidden;
 }
 
-function isWindowFocused(): boolean {
-  if (typeof document === "undefined") return true;
-  return document.hasFocus();
-}
-
+// Window-focus changes are intentionally ignored: backgrounds keep playing
+// while the app is visible behind other OS windows. Only document visibility
+// (which flips when the window is minimized or the page is hidden) pauses
+// playback at the environment level.
 export function useEnvironmentVisible(): boolean {
-  const [visible, setVisible] = useState<boolean>(() => isDocumentVisible() && isWindowFocused());
+  const [visible, setVisible] = useState<boolean>(() => isDocumentVisible());
 
   useEffect(() => {
     function sync() {
-      setVisible(isDocumentVisible() && isWindowFocused());
+      setVisible(isDocumentVisible());
     }
     document.addEventListener("visibilitychange", sync);
-    window.addEventListener("focus", sync);
-    window.addEventListener("blur", sync);
     return () => {
       document.removeEventListener("visibilitychange", sync);
-      window.removeEventListener("focus", sync);
-      window.removeEventListener("blur", sync);
     };
   }, []);
 
   return visible;
+}
+
+export function useElementOnScreen<T extends Element>(
+  ref: RefObject<T | null>,
+): boolean {
+  const [onScreen, setOnScreen] = useState<boolean>(true);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+    if (typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          setOnScreen(entry.isIntersecting);
+        }
+      },
+      { threshold: 0 },
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return onScreen;
 }
 
 export function DashboardAnimationGate({


### PR DESCRIPTION
The active View's background now keeps animating while KKTerm sits behind another OS
window. Removed the window-focus check from the animation gate so blur events no longer
pause playback; the document.hidden / visibilitychange signal still pauses when the app
is minimized. Added an IntersectionObserver-driven check (useElementOnScreen) on the
dynamic background wrapper and the video background host so playback also pauses if the
background is fully scrolled off screen. Video backgrounds now honor the same
environment-visible and on-screen gates as dynamic ones, matching the Module-switch
behavior already in place via dashboardActive.