### PR TITLE
Fix URL webview new-window link navigation

### DIFF
--- a/docs/manual/08-url-webview.md
+++ b/docs/manual/08-url-webview.md
@@ -22,7 +22,7 @@ Tutorial target: `webview.surface`.
 - Address bar: `webview.address`, placeholder `webview.urlPlaceholder`. The bar accepts hosts without a scheme; the backend assumes `https://` when no scheme is present.
 - Auto-refresh: `webview.autoRefresh` / `webview.autoRefreshOff`. Interval label `webview.autoRefreshSeconds`.
 - Open externally: toolbar button `webview.openExternally` (opens the current URL in the OS default browser).
-- In-page link shortcut: Shift-click an http(s) link in the embedded page to open it in the OS default browser instead of navigating the URL Pane.
+- In-page links: normal http(s) link clicks navigate inside the URL Pane, including links that ask for a new browser window. Shift-click an http(s) link in the embedded page to open it in the OS default browser instead of navigating the URL Pane.
 - Fill saved credential: `webview.fill` / `webview.fillCredential` / `webview.fillSavedCredential`.
 - Save password: `webview.savePassword`, dialog title `webview.savePasswordTitle`.
 - Save/reset split Pane layout for this URL Connection: `terminal.saveLayout` / `terminal.resetLayout`. Status Bar confirmations: `terminal.layoutSaved` / `terminal.layoutReset`.

--- a/src-tauri/src/webview.rs
+++ b/src-tauri/src/webview.rs
@@ -10,7 +10,7 @@ use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use tauri::{
     AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, Webview, WebviewBuilder, WebviewUrl,
-    webview::{DownloadEvent, PageLoadEvent},
+    webview::{DownloadEvent, NewWindowResponse, PageLoadEvent},
 };
 
 const HOST_WINDOW_LABEL: &str = "main";
@@ -495,6 +495,13 @@ struct WebviewDownloadPayload {
     success: Option<bool>,
 }
 
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WebviewNewWindowPayload {
+    session_id: String,
+    url: String,
+}
+
 /// RAII reservation for the `starting_sessions` set. Clears the reservation on
 /// drop — including any early `?` return or panic during startup — unless
 /// `commit()` is called on success. Without this, an error after the
@@ -601,6 +608,8 @@ impl WebviewSessionManager {
         let title_session_id = session_id.clone();
         let download_app = app.clone();
         let download_session_id = session_id.clone();
+        let new_window_app = app.clone();
+        let new_window_session_id = session_id.clone();
         let initial_webview_url = if ignore_certificate_errors && cfg!(windows) {
             parse_webview_blank_url()?
         } else {
@@ -645,6 +654,18 @@ impl WebviewSessionManager {
                         title,
                     },
                 );
+            })
+            .on_new_window(move |url, _features| {
+                if matches!(url.scheme(), "http" | "https") {
+                    let _ = new_window_app.emit(
+                        "webview-new-window",
+                        WebviewNewWindowPayload {
+                            session_id: new_window_session_id.clone(),
+                            url: url.to_string(),
+                        },
+                    );
+                }
+                NewWindowResponse::Deny
             })
             .on_download(move |_webview, event| {
                 let payload = match event {

--- a/src/modules/workspace/connections/webview/WebViewWorkspace.tsx
+++ b/src/modules/workspace/connections/webview/WebViewWorkspace.tsx
@@ -27,6 +27,11 @@ type WebviewTitleChangedEvent = {
   title: string;
 };
 
+type WebviewNewWindowEvent = {
+  sessionId: string;
+  url: string;
+};
+
 type WebviewDownloadEvent = {
   sessionId: string;
   url: string;
@@ -452,6 +457,16 @@ export function WebViewWorkspace({
           void maybeUpdateConnectionIcon(event.payload.url);
           void fillCredential({ automatic: true, showStatus: false });
         }
+      }),
+      listen<WebviewNewWindowEvent>("webview-new-window", (event) => {
+        if (event.payload.sessionId !== sessionIdRef.current) {
+          return;
+        }
+        void invokeCommand("webview_navigate", {
+          request: { sessionId: sessionIdRef.current, url: event.payload.url },
+        }).catch((error) => {
+          setNavError(error instanceof Error ? error.message : String(error));
+        });
       }),
       listen<WebviewTitleChangedEvent>("webview-title-changed", (event) => {
         if (event.payload.sessionId !== sessionIdRef.current) {


### PR DESCRIPTION
### Motivation
- Some sites open links using `target=_blank` / `window.open`, which previously caused those clicks to disappear instead of navigating the embedded URL Pane. 
- The intent is to keep normal http(s) link clicks inside the URL Connection surface while preserving Shift-click to open externally.

### Description
- Add a `WebviewNewWindowPayload` and an `on_new_window` handler in `src-tauri/src/webview.rs` that emits a `webview-new-window` event for http(s) new-window requests and returns `NewWindowResponse::Deny` to avoid creating a separate window. 
- Add a frontend `WebviewNewWindowEvent` listener in `src/modules/workspace/connections/webview/WebViewWorkspace.tsx` that routes the emitted URL into the same session by calling the existing `webview_navigate` command. 
- Update `docs/manual/08-url-webview.md` to clarify that normal in-page http(s) clicks (including links that request a new window) navigate inside the URL Pane and that Shift-click still opens externally. 
- Keep the change targeted and minimal to avoid touching unrelated behaviors or overlay rules.

### Testing
- Ran `npx tsc --noEmit`, which completed successfully. 
- Ran `git diff --check`, which reported no problems. 
- Attempted `npm run check`, which failed in this environment due to a Node runtime test error (`source.matchAll.flatMap is not a function`) in `tests/tutorial-target-navigation.test.mjs`. 
- Attempted `cargo check --manifest-path src-tauri/Cargo.toml`, which could not complete in this Linux CI environment due to a missing system dependency (`glib-2.0.pc` / `glib-2.0` pkg-config), so full Rust build checks were not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d67a430a4832f8c425704a21d68c3)