### PR TITLE
Increase pane resize hit target and add subtle hinge depth

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -108,9 +108,9 @@
   grid-template-columns:
     48px var(--connection-panel-width, 292px) var(
       --connection-resize-width,
-      1px
+      3px
     )
-    minmax(0, 1fr) var(--ai-resize-width, 1px)
+    minmax(0, 1fr) var(--ai-resize-width, 3px)
     var(--ai-panel-width, 334px);
   grid-template-rows: minmax(0, 1fr) 28px;
   width: 100%;
@@ -352,12 +352,21 @@
   z-index: 5;
   display: grid;
   place-items: center;
-  min-width: 1px;
+  min-width: 3px;
   width: 100%;
   height: 100%;
   padding: 0;
   color: var(--text-faint);
-  background: var(--border);
+  background: linear-gradient(
+    90deg,
+    rgb(0 0 0 / 0.08),
+    var(--border) 36%,
+    var(--border) 64%,
+    rgb(255 255 255 / 0.2)
+  );
+  box-shadow:
+    inset 1px 0 rgb(255 255 255 / 0.16),
+    inset -1px 0 rgb(0 0 0 / 0.12);
   cursor: col-resize;
 }
 
@@ -404,6 +413,7 @@
 .panel-resize-handle-collapsed {
   color: var(--text);
   background: #bfd0ea;
+  box-shadow: none;
   cursor: pointer;
 }
 

--- a/src/app/appShellEffects.ts
+++ b/src/app/appShellEffects.ts
@@ -214,9 +214,9 @@ export function useAppShellAppearance({
       "--connection-panel-width",
       connectionPanelLayout.collapsed ? "0px" : `${connectionPanelLayout.width}px`,
     );
-    node.style.setProperty("--connection-resize-width", "1px");
+    node.style.setProperty("--connection-resize-width", "3px");
     node.style.setProperty("--ai-panel-width", aiPanelLayout.collapsed ? "0px" : `${aiPanelLayout.width}px`);
-    node.style.setProperty("--ai-resize-width", aiPanelLayout.collapsed ? "34px" : "1px");
+    node.style.setProperty("--ai-resize-width", aiPanelLayout.collapsed ? "34px" : "3px");
     node.style.setProperty("--app-ui-font-family", appearanceSettings.appFontFamily);
     node.setAttribute("data-color-scheme", appearanceSettings.colorScheme);
     document.documentElement.setAttribute("data-color-scheme", appearanceSettings.colorScheme);


### PR DESCRIPTION
### Motivation
- The existing connection and AI-assistant pane resize tracks were only 1px and difficult to precisely grab. 
- A slightly larger drag target and a subtle visual depth cue improves usability and affordance without changing interaction behavior. 

### Description
- Increased the resize track fallback and runtime CSS variables from `1px` to `3px` for both the Connection and AI Assistant panels by updating the grid template and runtime style properties. (`src/app/app.css`, `src/app/appShellEffects.ts`).
- Enlarged the panel handle min-width to `3px` so the hit target matches the grid sizing. (`src/app/app.css`).
- Added a subtle linear-gradient and small inset `box-shadow` to the hinge for a VSCode-like depth feeling while preserving the existing 3px hover/focus accent bar. (`src/app/app.css`).

### Testing
- Ran TypeScript checks with `npx tsc --noEmit`, which completed successfully. 
- Ran the project's check script `npm run check`, which failed early due to an unrelated test/runtime issue in the test harness (Node v20.20.2: `source.matchAll(...).flatMap` not available), so the full test suite could not be exercised here. 
- Ran `git diff --check` to validate diffs and whitespace rules, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e6a7e9e08832fa3e0b3925d0455ff)