### PR TITLE
Add inline title rename for panel and hero widget presets

### DIFF
--- a/docs/localization_todo/dashboard.renameTitleHint.md
+++ b/docs/localization_todo/dashboard.renameTitleHint.md
@@ -1,0 +1,10 @@
+# dashboard.renameTitleHint
+
+- **English value**: `Double-click to rename`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/registry/presetRegistry.tsx`
+- **UI role**: `tooltip`
+- **User flow**: Hover tooltip on a panel or hero Widget Instance title bar, hinting that double-clicking the title text lets the user rename the widget inline.
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Domain notes**: "rename" here means editing the Widget Instance's custom title; it sets the same `customTitle` field as the Customize popover Title input.

--- a/docs/manual/10-dashboard.md
+++ b/docs/manual/10-dashboard.md
@@ -62,7 +62,7 @@ Fields:
 - **Canvas opacity**: `dashboard.canvasOpacity` — slider (0-100) that fades the Widget Instance body area only, leaving the title bar fully opaque. Default 70% for the built-in App Launcher and Connection widgets, 100% otherwise; visual effect is applied on the panel preset's `.dw-body`.
 - **Accent**: `dashboard.accent`, default `dashboard.accentDefault`.
 - **Icon**: `dashboard.icon`.
-- **Title**: `dashboard.titleLabel`, placeholder `dashboard.titlePlaceholder`. Untitled widgets show `dashboard.untitledWidget`.
+- **Title**: `dashboard.titleLabel`, placeholder `dashboard.titlePlaceholder`. Untitled widgets show `dashboard.untitledWidget`. On the panel and hero presets the title text in the Widget Instance title bar is also inline-editable: double-click it (tooltip `dashboard.renameTitleHint`) to edit, Enter or blur to commit, Escape to cancel; committing an empty value clears the custom title and reverts to the default. This sets the same `customTitle` field as this Title field.
 - **Advanced**: `dashboard.advanced`.
 
 Presets are CSS wrappers that read the Instance's `--w-accent` / `--w-accent-soft` variables — presets do not encode their own palette.

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -69,6 +69,7 @@
     "icon": "Icon",
     "titleLabel": "Title",
     "titlePlaceholder": "Custom title…",
+    "renameTitleHint": "Double-click to rename",
     "advanced": "Advanced",
     "changeBackground": "Change Background…",
     "backgroundModeDefault": "Theme Default",

--- a/src/modules/dashboard/dashboard.css
+++ b/src/modules/dashboard/dashboard.css
@@ -1506,6 +1506,20 @@ button.dashboard-pill-dot:focus-visible {
   text-shadow: 0 1px 1px rgb(0 0 0 / 22%);
 }
 
+/* Inline title editor opened by double-clicking a panel/hero title. Inherits the
+   title typography via the shared .dw-title / .dw-hero-title class. */
+.dw-title-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 1px 4px;
+  color: inherit;
+  background: rgb(255 255 255 / 14%);
+  border: 1px solid color-mix(in srgb, var(--w-accent) 55%, transparent);
+  border-radius: 4px;
+  outline: none;
+  text-shadow: none;
+}
+
 .dw-icon {
   display: inline-flex;
   align-items: center;

--- a/src/modules/dashboard/registry/presetRegistry.tsx
+++ b/src/modules/dashboard/registry/presetRegistry.tsx
@@ -1,4 +1,6 @@
 import type { ReactElement, ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import type { WidgetPreset } from "../types";
 
 export interface PresetChromeProps {
@@ -9,14 +11,98 @@ export interface PresetChromeProps {
   editMode: boolean;
   glass?: boolean;
   hideTitle?: boolean;
+  /** When provided, the title becomes inline-editable via double-click. */
+  onTitleCommit?: (next: string | null) => void;
 }
 
-function PanelChrome({ title, icon, body, controls, editMode }: PresetChromeProps) {
+/**
+ * Widget title that turns into an inline text field on double-click. Committing
+ * an empty value clears the custom title and reverts to the default. Used by the
+ * panel and hero presets, whose chrome shows a title bar.
+ */
+function EditableTitle({
+  title,
+  className,
+  onTitleCommit,
+}: {
+  title: string;
+  className: string;
+  onTitleCommit?: (next: string | null) => void;
+}) {
+  const { t } = useTranslation();
+  const [editing, setEditing] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const skipBlur = useRef(false);
+
+  useEffect(() => {
+    if (!editing) return;
+    const input = inputRef.current;
+    input?.focus();
+    input?.select();
+  }, [editing]);
+
+  if (!onTitleCommit) {
+    return <h3 className={className}>{title}</h3>;
+  }
+
+  function commit(value: string) {
+    const trimmed = value.trim();
+    onTitleCommit!(trimmed.length === 0 ? null : trimmed);
+    setEditing(false);
+  }
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        type="text"
+        aria-label={t("dashboard.titleLabel")}
+        className={`${className} dw-title-input`}
+        defaultValue={title}
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
+        onBlur={(e) => {
+          if (skipBlur.current) {
+            skipBlur.current = false;
+            setEditing(false);
+            return;
+          }
+          commit(e.currentTarget.value);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            commit(e.currentTarget.value);
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            skipBlur.current = true;
+            e.currentTarget.blur();
+          }
+        }}
+      />
+    );
+  }
+
+  return (
+    <h3
+      className={className}
+      title={t("dashboard.renameTitleHint")}
+      onDoubleClick={(e) => {
+        e.stopPropagation();
+        setEditing(true);
+      }}
+    >
+      {title}
+    </h3>
+  );
+}
+
+function PanelChrome({ title, icon, body, controls, editMode, onTitleCommit }: PresetChromeProps) {
   return (
     <div className="dw-preset dw-preset-panel">
       <div className={`dw-head${editMode ? " drag-handle" : ""}`}>
         <span className="dw-icon">{icon}</span>
-        <h3 className="dw-title">{title}</h3>
+        <EditableTitle title={title} className="dw-title" onTitleCommit={onTitleCommit} />
         {controls}
       </div>
       <div className="dw-body">{body}</div>
@@ -39,12 +125,12 @@ function AmbientChrome({ title, body, controls, editMode, glass, hideTitle }: Pr
   );
 }
 
-function HeroChrome({ title, icon, body, controls, editMode }: PresetChromeProps) {
+function HeroChrome({ title, icon, body, controls, editMode, onTitleCommit }: PresetChromeProps) {
   return (
     <div className="dw-preset dw-preset-hero">
       <div className={`dw-hero-head${editMode ? " drag-handle" : ""}`}>
         <span className="dw-hero-icon">{icon}</span>
-        <h3 className="dw-hero-title">{title}</h3>
+        <EditableTitle title={title} className="dw-hero-title" onTitleCommit={onTitleCommit} />
         {controls}
       </div>
       <div className="dw-hero-body">{body}</div>

--- a/src/modules/dashboard/view/WidgetFrame.tsx
+++ b/src/modules/dashboard/view/WidgetFrame.tsx
@@ -35,6 +35,7 @@ export function WidgetFrame({
 }: WidgetFrameProps) {
   const { t } = useTranslation();
   const editMode = useDashboardStore((s) => s.editMode);
+  const updateInstance = useDashboardStore((s) => s.updateInstance);
   const customWidgets = useDashboardStore((s) => s.customWidgets);
   const agentCreatedRevealInstanceIds = useDashboardStore((s) => s.agentCreatedRevealInstanceIds);
   const clearAgentCreatedReveal = useDashboardStore((s) => s.clearAgentCreatedReveal);
@@ -157,6 +158,7 @@ export function WidgetFrame({
         editMode={editMode}
         glass={instance.glass}
         hideTitle={instance.hideTitle}
+        onTitleCommit={(next) => { void updateInstance(instance.id, { customTitle: next }); }}
       />
     </div>
   );


### PR DESCRIPTION
Double-clicking a panel or hero Widget Instance title bar opens an inline
text field that writes the same customTitle field as the Customize popover.
Enter or blur commits, Escape cancels, and an empty value reverts to the
default title.