### PR TITLE
Add assistant selection Copy context menu

### DIFF
--- a/docs/manual/13-ai-assistant.md
+++ b/docs/manual/13-ai-assistant.md
@@ -2,7 +2,7 @@
 
 ## AI grep hints
 
-- Keys: `ai.*` (full namespace), `app.aiAssistant`, `settings.mcp*`, `settings.assistantSkills*`, `settings.aiToolsTitle`, `settings.sectionAiAssistant`, `settings.credentialKindAiApiKey`, `settings.aiTools.tutorial.*`, `common.expand`, `common.collapse`
+- Keys: `ai.*` (full namespace), `app.aiAssistant`, `settings.mcp*`, `settings.assistantSkills*`, `settings.aiToolsTitle`, `settings.sectionAiAssistant`, `settings.credentialKindAiApiKey`, `settings.aiTools.tutorial.*`, `common.expand`, `common.collapse`, `common.copy`
 - Topics: AI panel, chats, new chat, history, SQLite, tool permission modes, tool defaults, collapsible assistant tools, collapsible Assistant Skills, bundled skills, SKILL.md, Tutorial overlay, tutorial navigation, `connections.addConnection`, intents (Watchdog / Create Widget / Extension Draft), MCP servers, attachments (files, screenshots, terminal buffer), provider keys, send-to-terminal, compact page context, UTF-8 widget updates, non-English assistant output, Advanced Debugging, AI Assistant debug logs, MCP debug logs, Installer Helper debug logs, heartbeat debug logs
 - Synonyms: "chat", "copilot", "AI bot", "tools", "approval", "MCP", "agent", "skill", "skills", "SKILL.md", "workflow", "ssh-troubleshooter", "dashboard-widget-builder", "terminal-command-planner", "sftp-transfer-helper", "remote-desktop-helper", "network-connectivity-troubleshooter", "dns-dhcp-troubleshooter", "firewall-port-troubleshooter", "tls-certificate-troubleshooter", "network troubleshooting", "DNS", "DHCP", "firewall", "port check", "TLS", "certificate", "watchdog", "highlight this", "show me where", "where are chats stored", "clear chat storage", "expand tools", "collapse skills", "garbled text", "mojibake", "encoding", "UTF8", "UTF-8", "debug log", "AI debug log", "MCP debug log", "Installer Helper debug log", "heartbeat debug log", "aiassistant.debug.log", "mcp.debug.log", "installer.helper.debug.log", "kkterm-heartbeat.debug.log", "context too large"
 
@@ -22,7 +22,7 @@ Chat history is stored in SQLite table `assistant_chat_threads`, indexed for rec
 
 ## Composer
 
-Default placeholder `ai.composerPlaceholder`. Send `ai.sendMessage` / `ai.send`. Stop in-flight `ai.stopMessage`. Copy `ai.copy` / `ai.copyMessage`. Code label `ai.code`. Show-less / more `ai.showLess` / `ai.more`.
+Default placeholder `ai.composerPlaceholder`. Send `ai.sendMessage` / `ai.send`. Stop in-flight `ai.stopMessage`. Copy `ai.copy` / `ai.copyMessage`. Highlighted Assistant Panel text can also be copied from the right-click native context menu item `common.copy`. Code label `ai.code`. Show-less / more `ai.showLess` / `ai.more`.
 
 ### Attachments
 

--- a/src/ai/AssistantPanel.tsx
+++ b/src/ai/AssistantPanel.tsx
@@ -2510,6 +2510,47 @@ export function AssistantPanel({
     insertTextIntoComposer(textarea, "");
   }
 
+  function selectedAssistantPanelText(panel: HTMLElement) {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+      return "";
+    }
+
+    const anchorNode = selection.anchorNode;
+    const focusNode = selection.focusNode;
+    if (
+      (!anchorNode || !panel.contains(anchorNode)) &&
+      (!focusNode || !panel.contains(focusNode))
+    ) {
+      return "";
+    }
+
+    return selection.toString();
+  }
+
+  async function handleAssistantPanelContextMenu(event: MouseEvent<HTMLElement>) {
+    const selectedText = selectedAssistantPanelText(event.currentTarget);
+    if (!selectedText || !isTauriRuntime()) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    await showNativeContextMenu(
+      [
+        {
+          kind: "item",
+          label: t("common.copy"),
+          action: () => {
+            void writeToClipboard(selectedText);
+          },
+        },
+      ],
+      { x: event.clientX, y: event.clientY },
+    );
+  }
+
   async function handleComposerContextMenu(event: MouseEvent<HTMLTextAreaElement>) {
     event.preventDefault();
     event.stopPropagation();
@@ -2729,7 +2770,10 @@ export function AssistantPanel({
   }, [screenshotRegionState]);
 
   return (
-    <aside className="assistant-panel">
+    <aside
+      className="assistant-panel"
+      onContextMenu={(event) => void handleAssistantPanelContextMenu(event)}
+    >
       <div className="assistant-topbar">
         <h2>{t("ai.title")}</h2>
         <button


### PR DESCRIPTION
### Motivation
- Users expect to be able to right-click highlighted text and copy it from the AI Assistant panel just like other app surfaces. 
- Provide a native Tauri context menu affordance that mirrors existing composer menu behavior and avoids adding DOM-only menus.

### Description
- Added `selectedAssistantPanelText` helper and `handleAssistantPanelContextMenu` to `src/ai/AssistantPanel.tsx` to detect panel-scoped selection and show a native menu. 
- The native menu uses `showNativeContextMenu` and `writeToClipboard`, and guards on `isTauriRuntime()` so it only appears in the desktop runtime. 
- Wired the assistant container with `onContextMenu={(event) => void handleAssistantPanelContextMenu(event)}` and preserved the existing composer-specific context menu behavior. 
- Updated `docs/manual/13-ai-assistant.md` to document the highlighted-text copy behavior and added `common.copy` to the grep hints.

### Testing
- Ran the TypeScript check with `npx tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e71cac140832f8ccd5d6699a874bd)