### PR TITLE
Fix RDP automatic resolution coming up small until pane is nudged

### DIFF
--- a/src-tauri/src/rdp.rs
+++ b/src-tauri/src/rdp.rs
@@ -452,6 +452,8 @@ mod platform {
         dispatch: IDispatch,
         desktop_width: i32,
         desktop_height: i32,
+        desktop_scale_factor: i32,
+        device_scale_factor: i32,
         resolution_mode: RemoteResolutionMode,
     }
 
@@ -918,6 +920,8 @@ mod platform {
                 // startup bounds pushes retry the real remote desktop resize.
                 desktop_width: 0,
                 desktop_height: 0,
+                desktop_scale_factor: 0,
+                device_scale_factor: 0,
                 resolution_mode,
             },
         );
@@ -1787,8 +1791,12 @@ mod platform {
             && !should_resize_remote_desktop(
                 session.desktop_width,
                 session.desktop_height,
+                session.desktop_scale_factor,
+                session.device_scale_factor,
                 display_settings.desktop_width,
                 display_settings.desktop_height,
+                display_settings.desktop_scale_factor,
+                display_settings.device_scale_factor,
             )
         {
             return true;
@@ -1798,16 +1806,30 @@ mod platform {
         }
         session.desktop_width = display_settings.desktop_width;
         session.desktop_height = display_settings.desktop_height;
+        session.desktop_scale_factor = display_settings.desktop_scale_factor;
+        session.device_scale_factor = display_settings.device_scale_factor;
         true
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn should_resize_remote_desktop(
         current_width: i32,
         current_height: i32,
+        current_desktop_scale_factor: i32,
+        current_device_scale_factor: i32,
         desktop_width: i32,
         desktop_height: i32,
+        desktop_scale_factor: i32,
+        device_scale_factor: i32,
     ) -> bool {
-        current_width != desktop_width || current_height != desktop_height
+        // Compare the DPI scale factors alongside the pixel dimensions: the RDP
+        // ActiveX control can land at the right resolution but the wrong scale
+        // (the first UpdateSessionDisplaySettings after Connect is frequently
+        // ignored), and a scale-only correction must still re-issue the resize.
+        current_width != desktop_width
+            || current_height != desktop_height
+            || current_desktop_scale_factor != desktop_scale_factor
+            || current_device_scale_factor != device_scale_factor
     }
 
     fn resize_remote_desktop(
@@ -2282,9 +2304,31 @@ mod platform {
 
         #[test]
         fn treats_unknown_desktop_size_as_needing_resize() {
-            assert!(should_resize_remote_desktop(0, 0, 1920, 1080));
-            assert!(should_resize_remote_desktop(1920, 1080, 2048, 1080));
-            assert!(!should_resize_remote_desktop(1920, 1080, 1920, 1080));
+            // (current_w, current_h, current_desktop_scale, current_device_scale,
+            //  target_w, target_h, target_desktop_scale, target_device_scale)
+            assert!(should_resize_remote_desktop(0, 0, 0, 0, 1920, 1080, 100, 100));
+            assert!(should_resize_remote_desktop(
+                1920, 1080, 100, 100, 2048, 1080, 100, 100
+            ));
+            assert!(!should_resize_remote_desktop(
+                1920, 1080, 100, 100, 1920, 1080, 100, 100
+            ));
+        }
+
+        #[test]
+        fn treats_scale_factor_change_as_needing_resize() {
+            // Same pixel dimensions, but a corrected DPI scale still re-applies:
+            // the early post-Connect display sync often lands at 100% before the
+            // session is interactive enough to honor the host scale factor.
+            assert!(should_resize_remote_desktop(
+                1920, 1080, 100, 100, 1920, 1080, 150, 140
+            ));
+            assert!(should_resize_remote_desktop(
+                1920, 1080, 150, 100, 1920, 1080, 150, 140
+            ));
+            assert!(!should_resize_remote_desktop(
+                1920, 1080, 150, 140, 1920, 1080, 150, 140
+            ));
         }
 
         #[test]

--- a/src/modules/workspace/connections/remote-desktop/RemoteDesktopWorkspace.tsx
+++ b/src/modules/workspace/connections/remote-desktop/RemoteDesktopWorkspace.tsx
@@ -67,6 +67,13 @@ type VncSessionEvent =
 
 const RDP_ESTABLISHING_STATE = 2;
 const RDP_PRE_CAPTURE_INTERVAL_MS = 800;
+// After the RDP control first reports a displayable session, re-issue the
+// display-size sync a few more times. The MsRdpClient ActiveX frequently
+// ignores the first UpdateSessionDisplaySettings (it fires at the pre-login
+// screen, before the Display Control channel is ready), which left "automatic"
+// resolution stuck small until a manual pane nudge forced another resize.
+const RDP_DISPLAY_SETTLE_INTERVAL_MS = 1200;
+const RDP_DISPLAY_SETTLE_PASSES = 2;
 
 function createRemoteDesktopSessionId(kind: "rdp" | "vnc") {
   return `${kind}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
@@ -95,6 +102,8 @@ export function RemoteDesktopWorkspace({
   const rafRef = useRef<number | null>(null);
   const displayReadyRef = useRef(false);
   const displaySyncInFlightRef = useRef(false);
+  const displaySettleTimerRef = useRef<number | null>(null);
+  const displaySettlePassesRef = useRef(0);
   const rdpVisibleRef = useRef(false);
   const rdpControlRef = useRef("");
   const rdpSuppressionCaptureInFlightRef = useRef(false);
@@ -493,6 +502,66 @@ export function RemoteDesktopWorkspace({
     }
   };
 
+  const cancelRdpDisplaySettle = () => {
+    if (displaySettleTimerRef.current !== null) {
+      window.clearTimeout(displaySettleTimerRef.current);
+      displaySettleTimerRef.current = null;
+    }
+    displaySettlePassesRef.current = 0;
+  };
+
+  // Re-apply the remote display size for a short window after the session first
+  // becomes displayable. The first resize commonly lands before the session is
+  // interactive enough to honor it (especially the host DPI scale factor), so
+  // we re-issue it a couple of times instead of waiting for a manual nudge.
+  const scheduleRdpDisplaySettle = () => {
+    if (displaySettleTimerRef.current !== null) {
+      return;
+    }
+    displaySettlePassesRef.current = 0;
+    const run = () => {
+      displaySettleTimerRef.current = null;
+      const sessionId = sessionIdRef.current;
+      if (
+        !sessionStartedRef.current ||
+        !sessionId ||
+        !visibilityRef.current.isActive ||
+        visibilityRef.current.suppressed
+      ) {
+        return;
+      }
+      const bounds = computeBounds() ?? lastBoundsRef.current;
+      if (!bounds) {
+        return;
+      }
+      void invokeCommand("sync_rdp_display_size", {
+        request: { sessionId, ...bounds },
+      })
+        .then((result) => {
+          if (sessionIdRef.current !== result.sessionId) {
+            return;
+          }
+          if (result.displaySynced) {
+            lastBoundsRef.current = bounds;
+          }
+        })
+        .catch(() => {
+          // Settle passes are best-effort; the ResizeObserver path still
+          // re-syncs on any subsequent real bounds change.
+        })
+        .finally(() => {
+          displaySettlePassesRef.current += 1;
+          if (displaySettlePassesRef.current < RDP_DISPLAY_SETTLE_PASSES) {
+            displaySettleTimerRef.current = window.setTimeout(
+              run,
+              RDP_DISPLAY_SETTLE_INTERVAL_MS,
+            );
+          }
+        });
+    };
+    displaySettleTimerRef.current = window.setTimeout(run, RDP_DISPLAY_SETTLE_INTERVAL_MS);
+  };
+
   const attemptRdpDisplaySync = () => {
     const sessionId = sessionIdRef.current;
     if (
@@ -527,6 +596,7 @@ export function RemoteDesktopWorkspace({
               : t("remoteDesktop.connected"),
           );
           pushRdpVisibility();
+          scheduleRdpDisplaySettle();
         } else if (result.connected) {
           markRdpConnectionStarted();
           setRdpStatus(t("remoteDesktop.preparingDisplay"));
@@ -547,6 +617,7 @@ export function RemoteDesktopWorkspace({
       window.cancelAnimationFrame(rafRef.current);
       rafRef.current = null;
     }
+    cancelRdpDisplaySettle();
     sessionStartedRef.current = false;
     sessionStartingRef.current = false;
     rdpConnectionCountedRef.current = false;
@@ -765,6 +836,7 @@ export function RemoteDesktopWorkspace({
         window.cancelAnimationFrame(rafRef.current);
         rafRef.current = null;
       }
+      cancelRdpDisplaySettle();
       const ownsSession = sessionStartingRef.current || sessionStartedRef.current;
       sessionStartingRef.current = false;
       const counted = rdpConnectionCountedRef.current;


### PR DESCRIPTION
## Summary

Fixes RDP connections with `remoteResolution = automatic` coming up at the wrong (small) size on initial connect, only growing to the correct size after the pane was "nudged" (e.g. hiding/showing the connection tree).

## Root cause

A two-part interaction:

1. **The first `UpdateSessionDisplaySettings` fires too early to stick.** The frontend calls `sync_rdp_display_size` the moment the `MsRdpClient` ActiveX control reports `CONNECTED` — which is the pre-login screen, *before* the Display Control Virtual Channel that the API depends on is ready. This is a [well-documented MSTSCAX quirk](https://devolutions.net/blog/smart-resizing-and-high-dpi-issues-in-remote-desktop-manager/): the call only takes effect a (variable) second or two *after* connect. Once it returned, `displayReadyRef` latched and the frontend stopped re-applying.
2. **The resize gate ignored scale factors.** `should_resize_remote_desktop` compared only pixel dimensions, so a corrected DPI scale factor with identical resolution could never re-trigger the resize.

The manual nudge "worked" only because it perturbs width/height, which forced another `UpdateSessionDisplaySettings` — by then the session is interactive, so it finally took effect.

## Changes

**Frontend (`RemoteDesktopWorkspace.tsx`)**
- After the session first becomes displayable, re-issue `sync_rdp_display_size` a couple more times (`RDP_DISPLAY_SETTLE_PASSES` at `RDP_DISPLAY_SETTLE_INTERVAL_MS` spacing) so the display size is applied once the session is genuinely interactive — no manual nudge needed. Settle timers are cancelled on session reset and component unmount.

**Rust (`rdp.rs`)**
- Track `desktop_scale_factor`/`device_scale_factor` on `RdpSession` and include them in `should_resize_remote_desktop`, so a scale-only correction still re-issues `UpdateSessionDisplaySettings`.

## Testing

- `cargo test --lib rdp::` — 19 passed, including the updated `treats_unknown_desktop_size_as_needing_resize` (new signature) and the new `treats_scale_factor_change_as_needing_resize`.
- `tsc --noEmit` — clean.

## Reviewer notes

- Not yet verified against a live RDP host; the logic mirrors the existing post-nudge resize path that already works. Worth a manual smoke test on a high-DPI host with `remoteResolution = automatic`.
- The settle passes reuse the existing `sync_rdp_display_size` command (which always force-resizes), so they exercise the same code path the manual nudge did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
