### PR TITLE
Fix AI assistant text clipping by wrapping long inline tokens

### DIFF
--- a/src/ai/assistant.css
+++ b/src/ai/assistant.css
@@ -604,6 +604,7 @@
   display: grid;
   gap: 8px;
   min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .markdown-content h1,


### PR DESCRIPTION
Assistant markdown messages clipped long unbreakable tokens (URLs,
hostnames, inline code) on the right edge instead of wrapping, because
the chat log uses overflow-x: hidden and .markdown-content had no break
opportunity. CJK prose wrapped fine since it breaks between characters,
but Latin/monospace tokens overflowed, and different fonts render those
tokens at different widths, so the same pane width clipped with some
fonts and not others.

Add overflow-wrap: anywhere to .markdown-content, matching the user
bubble. anywhere (not break-word) is required so the grid-item markdown
blocks can shrink below the longest token's min-content width.