### PR TITLE
Add AI Agent contribution section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,21 @@ If you have not yet read [`CONTEXT.md`](CONTEXT.md) and [`AGENTS.md`](AGENTS.md)
 
 ---
 
+## Contributing with an AI Agent
+
+**The fastest way to contribute is to let your AI agent do the heavy lifting.** Point your agent at the project's AI instructions and it will orient itself — conventions, module boundaries, i18n rules, hard rules, all of it — before touching a single file.
+
+Just tell your agent:
+
+> Read the instructions at https://github.com/ryantsai/KKTerm/blob/main/docs/AIINSTRUCTIONS.md before making any changes to this project.
+
+That document is the single authoritative brief written for AI contributors. It covers everything an agent needs to contribute correctly without a round-trip to the maintainer.
+
+---
+
 ## Table of Contents
 
+- [Contributing with an AI Agent](#contributing-with-an-ai-agent)
 - [Quick Ways to Help](#quick-ways-to-help)
 - [Development Setup](#development-setup)
 - [Project Layout](#project-layout)


### PR DESCRIPTION
## Summary

- Adds a new **Contributing with an AI Agent** section as the first entry in `CONTRIBUTING.md` (both in the body and the Table of Contents)
- Points contributors to `docs/AIINSTRUCTIONS.md` as the single authoritative brief for AI agents, so they orient on conventions, module boundaries, and hard rules before touching any code

## Why

Contributors using AI coding agents had no clear entry point in the docs. Without guidance, agents would either miss project-specific rules or require multiple review round-trips to get aligned. This section gives a one-liner instruction contributors can paste into their agent to bootstrap it correctly.

## How to verify

Open `CONTRIBUTING.md` and confirm:
1. A new "Contributing with an AI Agent" section appears before the Table of Contents body sections
2. The ToC has a `Contributing with an AI Agent` entry at the top
3. The link to `docs/AIINSTRUCTIONS.md` is correct and resolves on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)