### PR TITLE
Hotfix: RDP desktop never shows after #180 (settle parked window off-screen)

### DIFF
--- a/src-tauri/src/rdp.rs
+++ b/src-tauri/src/rdp.rs
@@ -372,6 +372,13 @@ mod platform {
         y: f64,
         width: f64,
         height: f64,
+        // When set, re-issue the remote desktop resize even if the cached
+        // desktop size/scale already matches. Used by the post-connect settle
+        // passes: the ActiveX control often ignores the first resize, so we
+        // re-apply it (while keeping the control on-screen) once the session
+        // is interactive, instead of relying on a manual pane nudge.
+        #[serde(default)]
+        force: bool,
     }
 
     #[derive(Deserialize)]
@@ -506,6 +513,7 @@ mod platform {
                     request.y,
                     request.width,
                     request.height,
+                    request.force,
                 )
             })
         }
@@ -1761,6 +1769,7 @@ mod platform {
         y: f64,
         width: f64,
         height: f64,
+        force: bool,
     ) -> Result<(), String> {
         let rect = show_rdp(
             session.hwnd,
@@ -1778,7 +1787,7 @@ mod platform {
             session
                 .resolution_mode
                 .display_settings(width, height, rect.2, rect.3, scale_factor);
-        let _ = sync_remote_desktop_size(session, display_settings, false);
+        let _ = sync_remote_desktop_size(session, display_settings, force);
         Ok(())
     }
 
@@ -2435,6 +2444,8 @@ mod platform {
         pub y: f64,
         pub width: f64,
         pub height: f64,
+        #[serde(default)]
+        pub force: bool,
     }
 
     #[derive(Deserialize)]

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -600,6 +600,11 @@ export interface UpdateRdpBoundsRequest {
   y: number;
   width: number;
   height: number;
+  /**
+   * Re-apply the remote desktop resize even when the cached size already
+   * matches. Used by the post-connect settle passes; defaults to false.
+   */
+  force?: boolean;
 }
 
 export interface SetRdpVisibilityRequest {

--- a/src/modules/workspace/connections/remote-desktop/RemoteDesktopWorkspace.tsx
+++ b/src/modules/workspace/connections/remote-desktop/RemoteDesktopWorkspace.tsx
@@ -514,6 +514,8 @@ export function RemoteDesktopWorkspace({
   // becomes displayable. The first resize commonly lands before the session is
   // interactive enough to honor it (especially the host DPI scale factor), so
   // we re-issue it a couple of times instead of waiting for a manual nudge.
+  // This goes through update_rdp_bounds (which keeps the control on-screen) with
+  // force=true, rather than sync_rdp_display_size (which stages it off-screen).
   const scheduleRdpDisplaySettle = () => {
     if (displaySettleTimerRef.current !== null) {
       return;
@@ -525,6 +527,8 @@ export function RemoteDesktopWorkspace({
       if (
         !sessionStartedRef.current ||
         !sessionId ||
+        !displayReadyRef.current ||
+        !rdpVisibleRef.current ||
         !visibilityRef.current.isActive ||
         visibilityRef.current.suppressed
       ) {
@@ -534,24 +538,20 @@ export function RemoteDesktopWorkspace({
       if (!bounds) {
         return;
       }
-      void invokeCommand("sync_rdp_display_size", {
-        request: { sessionId, ...bounds },
+      lastBoundsRef.current = bounds;
+      void invokeCommand("update_rdp_bounds", {
+        request: { sessionId, ...bounds, force: true },
       })
-        .then((result) => {
-          if (sessionIdRef.current !== result.sessionId) {
-            return;
-          }
-          if (result.displaySynced) {
-            lastBoundsRef.current = bounds;
-          }
-        })
         .catch(() => {
           // Settle passes are best-effort; the ResizeObserver path still
           // re-syncs on any subsequent real bounds change.
         })
         .finally(() => {
           displaySettlePassesRef.current += 1;
-          if (displaySettlePassesRef.current < RDP_DISPLAY_SETTLE_PASSES) {
+          if (
+            displaySettlePassesRef.current < RDP_DISPLAY_SETTLE_PASSES &&
+            sessionStartedRef.current
+          ) {
             displaySettleTimerRef.current = window.setTimeout(
               run,
               RDP_DISPLAY_SETTLE_INTERVAL_MS,


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by #180. After that change, RDP connections showed **"Connected"** in the toolbar but the remote desktop **never appeared** (only the placeholder was visible).

## Root cause

The post-connect "settle" passes added in #180 called `sync_rdp_display_size`. Its Rust handler stages the native RDP ActiveX window **off-screen** (`stage_rdp` → `SetWindowPos` to the hidden staging position) and depends on a following `set_rdp_visibility` to bring it back. In the normal connect flow that follow-up happens; the settle had none, so ~1.2s after connect it parked the desktop off-screen and it never reappeared.

## Fix

Re-apply the display size through the **visible** path instead of the staging path:

- Added an optional `force` flag to `UpdateRdpBoundsRequest`, threaded through `update_bounds` → `show_and_resize_rdp` → `sync_remote_desktop_size`. This keeps the control on-screen (`show_rdp`) while still re-issuing `UpdateSessionDisplaySettings` even when the cached desktop size is unchanged (necessary because the ActiveX control commonly ignores the first resize).
- The settle now calls `update_rdp_bounds` with `force: true` — the exact path a manual pane nudge already uses — and only runs while the session is `ready && visible`, so it can never stage the window off-screen.

The scale-aware resize gate from #180 is unaffected (it can only make the gate stricter; it never hides the window).

## Testing

- `cargo test --lib rdp::` — 19 passed.
- `tsc --noEmit` — clean.

## Reviewer notes

- This restores the on-screen behavior and preserves the original goal of #180 (automatic resolution converging without a manual nudge), now via a path that keeps the native window visible.
- Still worth a live smoke test on the high-DPI host, since the off-screen regression only manifested at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
