### PR TITLE
Expand connection folders while searching

### DIFF
--- a/docs/manual/03-connections.md
+++ b/docs/manual/03-connections.md
@@ -34,7 +34,7 @@ Header row (top of the panel):
 - New Folder: `connections.newFolder`
 - Collapse / Expand all: `connections.collapseAll`, `connections.expandAll`
 - Show All: `connections.showAll`; flattens the Connection Tree across folders, shows the button in its pressed state while enabled, and persists the preference in the Settings database across app relaunches.
-- Search box: placeholder `connections.searchPlaceholder`
+- Search box: placeholder `connections.searchPlaceholder`. While a search is active, matching folders are shown expanded so nested result rows are immediately visible; clearing search restores the folder collapse/expand state from before the search.
 - Column toggle: custom title-bar `app.connections` icon or Workspace icon on the Activity Rail
 
 Tree accessible label: `connections.connectionTree`. Expand/collapse chevrons use `connections.expand` / `connections.collapse`.

--- a/src/modules/workspace/connections/ConnectionSidebar.tsx
+++ b/src/modules/workspace/connections/ConnectionSidebar.tsx
@@ -1204,6 +1204,10 @@ export function ConnectionSidebar({
   }, []);
 
   const isTreeFiltered = deferredQuery.trim().length > 0;
+  const visibleCollapsedFolderIds = useMemo(
+    () => (isTreeFiltered ? new Set<string>() : collapsedFolderIds),
+    [collapsedFolderIds, isTreeFiltered],
+  );
   const visibleFlatConnections = useMemo(() => {
     if (!showAllConnections) {
       return [];
@@ -2143,7 +2147,7 @@ export function ConnectionSidebar({
                 draggedSourceId={draggedSourceId}
                 dropTarget={dropTarget}
                 folder={folder}
-                collapsedFolderIds={collapsedFolderIds}
+                collapsedFolderIds={visibleCollapsedFolderIds}
                 key={folder.id}
                 level={0}
                 parentFolderId={undefined}
@@ -2177,7 +2181,7 @@ export function ConnectionSidebar({
                   handleOpenConnection(connection);
                 }}
                 onPointerDragStart={handlePointerDragStart}
-                onToggleFolder={handleToggleFolder}
+                onToggleFolder={isTreeFiltered ? undefined : handleToggleFolder}
               />
             ))}
       </div>
@@ -2461,7 +2465,7 @@ function ConnectionFolderNode({
     item: DraggedTreeItem,
     preview: Omit<TreeDragPreview, "x" | "y" | "offsetX" | "offsetY" | "width">,
   ) => void;
-  onToggleFolder: (folderId: string) => void;
+  onToggleFolder?: (folderId: string) => void;
   onCancelPendingFolder: () => void;
   onCommitPendingFolder: (name: string, parentFolderId?: string) => void | Promise<void>;
   inlineRenameTarget: InlineRenameTarget | null;
@@ -2532,7 +2536,7 @@ function ConnectionFolderNode({
             onClick={(event) => {
               event.preventDefault();
               event.stopPropagation();
-              onToggleFolder(folder.id);
+              onToggleFolder?.(folder.id);
             }}
             onPointerDown={(event) => event.stopPropagation()}
             title={isCollapsed ? t("connections.expandFolder") : t("connections.collapseFolder")}


### PR DESCRIPTION
### Motivation
- When a search in the Connections tree returns hits inside folders, those folders should auto-expand so matching rows are immediately visible without forcing the user to manually expand them.
- The user's persisted folder collapse/expand state must be preserved and restored when the search is cleared.

### Description
- Render a search-time collapsed-folder set by adding `visibleCollapsedFolderIds = useMemo(() => (isTreeFiltered ? new Set<string>() : collapsedFolderIds), ...)` and pass it to `ConnectionFolderNode` so folders appear expanded during filtering in `src/modules/workspace/connections/ConnectionSidebar.tsx`.
- Prevent search-time clicks from mutating saved state by making `onToggleFolder` optional and passing `onToggleFolder={isTreeFiltered ? undefined : handleToggleFolder}` so toggle actions are disabled while filtering.
- Use safe invocation `onToggleFolder?.(folder.id)` in the folder disclosure handler and update the `ConnectionFolderNode` prop type accordingly.
- Document the behavior in `docs/manual/03-connections.md` noting that matching folders are expanded during search and the previous collapse/expand state is restored when the search is cleared.

### Testing
- `npx tsc --noEmit` was run and succeeded (TypeScript compile pass).
- `npm run check` was executed but failed in an existing tutorial-target test (`tests/tutorial-target-navigation.test.mjs`) due to a Node v20.20.2 iterator/`flatMap` incompatibility unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d28c457c8832fa58d74055304a42a)