### PR TITLE
Fix Windows build errors in heartbeat and installer

### DIFF
--- a/src-tauri/src/debug_heartbeat.rs
+++ b/src-tauri/src/debug_heartbeat.rs
@@ -270,9 +270,8 @@ mod debug_impl {
     fn process_gui_resources() -> (Option<u32>, Option<u32>) {
         #[cfg(target_os = "windows")]
         {
-            use windows_sys::Win32::System::Threading::GetCurrentProcess;
-            use windows_sys::Win32::UI::WindowsAndMessaging::{
-                GR_GDIOBJECTS, GR_USEROBJECTS, GetGuiResources,
+            use windows_sys::Win32::System::Threading::{
+                GR_GDIOBJECTS, GR_USEROBJECTS, GetCurrentProcess, GetGuiResources,
             };
             // SAFETY: GetCurrentProcess returns a pseudo-handle; GetGuiResources
             // only reads this process's GDI/USER object counts. A zero return

--- a/src-tauri/src/installer/install.rs
+++ b/src-tauri/src/installer/install.rs
@@ -466,7 +466,8 @@ fn winget_app_installer_powershell_script(download_path: &PathBuf) -> String {
             "Add-AppxPackage -Path {package_path}; ",
             "try {{ Add-AppxPackage -RegisterByFamilyName -MainPackage $family -ErrorAction Stop }} catch {{ }}; ",
             "exit 0"
-        )
+        ),
+        package_path = package_path
     )
 }
 


### PR DESCRIPTION
- Import GR_GDIOBJECTS, GR_USEROBJECTS, GetGuiResources from
  Win32::System::Threading where windows-sys defines them, not
  Win32::UI::WindowsAndMessaging.
- Pass package_path explicitly as a named argument to format!; implicit
  capture is not allowed when the format string is expanded from concat!.

https://claude.ai/code/session_0165Dyysr2jVrxfr74FdZgtp