### PR TITLE
Fix watchdog lifecycle wonkiness and wire real tool-using interventions

### DIFF
--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -76,7 +76,7 @@ fn watchdog_intent_contract() -> String {
 \n\nSupported target kinds (pick the one whose example most resembles the user's request):\n{catalog_section}\n\nUse session_state to discover live session ids before creating sshSessionOutputSilence watchdogs; if multiple sessions match the user's description, ask one narrow question to disambiguate. \
 Predicate ops are gt | lt | gte | lte | eq | ne with a numeric value, or silenceFor {{ ms: u64 }} for output-silence targets. Always set sustainedForMs on threshold-style triggers (cpu/ram/disk over X for Y minutes) so transient spikes don't trip a false alarm. SilenceFor triggers don't need sustainedForMs — the threshold is built into the predicate. pollMs must be 500–3_600_000; choose a poll interval at least 10x smaller than the threshold so the timer has multiple samples to confirm. \
 stop is one of {{ kind: 'untilCanceled' }} (default for ongoing watches), {{ kind: 'afterFirstTrigger' }} (one-shot alert), {{ kind: 'afterTriggerCount', n: <u32> }}, {{ kind: 'afterPollCount', n: <u32> }}, or {{ kind: 'afterDuration', ms: <u64> }}. \
-action is either {{ kind: 'notify' }} (passive: status-bar surface only) or {{ kind: 'aiIntervene', goal: <imperative instructions>, contextSources: <subset of sessionOutputTail | sessionMeta | tickHistory | performanceSnapshot>, allowedTools: <exact tool names>, approvalPolicy: 'sessionAllow', maxInterventions: <hard cap, typically 3–10>, suppressionMs: <cooldown after each action, typically 15_000–60_000> }}. For SSH-session watchdogs that should nudge stalled CLIs, set contextSources to ['sessionOutputTail', 'sessionMeta', 'tickHistory'] so the intervention sub-turn sees recent terminal output; the typical allowedTools is ['session_send_text', 'session_state']. Use aiIntervene only when the user explicitly asks for the AI to act when the trigger fires (e.g. 'tell the codex CLI to continue when it stalls'); otherwise default to notify. For aiIntervene watchdogs the runtime will show the user an approval modal listing every allowed tool — be conservative with allowedTools, list only what's needed. \
+action is either {{ kind: 'notify' }} (passive: status-bar surface only) or {{ kind: 'aiIntervene', goal: <imperative instructions>, contextSources: <subset of sessionOutputTail | sessionMeta | tickHistory | performanceSnapshot>, allowedTools: <exact tool names>, approvalPolicy: 'sessionAllow', maxInterventions: <hard cap, typically 3–10>, suppressionMs: <cooldown after each action, typically 15_000–60_000> }}. For SSH-session watchdogs that should nudge stalled CLIs, set contextSources to ['sessionOutputTail', 'sessionMeta', 'tickHistory'] so the intervention sub-turn sees recent terminal output; the typical allowedTools is ['session_terminal_send_text', 'session_state']. Use aiIntervene only when the user explicitly asks for the AI to act when the trigger fires (e.g. 'tell the codex CLI to continue when it stalls'); otherwise default to notify. For aiIntervene watchdogs the runtime will show the user an approval modal listing every allowed tool — be conservative with allowedTools, list only what's needed. \
 notification is one of inAppOnly | inAppPlusToast | inAppPlusSound — default inAppOnly. Generate a short human-readable name like 'CPU > 90% (5 min)' or 'codex CLI keepalive'. If the user's request maps to a target kind not in the catalog above (process exit, log file pattern, HTTP endpoint health, SSL cert expiry, etc.), explain that limitation in one sentence and offer the closest currently-supported alternative — most often a performanceCounter, ping, tcpReachable, or sshSessionOutputSilence variant — instead of creating a watchdog you know will fail validation."
     )
 }
@@ -602,6 +602,12 @@ pub struct AgentRunRequest {
     intent: Option<String>,
     #[serde(default = "default_agent_allow_tools")]
     allow_tools: bool,
+    /// When non-empty, the agent is restricted to exactly these tool names and
+    /// they are treated as pre-approved (no per-call approval modal). Used by
+    /// watchdog intervention sub-turns, which are scoped to the tools the user
+    /// approved at watchdog creation. Empty means "no restriction".
+    #[serde(default)]
+    allowed_tools: Vec<String>,
     selected_output: Option<String>,
     screenshot: Option<AgentScreenshotContext>,
     #[serde(default)]
@@ -1595,6 +1601,7 @@ impl OpenAiCompatibleProvider {
         request: AgentRunRequest,
     ) -> Result<AgentRunResponse, String> {
         let prompt = trim_required("assistant prompt", request.prompt)?;
+        let allowed_tools = request.allowed_tools.clone();
         let context_label = trim_required("assistant context", request.context_label)?;
         let skill_summaries =
             enabled_skill_summaries_for_request(&app, settings.disabled_skill_names())?;
@@ -1617,11 +1624,12 @@ impl OpenAiCompatibleProvider {
             skill_summaries.clone(),
         );
         let client = ai_http_client(settings.allow_insecure_tls())?;
-        let tool_definitions = if request.allow_tools {
-            ai_tool_definitions_with_skills(settings.tools(), &skill_summaries)
-        } else {
-            Vec::new()
-        };
+        let tool_definitions = agent_tool_definitions(
+            request.allow_tools,
+            &allowed_tools,
+            settings.tools(),
+            &skill_summaries,
+        );
         let provider_tool_definitions = self.tool_definitions_for_provider(&tool_definitions);
         let app_data_dir = app
             .path()
@@ -1716,7 +1724,9 @@ impl OpenAiCompatibleProvider {
                 ),
             });
             for tool_call in tool_calls {
-                let result = run_ai_tool(&settings, &app_data_dir, &app, &tool_call, None).await;
+                let result =
+                    run_ai_tool(&settings, &app_data_dir, &app, &tool_call, None, &allowed_tools)
+                        .await;
                 messages.push(OpenAiCompatibleMessage {
                     role: "tool".to_string(),
                     content: OpenAiCompatibleContent::Text(result),
@@ -1799,6 +1809,7 @@ impl OpenAiCompatibleProvider {
         request: AgentRunRequest,
     ) -> Result<AgentRunResponse, String> {
         let prompt = trim_required("assistant prompt", request.prompt)?;
+        let allowed_tools = request.allowed_tools.clone();
         let context_label = trim_required("assistant context", request.context_label)?;
         let skill_summaries =
             enabled_skill_summaries_for_request(&app, settings.disabled_skill_names())?;
@@ -1821,11 +1832,12 @@ impl OpenAiCompatibleProvider {
         );
         let mut input = responses_input_from_messages(messages, request.files);
         let client = ai_http_client(settings.allow_insecure_tls())?;
-        let tool_definitions = if request.allow_tools {
-            ai_tool_definitions_with_skills(settings.tools(), &skill_summaries)
-        } else {
-            Vec::new()
-        };
+        let tool_definitions = agent_tool_definitions(
+            request.allow_tools,
+            &allowed_tools,
+            settings.tools(),
+            &skill_summaries,
+        );
         let provider_tool_definitions =
             self.responses_tool_definitions_for_provider(&tool_definitions);
         let app_data_dir = app
@@ -1917,7 +1929,9 @@ impl OpenAiCompatibleProvider {
                 input.extend(output.iter().cloned());
             }
             for tool_call in tool_calls {
-                let result = run_ai_tool(&settings, &app_data_dir, &app, &tool_call, None).await;
+                let result =
+                    run_ai_tool(&settings, &app_data_dir, &app, &tool_call, None, &allowed_tools)
+                        .await;
                 input.push(json!({
                     "type": "function_call_output",
                     "call_id": tool_call.id,
@@ -2014,6 +2028,7 @@ impl OpenAiCompatibleProvider {
         channel: Channel<Value>,
     ) -> Result<AgentRunResponse, String> {
         let prompt = trim_required("assistant prompt", request.prompt)?;
+        let allowed_tools = request.allowed_tools.clone();
         let context_label = trim_required("assistant context", request.context_label)?;
         let skill_summaries =
             enabled_skill_summaries_for_request(&app, settings.disabled_skill_names())?;
@@ -2036,11 +2051,12 @@ impl OpenAiCompatibleProvider {
             skill_summaries.clone(),
         );
         let client = ai_http_client(settings.allow_insecure_tls())?;
-        let tool_definitions = if request.allow_tools {
-            ai_tool_definitions_with_skills(settings.tools(), &skill_summaries)
-        } else {
-            Vec::new()
-        };
+        let tool_definitions = agent_tool_definitions(
+            request.allow_tools,
+            &allowed_tools,
+            settings.tools(),
+            &skill_summaries,
+        );
         let provider_tool_definitions = self.tool_definitions_for_provider(&tool_definitions);
         let app_data_dir = app
             .path()
@@ -2181,7 +2197,15 @@ impl OpenAiCompatibleProvider {
                     )?;
                 }
                 let result =
-                    run_ai_tool(&settings, &app_data_dir, &app, tool_call, Some(&channel)).await;
+                    run_ai_tool(
+                        &settings,
+                        &app_data_dir,
+                        &app,
+                        tool_call,
+                        Some(&channel),
+                        &allowed_tools,
+                    )
+                    .await;
                 ai_debug!(
                     "tool end provider={} model={} subturn={} id={} name={} result_len={}",
                     self.provider_kind,
@@ -2305,6 +2329,7 @@ impl OpenAiCompatibleProvider {
         channel: Channel<Value>,
     ) -> Result<AgentRunResponse, String> {
         let prompt = trim_required("assistant prompt", request.prompt)?;
+        let allowed_tools = request.allowed_tools.clone();
         let context_label = trim_required("assistant context", request.context_label)?;
         let skill_summaries =
             enabled_skill_summaries_for_request(&app, settings.disabled_skill_names())?;
@@ -2326,11 +2351,12 @@ impl OpenAiCompatibleProvider {
             skill_summaries.clone(),
         );
         let client = ai_http_client(settings.allow_insecure_tls())?;
-        let tool_definitions = if request.allow_tools {
-            ai_tool_definitions_with_skills(settings.tools(), &skill_summaries)
-        } else {
-            Vec::new()
-        };
+        let tool_definitions = agent_tool_definitions(
+            request.allow_tools,
+            &allowed_tools,
+            settings.tools(),
+            &skill_summaries,
+        );
         let app_data_dir = app
             .path()
             .app_data_dir()
@@ -2446,7 +2472,15 @@ impl OpenAiCompatibleProvider {
                     )?;
                 }
                 let result =
-                    run_ai_tool(&settings, &app_data_dir, &app, tool_call, Some(&channel)).await;
+                    run_ai_tool(
+                        &settings,
+                        &app_data_dir,
+                        &app,
+                        tool_call,
+                        Some(&channel),
+                        &allowed_tools,
+                    )
+                    .await;
                 let tool_error = tool_result_error(&result);
                 let abort_message = tool_error_tracker.note(&tool_call.function.name, &tool_error);
                 input.push(json!({
@@ -3439,6 +3473,27 @@ fn ai_tool_definitions(settings: &AiAssistantToolSettings) -> Vec<OpenAiToolDefi
     ai_tool_definitions_with_skills(settings, &[])
 }
 
+/// Build the agent's tool definitions, optionally narrowed to an explicit
+/// allow-list. An empty `allowed_tools` means "no restriction" (normal
+/// assistant turns); a non-empty list keeps only the named tools — used by
+/// watchdog intervention sub-turns, which are pre-scoped to the tools the user
+/// approved when the watchdog was created.
+fn agent_tool_definitions(
+    allow_tools: bool,
+    allowed_tools: &[String],
+    settings: &AiAssistantToolSettings,
+    skill_summaries: &[AssistantSkillSummary],
+) -> Vec<OpenAiToolDefinition> {
+    if !allow_tools {
+        return Vec::new();
+    }
+    let mut defs = ai_tool_definitions_with_skills(settings, skill_summaries);
+    if !allowed_tools.is_empty() {
+        defs.retain(|tool| crate::watchdog::check_allowed_tool(allowed_tools, tool.function.name));
+    }
+    defs
+}
+
 fn ai_tool_definitions_with_skills(
     settings: &AiAssistantToolSettings,
     skill_summaries: &[AssistantSkillSummary],
@@ -4355,6 +4410,7 @@ async fn run_ai_tool(
     app: &tauri::AppHandle,
     call: &OpenAiToolCall,
     stream_channel: Option<&Channel<Value>>,
+    allowed_tools: &[String],
 ) -> String {
     let args: Value = serde_json::from_str(&call.function.arguments).unwrap_or_else(|_| json!({}));
     let tool_settings = settings.tools();
@@ -4368,7 +4424,14 @@ async fn run_ai_tool(
             "permissionMode": settings.tool_permission_mode(),
         })
     );
-    if tool_requires_allow_all(&call.function.name) && settings.tool_permission_mode() != "allowAll"
+    // Tools the caller pre-approved (a watchdog intervention sub-turn scoped to
+    // the tools the user approved at watchdog creation — sessionAllow policy)
+    // skip the per-call approval modal; otherwise an unattended intervention
+    // would block here forever.
+    let pre_approved = crate::watchdog::check_allowed_tool(allowed_tools, &call.function.name);
+    if tool_requires_allow_all(&call.function.name)
+        && settings.tool_permission_mode() != "allowAll"
+        && !pre_approved
     {
         let approved = match app.try_state::<AssistantToolApprovalBridge>() {
             Some(bridge) => bridge.request(app, &call.function.name, &args).await,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1691,9 +1691,18 @@ fn resize_terminal(
 
 #[tauri::command]
 fn close_terminal_session(
+    app: tauri::AppHandle,
     sessions: tauri::State<'_, sessions::SessionManager>,
     session_id: String,
 ) -> Result<(), String> {
+    // Drop the watchdog activity-tracker entry so the per-session tail buffer
+    // doesn't leak across the app lifetime and a silence watchdog stops
+    // measuring against a session that no longer exists.
+    if let Some(tracker) =
+        app.try_state::<std::sync::Arc<watchdog::SessionActivityTracker>>()
+    {
+        tracker.forget(&session_id);
+    }
     sessions.close_terminal_session(session_id)
 }
 

--- a/src-tauri/src/watchdog/mod.rs
+++ b/src-tauri/src/watchdog/mod.rs
@@ -98,11 +98,10 @@ pub fn new_watchdog_id() -> String {
     format!("wd-{ts}-{seq}")
 }
 
-/// Runtime allow-list check. Step 6's intervention runner calls this before
-/// every tool invocation. Centralized here (not inline) so the policy is
-/// independently testable and the same rule applies whether the call comes
-/// from the intervention sub-turn or a future debug/replay code path.
-#[allow(dead_code)] // wired by step 6 intervention runner
+/// Runtime allow-list check. `run_ai_tool` calls this to decide both whether a
+/// tool is offered to an intervention sub-turn and whether it is pre-approved.
+/// Centralized here (not inline) so the policy is independently testable and the
+/// same rule applies wherever it is consumed.
 pub fn check_allowed_tool(allowed: &[String], tool_name: &str) -> bool {
     allowed.iter().any(|t| t == tool_name)
 }

--- a/src-tauri/src/watchdog/registry.rs
+++ b/src-tauri/src/watchdog/registry.rs
@@ -193,6 +193,7 @@ impl WatchdogRegistry {
             triggers: entry.triggers.clone(),
             interventions: entry.interventions.clone(),
             created_at: entry.created_at,
+            poll_count: entry.poll_count,
         })
     }
 
@@ -329,6 +330,12 @@ struct LoopState {
     /// predicate is met, we don't fire a trigger. Set after an intervention
     /// records; cleared when `now_ms() >= until`.
     suppression_until: Option<u64>,
+    /// Set when a `Notify` watchdog has latched into `Triggered`. Notify
+    /// watchdogs have no intervention/suppression path to move them onward,
+    /// so without this they'd display `Triggered` forever. Cleared (and the
+    /// state returned to `Running`) on the first tick where the predicate is
+    /// no longer met.
+    triggered_sticky: bool,
     /// Mock-target only: incremented each poll.
     mock_counter: f64,
 }
@@ -352,6 +359,7 @@ async fn run_poll_loop(
         trigger_count: 0,
         condition_true_since: None,
         suppression_until: None,
+        triggered_sticky: false,
         mock_counter: 0.0,
     };
 
@@ -395,6 +403,13 @@ async fn run_poll_loop(
                     state.suppression_until = None;
                     transition_to_running(&registry, &app, &id, &state);
                 }
+                // A Notify watchdog that latched into Triggered returns to
+                // Running once the condition clears, so its state doesn't stay
+                // stuck at Triggered after the metric recovers.
+                if !predicate_met && state.triggered_sticky {
+                    state.triggered_sticky = false;
+                    transition_to_running(&registry, &app, &id, &state);
+                }
                 let trigger_fired = !in_suppression
                     && update_sustained_window(
                         &mut state,
@@ -411,6 +426,13 @@ async fn run_poll_loop(
                     }));
                     apply_triggered_state(&registry, &app, &id, &state);
 
+                    if matches!(config.action, WatchdogAction::Notify) {
+                        // Notify watchdogs have no intervention path to move
+                        // them on; latch so the loop returns them to Running
+                        // once the predicate clears.
+                        state.triggered_sticky = true;
+                    }
+
                     if let WatchdogAction::AiIntervene {
                         goal,
                         context_sources,
@@ -421,22 +443,9 @@ async fn run_poll_loop(
                     } = &config.action
                     {
                         let intervention_id = format!("int-{}-{}", id, now_ms());
-                        // Cap check happens BEFORE intervening — if we're
-                        // already at the cap (which can only mean a previous
-                        // intervention recorded but the loop hasn't seen the
-                        // next trigger yet), finalize as Error here.
-                        let already_at_cap = current_intervention_count(&registry, &id)
-                            >= *max_interventions;
-                        if already_at_cap {
-                            finalize(&registry, &app, &id, WatchdogState::Error {
-                                message: format!(
-                                    "Intervention cap ({}) reached. Review log.",
-                                    max_interventions
-                                ),
-                                finished_at: now_ms(),
-                            });
-                            return;
-                        }
+                        // The intervention cap is enforced after each record
+                        // (below). The loop only re-enters this block when
+                        // under the cap, so no pre-check is needed here.
 
                         // Snapshot the context the frontend will hand to the
                         // AI sub-turn. Kept compact — last 8 ticks plus the
@@ -470,12 +479,23 @@ async fn run_poll_loop(
                             "snapshot": snapshot,
                         }));
 
-                        // Park here until the frontend records the outcome
-                        // (timeout protects against a dead frontend).
-                        let signal = tokio::time::timeout(
-                            Duration::from_millis(INTERVENTION_TIMEOUT_MS),
-                            rx.recv(),
-                        ).await;
+                        // Park here until the frontend records the outcome.
+                        // A cancel must stay responsive while parked, and the
+                        // timeout protects against a dead frontend.
+                        let signal = tokio::select! {
+                            biased;
+                            _ = cancel.cancelled() => {
+                                clear_intervention_sender(&registry, &id);
+                                finalize(&registry, &app, &id, WatchdogState::Canceled {
+                                    finished_at: now_ms(),
+                                });
+                                return;
+                            }
+                            outcome = tokio::time::timeout(
+                                Duration::from_millis(INTERVENTION_TIMEOUT_MS),
+                                rx.recv(),
+                            ) => outcome,
+                        };
                         // Clear the sender slot regardless of outcome.
                         clear_intervention_sender(&registry, &id);
                         match signal {
@@ -493,9 +513,11 @@ async fn run_poll_loop(
                                 if current_intervention_count(&registry, &id)
                                     >= *max_interventions
                                 {
-                                    finalize(&registry, &app, &id, WatchdogState::Error {
-                                        message: format!(
-                                            "Intervention cap ({}) reached. Review log.",
+                                    // Exhausting the allotted interventions is
+                                    // a normal terminal outcome, not an error.
+                                    finalize(&registry, &app, &id, WatchdogState::Completed {
+                                        reason: format!(
+                                            "Intervention cap ({}) reached.",
                                             max_interventions
                                         ),
                                         finished_at: now_ms(),
@@ -504,10 +526,13 @@ async fn run_poll_loop(
                                 }
                                 // Enter suppression window. The next interval
                                 // tick will sample but predicate-met evaluation
-                                // is gated by `suppression_until`.
-                                state.suppression_until = Some(now_ms() + suppression_ms);
+                                // is gated by `suppression_until`. Compute the
+                                // deadline once so the emitted `until` matches
+                                // the loop's internal gate exactly.
+                                let until = now_ms() + suppression_ms;
+                                state.suppression_until = Some(until);
                                 let suppressed = WatchdogState::Suppressed {
-                                    until: now_ms() + suppression_ms,
+                                    until,
                                     intervention_count: current_intervention_count(&registry, &id),
                                 };
                                 write_state(&registry, &id, suppressed.clone());
@@ -887,6 +912,7 @@ mod tests {
             trigger_count: 0,
             condition_true_since: None,
             suppression_until: None,
+            triggered_sticky: false,
             mock_counter: 0.0,
         };
         assert!(!update_sustained_window(&mut state, true, Some(1_000_000)));
@@ -903,6 +929,7 @@ mod tests {
             trigger_count: 0,
             condition_true_since: None,
             suppression_until: None,
+            triggered_sticky: false,
             mock_counter: 0.0,
         };
         // Without sustained_for_ms, the first true tick is the rising edge.
@@ -921,6 +948,7 @@ mod tests {
             trigger_count: 1,
             condition_true_since: None,
             suppression_until: None,
+            triggered_sticky: false,
             mock_counter: 0.0,
         };
         assert!(stop_reached(&WatchdogStop::AfterFirstTrigger, &state, true).is_some());
@@ -935,6 +963,7 @@ mod tests {
             trigger_count: 0,
             condition_true_since: None,
             suppression_until: None,
+            triggered_sticky: false,
             mock_counter: 0.0,
         };
         assert!(stop_reached(&WatchdogStop::AfterPollCount { n: 10 }, &state, false).is_some());

--- a/src-tauri/src/watchdog/session_activity.rs
+++ b/src-tauri/src/watchdog/session_activity.rs
@@ -86,12 +86,10 @@ impl SessionActivityTracker {
         Some(String::from_utf8_lossy(&bytes).into_owned())
     }
 
-    /// Forget a session — should be called by the session manager when a
+    /// Forget a session. Called by the `close_terminal_session` command when a
     /// terminal closes so the map doesn't grow unboundedly across the app
-    /// lifetime. Not yet wired: `close_terminal_session` doesn't carry an
-    /// AppHandle. Each entry is small (~8KB), and sessions per process are
-    /// bounded, so cleanup is a polish task rather than a leak.
-    #[allow(dead_code)]
+    /// lifetime, and so a `sshSessionOutputSilence` watchdog stops measuring
+    /// silence against a session that no longer exists.
     pub fn forget(&self, session_id: &str) {
         if let Ok(mut guard) = self.inner.lock() {
             guard.remove(session_id);

--- a/src-tauri/src/watchdog/types.rs
+++ b/src-tauri/src/watchdog/types.rs
@@ -257,6 +257,9 @@ pub struct WatchdogReport {
     pub triggers: Vec<WatchdogTriggerEvent>,
     pub interventions: Vec<WatchdogInterventionRecord>,
     pub created_at: u64,
+    /// Total polls taken across the watchdog's life. Authoritative count that
+    /// does not roll off, unlike `ticks` which is ring-capped.
+    pub poll_count: u32,
 }
 
 /// One AI intervention sub-turn. Recorded by the frontend after the sub-turn

--- a/src/watchdog/WatchdogDetail.tsx
+++ b/src/watchdog/WatchdogDetail.tsx
@@ -78,7 +78,7 @@ export function WatchdogDetail({ id, onClose }: { id: string; onClose: () => voi
         <Sparkline ticks={ticks ?? []} />
         <dl className="watchdog-detail-stats">
           <Stat label={t("watchdog.detail.elapsed")} value={formatElapsed(summary.createdAt)} />
-          <Stat label={t("watchdog.detail.nextCheck")} value={formatNextCheck(summary.state, summary.pollMs)} />
+          <Stat label={t("watchdog.detail.nextCheck")} value={formatNextCheck(summary.state, summary.pollMs, ticks ?? [])} />
           <Stat label={t("watchdog.detail.lastValue")} value={formatLastValue(summary.lastValue)} />
           <Stat label={t("watchdog.detail.polls")} value={String(summary.pollCount)} />
           <Stat label={t("watchdog.detail.triggers")} value={String(summary.triggerCount)} />
@@ -139,11 +139,16 @@ function formatElapsed(createdAt: number) {
   return formatDuration(Date.now() - createdAt);
 }
 
-function formatNextCheck(state: WatchdogState, pollMs: number) {
+function formatNextCheck(state: WatchdogState, pollMs: number, ticks: WatchdogTick[]) {
   if (isTerminalState(state)) {
     return "—";
   }
-  const lastPollAt = "lastPollAt" in state ? state.lastPollAt : Date.now();
+  // The `Running` state's `lastPollAt` is only stamped once at startup, so the
+  // last observed tick is the accurate anchor for the next poll. Fall back to
+  // the state field (then now) before any tick has arrived.
+  const lastTickAt = ticks.length > 0 ? ticks[ticks.length - 1].at : undefined;
+  const lastPollAt =
+    lastTickAt ?? ("lastPollAt" in state ? state.lastPollAt : Date.now());
   return formatDuration(Math.max(0, lastPollAt + pollMs - Date.now()));
 }
 

--- a/src/watchdog/interventionRunner.ts
+++ b/src/watchdog/interventionRunner.ts
@@ -5,10 +5,10 @@
 // AI request, awaits the response, and posts the outcome back to Rust via
 // `watchdog_record_intervention`.
 //
-// Scope v1: text-only sub-turn — the AI sees the snapshot + goal and writes
-// a brief recommendation. True tool-using sub-turns with allowedTools
-// enforcement at the provider edge are a follow-up; the runtime allow-list
-// primitive `check_allowed_tool` already lives in Rust ready for that wiring.
+// The sub-turn is tool-using: the AI sees the snapshot + goal and may call the
+// watchdog's allowedTools. The Rust agent loop executes those tools (restricted
+// to allowedTools and pre-approved via the sessionAllow policy approved at
+// watchdog creation), then returns the final assistant text.
 
 import { invoke } from "@tauri-apps/api/core";
 import { invokeCommand, isTauriRuntime } from "../lib/tauri";
@@ -102,10 +102,12 @@ async function invokeAiTurn(
       // 'chat' intent — we deliberately do NOT use 'watchdog' here because
       // that mode is for *creating* watchdogs, not running interventions.
       intent: "chat",
-      // No tools in v1 — the sub-turn is text-only. Setting false also
-      // sidesteps the global tool catalog so we don't accidentally expose
-      // tools outside the watchdog's allowedTools.
-      allowTools: false,
+      // Enable tools, but restrict them to the watchdog's allowedTools. The
+      // backend narrows the tool catalog to exactly this list and treats the
+      // listed tools as pre-approved (approved once at watchdog creation), so
+      // the unattended sub-turn can act without an approval modal.
+      allowTools: true,
+      allowedTools: payload.allowedTools,
       messages: [],
       systemContext,
     },
@@ -129,12 +131,13 @@ function buildSystemContext(
   return [
     `WATCHDOG INTERVENTION SUB-TURN.`,
     `Watchdog: "${watchdogName}" (id: hidden).`,
-    `You are responding to a triggered watchdog. This is NOT a chat with the user — it is an automated intervention.`,
-    `Hard rules: write a brief response (1–3 sentences). Do not ask questions. Do not propose tools you weren't given.`,
-    `Available actions in this version: text only — describe what *should* happen. Tool execution lands in a later release.`,
-    `If the situation is resolved (job finished, error cleared), include the literal phrase "WATCHDOG_DONE" in your response.`,
+    `You are responding to a triggered watchdog. This is NOT a chat with the user — it is an automated, unattended intervention. Nobody is watching to answer questions.`,
+    `Hard rules: act, don't ask. Do the minimum needed to advance the goal, then stop. Use ONLY the allowed tools below — no others are available.`,
+    `If you need a target pane or session id, call session_state first to discover it, then act. Keep any text you send to a terminal minimal and safe.`,
+    `When you are done, write a brief (1–2 sentence) summary of what you did.`,
+    `If the situation is fully resolved (job finished, error cleared, nothing left to do), include the literal phrase "WATCHDOG_DONE" in your summary so the watchdog can stop.`,
     `Goal: ${payload.goal}`,
-    `Allowed tools (reserved for the runtime; not callable from this sub-turn yet): ${payload.allowedTools.join(", ") || "(none)"}.`,
+    `Allowed tools: ${payload.allowedTools.join(", ") || "(none)"}.`,
   ].join("\n");
 }
 

--- a/src/watchdog/store.ts
+++ b/src/watchdog/store.ts
@@ -281,7 +281,9 @@ export const useWatchdogStore = create<WatchdogStoreState>((set, get) => ({
       createdAt: report.createdAt,
       pollMs: report.config.pollMs,
       triggerCount: report.triggers.length,
-      pollCount: Math.max(existing?.pollCount ?? 0, report.ticks.length),
+      // Authoritative count from the backend — `ticks` is ring-capped at 200,
+      // so deriving the count from it would understate long-running watchdogs.
+      pollCount: Math.max(existing?.pollCount ?? 0, report.pollCount),
       lastValue: report.ticks[report.ticks.length - 1]?.value ?? null,
     };
     set((s) => ({

--- a/src/watchdog/types.ts
+++ b/src/watchdog/types.ts
@@ -122,6 +122,7 @@ export interface WatchdogReport {
   triggers: WatchdogTriggerEvent[];
   interventions: WatchdogInterventionRecord[];
   createdAt: number;
+  pollCount: number;
 }
 
 /// Event payload from Rust `watchdog://event` channel.


### PR DESCRIPTION
Backend (registry/loop):
- Stay responsive to cancel while parked in an intervention: the poll loop
  now races cancellation against the record/timeout, so cancelling during
  Intervening no longer hangs up to the 5-minute intervention timeout.
- Notify watchdogs return to Running once the predicate clears instead of
  latching in Triggered forever (new triggered_sticky recovery).
- Treat reaching the intervention cap as a normal Completed outcome rather
  than Error; remove the unreachable pre-intervention cap check.
- Compute the suppression deadline once so the emitted Suppressed.until
  matches the loop's internal gate.
- Add authoritative poll_count to WatchdogReport (ticks are ring-capped).

Session activity:
- Wire SessionActivityTracker::forget into close_terminal_session so the
  per-session tail buffer no longer leaks and silence watchdogs stop
  measuring against closed sessions.

AI interventions (the headline gap):
- Intervention sub-turns now actually use tools. run_ai_agent gains an
  allowedTools list that narrows the tool catalog and marks those tools
  pre-approved (honoring the documented sessionAllow policy), so an
  unattended intervention can act without an approval modal. Enforced via
  the previously-dead check_allowed_tool primitive.
- Fix the intent contract's tool name (session_terminal_send_text, not the
  nonexistent session_send_text) and rewrite the sub-turn prompt to act.

Frontend:
- Derive the detail panel's "next check" from the latest tick instead of
  the frozen Running.lastPollAt.
- Use the report's authoritative pollCount.

Note: the Rust changes could not be compiled in this Linux container (Tauri
GTK system libs unavailable); validated by review. Frontend check suite,
tsc, and build all pass.

https://claude.ai/code/session_0149thwJGCeSnyW7YWQzNQY5