### PR TITLE
Redesign Installer Helper: popup dialog, streaming events, console-flash fix

### DIFF
--- a/docs/localization_todo/installer.checkingDots.md
+++ b/docs/localization_todo/installer.checkingDots.md
@@ -1,0 +1,10 @@
+# installer.checkingDots
+
+- **English value**: `Checking…`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `status`
+- **User flow**: `Header check-updates button label while a check sweep is in flight.`
+- **Tone**: `short progress phrase`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.cancelledTitle.md
+++ b/docs/localization_todo/installer.dialog.cancelledTitle.md
@@ -1,0 +1,10 @@
+# installer.dialog.cancelledTitle
+
+- **English value**: `Install cancelled: {{name}}`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `heading`
+- **User flow**: `Stepper-mode dialog title after a cancelled install.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `{{name}}`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.checkNow.md
+++ b/docs/localization_todo/installer.dialog.checkNow.md
@@ -1,0 +1,10 @@
+# installer.dialog.checkNow
+
+- **English value**: `Check now`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `button`
+- **User flow**: `Inline action in the not-installed dialog when no latest-version has been queried yet.`
+- **Tone**: `short imperative`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.checkingDots.md
+++ b/docs/localization_todo/installer.dialog.checkingDots.md
@@ -1,0 +1,10 @@
+# installer.dialog.checkingDots
+
+- **English value**: `Checking…`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `status`
+- **User flow**: `Inline replacement for the Check now action while a check is in flight.`
+- **Tone**: `short progress phrase`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.failedTitle.md
+++ b/docs/localization_todo/installer.dialog.failedTitle.md
@@ -1,0 +1,10 @@
+# installer.dialog.failedTitle
+
+- **English value**: `Install failed: {{name}}`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `heading`
+- **User flow**: `Stepper-mode dialog title after a failed install.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `{{name}}`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.homepage.md
+++ b/docs/localization_todo/installer.dialog.homepage.md
@@ -1,0 +1,10 @@
+# installer.dialog.homepage
+
+- **English value**: `Website`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `label`
+- **User flow**: `Not-installed-tool dialog row label for the official project URL.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.installLocation.md
+++ b/docs/localization_todo/installer.dialog.installLocation.md
@@ -1,0 +1,10 @@
+# installer.dialog.installLocation
+
+- **English value**: `Install location`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `label`
+- **User flow**: `Installed-tool dialog grid row label.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.installedTitle.md
+++ b/docs/localization_todo/installer.dialog.installedTitle.md
@@ -1,0 +1,10 @@
+# installer.dialog.installedTitle
+
+- **English value**: `Installed {{name}}`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `heading`
+- **User flow**: `Stepper-mode dialog title after a successful install.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `{{name}}`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.installedVersion.md
+++ b/docs/localization_todo/installer.dialog.installedVersion.md
@@ -1,0 +1,10 @@
+# installer.dialog.installedVersion
+
+- **English value**: `Installed version`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `label`
+- **User flow**: `Installed-tool dialog grid row label.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.installingTitle.md
+++ b/docs/localization_todo/installer.dialog.installingTitle.md
@@ -1,0 +1,10 @@
+# installer.dialog.installingTitle
+
+- **English value**: `Installing {{name}}…`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `heading`
+- **User flow**: `Stepper-mode dialog title while an install is running.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `{{name}}`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.lastChecked.md
+++ b/docs/localization_todo/installer.dialog.lastChecked.md
@@ -1,0 +1,10 @@
+# installer.dialog.lastChecked
+
+- **English value**: `Last checked`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `label`
+- **User flow**: `Installed-tool dialog grid row label for the last update-check timestamp.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.latestVersion.md
+++ b/docs/localization_todo/installer.dialog.latestVersion.md
@@ -1,0 +1,10 @@
+# installer.dialog.latestVersion
+
+- **English value**: `Latest version`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `label`
+- **User flow**: `Tool dialog grid row label showing the latest available version.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.prereqInstalled.md
+++ b/docs/localization_todo/installer.dialog.prereqInstalled.md
@@ -1,0 +1,10 @@
+# installer.dialog.prereqInstalled
+
+- **English value**: `Installed`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `status`
+- **User flow**: `Badge next to a prerequisite that is already on the host.`
+- **Tone**: `short status phrase`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.prereqMissing.md
+++ b/docs/localization_todo/installer.dialog.prereqMissing.md
@@ -1,0 +1,10 @@
+# installer.dialog.prereqMissing
+
+- **English value**: `Missing`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `status`
+- **User flow**: `Badge next to a prerequisite that needs to be installed.`
+- **Tone**: `short status phrase`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.prerequisites.md
+++ b/docs/localization_todo/installer.dialog.prerequisites.md
@@ -1,0 +1,10 @@
+# installer.dialog.prerequisites
+
+- **English value**: `Prerequisites`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `label`
+- **User flow**: `Not-installed-tool dialog row label listing required prereqs.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.provider.md
+++ b/docs/localization_todo/installer.dialog.provider.md
@@ -1,0 +1,10 @@
+# installer.dialog.provider
+
+- **English value**: `Provider`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `label`
+- **User flow**: `Tool dialog grid row label showing the provider kind (winget/npm/etc.).`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.releaseNotes.md
+++ b/docs/localization_todo/installer.dialog.releaseNotes.md
@@ -1,0 +1,10 @@
+# installer.dialog.releaseNotes
+
+- **English value**: `Release notes`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `label`
+- **User flow**: `Tool dialog row label for the release-notes / changelog URL.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.uninstallingTitle.md
+++ b/docs/localization_todo/installer.dialog.uninstallingTitle.md
@@ -1,0 +1,10 @@
+# installer.dialog.uninstallingTitle
+
+- **English value**: `Uninstalling {{name}}…`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `heading`
+- **User flow**: `Stepper-mode dialog title while an uninstall is running.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `{{name}}`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.dialog.updateAvailable.md
+++ b/docs/localization_todo/installer.dialog.updateAvailable.md
@@ -1,0 +1,10 @@
+# installer.dialog.updateAvailable
+
+- **English value**: `Update available: {{from}} → {{to}}`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `fragment`
+- **User flow**: `Banner in the installed-tool dialog when a newer version is known.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `{{from}} {{to}}`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.stepper.failedBadge.md
+++ b/docs/localization_todo/installer.stepper.failedBadge.md
@@ -1,0 +1,10 @@
+# installer.stepper.failedBadge
+
+- **English value**: `Failed`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `status`
+- **User flow**: `Right-aligned meta on a failed step row in the install stepper.`
+- **Tone**: `short status phrase`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.steps.download.md
+++ b/docs/localization_todo/installer.steps.download.md
@@ -1,0 +1,10 @@
+# installer.steps.download
+
+- **English value**: `Download`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `label`
+- **User flow**: `Stepper row label for the download step.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.steps.enable.md
+++ b/docs/localization_todo/installer.steps.enable.md
@@ -1,0 +1,10 @@
+# installer.steps.enable
+
+- **English value**: `Enable feature`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `label`
+- **User flow**: `Stepper row label for the Windows-feature enable step.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.steps.extract.md
+++ b/docs/localization_todo/installer.steps.extract.md
@@ -1,0 +1,10 @@
+# installer.steps.extract
+
+- **English value**: `Extract`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `label`
+- **User flow**: `Stepper row label for the archive extraction step.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.steps.install.md
+++ b/docs/localization_todo/installer.steps.install.md
@@ -1,0 +1,10 @@
+# installer.steps.install
+
+- **English value**: `Install`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `label`
+- **User flow**: `Stepper row label for the underlying installer execution step.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.steps.placeFiles.md
+++ b/docs/localization_todo/installer.steps.placeFiles.md
@@ -1,0 +1,10 @@
+# installer.steps.placeFiles
+
+- **English value**: `Place files`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `label`
+- **User flow**: `Stepper row label for the move-extracted-files-to-install-dir step.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.steps.resolve.md
+++ b/docs/localization_todo/installer.steps.resolve.md
@@ -1,0 +1,10 @@
+# installer.steps.resolve
+
+- **English value**: `Resolve version`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `label`
+- **User flow**: `Stepper row label for the resolve-version step.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.steps.updatePath.md
+++ b/docs/localization_todo/installer.steps.updatePath.md
@@ -1,0 +1,10 @@
+# installer.steps.updatePath
+
+- **English value**: `Update PATH`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `label`
+- **User flow**: `Stepper row label for the add-to-PATH step. PATH stays uppercase.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.steps.verify.md
+++ b/docs/localization_todo/installer.steps.verify.md
@@ -1,0 +1,10 @@
+# installer.steps.verify
+
+- **English value**: `Verify`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `label`
+- **User flow**: `Stepper row label for the post-install verification step.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/localization_todo/installer.steps.verifyChecksum.md
+++ b/docs/localization_todo/installer.steps.verifyChecksum.md
@@ -1,0 +1,10 @@
+# installer.steps.verifyChecksum
+
+- **English value**: `Verify checksum`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerToolDialog.tsx`
+- **UI role**: `label`
+- **User flow**: `Stepper row label for the checksum-verification step.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `none`
+- **Domain notes**: `Installer Helper is a built-in Module. "stepper" refers to the n8n-style install step list. Tool names like winget, npm, PATH, WSL stay English.`

--- a/docs/manual/18-installer.md
+++ b/docs/manual/18-installer.md
@@ -2,7 +2,7 @@
 
 ## AI grep hints
 
-- Keys: `installer.title`, `installer.subtitle`, `installer.railLabel`, `installer.refresh`, `installer.checkUpdates`, `installer.updateAll`, `installer.section.installed`, `installer.section.available`, `installer.section.updates`, `installer.actions.install`, `installer.actions.update`, `installer.actions.uninstall`, `installer.actions.cancel`, `installer.options.scope`, `installer.options.version`, `installer.options.location`, `installer.options.addToPath`, `installer.options.pinVersion`, `installer.status.installing`, `installer.status.uninstalling`, `installer.status.completed`, `installer.status.failed`, `installer.status.cancelled`, `installer.status.partial`, `installer.status.scanning`, `installer.empty.loading`, `installer.confirm.installTitle`, `installer.confirm.installWithPrereqsBody`, `installer.confirm.uacFooter`, `installer.confirm.uninstallTitle`, `installer.confirm.uninstallSimpleBody`, `installer.confirm.uninstallDependentsBody`, `installer.confirm.uninstallDependentsFooter`, `installer.confirm.updateAllTitle`, `installer.confirm.updateAllBody`, `installer.confirm.updateAllConfirm`, `installer.wslReboot`
+- Keys: `installer.title`, `installer.subtitle`, `installer.railLabel`, `installer.refresh`, `installer.checkUpdates`, `installer.checkingDots`, `installer.updateAll`, `installer.section.installed`, `installer.section.available`, `installer.section.updates`, `installer.actions.install`, `installer.actions.update`, `installer.actions.uninstall`, `installer.actions.cancel`, `installer.options.scope`, `installer.options.version`, `installer.options.location`, `installer.options.addToPath`, `installer.options.pinVersion`, `installer.status.installing`, `installer.status.uninstalling`, `installer.status.completed`, `installer.status.failed`, `installer.status.cancelled`, `installer.status.partial`, `installer.status.scanning`, `installer.empty.loading`, `installer.confirm.installTitle`, `installer.confirm.installWithPrereqsBody`, `installer.confirm.uacFooter`, `installer.confirm.uninstallTitle`, `installer.confirm.uninstallSimpleBody`, `installer.confirm.uninstallDependentsBody`, `installer.confirm.uninstallDependentsFooter`, `installer.confirm.updateAllTitle`, `installer.confirm.updateAllBody`, `installer.confirm.updateAllConfirm`, `installer.wslReboot`, `installer.dialog.installLocation`, `installer.dialog.provider`, `installer.dialog.installedVersion`, `installer.dialog.latestVersion`, `installer.dialog.lastChecked`, `installer.dialog.homepage`, `installer.dialog.releaseNotes`, `installer.dialog.prerequisites`, `installer.dialog.prereqInstalled`, `installer.dialog.prereqMissing`, `installer.dialog.checkNow`, `installer.dialog.checkingDots`, `installer.dialog.updateAvailable`, `installer.dialog.installingTitle`, `installer.dialog.uninstallingTitle`, `installer.dialog.installedTitle`, `installer.dialog.failedTitle`, `installer.dialog.cancelledTitle`, `installer.stepper.failedBadge`, `installer.steps.resolve`, `installer.steps.download`, `installer.steps.verifyChecksum`, `installer.steps.extract`, `installer.steps.placeFiles`, `installer.steps.updatePath`, `installer.steps.install`, `installer.steps.verify`, `installer.steps.enable`
 - Topics: Installer Helper Module, bundled catalog (compile-time embedded), ADR 0008 supersedes ADR 0007, winget recipes, npm recipes, github-release recipes, Windows feature recipes (DISM), bundles (node-bundle, python-bundle), dependency resolution, UAC prompts, WSL reboot gating, pin version, in-flight cancellation, tutorial targets `app.activityRailInstaller`, `installer.updateAll`, `installer.toolOptions`
 - Synonyms: "install nvm", "install Node", "install Python", "install Docker", "install Claude Code", "set up dev tools", "developer tools installer", "package manager"
 
@@ -24,7 +24,13 @@ The page has a header and three sections:
 - **Installed** (`installer.section.installed`) — tools currently present on the system.
 - **Available** (`installer.section.available`) — catalog tools not currently installed.
 
-Each tool row collapses by default and expands on click. The expanded body shows the description, the options form (only the options the recipe declares apply), an inline progress panel with the current step and a tail of the log, and the action buttons. Tutorial target: `installer.toolOptions`.
+Each tool surface is a **tile** in the section grid. Clicking a tile opens an app-owned popup dialog — `InstallerToolDialog` — that owns the detail surface (the previous inline expansion has been removed). Tutorial target on the options form inside the dialog: `installer.toolOptions`.
+
+The dialog has three rendering modes:
+
+- **Installed info** — version, install location (when known), provider summary, latest version + last checked timestamp, pin-version checkbox, and an Update banner when `latestVersionSeen` differs from `installedVersion`. Footer: `Uninstall` (danger) · `Update` (when available) · `Close`.
+- **Not-installed info** — official website (`recipe.homepage`), release notes (`recipe.releaseNotesUrl`, with a provider-derived fallback for github/npm/winget when absent), latest version (with an inline `installer.dialog.checkNow` action when no latest has been queried yet), provider summary, prerequisites list with installed/missing badges, and the options form. Footer: `Install` (primary) · `Cancel`.
+- **Stepper** — opened when the user presses Install/Update, or when reopening the dialog while an install/uninstall is in flight or has just terminated. The body renders the n8n-style step list with status dots (`pending`/`running`/`done`/`failed`), per-step duration / active-step ratio, and a click-to-expand per-step log panel. Terminal states swap the dialog title (`installer.dialog.installedTitle` / `installer.dialog.failedTitle` / `installer.dialog.cancelledTitle`).
 
 ## Tool detection
 
@@ -32,7 +38,7 @@ Detection runs once on the first Module entry per app session and is held in mem
 
 Per-provider detection methods:
 
-- **winget** — `winget list --id <id> --exact --source winget --disable-interactivity`. Exit 0 = installed; the version is parsed from the data row.
+- **winget** — `winget list --source winget --disable-interactivity` is run **once** per detection sweep; every winget recipe consults the parsed snapshot rather than spawning its own child process. The snapshot is cached until the next explicit `installer_detect_all` / `installer_redetect` call. All detection/check spawns set `CREATE_NO_WINDOW` so no `cmd.exe` window flashes on Module entry.
 - **npm** — `npm ls -g --json --depth=0`. Looks up the package in the top-level `dependencies`.
 - **github-release** — a marker file at `%LOCALAPPDATA%\KKTerm\installer\bin\<tool_id>\.kkterm-installer.json` written at install time. Only installs we performed count as "managed".
 - **windows-feature** — `dism /online /get-featureinfo /featurename:<X>`. Parses the `State :` line.
@@ -43,13 +49,13 @@ Per-provider detection methods:
 1. The user clicks `installer.actions.install` on a row.
 2. The frontend resolves the install plan: transitive `needs` are walked, and prerequisites already detected as installed are skipped.
 3. If the plan has unresolved prerequisites OR a non-zero UAC-prompt estimate, a confirm dialog (`installer.confirm.installTitle`) lists the prerequisites and a footer (`installer.confirm.uacFooter`) names the estimated prompt count.
-4. On confirm, the backend dispatches the install in a worker thread. Progress streams to the frontend on the `installer://progress` Tauri event channel as a discriminated union: `step`, `stdout`, `stderr`, `progress`, `completed`, `failed`, `cancelled`.
+4. On confirm, the backend dispatches the install in a worker thread. The dialog flips to stepper mode. Progress streams to the frontend on the `installer://progress` Tauri event channel as a discriminated union: `plan` (declared step list, emitted once before any work begins), `stepStarted` / `stepFinished` (per-step lifecycle), `stdout` / `stderr` / `progress` (each carrying an optional `stepId` so the UI can route lines and ratios to the active step row), `step` (legacy free-form label retained for unmigrated providers), `completed`, `failed`, `cancelled`.
 5. After a `completed` event, the row re-runs detection automatically and moves to the Installed section.
 
 ## Update flow
 
 1. The user clicks `installer.checkUpdates` (header).
-2. The backend calls each installed tool's latest-version query (`winget show`, `npm view <pkg> version`, GitHub releases API for `githubRelease`). Results are persisted in the `installer_tool_state` SQLite table.
+2. The backend launches a **streaming** sweep. It emits `checkStarted` with the id list, then per-tool `checkResult` events as each lookup lands (latest-version queries run in parallel — `winget show`, `npm view <pkg> version`, GitHub releases API — bounded to a small pool to hide slow legs behind fast ones), and finally `checkFinished`. The frontend writes each result into `toolState` as it arrives so rows light up incrementally instead of after one large blocking await. Results are persisted in the `installer_tool_state` SQLite table.
 3. Rows whose `latestVersionSeen ≠ installedVersion` move to the Updates section and show their per-row `installer.actions.update` button.
 4. Clicking `installer.updateAll` lists every pending update in a dialog (`installer.confirm.updateAllTitle`), warns about the likely UAC prompt count, and on confirm runs the queue sequentially. Pinned tools (see Pin version below) are skipped.
 

--- a/src-tauri/src/installer/commands.rs
+++ b/src-tauri/src/installer/commands.rs
@@ -12,7 +12,9 @@ use std::time::SystemTime;
 use tauri::{AppHandle, Emitter, State};
 
 use super::catalog::load_bundled_catalog;
-use super::detect::{detect_all, detect_one, detect_one_in_catalog, DetectedState};
+use super::detect::{
+    detect_all, detect_one, detect_one_in_catalog, invalidate_winget_snapshot, DetectedState,
+};
 use super::events::{ProgressEvent, PROGRESS_EVENT};
 use super::install::{install_recipe, EventSink};
 use super::latest_version::latest_version;
@@ -83,33 +85,87 @@ pub fn installer_detect_all(
     Ok(detect_all(&catalog))
 }
 
+/// Synthetic cancel-flag key used by the streaming check-for-updates sweep.
+/// Routes through the same cancel-flag map as installs so `installer_cancel`
+/// with this id aborts the sweep mid-list.
+pub const CHECK_UPDATES_CANCEL_ID: &str = "__check_updates__";
+
+/// Bounded parallelism for latest-version lookups. Most operations are
+/// network or CLI-bound; 4 in flight saturates a typical home connection
+/// without overwhelming winget's source backend.
+const CHECK_UPDATES_PARALLELISM: usize = 4;
+
+/// Streaming check-for-updates. Runs on Tauri's worker thread (the UI is
+/// never blocked), but emits one `CheckResult` per tool as its lookup
+/// lands so the frontend can light rows up incrementally. Lookups run in
+/// parallel via a scoped thread pool; the per-tool work is network/CLI
+/// bound, so a small pool (`CHECK_UPDATES_PARALLELISM`) is enough to hide
+/// the slow legs (winget) behind the fast ones (cached npm).
 #[tauri::command]
 pub fn installer_check_latest_versions(
+    app: AppHandle,
     storage: State<'_, Storage>,
     runtime: State<'_, InstallerRuntime>,
     tool_ids: Vec<String>,
-) -> Result<HashMap<String, Option<String>>, String> {
+) -> Result<(), String> {
     let catalog = runtime
         .catalog
         .lock()
         .unwrap()
         .clone()
         .ok_or("catalog not loaded yet")?;
+    let cancel = runtime.cancel_flag_for(CHECK_UPDATES_CANCEL_ID);
+    runtime.reset_cancel(CHECK_UPDATES_CANCEL_ID);
+
+    let emit: EventSink = make_emit_sink(app);
+    emit(ProgressEvent::CheckStarted {
+        tool_ids: tool_ids.clone(),
+    });
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0);
-    let mut out = HashMap::new();
-    for tool_id in tool_ids {
-        if let Some(recipe) = find_recipe(&catalog, &tool_id) {
-            let v = latest_version(recipe);
-            st::record_latest_version(&storage, &tool_id, v.as_deref(), now)?;
-            out.insert(tool_id, v);
-        } else {
-            out.insert(tool_id, None);
+    let storage_ref = &*storage;
+    let catalog_ref = &catalog;
+    let emit_ref = &emit;
+    let work: Mutex<Vec<String>> = Mutex::new(tool_ids);
+
+    std::thread::scope(|scope| {
+        for _ in 0..CHECK_UPDATES_PARALLELISM {
+            let cancel = cancel.clone();
+            let work = &work;
+            scope.spawn(move || loop {
+                if cancel.load(Ordering::Relaxed) {
+                    return;
+                }
+                let tool_id = {
+                    let mut q = work.lock().unwrap();
+                    match q.pop() {
+                        Some(id) => id,
+                        None => return,
+                    }
+                };
+                let (latest, error) = match find_recipe(catalog_ref, &tool_id) {
+                    Some(recipe) => (latest_version(recipe), None),
+                    None => (None, Some("unknown tool id".to_string())),
+                };
+                let _ = st::record_latest_version(
+                    storage_ref,
+                    &tool_id,
+                    latest.as_deref(),
+                    now,
+                );
+                emit_ref(ProgressEvent::CheckResult {
+                    tool_id,
+                    latest_version: latest,
+                    error,
+                });
+            });
         }
-    }
-    Ok(out)
+    });
+
+    emit(ProgressEvent::CheckFinished);
+    Ok(())
 }
 
 #[tauri::command]
@@ -213,6 +269,10 @@ pub fn installer_redetect(
         .ok_or("catalog not loaded yet")?;
     let recipe = find_recipe(&catalog, &tool_id)
         .ok_or_else(|| format!("unknown tool id `{tool_id}`"))?;
+    // A redetect is the user's signal that the world may have changed
+    // (install/uninstall just finished, or they hit Refresh on one row).
+    // Drop the cached winget snapshot so the next winget recipe re-queries.
+    invalidate_winget_snapshot();
     Ok(detect_one_in_catalog(recipe, &catalog))
 }
 
@@ -270,6 +330,7 @@ fn run_bundle_install(
         if detected.installed {
             emit(ProgressEvent::Stdout {
                 tool_id: bundle_id.into(),
+                step_id: None,
                 line: format!("Step `{step_id}` already installed, skipping"),
             });
             continue;

--- a/src-tauri/src/installer/detect.rs
+++ b/src-tauri/src/installer/detect.rs
@@ -6,9 +6,11 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::OnceLock;
 
 use serde::Serialize;
 
+use super::proc::no_window;
 use super::schema::{Catalog, GithubReleaseLayout, Provider, Recipe};
 
 #[derive(Debug, Clone, Serialize)]
@@ -19,6 +21,13 @@ pub struct DetectedState {
     /// Only populated for bundles where some-but-not-all children are
     /// installed. Renders as "Partially installed (N/M)".
     pub partial_count: Option<(u32, u32)>,
+    /// Best-effort install directory for installed tools, surfaced in the
+    /// installed-tool info dialog. Currently populated for github-release
+    /// recipes (we own the install dir under %LOCALAPPDATA%) and left as
+    /// None elsewhere — winget/npm/dism install paths are not uniformly
+    /// recoverable from their detection output, and the dialog hides the
+    /// row when this is None.
+    pub install_location: Option<String>,
 }
 
 impl DetectedState {
@@ -27,6 +36,7 @@ impl DetectedState {
             installed: false,
             installed_version: None,
             partial_count: None,
+            install_location: None,
         }
     }
     pub fn installed(version: Option<String>) -> Self {
@@ -34,18 +44,25 @@ impl DetectedState {
             installed: true,
             installed_version: version,
             partial_count: None,
+            install_location: None,
         }
+    }
+    pub fn with_install_location(mut self, location: Option<String>) -> Self {
+        self.install_location = location;
+        self
     }
 }
 
 /// Detect every recipe in the catalog. Sequential — a 25-tool scan typically
 /// finishes in ~3–5 s on a warm host (winget is the slow leg). The frontend
 /// only runs this on first Module entry per session; subsequent visits use
-/// the in-memory cache.
+/// the in-memory cache. All winget recipes share a single `winget list` call;
+/// detect_winget consults the resulting map instead of spawning per recipe.
 pub fn detect_all(catalog: &Catalog) -> HashMap<String, DetectedState> {
     let mut out: HashMap<String, DetectedState> = HashMap::new();
     // Detect leaves first so bundles can compose their result.
     let mut bundles: Vec<&Recipe> = Vec::new();
+    refresh_winget_snapshot();
     for recipe in &catalog.recipes {
         if let Provider::Bundle { .. } = recipe.provider {
             bundles.push(recipe);
@@ -107,54 +124,137 @@ fn bundle_detected_state(installed_count: u32, total: u32) -> DetectedState {
             installed: false,
             installed_version: None,
             partial_count: Some((installed_count, total)),
+            install_location: None,
         }
     }
 }
 
 // ---- winget ------------------------------------------------------------
+//
+// Per-recipe winget spawns were the dominant cost of `detect_all` and the
+// dominant cause of the Module-entry console-window flash storm. We now
+// take one snapshot of `winget list --source winget` per detection sweep
+// and look up each recipe's id in the parsed map.
 
-fn detect_winget(id: &str) -> DetectedState {
-    let output = match Command::new("winget")
+#[derive(Default)]
+struct WingetSnapshot {
+    /// Lower-cased package id → installed version (None when winget did not
+    /// surface a parseable version column).
+    by_id: HashMap<String, Option<String>>,
+}
+
+static WINGET_SNAPSHOT: OnceLock<std::sync::Mutex<Option<WingetSnapshot>>> =
+    OnceLock::new();
+
+fn winget_snapshot_cell() -> &'static std::sync::Mutex<Option<WingetSnapshot>> {
+    WINGET_SNAPSHOT.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+/// Take one batched `winget list` and cache its parsed map. Called by
+/// `detect_all` before iterating recipes. Safe to call repeatedly; later
+/// callers (e.g. `installer_redetect`) reuse the cached snapshot unless
+/// they explicitly clear it.
+pub fn refresh_winget_snapshot() {
+    let parsed = run_winget_list().unwrap_or_default();
+    *winget_snapshot_cell().lock().unwrap() = Some(parsed);
+}
+
+fn run_winget_list() -> Option<WingetSnapshot> {
+    let output = no_window(&mut Command::new("winget"))
         .args([
             "list",
-            "--id",
-            id,
-            "--exact",
             "--source",
             "winget",
             "--disable-interactivity",
         ])
         .output()
-    {
-        Ok(o) => o,
-        Err(_) => return DetectedState::not_installed(),
-    };
+        .ok()?;
     if !output.status.success() {
-        return DetectedState::not_installed();
+        return None;
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
-    // The data row contains the id; the version is the 3rd whitespace-separated
-    // column on lines following the header. We look for a row containing the
-    // exact id, then take the next whitespace token after it as the version.
+    let mut by_id: HashMap<String, Option<String>> = HashMap::new();
+    // `winget list` emits a header band ("Name Id Version …"), a separator
+    // row of dashes, then one whitespace-separated data row per installed
+    // package. The Id column may itself contain dots; we extract the id
+    // and version using the column offsets discovered from the header row.
+    let mut header_offsets: Option<(usize, usize, usize)> = None;
     for line in stdout.lines() {
-        if let Some(after_id) = line.split(id).nth(1) {
-            let version = after_id
-                .split_whitespace()
-                .next()
-                .map(|s| s.to_string())
-                .filter(|s| !s.is_empty());
-            return DetectedState::installed(version);
+        if header_offsets.is_none() {
+            if let Some(o) = winget_header_offsets(line) {
+                header_offsets = Some(o);
+            }
+            continue;
         }
+        if line.trim_start().starts_with('-') {
+            continue;
+        }
+        let (id_start, version_start, version_end) = header_offsets.unwrap();
+        if line.len() < id_start {
+            continue;
+        }
+        let id_slice = if line.len() >= version_start {
+            &line[id_start..version_start]
+        } else {
+            &line[id_start..]
+        };
+        let id = id_slice.split_whitespace().next().unwrap_or("").to_string();
+        if id.is_empty() {
+            continue;
+        }
+        let version = if line.len() >= version_start {
+            let end = version_end.min(line.len());
+            let raw = &line[version_start..end];
+            raw.split_whitespace().next().map(|s| s.to_string())
+        } else {
+            None
+        };
+        by_id.insert(id.to_ascii_lowercase(), version);
     }
-    // Exit code said success but we couldn't parse — treat as installed,
-    // unknown version.
-    DetectedState::installed(None)
+    Some(WingetSnapshot { by_id })
+}
+
+fn winget_header_offsets(line: &str) -> Option<(usize, usize, usize)> {
+    let id_idx = line.find("Id")?;
+    let version_idx = line[id_idx..].find("Version").map(|o| id_idx + o)?;
+    let after_version = &line[version_idx + "Version".len()..];
+    let next_col = after_version
+        .char_indices()
+        .find(|(_, c)| !c.is_whitespace())
+        .map(|(i, _)| version_idx + "Version".len() + i)
+        .unwrap_or(line.len());
+    Some((id_idx, version_idx, next_col))
+}
+
+fn detect_winget(id: &str) -> DetectedState {
+    let cell = winget_snapshot_cell();
+    let mut guard = cell.lock().unwrap();
+    if guard.is_none() {
+        // Single-recipe path (installer_redetect) hits this; take a snapshot
+        // on demand so subsequent winget recipes in the same sweep are free.
+        drop(guard);
+        let parsed = run_winget_list().unwrap_or_default();
+        *cell.lock().unwrap() = Some(parsed);
+        guard = cell.lock().unwrap();
+    }
+    let snapshot = guard.as_ref().unwrap();
+    match snapshot.by_id.get(&id.to_ascii_lowercase()) {
+        Some(version) => DetectedState::installed(version.clone()),
+        None => DetectedState::not_installed(),
+    }
+}
+
+/// Discard the cached snapshot so the next `detect_winget`/`detect_all`
+/// call re-queries `winget list`. Used by post-install/uninstall redetect
+/// paths in commands.rs so an install that just landed is visible.
+pub fn invalidate_winget_snapshot() {
+    *winget_snapshot_cell().lock().unwrap() = None;
 }
 
 // ---- npm ---------------------------------------------------------------
 
 fn detect_npm(pkg: &str) -> DetectedState {
-    let output = match Command::new("npm")
+    let output = match no_window(&mut Command::new("npm"))
         .args(["ls", "-g", "--json", "--depth=0"])
         .output()
     {
@@ -194,13 +294,19 @@ fn detect_github_release_marker(tool_id: &str) -> DetectedState {
     };
     let parsed: serde_json::Value = match serde_json::from_str(&text) {
         Ok(v) => v,
-        Err(_) => return DetectedState::installed(None),
+        Err(_) => {
+            return DetectedState::installed(None).with_install_location(Some(
+                github_release_install_dir(tool_id).to_string_lossy().into_owned(),
+            ));
+        }
     };
     let version = parsed
         .get("version")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
-    DetectedState::installed(version)
+    DetectedState::installed(version).with_install_location(Some(
+        github_release_install_dir(tool_id).to_string_lossy().into_owned(),
+    ))
 }
 
 pub fn github_release_install_dir(tool_id: &str) -> PathBuf {
@@ -217,7 +323,7 @@ pub fn github_release_marker_path(tool_id: &str) -> PathBuf {
 // ---- windows-feature ---------------------------------------------------
 
 fn detect_windows_feature(feature: &str) -> DetectedState {
-    let output = match Command::new("dism")
+    let output = match no_window(&mut Command::new("dism"))
         .args([
             "/online",
             "/get-featureinfo",

--- a/src-tauri/src/installer/events.rs
+++ b/src-tauri/src/installer/events.rs
@@ -1,16 +1,51 @@
 // Tauri event payloads streamed during install/uninstall/check operations.
 // The frontend subscribes once on Module mount and routes events to per-tool
-// detail panels by `tool_id`.
+// dialog/stepper state by `tool_id`.
+//
+// Stepper protocol: a provider runner that supports the n8n-style stepper
+// emits `Plan` once before any work, then brackets each step with
+// `StepStarted` / `StepFinished`. `Stdout` / `Stderr` / `Progress` carry an
+// optional `step_id` so the frontend can route the line / ratio to the
+// active step row. The legacy `Step { message }` variant remains for
+// providers that have not been migrated to the structured plan yet and
+// is rendered as a generic log line.
+//
+// Check-for-updates protocol: a fire-and-forget check emits one
+// `CheckStarted` with the full id list, then one `CheckResult` per tool
+// as its lookup lands, then one `CheckFinished`. Errors are surfaced
+// per-tool — a single failed lookup does not abort the sweep.
 
 use serde::Serialize;
+
+use super::schema::PlanStep;
 
 pub const PROGRESS_EVENT: &str = "installer://progress";
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum ProgressEvent {
-    /// A new step started, e.g. "Downloading", "Extracting", "Running
-    /// installer". UI replaces the current-step label.
+    /// Declared step list for the upcoming install/uninstall. Emitted once
+    /// before any `StepStarted`. UI renders all steps as `pending`.
+    Plan {
+        tool_id: String,
+        steps: Vec<PlanStep>,
+    },
+    /// Stepper transitions. The active step is the most recent
+    /// `StepStarted` that has not been matched by a `StepFinished`.
+    StepStarted {
+        tool_id: String,
+        step_id: String,
+    },
+    StepFinished {
+        tool_id: String,
+        step_id: String,
+        ok: bool,
+        error: Option<String>,
+    },
+    /// Legacy free-form step label. Kept for providers that have not been
+    /// migrated to the `Plan`/`StepStarted`/`StepFinished` protocol; the
+    /// frontend renders these as generic log lines when a `Plan` is in
+    /// effect, or as today's current-step label otherwise.
     Step {
         tool_id: String,
         message: String,
@@ -18,17 +53,23 @@ pub enum ProgressEvent {
     /// Captured stdout line from a child process.
     Stdout {
         tool_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        step_id: Option<String>,
         line: String,
     },
     /// Captured stderr line from a child process.
     Stderr {
         tool_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        step_id: Option<String>,
         line: String,
     },
     /// Determinate progress, 0.0..=1.0. Emitted by downloaders that know
     /// the content length. Not all providers can emit this.
     Progress {
         tool_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        step_id: Option<String>,
         ratio: f32,
     },
     /// Terminal state. UI moves the row to "Installed" / "Available" /
@@ -44,4 +85,24 @@ pub enum ProgressEvent {
     Cancelled {
         tool_id: String,
     },
+
+    // ---- Check-for-updates streaming protocol -------------------------
+
+    /// A check-for-updates sweep just started. UI shows a spinner and
+    /// disables the Check button. `tool_ids` are the ids about to be
+    /// queried, in submission order.
+    CheckStarted {
+        tool_ids: Vec<String>,
+    },
+    /// One tool's latest-version lookup landed. `latest_version` is None
+    /// when the provider could not produce a version; `error` is set when
+    /// the lookup itself failed (e.g. network/CLI error).
+    CheckResult {
+        tool_id: String,
+        latest_version: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+    /// All queued tools have produced a `CheckResult` (or were cancelled).
+    CheckFinished,
 }

--- a/src-tauri/src/installer/install.rs
+++ b/src-tauri/src/installer/install.rs
@@ -321,6 +321,7 @@ fn download_with_progress(
                 let ratio = (downloaded as f32 / t as f32).clamp(0.0, 1.0);
                 emit(ProgressEvent::Progress {
                     tool_id: tool_id.into(),
+                    step_id: None,
                     ratio,
                 });
             }
@@ -367,10 +368,12 @@ fn add_to_user_path(dir: &PathBuf, tool_id: &str, emit: &EventSink) {
     match result {
         Ok(o) if o.status.success() => emit(ProgressEvent::Stdout {
             tool_id: tool_id.into(),
+            step_id: None,
             line: format!("Added {dir_str} to user PATH (open a new shell to pick up)"),
         }),
         Ok(o) => emit(ProgressEvent::Stderr {
             tool_id: tool_id.into(),
+            step_id: None,
             line: format!(
                 "Could not add to PATH: {}",
                 String::from_utf8_lossy(&o.stderr).trim()
@@ -378,6 +381,7 @@ fn add_to_user_path(dir: &PathBuf, tool_id: &str, emit: &EventSink) {
         }),
         Err(e) => emit(ProgressEvent::Stderr {
             tool_id: tool_id.into(),
+            step_id: None,
             line: format!("Could not add to PATH: {e}"),
         }),
     }
@@ -470,6 +474,7 @@ fn run_streamed(
     // below makes the silence visible instead of looking frozen.
     emit(ProgressEvent::Stdout {
         tool_id: tool_id.into(),
+        step_id: None,
         line: format!("$ {program} {}", args.join(" ")),
     });
 
@@ -518,6 +523,7 @@ fn run_streamed(
             let silent = last_output_at.elapsed().as_secs();
             emit(ProgressEvent::Stderr {
                 tool_id: tool_id.into(),
+                step_id: None,
                 line: format!(
                     "[installer] still running: {elapsed}s elapsed, {silent}s since last output"
                 ),
@@ -536,6 +542,7 @@ fn run_streamed(
                 if status.success() {
                     emit(ProgressEvent::Stdout {
                         tool_id: tool_id.into(),
+                        step_id: None,
                         line: format!(
                             "[installer] `{program}` exited 0 after {elapsed}s"
                         ),
@@ -545,6 +552,7 @@ fn run_streamed(
                 let code = status.code().unwrap_or(-1);
                 emit(ProgressEvent::Stderr {
                     tool_id: tool_id.into(),
+                    step_id: None,
                     line: format!(
                         "[installer] `{program}` exited {code} after {elapsed}s"
                     ),
@@ -601,11 +609,13 @@ fn emit_stream_line(tool_id: &str, emit: &EventSink, line: StreamLine) {
     if line.is_stdout {
         emit(ProgressEvent::Stdout {
             tool_id: tool_id.into(),
+            step_id: None,
             line: line.line,
         });
     } else {
         emit(ProgressEvent::Stderr {
             tool_id: tool_id.into(),
+            step_id: None,
             line: line.line,
         });
     }

--- a/src-tauri/src/installer/latest_version.rs
+++ b/src-tauri/src/installer/latest_version.rs
@@ -3,6 +3,7 @@
 
 use std::process::Command;
 
+use super::proc::no_window;
 use super::schema::{Provider, Recipe};
 
 pub fn latest_version(recipe: &Recipe) -> Option<String> {
@@ -16,7 +17,7 @@ pub fn latest_version(recipe: &Recipe) -> Option<String> {
 }
 
 fn winget_latest(id: &str) -> Option<String> {
-    let output = Command::new("winget")
+    let output = no_window(&mut Command::new("winget"))
         .args([
             "show",
             "--id",
@@ -45,7 +46,7 @@ fn winget_latest(id: &str) -> Option<String> {
 }
 
 fn npm_latest(pkg: &str) -> Option<String> {
-    let output = Command::new("npm")
+    let output = no_window(&mut Command::new("npm"))
         .args(["view", pkg, "version"])
         .output()
         .ok()?;

--- a/src-tauri/src/installer/mod.rs
+++ b/src-tauri/src/installer/mod.rs
@@ -11,6 +11,7 @@ pub mod events;
 pub mod install;
 pub mod latest_version;
 pub mod options;
+pub mod proc;
 pub mod schema;
 pub mod state;
 pub mod uninstall;

--- a/src-tauri/src/installer/proc.rs
+++ b/src-tauri/src/installer/proc.rs
@@ -1,0 +1,26 @@
+// Process-spawning helpers shared by detect/check/install code paths.
+//
+// On Windows, a GUI parent process (Tauri host) spawning a console-subsystem
+// child like `winget.exe`, `npm.cmd`, or `dism.exe` causes Windows to
+// allocate a console for the child and briefly flash a black cmd window
+// on screen. Detection and version-check work runs on Module entry and
+// during "Check for updates", so without suppression the user sees several
+// console windows flicker every time. `CREATE_NO_WINDOW` (0x0800_0000)
+// suppresses the console allocation; on non-Windows targets the helper is
+// a no-op.
+
+use std::process::Command;
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// Apply the platform-appropriate "do not flash a console window" flag to a
+/// `Command` before spawning. Returns the same `Command` for chaining.
+pub fn no_window(cmd: &mut Command) -> &mut Command {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    cmd
+}

--- a/src-tauri/src/installer/schema.rs
+++ b/src-tauri/src/installer/schema.rs
@@ -53,6 +53,30 @@ pub struct Recipe {
     /// See `RecipeOptions` enum.
     #[serde(default)]
     pub options: Vec<RecipeOption>,
+    /// Optional official project website, surfaced in the not-installed
+    /// dialog. Free-form URL. Absent when the catalog entry has not yet
+    /// been backfilled.
+    #[serde(default)]
+    pub homepage: Option<String>,
+    /// Optional release-notes / changelog URL, surfaced in the
+    /// not-installed dialog and as a "Latest release" link in the
+    /// installed dialog. Frontend derives a fallback from the provider
+    /// when this is None.
+    #[serde(default)]
+    pub release_notes_url: Option<String>,
+}
+
+/// One declared step in an install plan, emitted via
+/// `ProgressEvent::Plan` before any work begins. `id` is stable per
+/// provider (`resolve`, `download`, `install`, …) and is echoed by
+/// `StepStarted` / `StepFinished` / stdout-routing. `label_key` is an
+/// i18n key under `installer.steps.*`; the frontend resolves it through
+/// `t()`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PlanStep {
+    pub id: String,
+    pub label_key: String,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -267,6 +291,8 @@ mod tests {
                 id: winget_id.into(),
             },
             options: vec![],
+            homepage: None,
+            release_notes_url: None,
         }
     }
 
@@ -335,6 +361,8 @@ mod tests {
                 steps: vec!["ghost".into()],
             },
             options: vec![],
+            homepage: None,
+            release_notes_url: None,
         };
         let catalog = Catalog {
             schema_version: 1,
@@ -408,6 +436,8 @@ mod tests {
                 steps: vec!["nvm".into(), "node".into()],
             },
             options: vec![],
+            homepage: None,
+            release_notes_url: None,
         };
         let catalog = Catalog {
             schema_version: 1,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -513,7 +513,42 @@
       "updateAllBody": "{{count}} update(s) will be installed.",
       "updateAllConfirm": "Update all"
     },
-    "wslReboot": "WSL was enabled this session. Reboot Windows before installing Docker Desktop."
+    "wslReboot": "WSL was enabled this session. Reboot Windows before installing Docker Desktop.",
+    "checkingDots": "Checking…",
+    "dialog": {
+      "installLocation": "Install location",
+      "provider": "Provider",
+      "installedVersion": "Installed version",
+      "latestVersion": "Latest version",
+      "lastChecked": "Last checked",
+      "homepage": "Website",
+      "releaseNotes": "Release notes",
+      "prerequisites": "Prerequisites",
+      "prereqInstalled": "Installed",
+      "prereqMissing": "Missing",
+      "checkNow": "Check now",
+      "checkingDots": "Checking…",
+      "updateAvailable": "Update available: {{from}} → {{to}}",
+      "installingTitle": "Installing {{name}}…",
+      "uninstallingTitle": "Uninstalling {{name}}…",
+      "installedTitle": "Installed {{name}}",
+      "failedTitle": "Install failed: {{name}}",
+      "cancelledTitle": "Install cancelled: {{name}}"
+    },
+    "stepper": {
+      "failedBadge": "Failed"
+    },
+    "steps": {
+      "resolve": "Resolve version",
+      "download": "Download",
+      "verifyChecksum": "Verify checksum",
+      "extract": "Extract",
+      "placeFiles": "Place files",
+      "updatePath": "Update PATH",
+      "install": "Install",
+      "verify": "Verify",
+      "enable": "Enable feature"
+    }
   },
   "settings": {
     "title": "Settings",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1884,7 +1884,9 @@ type CommandMap = {
   };
   installer_check_latest_versions: {
     args: { toolIds: string[] };
-    result: Record<string, string | null>;
+    /// Fire-and-forget: results stream as `checkResult` events on
+    /// installer://progress. Backend returns when the sweep finishes.
+    result: void;
   };
   installer_install_recipe: {
     args: {

--- a/src/modules/installer/InstallerPage.tsx
+++ b/src/modules/installer/InstallerPage.tsx
@@ -18,6 +18,7 @@ import { useWorkspaceStore } from "../../store";
 import { useInstallerStore } from "./state";
 import { isWslFeature } from "./dag";
 import { InstallerConfirmDialog } from "./InstallerConfirmDialog";
+import { InstallerToolDialog } from "./InstallerToolDialog";
 import {
   PROGRESS_EVENT_NAME,
   type ProgressEvent,
@@ -36,6 +37,7 @@ export function InstallerPage({ active }: { active: boolean }) {
   const detected = useInstallerStore((s) => s.detected);
   const toolState = useInstallerStore((s) => s.toolState);
   const scanning = useInstallerStore((s) => s.scanning);
+  const checking = useInstallerStore((s) => s.checking);
   const hasInitialScanned = useInstallerStore((s) => s.hasInitialScanned);
   const setCatalog = useInstallerStore((s) => s.setCatalog);
   const setDetected = useInstallerStore((s) => s.setDetected);
@@ -171,11 +173,12 @@ export function InstallerPage({ active }: { active: boolean }) {
       .map((r) => r.id);
     if (installedIds.length === 0) return;
     try {
+      // Streaming: backend emits checkStarted → checkResult* → checkFinished.
+      // applyProgress writes each result into toolState as it lands, so rows
+      // light up incrementally and the UI stays responsive.
       await invokeCommand("installer_check_latest_versions", {
         toolIds: installedIds,
       });
-      const states = await invokeCommand("installer_get_state");
-      setToolStates(states);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       showStatusBarNotice(message, { tone: "error" });
@@ -256,9 +259,15 @@ export function InstallerPage({ active }: { active: boolean }) {
             type="button"
             className="installer-button"
             onClick={() => void handleCheckUpdates()}
-            disabled={scanning || !catalog || sections.installed.length === 0}
+            disabled={
+              scanning || checking || !catalog || sections.installed.length === 0
+            }
           >
-            {t("installer.checkUpdates")}
+            {checking
+              ? t("installer.checkingDots", {
+                  defaultValue: t("installer.checkUpdates") + "…",
+                })
+              : t("installer.checkUpdates")}
           </button>
           <button
             type="button"
@@ -294,6 +303,7 @@ export function InstallerPage({ active }: { active: boolean }) {
           />
         </>
       )}
+      <InstallerToolDialog />
       {updateAllConfirm ? (
         <InstallerConfirmDialog
           title={t("installer.confirm.updateAllTitle")}

--- a/src/modules/installer/InstallerToolDialog.tsx
+++ b/src/modules/installer/InstallerToolDialog.tsx
@@ -1,0 +1,838 @@
+// Centered, app-owned dialog for one Installer Helper tool. Replaces the
+// inline expanding tile body — single click on a tile opens this. Modes:
+//   * "info" — installed: location, provider, versions, pin, update/uninstall.
+//             not installed: homepage, release notes, latest, prereqs, options.
+//   * "stepper" — install in progress or just completed; renders the n8n-style
+//                 step list with per-step logs. Pressing Install from "info"
+//                 mode flips the dialog to "stepper".
+//
+// Honors AGENTS.md dialog rules: top-right close, concise title (no
+// subtitle), Windows-order footer buttons (primary immediately before Cancel
+// at bottom right).
+
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  invokeCommand,
+  isTauriRuntime,
+  openExternalUrl,
+} from "../../lib/tauri";
+import { useWorkspaceStore } from "../../store";
+import {
+  findInstalledDependents,
+  recipeNeedsWsl,
+  resolveInstallPlan,
+} from "./dag";
+import { iconUrlForRecipe, FALLBACK_ICON_URL } from "./icons";
+import { InstallerConfirmDialog } from "./InstallerConfirmDialog";
+import { installRecipeAndWait } from "./progress";
+import {
+  GENERAL_STEP_BUCKET,
+  useInstallerStore,
+  type StepStatus,
+} from "./state";
+import type {
+  InstallOptions,
+  Provider,
+  Recipe,
+  RecipeOption,
+} from "./types";
+
+export function InstallerToolDialog() {
+  const { t } = useTranslation();
+  const open = useInstallerStore((s) => s.openDialog);
+  const catalog = useInstallerStore((s) => s.catalog);
+  const closeDialog = useInstallerStore((s) => s.closeDialog);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeDialog();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, closeDialog]);
+
+  if (!open || !catalog) return null;
+  const recipe = catalog.recipes.find((r) => r.id === open.toolId);
+  if (!recipe) return null;
+
+  return (
+    <div className="dialog-backdrop connection-dialog-backdrop" role="presentation">
+      <div
+        aria-label={recipe.name}
+        aria-modal="true"
+        className="connection-dialog installer-tool-dialog"
+        role="dialog"
+      >
+        <button
+          type="button"
+          className="installer-tool-dialog__close"
+          aria-label={t("common.close")}
+          onClick={closeDialog}
+        >
+          ×
+        </button>
+        {open.mode === "stepper" ? (
+          <StepperBody recipe={recipe} />
+        ) : (
+          <InfoBody recipe={recipe} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// =================================================================
+// Info mode
+// =================================================================
+
+function InfoBody({ recipe }: { recipe: Recipe }) {
+  const detected = useInstallerStore((s) => s.detected[recipe.id]);
+  if (detected?.installed) {
+    return <InstalledInfoBody recipe={recipe} />;
+  }
+  return <NotInstalledInfoBody recipe={recipe} />;
+}
+
+function InstalledInfoBody({ recipe }: { recipe: Recipe }) {
+  const { t, i18n } = useTranslation();
+  const detected = useInstallerStore((s) => s.detected[recipe.id]);
+  const toolState = useInstallerStore((s) => s.toolState[recipe.id]);
+  const allDetected = useInstallerStore((s) => s.detected);
+  const catalog = useInstallerStore((s) => s.catalog);
+  const closeDialog = useInstallerStore((s) => s.closeDialog);
+  const openStepperDialog = useInstallerStore((s) => s.openStepperDialog);
+  const beginInFlight = useInstallerStore((s) => s.beginInFlight);
+
+  const [uninstallConfirm, setUninstallConfirm] = useState<null | {
+    dependents: string[];
+  }>(null);
+
+  const description =
+    recipe.descriptionLocales?.[i18n.language] ?? recipe.descriptionEn;
+  const version = detected?.installedVersion ?? null;
+  const latest = toolState?.latestVersionSeen ?? null;
+  const hasUpdate = latest && version && latest !== version;
+
+  async function handleTogglePin() {
+    if (!isTauriRuntime()) return;
+    const next = !(toolState?.pinned ?? false);
+    try {
+      await invokeCommand("installer_set_pinned", {
+        toolId: recipe.id,
+        pinned: next,
+      });
+      const states = await invokeCommand("installer_get_state");
+      useInstallerStore.getState().setToolStates(states);
+    } catch {
+      // ignore — non-fatal
+    }
+  }
+
+  function startUpdate() {
+    if (!catalog) return;
+    openStepperDialog(recipe.id);
+    beginInFlight(recipe.id, "install");
+    void installRecipeAndWait(recipe.id, {}).catch(() => {
+      // failure surfaces via the failed terminal event into stepperState.
+    });
+  }
+
+  function attemptUninstall() {
+    if (!catalog) return;
+    const dependents = findInstalledDependents(recipe.id, catalog, allDetected);
+    setUninstallConfirm({ dependents: dependents.map((d) => d.name) });
+  }
+
+  async function doUninstall() {
+    if (!isTauriRuntime()) return;
+    setUninstallConfirm(null);
+    beginInFlight(recipe.id, "uninstall");
+    openStepperDialog(recipe.id);
+    try {
+      await invokeCommand("installer_uninstall_recipe", { toolId: recipe.id });
+    } catch {
+      // backend emits Failed
+    }
+  }
+
+  return (
+    <>
+      <header className="installer-tool-dialog__header">
+        <ToolIcon recipe={recipe} />
+        <div>
+          <h2>
+            {recipe.name}
+            {version ? (
+              <span className="installer-tool-dialog__version"> {version}</span>
+            ) : null}
+          </h2>
+        </div>
+      </header>
+      <div className="installer-tool-dialog__body">
+        {description ? (
+          <p className="installer-tool-dialog__desc">{description}</p>
+        ) : null}
+        {hasUpdate ? (
+          <div className="installer-tool-dialog__update-banner">
+            <span>
+              {t("installer.dialog.updateAvailable", {
+                from: version,
+                to: latest,
+              })}
+            </span>
+            <button
+              type="button"
+              className="installer-button primary"
+              onClick={startUpdate}
+            >
+              {t("installer.actions.update")}
+            </button>
+          </div>
+        ) : null}
+        <dl className="installer-tool-dialog__grid">
+          {detected?.installLocation ? (
+            <Row label={t("installer.dialog.installLocation")}>
+              <code>{detected.installLocation}</code>
+            </Row>
+          ) : null}
+          <Row label={t("installer.dialog.provider")}>
+            {providerSummary(recipe.provider)}
+          </Row>
+          {version ? (
+            <Row label={t("installer.dialog.installedVersion")}>
+              {version}
+            </Row>
+          ) : null}
+          {latest ? (
+            <Row label={t("installer.dialog.latestVersion")}>{latest}</Row>
+          ) : null}
+          {toolState?.lastCheckAt ? (
+            <Row label={t("installer.dialog.lastChecked")}>
+              {formatTimestamp(toolState.lastCheckAt)}
+            </Row>
+          ) : null}
+        </dl>
+        <label className="installer-tool-dialog__pin">
+          <input
+            type="checkbox"
+            checked={toolState?.pinned ?? false}
+            onChange={() => void handleTogglePin()}
+          />
+          <span>{t("installer.options.pinVersion")}</span>
+        </label>
+      </div>
+      <div className="dialog-actions installer-tool-dialog__actions">
+        <button
+          type="button"
+          className="secondary-button danger"
+          onClick={attemptUninstall}
+        >
+          {t("installer.actions.uninstall")}
+        </button>
+        {hasUpdate ? (
+          <button
+            type="button"
+            className="secondary-button"
+            onClick={startUpdate}
+          >
+            {t("installer.actions.update")}
+          </button>
+        ) : null}
+        <button type="button" className="toolbar-button" onClick={closeDialog}>
+          {t("common.close")}
+        </button>
+      </div>
+      {uninstallConfirm ? (
+        <InstallerConfirmDialog
+          title={t("installer.confirm.uninstallTitle", { name: recipe.name })}
+          body={
+            uninstallConfirm.dependents.length > 0
+              ? t("installer.confirm.uninstallDependentsBody", {
+                  name: recipe.name,
+                })
+              : t("installer.confirm.uninstallSimpleBody", { name: recipe.name })
+          }
+          items={
+            uninstallConfirm.dependents.length > 0
+              ? uninstallConfirm.dependents
+              : undefined
+          }
+          footer={
+            uninstallConfirm.dependents.length > 0
+              ? t("installer.confirm.uninstallDependentsFooter")
+              : undefined
+          }
+          confirmLabel={t("installer.confirm.uninstallConfirm")}
+          tone="danger"
+          onConfirm={() => void doUninstall()}
+          onCancel={() => setUninstallConfirm(null)}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function NotInstalledInfoBody({ recipe }: { recipe: Recipe }) {
+  const { t, i18n } = useTranslation();
+  const showStatusBarNotice = useWorkspaceStore(
+    (state) => state.showStatusBarNotice,
+  );
+  const detected = useInstallerStore((s) => s.detected);
+  const toolState = useInstallerStore((s) => s.toolState[recipe.id]);
+  const checking = useInstallerStore((s) => s.checking);
+  const catalog = useInstallerStore((s) => s.catalog);
+  const closeDialog = useInstallerStore((s) => s.closeDialog);
+  const openStepperDialog = useInstallerStore((s) => s.openStepperDialog);
+  const beginInFlight = useInstallerStore((s) => s.beginInFlight);
+  const wslJustEnabled = useInstallerStore((s) => s.wslJustEnabled);
+
+  const [options, setOptions] = useState<InstallOptions>({});
+  const [installConfirm, setInstallConfirm] = useState<null | {
+    items: string[];
+    recipes: Recipe[];
+    uacEstimate: number;
+  }>(null);
+
+  const description =
+    recipe.descriptionLocales?.[i18n.language] ?? recipe.descriptionEn;
+  const wslBlocked =
+    !!catalog && wslJustEnabled && recipeNeedsWsl(recipe, catalog);
+  const homepage = recipe.homepage;
+  const releaseUrl = recipe.releaseNotesUrl ?? deriveProviderUrl(recipe.provider);
+
+  function applyOption<K extends keyof InstallOptions>(
+    key: K,
+    value: InstallOptions[K],
+  ) {
+    setOptions((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function handleCheckNow() {
+    if (!isTauriRuntime()) return;
+    try {
+      await invokeCommand("installer_check_latest_versions", {
+        toolIds: [recipe.id],
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      showStatusBarNotice(message, { tone: "error" });
+    }
+  }
+
+  function attemptInstall() {
+    if (!catalog || wslBlocked) return;
+    const plan = resolveInstallPlan(recipe.id, catalog, detected, options);
+    const prereqActionable = plan.actionable.filter((s) => s.isPrerequisite);
+    if (prereqActionable.length > 0 || plan.uacPromptEstimate > 0) {
+      setInstallConfirm({
+        items: prereqActionable.map((s) => s.recipe.name),
+        recipes: plan.actionable.map((s) => s.recipe),
+        uacEstimate: plan.uacPromptEstimate,
+      });
+      return;
+    }
+    void doInstall(plan.actionable.map((s) => s.recipe));
+  }
+
+  async function doInstall(recipes: Recipe[]) {
+    if (!isTauriRuntime()) return;
+    setInstallConfirm(null);
+    openStepperDialog(recipe.id);
+    for (const queuedRecipe of recipes) {
+      beginInFlight(queuedRecipe.id, "install");
+      try {
+        const terminalEvent = await installRecipeAndWait(
+          queuedRecipe.id,
+          queuedRecipe.id === recipe.id ? options : {},
+        );
+        if (terminalEvent.kind !== "completed") {
+          break;
+        }
+      } catch {
+        break;
+      }
+    }
+  }
+
+  const prereqs = (recipe.needs ?? [])
+    .map((id) => catalog?.recipes.find((r) => r.id === id))
+    .filter((r): r is Recipe => !!r);
+
+  return (
+    <>
+      <header className="installer-tool-dialog__header">
+        <ToolIcon recipe={recipe} />
+        <div>
+          <h2>{recipe.name}</h2>
+        </div>
+      </header>
+      <div className="installer-tool-dialog__body">
+        {description ? (
+          <p className="installer-tool-dialog__desc">{description}</p>
+        ) : null}
+        {wslBlocked ? (
+          <p
+            className="installer-tool-dialog__hint installer-tool-dialog__hint--warn"
+            role="status"
+          >
+            {t("installer.wslReboot")}
+          </p>
+        ) : null}
+        <dl className="installer-tool-dialog__grid">
+          {homepage ? (
+            <Row label={t("installer.dialog.homepage")}>
+              <ExternalLink href={homepage} />
+            </Row>
+          ) : null}
+          {releaseUrl ? (
+            <Row label={t("installer.dialog.releaseNotes")}>
+              <ExternalLink href={releaseUrl} />
+            </Row>
+          ) : null}
+          <Row label={t("installer.dialog.provider")}>
+            {providerSummary(recipe.provider)}
+          </Row>
+          <Row label={t("installer.dialog.latestVersion")}>
+            {toolState?.latestVersionSeen ?? (
+              <button
+                type="button"
+                className="installer-tool-dialog__inline-action"
+                onClick={() => void handleCheckNow()}
+                disabled={checking}
+              >
+                {checking
+                  ? t("installer.dialog.checkingDots")
+                  : t("installer.dialog.checkNow")}
+              </button>
+            )}
+          </Row>
+          {prereqs.length > 0 ? (
+            <Row label={t("installer.dialog.prerequisites")}>
+              <ul className="installer-tool-dialog__prereqs">
+                {prereqs.map((p) => {
+                  const ok = detected[p.id]?.installed ?? false;
+                  return (
+                    <li key={p.id} data-installed={ok ? "true" : "false"}>
+                      <span>{p.name}</span>
+                      <span>
+                        {ok
+                          ? t("installer.dialog.prereqInstalled")
+                          : t("installer.dialog.prereqMissing")}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </Row>
+          ) : null}
+        </dl>
+        <OptionsForm recipe={recipe} options={options} onChange={applyOption} />
+      </div>
+      <div className="dialog-actions installer-tool-dialog__actions">
+        <button
+          type="button"
+          className="secondary-button"
+          onClick={attemptInstall}
+          disabled={wslBlocked}
+        >
+          {t("installer.actions.install")}
+        </button>
+        <button type="button" className="toolbar-button" onClick={closeDialog}>
+          {t("common.cancel")}
+        </button>
+      </div>
+      {installConfirm ? (
+        <InstallerConfirmDialog
+          title={t("installer.confirm.installTitle", { name: recipe.name })}
+          body={
+            installConfirm.items.length > 0
+              ? t("installer.confirm.installWithPrereqsBody")
+              : undefined
+          }
+          items={
+            installConfirm.items.length > 0 ? installConfirm.items : undefined
+          }
+          footer={
+            installConfirm.uacEstimate > 0
+              ? t("installer.confirm.uacFooter", {
+                  count: installConfirm.uacEstimate,
+                })
+              : undefined
+          }
+          confirmLabel={t("installer.confirm.installConfirm")}
+          onConfirm={() => void doInstall(installConfirm.recipes)}
+          onCancel={() => setInstallConfirm(null)}
+        />
+      ) : null}
+    </>
+  );
+}
+
+// =================================================================
+// Stepper mode
+// =================================================================
+
+function StepperBody({ recipe }: { recipe: Recipe }) {
+  const { t } = useTranslation();
+  const stepper = useInstallerStore((s) => s.stepperState[recipe.id]);
+  const inFlight = useInstallerStore((s) => s.inFlight[recipe.id]);
+  const lastStatus = useInstallerStore((s) => s.lastStatus[recipe.id]);
+  const closeDialog = useInstallerStore((s) => s.closeDialog);
+
+  async function handleCancel() {
+    if (!isTauriRuntime()) return;
+    try {
+      await invokeCommand("installer_cancel", { toolId: recipe.id });
+    } catch {
+      // best effort
+    }
+  }
+
+  const running = !!inFlight;
+  const titleKey = running
+    ? inFlight?.operation === "uninstall"
+      ? "installer.dialog.uninstallingTitle"
+      : "installer.dialog.installingTitle"
+    : lastStatus?.kind === "completed"
+      ? "installer.dialog.installedTitle"
+      : lastStatus?.kind === "failed"
+        ? "installer.dialog.failedTitle"
+        : lastStatus?.kind === "cancelled"
+          ? "installer.dialog.cancelledTitle"
+          : "installer.dialog.installingTitle";
+
+  return (
+    <>
+      <header className="installer-tool-dialog__header">
+        <ToolIcon recipe={recipe} />
+        <div>
+          <h2>{t(titleKey, { name: recipe.name })}</h2>
+        </div>
+      </header>
+      <div className="installer-tool-dialog__body">
+        {lastStatus?.kind === "failed" ? (
+          <p
+            className="installer-tool-dialog__hint installer-tool-dialog__hint--error"
+            role="status"
+          >
+            {lastStatus.message}
+          </p>
+        ) : null}
+        {lastStatus?.kind === "cancelled" ? (
+          <p className="installer-tool-dialog__hint" role="status">
+            {t("installer.status.cancelled")}
+          </p>
+        ) : null}
+        <StepperList stepper={stepper} inFlight={inFlight} />
+      </div>
+      <div className="dialog-actions installer-tool-dialog__actions">
+        {running ? (
+          <button
+            type="button"
+            className="secondary-button danger"
+            onClick={() => void handleCancel()}
+          >
+            {t("installer.actions.cancel")}
+          </button>
+        ) : null}
+        <button type="button" className="toolbar-button" onClick={closeDialog}>
+          {t("common.close")}
+        </button>
+      </div>
+    </>
+  );
+}
+
+function StepperList({
+  stepper,
+  inFlight,
+}: {
+  stepper:
+    | ReturnType<typeof useInstallerStore.getState>["stepperState"][string]
+    | undefined;
+  inFlight: ReturnType<typeof useInstallerStore.getState>["inFlight"][string];
+}) {
+  const { t } = useTranslation();
+  const [manualExpanded, setManualExpanded] = useState<Record<string, boolean>>(
+    {},
+  );
+
+  // No declared plan yet (legacy provider or stepper opened before plan
+  // event lands). Fall back to today's single-current-step view from
+  // inFlight so the user always sees activity.
+  const hasPlan = !!stepper && stepper.plan.length > 0;
+
+  if (!hasPlan) {
+    return (
+      <div className="installer-stepper installer-stepper--legacy">
+        {inFlight?.currentStep ? (
+          <div className="installer-stepper__legacy-step">
+            {inFlight.currentStep}
+          </div>
+        ) : null}
+        {inFlight?.ratio != null ? (
+          <progress
+            className="installer-stepper__bar"
+            value={inFlight.ratio}
+            max={1}
+          />
+        ) : null}
+        {inFlight?.log && inFlight.log.length > 0 ? (
+          <pre className="installer-stepper__log" aria-live="polite">
+            {inFlight.log.slice(-30).join("\n")}
+          </pre>
+        ) : null}
+        {stepper?.logs[GENERAL_STEP_BUCKET]?.length ? (
+          <pre className="installer-stepper__log" aria-live="polite">
+            {stepper.logs[GENERAL_STEP_BUCKET].slice(-30).join("\n")}
+          </pre>
+        ) : null}
+      </div>
+    );
+  }
+
+  const active = stepper!.activeStepId;
+  function isExpanded(stepId: string): boolean {
+    if (stepId in manualExpanded) return manualExpanded[stepId]!;
+    return stepId === active;
+  }
+
+  return (
+    <ol className="installer-stepper">
+      {stepper!.plan.map((step) => {
+        const status = (stepper!.status[step.id] ?? "pending") as StepStatus;
+        const expanded = isExpanded(step.id);
+        const log = stepper!.logs[step.id] ?? [];
+        const duration = stepper!.durations[step.id];
+        const error = stepper!.errors[step.id];
+        const ratio =
+          status === "running" && inFlight?.ratio != null ? inFlight.ratio : null;
+        return (
+          <li
+            key={step.id}
+            className="installer-stepper__row"
+            data-status={status}
+            data-active={status === "running" ? "true" : "false"}
+          >
+            <button
+              type="button"
+              className="installer-stepper__row-head"
+              aria-expanded={expanded}
+              onClick={() =>
+                setManualExpanded((prev) => ({
+                  ...prev,
+                  [step.id]: !expanded,
+                }))
+              }
+            >
+              <span
+                className={`installer-stepper__dot installer-stepper__dot--${status}`}
+                aria-hidden="true"
+              />
+              <span className="installer-stepper__label">
+                {t(step.labelKey, { defaultValue: step.id })}
+              </span>
+              <span className="installer-stepper__meta">
+                {status === "done" && duration != null
+                  ? formatDuration(duration)
+                  : status === "running" && ratio != null
+                    ? `${Math.round(ratio * 100)}%`
+                    : status === "failed"
+                      ? t("installer.stepper.failedBadge")
+                      : ""}
+              </span>
+            </button>
+            {expanded ? (
+              <div className="installer-stepper__row-body">
+                {status === "running" && ratio != null ? (
+                  <progress
+                    className="installer-stepper__bar"
+                    value={ratio}
+                    max={1}
+                  />
+                ) : null}
+                {error ? (
+                  <p className="installer-tool-dialog__hint installer-tool-dialog__hint--error">
+                    {error}
+                  </p>
+                ) : null}
+                {log.length > 0 ? (
+                  <pre className="installer-stepper__log" aria-live="polite">
+                    {log.slice(-200).join("\n")}
+                  </pre>
+                ) : null}
+              </div>
+            ) : null}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+// =================================================================
+// Small shared helpers
+// =================================================================
+
+function ToolIcon({ recipe }: { recipe: Recipe }) {
+  return (
+    <img
+      className="installer-tool-dialog__icon"
+      src={iconUrlForRecipe(recipe.id)}
+      alt=""
+      draggable={false}
+      onError={(event) => {
+        const img = event.currentTarget;
+        if (img.src !== FALLBACK_ICON_URL) {
+          img.src = FALLBACK_ICON_URL;
+        }
+      }}
+    />
+  );
+}
+
+function Row({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <dt>{label}</dt>
+      <dd>{children}</dd>
+    </>
+  );
+}
+
+function ExternalLink({ href }: { href: string }) {
+  // Open via opener plugin so external URLs go to the system browser, not
+  // an in-app webview that we don't intend to host arbitrary sites in.
+  function handleClick(event: React.MouseEvent<HTMLAnchorElement>) {
+    event.preventDefault();
+    if (!isTauriRuntime()) {
+      window.open(href, "_blank", "noopener,noreferrer");
+      return;
+    }
+    void openExternalUrl(href).catch(() => {
+      window.open(href, "_blank", "noopener,noreferrer");
+    });
+  }
+  return (
+    <a href={href} onClick={handleClick} rel="noopener noreferrer">
+      {href}
+    </a>
+  );
+}
+
+function OptionsForm({
+  recipe,
+  options,
+  onChange,
+}: {
+  recipe: Recipe;
+  options: InstallOptions;
+  onChange: <K extends keyof InstallOptions>(
+    key: K,
+    value: InstallOptions[K],
+  ) => void;
+}) {
+  const { t } = useTranslation();
+  const supported = new Set<RecipeOption>(recipe.options ?? []);
+  if (supported.size === 0) return null;
+  return (
+    <div
+      className="installer-tool-dialog__options"
+      data-tutorial-id="installer.toolOptions"
+    >
+      {supported.has("scope") ? (
+        <label>
+          <span>{t("installer.options.scope")}</span>
+          <select
+            value={options.scope ?? "user"}
+            onChange={(event) =>
+              onChange("scope", event.target.value as "user" | "machine")
+            }
+          >
+            <option value="user">{t("installer.options.scopeUser")}</option>
+            <option value="machine">
+              {t("installer.options.scopeMachine")}
+            </option>
+          </select>
+        </label>
+      ) : null}
+      {supported.has("version") ? (
+        <label>
+          <span>{t("installer.options.version")}</span>
+          <input
+            type="text"
+            placeholder={t("installer.options.versionLatest")}
+            value={options.version ?? ""}
+            onChange={(event) => onChange("version", event.target.value)}
+          />
+        </label>
+      ) : null}
+      {supported.has("location") ? (
+        <label>
+          <span>{t("installer.options.location")}</span>
+          <input
+            type="text"
+            value={options.location ?? ""}
+            onChange={(event) => onChange("location", event.target.value)}
+          />
+        </label>
+      ) : null}
+      {supported.has("addToPath") ? (
+        <label>
+          <input
+            type="checkbox"
+            checked={options.addToPath ?? false}
+            onChange={(event) => onChange("addToPath", event.target.checked)}
+          />
+          <span>{t("installer.options.addToPath")}</span>
+        </label>
+      ) : null}
+    </div>
+  );
+}
+
+function providerSummary(provider: Provider): string {
+  switch (provider.kind) {
+    case "winget":
+      return `winget · ${provider.id}`;
+    case "npm":
+      return `npm · ${provider.pkg}`;
+    case "githubRelease":
+      return `GitHub release · ${provider.repo}`;
+    case "windowsFeature":
+      return `Windows feature · ${provider.feature}`;
+    case "bundle":
+      return `bundle · ${provider.steps.length} step(s)`;
+  }
+}
+
+function deriveProviderUrl(provider: Provider): string | null {
+  switch (provider.kind) {
+    case "githubRelease":
+      return `https://github.com/${provider.repo}/releases`;
+    case "npm":
+      return `https://www.npmjs.com/package/${encodeURIComponent(provider.pkg)}`;
+    case "winget":
+      return `https://winstall.app/apps/${encodeURIComponent(provider.id)}`;
+    default:
+      return null;
+  }
+}
+
+function formatTimestamp(epochSeconds: number): string {
+  return new Date(epochSeconds * 1000).toLocaleString();
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.round(ms / 100) / 10;
+  return `${seconds}s`;
+}

--- a/src/modules/installer/ToolRow.tsx
+++ b/src/modules/installer/ToolRow.tsx
@@ -1,46 +1,22 @@
-// One tool row — collapsed shows summary + primary action; expanded shows
-// progress, log, options form, and uninstall. Per ADR 0007 / Q10:
-// "Inline expanding detail panel per tool".
+// One tool tile in the Installer Helper catalog grid. Click opens the
+// app-owned `InstallerToolDialog` — info mode for already-installed and
+// not-installed tools, stepper mode while an install/uninstall is running
+// or just finished. Inline expansion was removed; the dialog owns the
+// detail surface.
 
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { invokeCommand, isTauriRuntime } from "../../lib/tauri";
-import {
-  findInstalledDependents,
-  recipeNeedsWsl,
-  resolveInstallPlan,
-} from "./dag";
 import { iconUrlForRecipe, FALLBACK_ICON_URL } from "./icons";
-import { InstallerConfirmDialog } from "./InstallerConfirmDialog";
-import { installRecipeAndWait } from "./progress";
 import { useInstallerStore } from "./state";
-import type { InstallOptions, Recipe } from "./types";
+import type { Recipe } from "./types";
 
 export function ToolRow({ recipe }: { recipe: Recipe }) {
-  const { t, i18n } = useTranslation();
-  const catalog = useInstallerStore((s) => s.catalog);
+  const { t } = useTranslation();
   const detected = useInstallerStore((s) => s.detected[recipe.id]);
-  const allDetected = useInstallerStore((s) => s.detected);
   const toolState = useInstallerStore((s) => s.toolState[recipe.id]);
   const inFlight = useInstallerStore((s) => s.inFlight[recipe.id]);
   const lastStatus = useInstallerStore((s) => s.lastStatus[recipe.id]);
-  const expanded = useInstallerStore((s) => s.expanded[recipe.id]);
-  const wslJustEnabled = useInstallerStore((s) => s.wslJustEnabled);
-  const toggleExpanded = useInstallerStore((s) => s.toggleExpanded);
-  const beginInFlight = useInstallerStore((s) => s.beginInFlight);
-
-  const [options, setOptions] = useState<InstallOptions>({});
-  const [installConfirm, setInstallConfirm] = useState<null | {
-    items: string[];
-    recipes: Recipe[];
-    uacEstimate: number;
-  }>(null);
-  const [uninstallConfirm, setUninstallConfirm] = useState<null | {
-    dependents: string[];
-  }>(null);
-
-  const wslBlocked =
-    !!catalog && wslJustEnabled && recipeNeedsWsl(recipe, catalog);
+  const openInfoDialog = useInstallerStore((s) => s.openInfoDialog);
+  const openStepperDialog = useInstallerStore((s) => s.openStepperDialog);
 
   const isInstalled = detected?.installed ?? false;
   const installedVersion = detected?.installedVersion;
@@ -53,132 +29,55 @@ export function ToolRow({ recipe }: { recipe: Recipe }) {
     latestSeen !== installedVersion;
   const busy = !!inFlight;
 
-  const description =
-    recipe.descriptionLocales?.[i18n.language] ?? recipe.descriptionEn;
+  const statusTone:
+    | "installed"
+    | "update"
+    | "busy"
+    | "failed"
+    | "partial"
+    | "none" = busy
+    ? "busy"
+    : lastStatus?.kind === "failed"
+      ? "failed"
+      : hasUpdate
+        ? "update"
+        : isInstalled
+          ? "installed"
+          : partial
+            ? "partial"
+            : "none";
 
-  function applyOption<K extends keyof InstallOptions>(
-    key: K,
-    value: InstallOptions[K],
-  ) {
-    setOptions((prev) => ({ ...prev, [key]: value }));
-  }
-
-  function attemptInstall() {
-    if (!catalog || wslBlocked) return;
-    const plan = resolveInstallPlan(recipe.id, catalog, allDetected, options);
-    const prereqActionable = plan.actionable.filter((s) => s.isPrerequisite);
-    if (prereqActionable.length > 0 || plan.uacPromptEstimate > 0) {
-      setInstallConfirm({
-        items: prereqActionable.map((s) => s.recipe.name),
-        recipes: plan.actionable.map((s) => s.recipe),
-        uacEstimate: plan.uacPromptEstimate,
-      });
-      return;
-    }
-    void doInstall(plan.actionable.map((s) => s.recipe));
-  }
-
-  async function doInstall(recipes: Recipe[]) {
-    if (!isTauriRuntime()) return;
-    setInstallConfirm(null);
-    for (const queuedRecipe of recipes) {
-      beginInFlight(queuedRecipe.id, "install");
-      try {
-        const terminalEvent = await installRecipeAndWait(
-          queuedRecipe.id,
-          queuedRecipe.id === recipe.id ? options : {},
-        );
-        if (terminalEvent.kind !== "completed") {
-          break;
-        }
-      } catch {
-        break;
-      }
+  function handleOpen() {
+    // While an install/uninstall is in flight (or its terminal state is the
+    // most recent thing the user saw), open into the stepper view so they
+    // see live progress / the result. Otherwise show the info dialog.
+    if (busy) {
+      openStepperDialog(recipe.id);
+    } else {
+      openInfoDialog(recipe.id);
     }
   }
-
-  function attemptUninstall() {
-    if (!catalog) return;
-    const dependents = findInstalledDependents(recipe.id, catalog, allDetected);
-    if (dependents.length > 0) {
-      setUninstallConfirm({ dependents: dependents.map((d) => d.name) });
-      return;
-    }
-    setUninstallConfirm({ dependents: [] });
-  }
-
-  async function doUninstall() {
-    if (!isTauriRuntime()) return;
-    setUninstallConfirm(null);
-    beginInFlight(recipe.id, "uninstall");
-    try {
-      await invokeCommand("installer_uninstall_recipe", { toolId: recipe.id });
-    } catch {
-      // Backend will emit Failed event.
-    }
-  }
-
-  async function handleCancel() {
-    if (!isTauriRuntime()) return;
-    try {
-      await invokeCommand("installer_cancel", { toolId: recipe.id });
-    } catch {
-      // Best-effort.
-    }
-  }
-
-  async function handleTogglePin() {
-    if (!isTauriRuntime()) return;
-    const next = !(toolState?.pinned ?? false);
-    try {
-      await invokeCommand("installer_set_pinned", {
-        toolId: recipe.id,
-        pinned: next,
-      });
-      const states = await invokeCommand("installer_get_state");
-      useInstallerStore.getState().setToolStates(states);
-    } catch {
-      // ignore
-    }
-  }
-
-  const statusTone: "installed" | "update" | "busy" | "failed" | "partial" | "none" =
-    busy
-      ? "busy"
-      : lastStatus?.kind === "failed"
-        ? "failed"
-        : hasUpdate
-          ? "update"
-          : isInstalled
-            ? "installed"
-            : partial
-              ? "partial"
-              : "none";
-
-  const iconUrl = iconUrlForRecipe(recipe.id);
 
   return (
     <article
-      className={`installer-tile ${expanded ? "expanded" : ""} ${busy ? "busy" : ""}`}
+      className={`installer-tile ${busy ? "busy" : ""}`}
       data-status={statusTone}
+      onClick={handleOpen}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          handleOpen();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      aria-label={recipe.name}
     >
-      <header
-        className="installer-tile__head"
-        onClick={() => toggleExpanded(recipe.id)}
-        role="button"
-        tabIndex={0}
-        aria-expanded={expanded ? "true" : "false"}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            toggleExpanded(recipe.id);
-          }
-        }}
-      >
+      <div className="installer-tile__head">
         <div className="installer-tile__icon-wrap">
           <img
             className="installer-tile__icon"
-            src={iconUrl}
+            src={iconUrlForRecipe(recipe.id)}
             alt=""
             draggable={false}
             onError={(event) => {
@@ -216,219 +115,7 @@ export function ToolRow({ recipe }: { recipe: Recipe }) {
                     : recipe.provider.kind}
           </span>
         </div>
-      </header>
-      {expanded ? (
-        <div className="installer-tile__body">
-          {description ? (
-            <p className="installer-row__desc">{description}</p>
-          ) : null}
-          {wslBlocked ? (
-            <p className="installer-row__hint" role="status">
-              {t("installer.wslReboot")}
-            </p>
-          ) : null}
-          {!inFlight && lastStatus?.kind === "failed" ? (
-            <p className="installer-row__hint installer-row__hint--error" role="status">
-              {t("installer.status.failed", { message: lastStatus.message })}
-            </p>
-          ) : null}
-          {!inFlight && lastStatus?.kind === "cancelled" ? (
-            <p className="installer-row__hint" role="status">
-              {t("installer.status.cancelled")}
-            </p>
-          ) : null}
-          {inFlight ? (
-            <div className="installer-row__progress">
-              {inFlight.currentStep ? (
-                <div className="installer-row__step">{inFlight.currentStep}</div>
-              ) : null}
-              {inFlight.ratio != null ? (
-                <progress
-                  className="installer-row__bar"
-                  value={inFlight.ratio}
-                  max={1}
-                />
-              ) : null}
-              {inFlight.log.length > 0 ? (
-                <pre className="installer-row__log" aria-live="polite">
-                  {inFlight.log.slice(-30).join("\n")}
-                </pre>
-              ) : null}
-            </div>
-          ) : null}
-          <OptionsForm recipe={recipe} options={options} onChange={applyOption} />
-          <div className="installer-row__actions">
-            {busy ? (
-              <button
-                type="button"
-                className="installer-button danger"
-                onClick={() => void handleCancel()}
-              >
-                {t("installer.actions.cancel")}
-              </button>
-            ) : isInstalled ? (
-              <>
-                {hasUpdate ? (
-                  <button
-                    type="button"
-                    className="installer-button primary"
-                    onClick={attemptInstall}
-                    disabled={wslBlocked}
-                  >
-                    {t("installer.actions.update")}
-                  </button>
-                ) : null}
-                <button
-                  type="button"
-                  className="installer-button danger"
-                  onClick={attemptUninstall}
-                >
-                  {t("installer.actions.uninstall")}
-                </button>
-              </>
-            ) : (
-              <button
-                type="button"
-                className="installer-button primary"
-                onClick={attemptInstall}
-                disabled={wslBlocked}
-              >
-                {t("installer.actions.install")}
-              </button>
-            )}
-            <label className="installer-row__pin">
-              <input
-                type="checkbox"
-                checked={toolState?.pinned ?? false}
-                onChange={() => void handleTogglePin()}
-              />
-              <span>{t("installer.options.pinVersion")}</span>
-            </label>
-          </div>
-        </div>
-      ) : null}
-      {installConfirm ? (
-        <InstallerConfirmDialog
-          title={t("installer.confirm.installTitle", { name: recipe.name })}
-          body={
-            installConfirm.items.length > 0
-              ? t("installer.confirm.installWithPrereqsBody")
-              : undefined
-          }
-          items={
-            installConfirm.items.length > 0 ? installConfirm.items : undefined
-          }
-          footer={
-            installConfirm.uacEstimate > 0
-              ? t("installer.confirm.uacFooter", {
-                  count: installConfirm.uacEstimate,
-                })
-              : undefined
-          }
-          confirmLabel={t("installer.confirm.installConfirm")}
-          onConfirm={() => void doInstall(installConfirm.recipes)}
-          onCancel={() => setInstallConfirm(null)}
-        />
-      ) : null}
-      {uninstallConfirm ? (
-        <InstallerConfirmDialog
-          title={t("installer.confirm.uninstallTitle", { name: recipe.name })}
-          body={
-            uninstallConfirm.dependents.length > 0
-              ? t("installer.confirm.uninstallDependentsBody", {
-                  name: recipe.name,
-                })
-              : t("installer.confirm.uninstallSimpleBody", {
-                  name: recipe.name,
-                })
-          }
-          items={
-            uninstallConfirm.dependents.length > 0
-              ? uninstallConfirm.dependents
-              : undefined
-          }
-          footer={
-            uninstallConfirm.dependents.length > 0
-              ? t("installer.confirm.uninstallDependentsFooter")
-              : undefined
-          }
-          confirmLabel={t("installer.confirm.uninstallConfirm")}
-          tone="danger"
-          onConfirm={() => void doUninstall()}
-          onCancel={() => setUninstallConfirm(null)}
-        />
-      ) : null}
+      </div>
     </article>
-  );
-}
-
-function OptionsForm({
-  recipe,
-  options,
-  onChange,
-}: {
-  recipe: Recipe;
-  options: InstallOptions;
-  onChange: <K extends keyof InstallOptions>(
-    key: K,
-    value: InstallOptions[K],
-  ) => void;
-}) {
-  const { t } = useTranslation();
-  const supported = new Set(recipe.options ?? []);
-  if (supported.size === 0) return null;
-  return (
-    <div className="installer-row__options" data-tutorial-id="installer.toolOptions">
-      {supported.has("scope") ? (
-        <label>
-          <span>{t("installer.options.scope")}</span>
-          <select
-            value={options.scope ?? "user"}
-            onChange={(event) =>
-              onChange(
-                "scope",
-                event.target.value as "user" | "machine",
-              )
-            }
-          >
-            <option value="user">{t("installer.options.scopeUser")}</option>
-            <option value="machine">
-              {t("installer.options.scopeMachine")}
-            </option>
-          </select>
-        </label>
-      ) : null}
-      {supported.has("version") ? (
-        <label>
-          <span>{t("installer.options.version")}</span>
-          <input
-            type="text"
-            placeholder={t("installer.options.versionLatest")}
-            value={options.version ?? ""}
-            onChange={(event) => onChange("version", event.target.value)}
-          />
-        </label>
-      ) : null}
-      {supported.has("location") ? (
-        <label>
-          <span>{t("installer.options.location")}</span>
-          <input
-            type="text"
-            value={options.location ?? ""}
-            onChange={(event) => onChange("location", event.target.value)}
-          />
-        </label>
-      ) : null}
-      {supported.has("addToPath") ? (
-        <label>
-          <input
-            type="checkbox"
-            checked={options.addToPath ?? false}
-            onChange={(event) => onChange("addToPath", event.target.checked)}
-          />
-          <span>{t("installer.options.addToPath")}</span>
-        </label>
-      ) : null}
-    </div>
   );
 }

--- a/src/modules/installer/installer.css
+++ b/src/modules/installer/installer.css
@@ -117,9 +117,13 @@
   transition: border-color 0.12s ease, transform 0.12s ease;
 }
 
-.installer-tile.expanded {
-  grid-column: 1 / -1;
-  border-color: var(--accent);
+.installer-tile {
+  cursor: pointer;
+}
+
+.installer-tile:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .installer-tile.busy {
@@ -133,21 +137,12 @@
   justify-content: flex-start;
   gap: 0.5rem;
   padding: 0.85rem 0.6rem 0.7rem;
-  cursor: pointer;
   user-select: none;
   text-align: center;
   min-height: 7.5rem;
 }
 
-.installer-tile.expanded .installer-tile__head {
-  flex-direction: row;
-  align-items: center;
-  text-align: left;
-  min-height: 0;
-  padding: 0.65rem 0.85rem;
-}
-
-.installer-tile__head:hover {
+.installer-tile:hover .installer-tile__head {
   background: var(--surface-muted);
 }
 
@@ -159,11 +154,6 @@
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
-}
-
-.installer-tile.expanded .installer-tile__icon-wrap {
-  width: 32px;
-  height: 32px;
 }
 
 .installer-tile__icon {
@@ -219,10 +209,6 @@
   min-width: 0;
 }
 
-.installer-tile.expanded .installer-tile__label {
-  flex: 1 1 auto;
-}
-
 .installer-tile__name {
   font-weight: 500;
   font-size: 0.85rem;
@@ -242,201 +228,322 @@
   text-overflow: ellipsis;
 }
 
-.installer-tile__body {
-  padding: 0.75rem 0.85rem 0.85rem;
-  border-top: 1px solid var(--border);
+/* ---------- InstallerToolDialog ---------- */
+
+.installer-tool-dialog {
+  position: relative;
+  min-width: 32rem;
+  max-width: 44rem;
+  max-height: 80vh;
   display: flex;
   flex-direction: column;
-  gap: 0.65rem;
+  padding: 1.25rem 1.5rem 1rem;
 }
 
-.installer-row__hint--error {
-  color: var(--red);
+.installer-tool-dialog__close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  z-index: 1;
 }
 
-.installer-row {
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--surface);
-  overflow: hidden;
-  transition: border-color 0.12s ease;
+.installer-tool-dialog__close:hover {
+  background: var(--surface-muted);
+  color: var(--text);
 }
 
-.installer-row.expanded {
-  border-color: var(--accent);
+.installer-tool-dialog__header {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  margin: 0 2rem 0.75rem 0;
 }
 
-.installer-row.busy {
-  border-color: var(--amber);
+.installer-tool-dialog__header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
 }
 
-.installer-row__head {
+.installer-tool-dialog__version {
+  font-weight: 400;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.installer-tool-dialog__icon {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  flex: 0 0 auto;
+}
+
+.installer-tool-dialog__body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 0.25rem 0 0.5rem;
+}
+
+.installer-tool-dialog__desc {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+}
+
+.installer-tool-dialog__update-banner {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0.65rem 0.85rem;
-  cursor: pointer;
-  user-select: none;
-}
-
-.installer-row__head:hover {
-  background: var(--surface-muted);
-}
-
-.installer-row__title {
-  display: flex;
-  align-items: baseline;
-  gap: 0.5rem;
-}
-
-.installer-row__name {
-  font-weight: 500;
-}
-
-.installer-row__provider {
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  text-transform: lowercase;
-}
-
-.installer-row__meta {
-  display: flex;
-  gap: 0.4rem;
-  flex-wrap: wrap;
-}
-
-.installer-pill {
-  font-size: 0.75rem;
-  padding: 0.15rem 0.5rem;
-  border-radius: 999px;
-  background: var(--surface-muted);
-}
-
-.installer-pill.installed {
-  background: var(--green-soft);
-  color: var(--green);
-}
-
-.installer-pill.partial {
-  background: var(--amber-soft);
-  color: var(--amber);
-}
-
-.installer-pill.update {
+  padding: 0.6rem 0.85rem;
+  border-radius: 6px;
   background: var(--accent-soft);
   color: var(--accent);
+  font-size: 0.875rem;
 }
 
-.installer-pill.busy {
-  background: var(--amber-soft);
-  color: var(--amber);
-}
-
-.installer-pill.done {
-  background: var(--green-soft);
-  color: var(--green);
-}
-
-.installer-pill.failed {
-  background: color-mix(in srgb, var(--red) 14%, transparent);
-  color: var(--red);
-}
-
-.installer-pill.cancelled {
-  background: var(--surface-muted);
-  color: var(--text-muted);
-}
-
-.installer-row__body {
-  padding: 0.75rem 0.85rem 0.85rem;
-  border-top: 1px solid var(--border);
-  display: flex;
-  flex-direction: column;
-  gap: 0.65rem;
-}
-
-.installer-row__desc {
+.installer-tool-dialog__grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.4rem 0.85rem;
   margin: 0;
   font-size: 0.85rem;
+}
+
+.installer-tool-dialog__grid dt {
   color: var(--text-muted);
-}
-
-.installer-row__progress {
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-}
-
-.installer-row__step {
-  font-size: 0.85rem;
   font-weight: 500;
 }
 
-.installer-row__bar {
-  width: 100%;
-  height: 6px;
-}
-
-.installer-row__log {
+.installer-tool-dialog__grid dd {
   margin: 0;
-  padding: 0.5rem;
-  background: var(--terminal);
-  border-radius: 4px;
-  font-size: 0.75rem;
-  max-height: 12rem;
-  overflow-y: auto;
-  white-space: pre-wrap;
   word-break: break-word;
 }
 
-.installer-row__options {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+.installer-tool-dialog__grid dd code {
+  font-size: 0.8rem;
+  background: var(--surface-muted);
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+}
+
+.installer-tool-dialog__inline-action {
+  background: none;
+  border: none;
+  color: var(--accent);
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+}
+
+.installer-tool-dialog__inline-action:disabled {
+  color: var(--text-muted);
+  cursor: default;
+}
+
+.installer-tool-dialog__prereqs {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.installer-tool-dialog__prereqs li {
+  display: flex;
+  justify-content: space-between;
   gap: 0.5rem;
 }
 
-.installer-row__options label {
+.installer-tool-dialog__prereqs li[data-installed="true"] span:last-child {
+  color: var(--green);
+}
+
+.installer-tool-dialog__prereqs li[data-installed="false"] span:last-child {
+  color: var(--amber);
+}
+
+.installer-tool-dialog__pin {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.installer-tool-dialog__options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.6rem;
+  padding: 0.75rem;
+  border-radius: 6px;
+  background: var(--surface-muted);
+}
+
+.installer-tool-dialog__options label {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
   font-size: 0.8rem;
 }
 
-.installer-row__options input[type="text"],
-.installer-row__options select {
+.installer-tool-dialog__options input[type="text"],
+.installer-tool-dialog__options select {
   padding: 0.3rem 0.5rem;
   border-radius: 4px;
   border: 1px solid var(--border);
-  background: var(--surface-muted);
+  background: var(--surface);
   color: inherit;
 }
 
-.installer-row__options label:has(> input[type="checkbox"]) {
+.installer-tool-dialog__options label:has(> input[type="checkbox"]) {
   flex-direction: row;
   align-items: center;
 }
 
-.installer-row__actions {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-  align-items: center;
+.installer-tool-dialog__hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--amber);
 }
 
-.installer-row__pin {
-  margin-left: auto;
+.installer-tool-dialog__hint--warn {
+  color: var(--amber);
+}
+
+.installer-tool-dialog__hint--error {
+  color: var(--red);
+}
+
+.installer-tool-dialog__actions {
+  margin-top: auto;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--border);
+}
+
+/* ---------- InstallerInstallStepper ---------- */
+
+.installer-stepper {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.installer-stepper--legacy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.installer-stepper__legacy-step {
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.installer-stepper__row {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--surface);
+}
+
+.installer-stepper__row[data-active="true"] {
+  border-color: var(--accent);
+}
+
+.installer-stepper__row-head {
+  width: 100%;
   display: flex;
   align-items: center;
-  gap: 0.35rem;
-  font-size: 0.8rem;
+  gap: 0.6rem;
+  padding: 0.55rem 0.75rem;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.installer-stepper__row-head:hover {
+  background: var(--surface-muted);
+}
+
+.installer-stepper__dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+}
+
+.installer-stepper__dot--running {
+  background: var(--amber);
+  border-color: var(--amber);
+  animation: installer-tile-pulse 1.2s ease-in-out infinite;
+}
+
+.installer-stepper__dot--done {
+  background: var(--green);
+  border-color: var(--green);
+}
+
+.installer-stepper__dot--failed {
+  background: var(--red);
+  border-color: var(--red);
+}
+
+.installer-stepper__label {
+  flex: 1 1 auto;
+  font-size: 0.875rem;
+}
+
+.installer-stepper__meta {
+  font-size: 0.75rem;
   color: var(--text-muted);
 }
 
-.installer-row__hint {
+.installer-stepper__row-body {
+  padding: 0 0.75rem 0.6rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  border-top: 1px solid var(--border);
+}
+
+.installer-stepper__bar {
+  width: 100%;
+  height: 6px;
+}
+
+.installer-stepper__log {
   margin: 0;
-  font-size: 0.8rem;
-  color: var(--amber);
+  padding: 0.5rem;
+  background: var(--terminal, #1a1a1a);
+  color: var(--terminal-fg, #ddd);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  max-height: 10rem;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .installer-confirm-items {

--- a/src/modules/installer/progress.ts
+++ b/src/modules/installer/progress.ts
@@ -44,9 +44,8 @@ function waitForTerminalProgress(toolId: string) {
   });
   const ready = listen<ProgressEvent>(PROGRESS_EVENT_NAME, (event) => {
     const payload = event.payload;
-    if (payload.toolId !== toolId || !isTerminalProgressEvent(payload)) {
-      return;
-    }
+    if (!isTerminalProgressEvent(payload)) return;
+    if (payload.toolId !== toolId) return;
     unlisten?.();
     resolveTerminalEvent(payload);
   }).then((u) => {

--- a/src/modules/installer/state.ts
+++ b/src/modules/installer/state.ts
@@ -2,18 +2,32 @@
 //
 // Per ADR 0007 / Q13b: detection is never persisted across restarts. The
 // store auto-scans on first Module entry per app session and holds results
-// until the user clicks Refresh or quits the app. Catalog is cached on disk
-// by the Rust side; the store just mirrors the last-loaded copy.
+// until the user clicks Refresh or quits the app. Catalog is cached on
+// disk by the Rust side; the store just mirrors the last-loaded copy.
+//
+// This module owns two parallel transient slices:
+//   * inFlight — the legacy current-step + log view used by tile status
+//     dots and the back-compat path for providers that have not yet been
+//     migrated to the declared-plan stepper protocol.
+//   * stepperState — the n8n-style stepper view: declared plan, per-step
+//     status, per-step logs, per-step durations and errors. Populated from
+//     `plan` / `stepStarted` / `stepFinished` events; stdout/stderr lines
+//     get routed to the active step when they carry a stepId, otherwise to
+//     a synthetic "_general" bucket that the stepper renders as raw output
+//     above the plan rows.
 
 import { create } from "zustand";
 import type {
   Catalog,
   DetectedState,
+  PlanStep,
   ProgressEvent,
   ToolState,
 } from "./types";
 
 const MAX_LOG_LINES = 200;
+const MAX_STEP_LOG_LINES = 500;
+const GENERAL_STEP_BUCKET = "_general";
 
 interface InFlight {
   /// "install" or "uninstall"
@@ -23,13 +37,42 @@ interface InFlight {
   log: string[];
 }
 
+type StepStatus = "pending" | "running" | "done" | "failed";
+
+interface StepperState {
+  plan: PlanStep[];
+  status: Record<string, StepStatus>;
+  startedAt: Record<string, number>;
+  durations: Record<string, number>;
+  errors: Record<string, string>;
+  logs: Record<string, string[]>;
+  activeStepId: string | null;
+  startedAtMs: number;
+}
+
+interface OpenDialog {
+  toolId: string;
+  /// "info" — installed/not-installed details. "stepper" — install in
+  /// progress or just completed; the dialog body renders the stepper.
+  mode: "info" | "stepper";
+}
+
 interface InstallerStoreState {
   catalog: Catalog | null;
   detected: Record<string, DetectedState>;
   toolState: Record<string, ToolState>;
   hasInitialScanned: boolean;
   scanning: boolean;
+  /// True for the duration of a streaming check-for-updates sweep.
+  checking: boolean;
+  /// Optional per-tool error from the most recent check sweep (null when
+  /// the latest lookup succeeded).
+  checkError: Record<string, string | null>;
   inFlight: Record<string, InFlight>;
+  /// Per-tool stepper state, parallel to `inFlight`. Retained across
+  /// dialog open/close so reopening an in-flight install shows current
+  /// progress, and so a just-completed stepper can be reviewed.
+  stepperState: Record<string, StepperState>;
   /// Terminal status echo for the most recent operation per tool.
   /// `null` means no recent status.
   lastStatus: Record<
@@ -39,8 +82,10 @@ interface InstallerStoreState {
     | { kind: "cancelled" }
     | null
   >;
-  /// Per-tool detail panel expansion. Closed on Module mount.
-  expanded: Record<string, boolean>;
+  /// Tool whose detail dialog is currently open, plus dialog mode. The
+  /// dialog reads detected/toolState/stepperState from the store, so it
+  /// can be closed and reopened without losing in-flight progress.
+  openDialog: OpenDialog | null;
   /// Set to `true` for the rest of the app session once any WSL feature
   /// install completes. Docker (and anything else that `needsWsl`) is then
   /// disabled with a reboot-required hint until the user restarts Windows.
@@ -53,8 +98,11 @@ interface InstallerStoreState {
   setToolStates: (states: ToolState[]) => void;
   beginInFlight: (toolId: string, operation: "install" | "uninstall") => void;
   applyProgress: (event: ProgressEvent) => void;
-  toggleExpanded: (toolId: string) => void;
+  openInfoDialog: (toolId: string) => void;
+  openStepperDialog: (toolId: string) => void;
+  closeDialog: () => void;
   setScanning: (scanning: boolean) => void;
+  setChecking: (checking: boolean) => void;
   markInitialScanned: () => void;
   markWslJustEnabled: () => void;
   reset: () => void;
@@ -67,9 +115,12 @@ const initial: Pick<
   | "toolState"
   | "hasInitialScanned"
   | "scanning"
+  | "checking"
+  | "checkError"
   | "inFlight"
+  | "stepperState"
   | "lastStatus"
-  | "expanded"
+  | "openDialog"
   | "wslJustEnabled"
 > = {
   catalog: null,
@@ -77,9 +128,12 @@ const initial: Pick<
   toolState: {},
   hasInitialScanned: false,
   scanning: false,
+  checking: false,
+  checkError: {},
   inFlight: {},
+  stepperState: {},
   lastStatus: {},
-  expanded: {},
+  openDialog: null,
   wslJustEnabled: false,
 };
 
@@ -99,17 +153,135 @@ export const useInstallerStore = create<InstallerStoreState>((set) => ({
         ...s.inFlight,
         [toolId]: { operation, currentStep: null, ratio: null, log: [] },
       },
+      stepperState: {
+        ...s.stepperState,
+        // Fresh stepper slate for this install; an immediate `plan` event
+        // will fill it in. Pre-seeded so the stepper UI has something to
+        // render even before the first plan event lands.
+        [toolId]: {
+          plan: [],
+          status: {},
+          startedAt: {},
+          durations: {},
+          errors: {},
+          logs: {},
+          activeStepId: null,
+          startedAtMs: Date.now(),
+        },
+      },
       lastStatus: { ...s.lastStatus, [toolId]: null },
     })),
   applyProgress: (event) =>
     set((s) => {
-      const current = s.inFlight[event.toolId];
-      if (!current) return s;
+      // ---- check-for-updates protocol --------------------------------
+      if (event.kind === "checkStarted") {
+        const cleared: Record<string, string | null> = {};
+        for (const id of event.toolIds) cleared[id] = null;
+        return {
+          checking: true,
+          checkError: { ...s.checkError, ...cleared },
+        };
+      }
+      if (event.kind === "checkResult") {
+        const nextToolState = { ...s.toolState };
+        const existing = nextToolState[event.toolId];
+        nextToolState[event.toolId] = {
+          toolId: event.toolId,
+          pinned: existing?.pinned ?? false,
+          latestVersionSeen:
+            event.latestVersion ?? existing?.latestVersionSeen ?? null,
+          lastCheckAt: Math.floor(Date.now() / 1000),
+        };
+        return {
+          toolState: nextToolState,
+          checkError: {
+            ...s.checkError,
+            [event.toolId]: event.error ?? null,
+          },
+        };
+      }
+      if (event.kind === "checkFinished") {
+        return { checking: false };
+      }
+
+      // ---- install/uninstall events ---------------------------------
+      const toolId = "toolId" in event ? event.toolId : null;
+      if (!toolId) return s;
+
+      // Stepper protocol events first; they may exist even when inFlight
+      // has not been seeded yet (e.g. plan arrives before beginInFlight
+      // commits, though current code paths set beginInFlight first).
+      if (event.kind === "plan") {
+        const seeded: StepperState = {
+          plan: event.steps,
+          status: Object.fromEntries(
+            event.steps.map((step) => [step.id, "pending" as StepStatus]),
+          ),
+          startedAt: {},
+          durations: {},
+          errors: {},
+          logs: {},
+          activeStepId: null,
+          startedAtMs: s.stepperState[toolId]?.startedAtMs ?? Date.now(),
+        };
+        return {
+          stepperState: { ...s.stepperState, [toolId]: seeded },
+        };
+      }
+      if (event.kind === "stepStarted") {
+        const current =
+          s.stepperState[toolId] ?? emptyStepperState();
+        const status = { ...current.status, [event.stepId]: "running" as StepStatus };
+        const startedAt = { ...current.startedAt, [event.stepId]: Date.now() };
+        return {
+          stepperState: {
+            ...s.stepperState,
+            [toolId]: {
+              ...current,
+              status,
+              startedAt,
+              activeStepId: event.stepId,
+            },
+          },
+        };
+      }
+      if (event.kind === "stepFinished") {
+        const current =
+          s.stepperState[toolId] ?? emptyStepperState();
+        const startedAt = current.startedAt[event.stepId] ?? Date.now();
+        const status: StepStatus = event.ok ? "done" : "failed";
+        return {
+          stepperState: {
+            ...s.stepperState,
+            [toolId]: {
+              ...current,
+              status: { ...current.status, [event.stepId]: status },
+              durations: {
+                ...current.durations,
+                [event.stepId]: Date.now() - startedAt,
+              },
+              errors: event.error
+                ? { ...current.errors, [event.stepId]: event.error }
+                : current.errors,
+              activeStepId:
+                current.activeStepId === event.stepId
+                  ? null
+                  : current.activeStepId,
+            },
+          },
+        };
+      }
+
+      // Legacy inFlight slice — only updated when an install is in flight.
+      const current = s.inFlight[toolId];
+      const stepperCurrent = s.stepperState[toolId];
+
       if (event.kind === "step") {
+        if (!current) return s;
         return {
           inFlight: {
             ...s.inFlight,
-            [event.toolId]: {
+            [toolId]: {
               ...current,
               currentStep: event.message,
               log: trimLog([...current.log, `▸ ${event.message}`]),
@@ -118,26 +290,40 @@ export const useInstallerStore = create<InstallerStoreState>((set) => ({
         };
       }
       if (event.kind === "stdout" || event.kind === "stderr") {
+        const nextStepper = stepperCurrent
+          ? withStepLog(stepperCurrent, event.stepId, event.line)
+          : stepperCurrent;
+        if (!current) {
+          return nextStepper
+            ? { stepperState: { ...s.stepperState, [toolId]: nextStepper } }
+            : s;
+        }
         return {
           inFlight: {
             ...s.inFlight,
-            [event.toolId]: {
+            [toolId]: {
               ...current,
               log: trimLog([...current.log, event.line]),
             },
           },
+          ...(nextStepper
+            ? { stepperState: { ...s.stepperState, [toolId]: nextStepper } }
+            : {}),
         };
       }
       if (event.kind === "progress") {
+        if (!current) return s;
         return {
           inFlight: {
             ...s.inFlight,
-            [event.toolId]: { ...current, ratio: event.ratio },
+            [toolId]: { ...current, ratio: event.ratio },
           },
         };
       }
-      // Terminal events: drop in-flight, record lastStatus.
-      const { [event.toolId]: _gone, ...restInFlight } = s.inFlight;
+
+      // Terminal events: drop in-flight, record lastStatus. Stepper state
+      // stays around so the user can review what just happened.
+      const { [toolId]: _gone, ...restInFlight } = s.inFlight;
       const lastStatus: InstallerStoreState["lastStatus"][string] =
         event.kind === "completed"
           ? { kind: "completed", installedVersion: event.installedVersion }
@@ -146,22 +332,50 @@ export const useInstallerStore = create<InstallerStoreState>((set) => ({
             : { kind: "cancelled" };
       return {
         inFlight: restInFlight,
-        lastStatus: { ...s.lastStatus, [event.toolId]: lastStatus },
+        lastStatus: { ...s.lastStatus, [toolId]: lastStatus },
       };
     }),
-  toggleExpanded: (toolId) =>
-    set((s) => ({
-      expanded: { ...s.expanded, [toolId]: !s.expanded[toolId] },
-    })),
+  openInfoDialog: (toolId) => set({ openDialog: { toolId, mode: "info" } }),
+  openStepperDialog: (toolId) =>
+    set({ openDialog: { toolId, mode: "stepper" } }),
+  closeDialog: () => set({ openDialog: null }),
   setScanning: (scanning) => set({ scanning }),
+  setChecking: (checking) => set({ checking }),
   markInitialScanned: () => set({ hasInitialScanned: true }),
   markWslJustEnabled: () => set({ wslJustEnabled: true }),
   reset: () => set(initial),
 }));
+
+function emptyStepperState(): StepperState {
+  return {
+    plan: [],
+    status: {},
+    startedAt: {},
+    durations: {},
+    errors: {},
+    logs: {},
+    activeStepId: null,
+    startedAtMs: Date.now(),
+  };
+}
+
+function withStepLog(
+  current: StepperState,
+  stepId: string | undefined,
+  line: string,
+): StepperState {
+  const bucket = stepId ?? current.activeStepId ?? GENERAL_STEP_BUCKET;
+  const prev = current.logs[bucket] ?? [];
+  const next = prev.length >= MAX_STEP_LOG_LINES
+    ? [...prev.slice(prev.length - MAX_STEP_LOG_LINES + 1), line]
+    : [...prev, line];
+  return { ...current, logs: { ...current.logs, [bucket]: next } };
+}
 
 function trimLog(lines: string[]): string[] {
   if (lines.length <= MAX_LOG_LINES) return lines;
   return lines.slice(lines.length - MAX_LOG_LINES);
 }
 
-export type { InstallerStoreState };
+export { GENERAL_STEP_BUCKET };
+export type { InstallerStoreState, StepperState, StepStatus };

--- a/src/modules/installer/types.ts
+++ b/src/modules/installer/types.ts
@@ -34,6 +34,21 @@ export interface Recipe {
   category?: string;
   provider: Provider;
   options?: RecipeOption[];
+  /// Optional official project website, surfaced in the not-installed dialog.
+  homepage?: string;
+  /// Optional release-notes / changelog URL. UI derives a fallback from the
+  /// provider when absent.
+  releaseNotesUrl?: string;
+}
+
+/// Stepper plan declared by a provider runner before any work begins. The
+/// frontend renders one row per step in declared order, lighting each up as
+/// `StepStarted` / `StepFinished` events land.
+export interface PlanStep {
+  id: string;
+  /// i18n key under `installer.steps.*`. The frontend resolves it through
+  /// `t()`; the backend never sends English strings.
+  labelKey: string;
 }
 
 export interface Catalog {
@@ -46,6 +61,9 @@ export interface DetectedState {
   installed: boolean;
   installedVersion: string | null;
   partialCount: [number, number] | null;
+  /// Best-effort install directory. Populated for github-release recipes
+  /// (we own the install dir); null elsewhere. UI hides the row when null.
+  installLocation?: string | null;
 }
 
 export interface ToolState {
@@ -63,17 +81,34 @@ export interface InstallOptions {
 }
 
 export type ProgressEvent =
+  | { kind: "plan"; toolId: string; steps: PlanStep[] }
+  | { kind: "stepStarted"; toolId: string; stepId: string }
+  | {
+      kind: "stepFinished";
+      toolId: string;
+      stepId: string;
+      ok: boolean;
+      error?: string;
+    }
   | { kind: "step"; toolId: string; message: string }
-  | { kind: "stdout"; toolId: string; line: string }
-  | { kind: "stderr"; toolId: string; line: string }
-  | { kind: "progress"; toolId: string; ratio: number }
+  | { kind: "stdout"; toolId: string; stepId?: string; line: string }
+  | { kind: "stderr"; toolId: string; stepId?: string; line: string }
+  | { kind: "progress"; toolId: string; stepId?: string; ratio: number }
   | {
       kind: "completed";
       toolId: string;
       installedVersion: string | null;
     }
   | { kind: "failed"; toolId: string; message: string }
-  | { kind: "cancelled"; toolId: string };
+  | { kind: "cancelled"; toolId: string }
+  | { kind: "checkStarted"; toolIds: string[] }
+  | {
+      kind: "checkResult";
+      toolId: string;
+      latestVersion: string | null;
+      error?: string;
+    }
+  | { kind: "checkFinished" };
 
 export const PROGRESS_EVENT_NAME = "installer://progress";
 


### PR DESCRIPTION
## Summary

- Replaces inline tile expansion with `InstallerToolDialog` — info mode for installed/not-installed tools, and an n8n-style top-down stepper while installing/uninstalling.
- Fixes the Module-entry console-flash storm: all detection/check spawns now set `CREATE_NO_WINDOW`, and winget detection uses one batched `winget list` snapshot per sweep instead of one process per recipe.
- Makes Check for updates non-blocking: streaming `checkStarted` → per-tool `checkResult` (parallel lookups, bounded pool) → `checkFinished`, with rows lighting up incrementally.

## What changed

**Backend ([src-tauri/src/installer/](src-tauri/src/installer))**
- New [`proc.rs`](src-tauri/src/installer/proc.rs) with `no_window()` helper applied to every detect/check spawn (winget, npm, dism).
- [`detect.rs`](src-tauri/src/installer/detect.rs): coalesced winget detection via `refresh_winget_snapshot` + `invalidate_winget_snapshot`; `DetectedState.install_location` populated for github-release recipes.
- [`events.rs`](src-tauri/src/installer/events.rs): new `Plan` / `StepStarted` / `StepFinished` + `CheckStarted` / `CheckResult` / `CheckFinished` variants. `Stdout` / `Stderr` / `Progress` gained optional `step_id`.
- [`commands.rs`](src-tauri/src/installer/commands.rs): `installer_check_latest_versions` now streams results via `std::thread::scope` with 4-way parallelism; cancellable via the synthetic `__check_updates__` id. `installer_redetect` invalidates the winget snapshot.
- [`schema.rs`](src-tauri/src/installer/schema.rs): optional `homepage` / `release_notes_url` on `Recipe`; new `PlanStep` type.

**Frontend ([src/modules/installer/](src/modules/installer))**
- New [`InstallerToolDialog.tsx`](src/modules/installer/InstallerToolDialog.tsx) — three modes: installed-info, not-installed-info, stepper. App-owned, top-right close, Windows-order footer.
- [`ToolRow.tsx`](src/modules/installer/ToolRow.tsx) stripped to tile-only; click opens the dialog (stepper if busy, info otherwise).
- [`state.ts`](src/modules/installer/state.ts) gained `openDialog`, `checking`, `stepperState` (plan/status/durations/errors/per-step logs). `applyProgress` routes new event variants.
- [`installer.css`](src/modules/installer/installer.css): removed `.installer-tile.expanded` and `.installer-row__*`; added `.installer-tool-dialog__*` and `.installer-stepper__*`.
- [`types.ts`](src/modules/installer/types.ts) mirrored new schema/event shapes.

**i18n / docs**
- 29 new English keys under `installer.dialog.*`, `installer.stepper.*`, `installer.steps.*`, plus `installer.checkingDots`.
- 29 matching pending-translation files under [docs/localization_todo/](docs/localization_todo/) following the project's per-key workflow.
- [docs/manual/18-installer.md](docs/manual/18-installer.md) updated for the popup flow, streaming check, declared-plan event protocol, and console-flash suppression.

## Deferred (tracked as Phase 2b)

Per-provider plan migration in `install.rs` — wrapping each runner with a `with_step(step_id, …)` helper that injects `step_id` into emitted stdout/stderr/progress. Until that lands, the stepper falls back to today's legacy single-current-step view for in-flight installs. Everything else (dialog UX, streaming check, console-flash fix, winget coalescing) is fully operational now.

## Test plan

- [ ] `npm run check` passes (verified locally)
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml` passes (verified locally)
- [ ] Enter Installer Helper Module fresh — no cmd.exe windows flash on screen
- [ ] Click a tool tile — dialog opens; installed tools show info+uninstall; not-installed show details+install
- [ ] Press Check for updates — button shows "Checking…" and stays clickable; rows update incrementally as results arrive
- [ ] Press Install on a not-installed tool — dialog flips to stepper view; progress streams live; Cancel works
- [ ] Reopen the dialog while an install is in flight — sees current progress (state retained)
- [ ] Uninstall flow still triggers the dependents-warning confirm dialog where applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)