### PR TITLE
Optimize workspace pane collapse animation

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -129,7 +129,7 @@
 }
 
 .app-shell.panel-animating {
-  transition: grid-template-columns 500ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition: grid-template-columns 180ms cubic-bezier(0.2, 0, 0, 1);
 }
 
 .workspace-page {
@@ -311,7 +311,8 @@
   background: var(--chrome);
   border-right: 1px solid var(--border);
   opacity: 1;
-  transition: opacity 300ms ease-out;
+  contain: layout style;
+  transition: opacity 120ms ease-out;
 }
 
 .connection-sidebar {
@@ -342,7 +343,7 @@
   opacity: 0;
   border-right: 0;
   pointer-events: none;
-  transition: opacity 150ms ease-in;
+  transition: opacity 90ms ease-in;
 }
 
 .panel-resize-handle {

--- a/src/app/workspaceChromeLayout.tsx
+++ b/src/app/workspaceChromeLayout.tsx
@@ -17,6 +17,7 @@ const AI_PANEL_MAX_WIDTH = 1860;
 
 const CONNECTION_PANEL_LAYOUT_KEY = "kkterm.layout.connectionsPanel.v1";
 const AI_PANEL_LAYOUT_KEY = "kkterm.layout.aiAssistPanel.v2";
+const PANEL_ANIMATION_MS = 180;
 
 const defaultConnectionPanelLayout: PanelLayoutState = {
   collapsed: false,
@@ -140,7 +141,7 @@ export function useWorkspaceChromeLayout(resetAllLayouts: () => void) {
     if (!panelAnimating) {
       return;
     }
-    const timer = setTimeout(() => setPanelAnimating(false), 500);
+    const timer = setTimeout(() => setPanelAnimating(false), PANEL_ANIMATION_MS);
     return () => clearTimeout(timer);
   }, [panelAnimating]);
 


### PR DESCRIPTION
### Motivation
- The Connection sidebar and AI Assistant panel collapse/expand animation felt sluggish on machines without a dedicated GPU, so make a small, surgical change to reduce perceived latency and lower layout/paint work during the transition.

### Description
- Replace the 500ms bouncy grid transition with a 180ms non-bouncy easing curve in `.app-shell.panel-animating`, add `PANEL_ANIMATION_MS` and align the React `panelAnimating` timeout in `useWorkspaceChromeLayout`, and add `contain: layout style` plus shorter opacity transitions for `.connection-sidebar` and `.assistant-panel` to reduce reflow/paint during show/hide.

### Testing
- Ran `npx tsc --noEmit` (succeeded), ran `git diff --check` (succeeded), and executed `npm run check` which failed due to an existing test (`tests/tutorial-target-navigation.test.mjs`) error on the Node.js v20.20.2 environment (`source.matchAll(...).flatMap` usage), so the TypeScript build is clean but the full check-suite cannot pass in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e364fbb00832fb18305e09c6c89d3)