### PR TITLE
Enable widget file drag-and-drop from Windows Explorer

### DIFF
--- a/assistant-skills/dashboard-widget-builder/SKILL.md
+++ b/assistant-skills/dashboard-widget-builder/SKILL.md
@@ -33,3 +33,13 @@ Use this skill when the user asks the AI Assistant to create, modify, fix, or im
 - Runtime CDN scripts are blocked; use curated local libraries when available.
 - Secret values are stored outside SQLite.
 - Generated widgets must fit inside their assigned Dashboard grid bounds.
+
+## File I/O
+
+Use these KK bridge methods for any widget that reads or writes local files:
+
+- **Drag-and-drop from Explorer**: `KK.onFileDrop(target, callback, options?)` — attach to a drop-zone element. Callback receives `(items, event)` where each item is `{ kind, name, path, bytes?, children? }`. Returns a cleanup function. Add a visual `hoverClass` via `options.hoverClass` (default `'is-drop-target'`).
+- **File picker (read)**: `KK.readLocalFile({ filters? })` — opens a native open dialog; resolves to `{ name, bytes, path }` or `null` on cancel.
+- **File picker (save)**: `KK.saveFile(filename, bytes, filters?)` — opens a native save dialog and writes bytes; resolves to the saved path or `null` on cancel.
+
+Do not use raw `dragover`/`drop` DOM events for OS file drops — always go through `KK.onFileDrop` so the widget code follows the established bridge pattern.

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -253,7 +253,13 @@ Declared permissions:
 
 External website links must leave the widget iframe. The host script intercepts absolute `http:` / `https:` anchor clicks and sends an `openExternalUrl` bridge message to the parent, where `ScriptWidgetHost.tsx` validates the URL and calls Tauri's opener plugin. Script widgets may also call `KK.openExternal(url)` directly. This avoids navigating third-party sites inside a sandboxed `srcdoc` iframe with an opaque origin, which can produce site errors such as unknown/null origin headers.
 
-The bridge exposes `KK.openExternal(url)`, `KK.getSettings()`, `KK.setSetting(key, value)`, `KK.setSettings(nextSettings)`, `KK.getViewport()`, `KK.onViewportResize(callback)`, `KK.getSecret(key)`, `KK.requestPermission(name)`, and `KK.postMessage(payload)` at the iframe globals. Future Tauri command access is added by extending this bridge with explicit handlers — not by widening the iframe surface.
+The bridge exposes `KK.openExternal(url)`, `KK.getSettings()`, `KK.setSetting(key, value)`, `KK.setSettings(nextSettings)`, `KK.getViewport()`, `KK.onViewportResize(callback)`, `KK.getSecret(key)`, `KK.requestPermission(name)`, `KK.postMessage(payload)`, `KK.readLocalFile(options?)`, `KK.saveFile(filename, bytes, filters?)`, and `KK.onFileDrop(target, callback, options?)` at the iframe globals. Future Tauri command access is added by extending this bridge with explicit handlers — not by widening the iframe surface.
+
+File I/O bridge methods:
+
+- `KK.readLocalFile({ filters? })` — opens a native file-picker dialog and resolves to `{ name, bytes: Uint8Array, path }`, or `null` if the user cancels. Rate-limited to one open dialog per second.
+- `KK.saveFile(filename, bytes, filters?)` — opens a native save dialog and writes `bytes` (Uint8Array or ArrayBuffer) to the chosen path. Resolves to the chosen path string or `null` on cancel. Rate-limited to one save dialog per second.
+- `KK.onFileDrop(target, callback, options?)` — registers HTML5 drag-and-drop listeners on `target` (a CSS selector string or DOM element inside the widget). When the user drops files or folders from Windows Explorer onto the target, `callback(items, event)` is called with an array of `{ kind: 'file'|'directory'|'unknown', name, path, bytes?, children? }` entries. Folders are walked recursively. Passes `options.hoverClass` (default `'is-drop-target'`) as the class toggled on the element during hover. Returns a cleanup function. Use this for widgets that accept file drag-and-drop from the OS.
 
 ### Script Widget Libraries
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "height": 860,
         "minWidth": 1120,
         "minHeight": 720,
-        "decorations": false
+        "decorations": false,
+        "dragDropEnabled": false
       }
     ],
     "security": {


### PR DESCRIPTION
## Summary

- **`src-tauri/tauri.conf.json`**: Set `dragDropEnabled: false` so Tauri stops intercepting OS file drops at the Win32 `IDropTarget` level, allowing WebView2 to deliver them as standard HTML5 `dragover`/`drop` events inside widget iframes.
- **`docs/DASHBOARD.md`**: Added `KK.readLocalFile`, `KK.saveFile`, and `KK.onFileDrop` to the bridge API description — these were implemented in `permissions.ts` but undocumented, so the AI assistant had no way to generate correct widget code for file operations.
- **`assistant-skills/dashboard-widget-builder/SKILL.md`**: Added a "File I/O" section with concrete guidance on `KK.onFileDrop` for drag-and-drop and `KK.readLocalFile`/`KK.saveFile` for file picker flows.

## Root Cause

Two bugs compounded to make file drag-and-drop fail in AI-created widgets:

1. **Tauri interception**: Tauri v2 registers a Win32 `IDropTarget` COM handler by default (`dragDropEnabled: true`). This handler swallows OS-sourced file drops before WebView2's own handler fires, so the HTML5 `drop` event never reaches the iframe DOM. Per Tauri docs: *"Disabling it is required to use HTML5 drag and drop on Windows."* No Tauri-level file-drop handling exists in this codebase, so the default was silently discarding every Explorer drag.

2. **Undocumented bridge API**: `KK.onFileDrop` was fully implemented (including `webkitGetAsEntry` folder walking and `FileReader` async reads) but absent from the `DASHBOARD.md` bridge description the AI assistant reads as context. The AI had no knowledge of this API and either generated broken raw-event code or gave up.

## Test Plan

- [ ] Build and launch the app (`cargo tauri dev`)
- [ ] Create a new AI widget that uses `KK.onFileDrop` on a drop-zone div; confirm files dragged from Windows Explorer trigger the callback with correct `{ name, bytes, path }` entries
- [ ] Confirm the existing `KK.readLocalFile` file-picker button flow still works (no regression)
- [ ] Confirm `KK.saveFile` still works (no regression)
- [ ] Confirm dashboard widget drag-to-reorder (`.drag-handle`) still works — this uses React DnD, not OS file drops, and is unaffected by the Tauri flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)