### PR TITLE
Add dashboard view tab reorder

### DIFF
--- a/docs/manual/10-dashboard.md
+++ b/docs/manual/10-dashboard.md
@@ -21,6 +21,7 @@ A View is a Dashboard tab. The first View is named `dashboard.defaultView` and s
 - Rename: `dashboard.renameView`.
 - Remove: `dashboard.removeView`. Confirmation body `dashboard.deleteViewBody`.
 - Tab color styling: `dashboard.viewTabGradient`, theme/default swatch `dashboard.clearViewTabGradient`.
+- In edit layout mode, drag View tab buttons to reorder Dashboard Views.
 
 Each View has its own `grid_density` (`dashboard.density.compact`, `dashboard.density.default`, `dashboard.density.roomy`) and its own background.
 Previously opened Views remain mounted while hidden so switching between View tabs preserves Widget Instance state and keeps embedded Connection panes responsive; hidden Connection panes are marked inactive instead of being closed. Embedded URL Connection panes use a native WebView2 child surface in the desktop runtime, so KKTerm explicitly hides that native surface whenever its Dashboard View or the Dashboard Module is inactive.
@@ -28,7 +29,7 @@ Previously opened Views remain mounted while hidden so switching between View ta
 ## Edit layout mode
 
 `dashboard.editLayout` toggles drag/drop + resize on the 12-column grid. Done editing: `dashboard.editDone`. Empty Views show `dashboard.emptyTitle` and `dashboard.emptyHint`.
-Right-clicking empty Dashboard View canvas space opens a shortcut menu for `dashboard.addWidgetLabel`, `dashboard.editLayout`, and `dashboard.changeBackground`.
+Right-clicking empty Dashboard View canvas space opens a shortcut menu for `dashboard.addWidgetLabel`, `dashboard.editLayout`, and `dashboard.changeBackground`. While edit layout mode is active, the same empty-canvas menu remains available and the edit command uses `dashboard.editDone`.
 
 While editing:
 

--- a/src/modules/dashboard/DashboardPage.tsx
+++ b/src/modules/dashboard/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { Edit3, Plus } from "lucide-react";
-import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type PointerEvent } from "react";
 import { useTranslation } from "react-i18next";
 import type { AssistantPageContext } from "../../ai/AssistantPanel";
 import { DeleteConfirmationDialog } from "../../app/DeleteConfirmationDialog";
@@ -21,6 +21,7 @@ import type { DashboardView, DashboardWidgetInstance, GridDensity } from "./type
 import { dashboardVisualContextForView } from "./visualContext";
 import { DashboardBackgroundHost } from "./view/DashboardBackgroundHost";
 import { DashboardCanvas, DENSITY_SETTINGS } from "./view/DashboardCanvas";
+import { reorderDashboardViews, type DashboardViewReorderPlacement } from "./view/viewReorder";
 import type { DashboardWidgetDeleteRequest } from "./view/WidgetFrame";
 
 function parseJsonObject(value: string | null | undefined): Record<string, unknown> | null {
@@ -96,6 +97,7 @@ export function DashboardPage({
   const removeView = useDashboardStore((s) => s.removeView);
   const removeInstance = useDashboardStore((s) => s.removeInstance);
   const setViewTabColor = useDashboardStore((s) => s.setViewTabColor);
+  const reorderViews = useDashboardStore((s) => s.reorderViews);
   const defaultLandingView = useWorkspaceStore((s) => s.dashboardSettings.defaultLandingView);
 
   const [catalogOpen, setCatalogOpen] = useState(false);
@@ -107,6 +109,20 @@ export function DashboardPage({
   const [backgroundOpen, setBackgroundOpen] = useState(false);
   const [mcpServers, setMcpServers] = useState<McpServer[]>([]);
   const appliedLandingPref = useRef(false);
+  const viewDragRef = useRef<{
+    id: string;
+    pointerId: number;
+    startX: number;
+    startY: number;
+    active: boolean;
+  } | null>(null);
+  const viewDragDropRef = useRef<{ targetId: string | null; placement: DashboardViewReorderPlacement } | null>(null);
+  const suppressViewClickRef = useRef(false);
+  const [viewDragState, setViewDragState] = useState<{
+    draggedId: string;
+    targetId: string | null;
+    placement: DashboardViewReorderPlacement;
+  } | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -167,6 +183,66 @@ export function DashboardPage({
       "--dw-grid-gap-x": `${densitySettings.margin[0]}px`,
       "--dw-grid-gap-y": `${densitySettings.margin[1]}px`,
     } as CSSProperties;
+  }
+
+  function resetViewDrag() {
+    viewDragRef.current = null;
+    viewDragDropRef.current = null;
+    setViewDragState(null);
+  }
+
+  function onViewPillPointerDown(event: PointerEvent<HTMLDivElement>, viewId: string) {
+    if (!editMode || event.button !== 0) return;
+    const target = event.target as HTMLElement;
+    if (target.closest(".dashboard-pill-dot, .dashboard-pill-close, .dashboard-pill-rename")) return;
+    viewDragRef.current = {
+      id: viewId,
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      active: false,
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  }
+
+  function onViewPillPointerMove(event: PointerEvent<HTMLDivElement>) {
+    const drag = viewDragRef.current;
+    if (!editMode || !drag || drag.pointerId !== event.pointerId) return;
+
+    const distance = Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY);
+    if (!drag.active && distance < 4) return;
+    drag.active = true;
+    event.preventDefault();
+
+    const target = document
+      .elementFromPoint(event.clientX, event.clientY)
+      ?.closest<HTMLElement>(".dashboard-pill[data-view-id]");
+    const targetId = target?.dataset.viewId ?? null;
+    let placement: DashboardViewReorderPlacement = "before";
+    if (target) {
+      const rect = target.getBoundingClientRect();
+      placement = event.clientX > rect.left + rect.width / 2 ? "after" : "before";
+    }
+    viewDragDropRef.current = { targetId, placement };
+    setViewDragState({ draggedId: drag.id, targetId, placement });
+  }
+
+  function onViewPillPointerUp(event: PointerEvent<HTMLDivElement>) {
+    const drag = viewDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+
+    const wasActive = drag.active;
+    const target = viewDragDropRef.current?.targetId;
+    const placement = viewDragDropRef.current?.placement ?? "before";
+    resetViewDrag();
+    if (!wasActive || !target) return;
+
+    suppressViewClickRef.current = true;
+    window.setTimeout(() => {
+      suppressViewClickRef.current = false;
+    }, 0);
+    const orderedIds = reorderDashboardViews(views, drag.id, target, placement);
+    if (orderedIds) void reorderViews(orderedIds);
   }
 
   useEffect(() => {
@@ -297,7 +373,7 @@ export function DashboardPage({
         <div className="dashboard-brand">
           <span className="crumb">{t("dashboard.title")}</span>
         </div>
-        <div className="dashboard-view-pills">
+        <div className={`dashboard-view-pills${editMode ? " is-editing" : ""}`}>
           {views.map((v) => {
             const isActiveView = v.id === activeView.id;
             const isEditingView = editingViewId === v.id;
@@ -306,10 +382,16 @@ export function DashboardPage({
             return (
               <div
                 key={v.id}
-                className={`dashboard-pill${isActiveView ? " active" : ""}${isEditingView ? " editing" : ""}${v.tabColor ? " has-tab-color" : ""}`}
+                className={`dashboard-pill${isActiveView ? " active" : ""}${isEditingView ? " editing" : ""}${v.tabColor ? " has-tab-color" : ""}${viewDragState?.draggedId === v.id ? " is-dragging" : ""}${viewDragState?.targetId === v.id ? ` is-drop-${viewDragState.placement}` : ""}`}
+                data-view-id={v.id}
                 onClick={() => {
+                  if (suppressViewClickRef.current) return;
                   if (!isEditingView) setActiveView(v.id);
                 }}
+                onPointerDown={(event) => onViewPillPointerDown(event, v.id)}
+                onPointerMove={onViewPillPointerMove}
+                onPointerUp={onViewPillPointerUp}
+                onPointerCancel={resetViewDrag}
                 style={dashboardTabColorStyle(v.tabColor)}
               >
                 {editMode ? (

--- a/src/modules/dashboard/dashboard.css
+++ b/src/modules/dashboard/dashboard.css
@@ -611,6 +611,36 @@ main.dashboard-page.dashboard-page-hidden,
   padding-left: 14px;
 }
 
+.dashboard-view-pills.is-editing .dashboard-pill {
+  cursor: grab;
+}
+
+.dashboard-view-pills.is-editing .dashboard-pill.is-dragging {
+  cursor: grabbing;
+  opacity: 0.62;
+}
+
+.dashboard-pill.is-drop-before::before,
+.dashboard-pill.is-drop-after::before {
+  content: "";
+  position: absolute;
+  top: 5px;
+  bottom: 5px;
+  z-index: 2;
+  width: 2px;
+  background: var(--accent);
+  border-radius: 999px;
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+.dashboard-pill.is-drop-before::before {
+  left: -3px;
+}
+
+.dashboard-pill.is-drop-after::before {
+  right: -3px;
+}
+
 .dashboard-pill-main {
   min-width: 0;
   padding: 0;
@@ -631,8 +661,22 @@ main.dashboard-page.dashboard-page-hidden,
   color: var(--text);
   background: var(--surface);
   border-color: var(--border);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 6%);
+  box-shadow:
+    0 1px 2px rgb(0 0 0 / 6%),
+    0 0 0 1px var(--accent),
+    0 0 0 4px color-mix(in srgb, var(--accent) 14%, transparent);
   font-weight: 650;
+}
+
+.dashboard-pill.active::after {
+  content: "";
+  position: absolute;
+  inset: -3px;
+  pointer-events: none;
+  border: 1px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  border-radius: inherit;
+  opacity: 0.45;
+  animation: dashboard-pill-selected-pulse 2.4s ease-in-out infinite;
 }
 
 .dashboard-pill.has-tab-color {
@@ -648,7 +692,9 @@ main.dashboard-page.dashboard-page-hidden,
   border-color: rgb(0 0 0 / 16%);
   box-shadow:
     0 1px 2px rgb(0 0 0 / 10%),
-    inset 0 0 0 1px rgb(255 255 255 / 18%);
+    inset 0 0 0 1px rgb(255 255 255 / 18%),
+    0 0 0 2px color-mix(in srgb, var(--accent) 60%, white 20%),
+    0 0 0 5px color-mix(in srgb, var(--accent) 16%, transparent);
 }
 
 .dashboard-pill-dot {
@@ -711,6 +757,25 @@ button.dashboard-pill-dot:focus-visible {
 .dashboard-pill.has-tab-color .dashboard-pill-close:hover {
   color: var(--dashboard-pill-text);
   background: rgb(255 255 255 / 20%);
+}
+
+@keyframes dashboard-pill-selected-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.32;
+  }
+
+  50% {
+    transform: scale(1.045);
+    opacity: 0.78;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dashboard-pill.active::after {
+    animation: none;
+  }
 }
 
 .dashboard-tab-gradient-popover {

--- a/src/modules/dashboard/state/dashboardStore.ts
+++ b/src/modules/dashboard/state/dashboardStore.ts
@@ -52,6 +52,7 @@ interface DashboardStoreState {
   setViewDensity: (id: string, density: GridDensity) => Promise<void>;
   setViewBackground: (id: string, background: DashboardBackground | null) => Promise<void>;
   setViewTabColor: (id: string, tabColor: string | null) => Promise<void>;
+  reorderViews: (orderedIds: string[]) => Promise<void>;
   backgroundImages: Record<string, string>;
   loadBackgroundImage: (file: string) => Promise<void>;
   removeView: (id: string) => Promise<void>;
@@ -204,6 +205,23 @@ export const useDashboardStore = create<DashboardStoreState>((set, get) => ({
     try {
       const updated = await persistence.updateView(id, { tabColor });
       set((s) => ({ views: s.views.map((v) => (v.id === id ? updated : v)) }));
+    } catch (e) { set({ lastError: String(e) }); }
+  },
+
+  reorderViews: async (orderedIds) => {
+    try {
+      await persistence.reorderViews(orderedIds);
+      set((s) => {
+        const byId = new Map(s.views.map((view) => [view.id, view]));
+        return {
+          views: orderedIds
+            .map((id, sortOrder) => {
+              const view = byId.get(id);
+              return view ? { ...view, sortOrder } : null;
+            })
+            .filter((view): view is DashboardView => view !== null),
+        };
+      });
     } catch (e) { set({ lastError: String(e) }); }
   },
 

--- a/src/modules/dashboard/view/DashboardCanvas.tsx
+++ b/src/modules/dashboard/view/DashboardCanvas.tsx
@@ -93,14 +93,13 @@ export function DashboardCanvas({
   }
 
   async function onCanvasContextMenu(event: MouseEvent<HTMLDivElement>) {
-    // Only react on empty canvas space, and never while editing layout.
-    if (editMode) return;
+    // Only react on empty canvas space.
     if ((event.target as HTMLElement).closest(".react-grid-item")) return;
     event.preventDefault();
     await showNativeContextMenu(
       [
         { kind: "item", label: t("dashboard.addWidgetLabel"), action: onOpenCatalog },
-        { kind: "item", label: t("dashboard.editLayout"), action: onToggleEditMode },
+        { kind: "item", label: editMode ? t("dashboard.editDone") : t("dashboard.editLayout"), action: onToggleEditMode },
         { kind: "separator" },
         { kind: "item", label: t("dashboard.changeBackground"), action: onOpenBackground },
       ],

--- a/src/modules/dashboard/view/viewReorder.test.ts
+++ b/src/modules/dashboard/view/viewReorder.test.ts
@@ -1,0 +1,31 @@
+import type { DashboardView } from "../types";
+import { reorderDashboardViews } from "./viewReorder";
+
+const views: DashboardView[] = ["alpha", "bravo", "charlie"].map((title, index) => ({
+  id: title,
+  title,
+  sortOrder: index,
+  gridDensity: "default",
+  background: null,
+  tabColor: null,
+}));
+
+const reordered = reorderDashboardViews(views, "charlie", "alpha");
+
+if (reordered?.join(",") !== "charlie,alpha,bravo") {
+  throw new Error("Dashboard Views should move before the hovered View.");
+}
+
+const movedToEnd = reorderDashboardViews(views, "alpha", "charlie", "after");
+
+if (movedToEnd?.join(",") !== "bravo,charlie,alpha") {
+  throw new Error("Dashboard Views should move after the hovered View.");
+}
+
+if (reorderDashboardViews(views, "alpha", "alpha") !== null) {
+  throw new Error("Dropping a Dashboard View onto itself should not request persistence.");
+}
+
+if (reorderDashboardViews(views, "alpha", "missing") !== null) {
+  throw new Error("Dropping onto an unknown Dashboard View should not request persistence.");
+}

--- a/src/modules/dashboard/view/viewReorder.ts
+++ b/src/modules/dashboard/view/viewReorder.ts
@@ -1,0 +1,25 @@
+import type { DashboardView } from "../types";
+
+export type DashboardViewReorderPlacement = "before" | "after";
+
+export function reorderDashboardViews(
+  views: readonly Pick<DashboardView, "id">[],
+  draggedId: string,
+  targetId: string,
+  placement: DashboardViewReorderPlacement = "before",
+): string[] | null {
+  if (draggedId === targetId) return null;
+
+  const orderedIds = views.map((view) => view.id);
+  const draggedIndex = orderedIds.indexOf(draggedId);
+  const targetIndex = orderedIds.indexOf(targetId);
+  if (draggedIndex === -1 || targetIndex === -1) return null;
+
+  const next = [...orderedIds];
+  const [dragged] = next.splice(draggedIndex, 1);
+  const targetIndexAfterRemoval = next.indexOf(targetId);
+  if (targetIndexAfterRemoval === -1) return null;
+
+  next.splice(placement === "after" ? targetIndexAfterRemoval + 1 : targetIndexAfterRemoval, 0, dragged);
+  return next.join("\0") === orderedIds.join("\0") ? null : next;
+}


### PR DESCRIPTION
## Summary
- Enabled dragging Dashboard View tabs in edit mode to reorder views.
- Kept the empty-canvas context menu available during edit mode and switched the edit item to End Edit mode.
- Added a subtler selected-tab pulse/ring so the active view is easier to identify across tab colors.

## Testing
- Added a focused unit test for Dashboard View reorder logic.
- Ran local type-check and production build successfully.
- Verified the Dashboard UI in a local browser: created a second view, entered edit mode, dragged it to reorder, and confirmed the active-tab pulse and edit-mode context-menu behavior.