### PR TITLE
Fix App Launcher icon-mode grid trailing empty slot

### DIFF
--- a/src/modules/dashboard/widgets/builtin/app-launcher/app-launcher.css
+++ b/src/modules/dashboard/widgets/builtin/app-launcher/app-launcher.css
@@ -63,7 +63,7 @@
   align-content: start;
   align-items: start;
   grid-auto-rows: max-content;
-  grid-template-columns: repeat(auto-fill, minmax(84px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(84px, 1fr));
   gap: 8px;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent the App Launcher icon-mode from reserving an empty trailing grid slot when the widget width can fit one more track than there are icons, avoiding permanent blank space or unexpected wrapping/scrollbars.

### Description
- Change `grid-template-columns` in `src/modules/dashboard/widgets/builtin/app-launcher/app-launcher.css` from `repeat(auto-fill, minmax(84px, 1fr))` to `repeat(auto-fit, minmax(84px, 1fr))` so unused implicit tracks collapse.

### Testing
- No automated test suite was run because this is a single-line CSS layout adjustment, and the change was verified by inspecting the updated `app-launcher.css` to confirm the `auto-fit` substitution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a167081bd00832fa1116833f8308f1e)