### PR TITLE
Fix SFTP drive and symlink navigation

### DIFF
--- a/docs/manual/07-sftp.md
+++ b/docs/manual/07-sftp.md
@@ -28,7 +28,7 @@ Startup states:
 
 Two columns:
 
-- **Local** (`sftp.local`, `sftp.localFiles`) — loading state `sftp.loadingLocal`.
+- **Local** (`sftp.local`, `sftp.localFiles`) — loading state `sftp.loadingLocal`. On Windows, opening the parent of a drive root shows the drive picker path label `sftp.windowsDrives`, where double-clicking a drive opens that drive root.
 - **Remote** (`sftp.remote`) — empty state `sftp.noFiles`, loading `sftp.loading`.
 
 A bottom strip shows the **Transfer Activity** queue (`sftp.transferActivity`):
@@ -50,7 +50,7 @@ Both panes share the same set of actions (with `Aria` siblings for accessibility
 - Refresh files: `sftp.refreshFiles` (`sftp.refreshFilesAria`)
 - Sort: `sftp.sortBy` (`sftp.sortByAria`, title `sftp.sortByTitle`). Modes: `sftp.name`, `sftp.date`.
 
-Double-click affordance hint: `sftp.doubleClickToOpen`, `sftp.doubleClickToOpenFile`.
+Double-click affordance hint: `sftp.doubleClickToOpen`, `sftp.doubleClickToOpenFile`. Remote symbolic links that resolve to directories are listed as openable folder entries so double-clicking enters the resolved target directory.
 
 ## Transferring files
 

--- a/src-tauri/src/sftp.rs
+++ b/src-tauri/src/sftp.rs
@@ -1,7 +1,7 @@
 use crate::{secrets, ssh};
-use russh::{Disconnect, client};
+use russh::{client, Disconnect};
 use russh_sftp::{
-    client::{SftpSession, fs::Metadata},
+    client::{fs::Metadata, SftpSession},
     protocol::{FileAttributes, FileType, OpenFlags},
 };
 use serde::{Deserialize, Serialize};
@@ -13,8 +13,8 @@ use std::{
     path::{Path, PathBuf},
     pin::Pin,
     sync::{
-        Arc,
         atomic::{AtomicBool, Ordering},
+        Arc,
     },
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -24,6 +24,7 @@ use tokio::runtime::Runtime;
 
 const TRANSFER_CHUNK_SIZE: usize = 64 * 1024;
 const TRANSFER_CANCELED: &str = "transfer canceled";
+const WINDOWS_DRIVES_PATH: &str = "__KKTERM_WINDOWS_DRIVES__";
 
 pub struct SftpSessionManager {
     sessions: std::sync::Mutex<HashMap<String, SftpConnection>>,
@@ -867,7 +868,15 @@ async fn download_file_chunks(
 pub fn list_local_directory(
     request: ListLocalDirectoryRequest,
 ) -> Result<LocalDirectoryListing, String> {
-    let directory = resolve_local_directory(request.path.as_deref())?;
+    let requested_path = request.path.as_deref();
+    if requested_path == Some(WINDOWS_DRIVES_PATH) {
+        return list_windows_drives();
+    }
+
+    let directory = resolve_local_directory(requested_path)?;
+    if requested_path.is_some_and(requests_parent_directory) && is_windows_drive_root(&directory) {
+        return list_windows_drives();
+    }
     let mut entries = fs::read_dir(&directory)
         .map_err(|error| format!("failed to list local directory: {error}"))?
         .filter_map(|entry| entry.ok())
@@ -912,32 +921,35 @@ async fn read_directory(
         .canonicalize(path)
         .await
         .map_err(|error| format!("failed to resolve SFTP directory: {error}"))?;
-    let mut entries = sftp
+    let dir_entries = sftp
         .read_dir(canonical_path.clone())
         .await
         .map_err(|error| format!("failed to list SFTP directory: {error}"))?
-        .map(|entry| {
-            let metadata = entry.metadata();
-            SftpDirectoryEntry {
-                name: entry.file_name(),
-                kind: file_kind(metadata.file_type()).to_string(),
-                size: metadata.size,
-                modified: metadata
-                    .modified()
-                    .ok()
-                    .and_then(|time| unix_timestamp(time).ok()),
-                accessed: metadata
-                    .accessed()
-                    .ok()
-                    .and_then(|time| unix_timestamp(time).ok()),
-                permissions: metadata.permissions.map(sftp_file_mode),
-                uid: metadata.uid,
-                user: metadata.user,
-                gid: metadata.gid,
-                group: metadata.group,
-            }
-        })
         .collect::<Vec<_>>();
+    let mut entries = Vec::with_capacity(dir_entries.len());
+    for entry in dir_entries {
+        let metadata = entry.metadata();
+        let name = entry.file_name();
+        let kind = remote_listing_kind(sftp, &canonical_path, &name, metadata.file_type()).await;
+        entries.push(SftpDirectoryEntry {
+            name,
+            kind: kind.to_string(),
+            size: metadata.size,
+            modified: metadata
+                .modified()
+                .ok()
+                .and_then(|time| unix_timestamp(time).ok()),
+            accessed: metadata
+                .accessed()
+                .ok()
+                .and_then(|time| unix_timestamp(time).ok()),
+            permissions: metadata.permissions.map(sftp_file_mode),
+            uid: metadata.uid,
+            user: metadata.user,
+            gid: metadata.gid,
+            group: metadata.group,
+        });
+    }
     entries.sort_by(|left, right| {
         file_kind_rank(&left.kind)
             .cmp(&file_kind_rank(&right.kind))
@@ -949,6 +961,23 @@ async fn read_directory(
         path: canonical_path,
         entries,
     })
+}
+
+async fn remote_listing_kind(
+    sftp: &SftpSession,
+    parent_path: &str,
+    name: &str,
+    file_type: FileType,
+) -> &'static str {
+    if file_type != FileType::Symlink {
+        return file_kind(file_type);
+    }
+
+    let path = join_remote_path(parent_path, name);
+    match sftp.metadata(path).await {
+        Ok(metadata) if metadata.file_type() == FileType::Dir => "folder",
+        _ => file_kind(file_type),
+    }
 }
 
 async fn path_properties(sftp: &SftpSession, path: &str) -> Result<SftpPathProperties, String> {
@@ -1374,6 +1403,50 @@ fn resolve_local_directory(path: Option<&str>) -> Result<PathBuf, String> {
         return Err("local path is not a directory".to_string());
     }
     Ok(directory)
+}
+
+fn list_windows_drives() -> Result<LocalDirectoryListing, String> {
+    #[cfg(windows)]
+    {
+        let mut entries = Vec::new();
+        for letter in b'A'..=b'Z' {
+            let path = format!("{}:\\", letter as char);
+            if Path::new(&path).is_dir() {
+                entries.push(LocalDirectoryEntry {
+                    name: path,
+                    kind: "folder".to_string(),
+                    size: None,
+                    modified: None,
+                });
+            }
+        }
+
+        return Ok(LocalDirectoryListing {
+            path: WINDOWS_DRIVES_PATH.to_string(),
+            entries,
+        });
+    }
+
+    #[cfg(not(windows))]
+    {
+        Err("Windows drive navigation is only available on Windows".to_string())
+    }
+}
+
+fn requests_parent_directory(path: &str) -> bool {
+    Path::new(path)
+        .components()
+        .any(|component| component == std::path::Component::ParentDir)
+}
+
+fn is_windows_drive_root(path: &Path) -> bool {
+    let value = display_local_path(path);
+    let mut chars = value.chars();
+    matches!(
+        (chars.next(), chars.next(), chars.next(), chars.next()),
+        (Some(letter), Some(':'), Some(separator), None)
+            if letter.is_ascii_alphabetic() && (separator == '\\' || separator == '/')
+    )
 }
 
 fn default_local_directory() -> PathBuf {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1977,7 +1977,8 @@
     "uploadConflict": "Upload-Konflikt",
     "verifyingHost": "Host überprüfen",
     "waiting": "Warten",
-    "waitingToOverwrite": "Warten auf Überschreiben"
+    "waitingToOverwrite": "Warten auf Überschreiben",
+    "windowsDrives": "Dieser PC"
   },
   "terminal": {
     "actions": "Terminalaktionen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1984,7 +1984,8 @@
     "deleteRemoteItemsMultiple": "Delete {{count}} remote items?",
     "renameFileAria": "Rename {{name}}",
     "fileTypeLabel": "{{ext}} file",
-    "targetExistsDetail": "The target {{kind}} already exists. Choose whether to overwrite {{name}}."
+    "targetExistsDetail": "The target {{kind}} already exists. Choose whether to overwrite {{name}}.",
+    "windowsDrives": "This PC"
   },
   "webview": {
     "goBack": "Go back",

--- a/src/i18n/locales/es-MX.json
+++ b/src/i18n/locales/es-MX.json
@@ -1977,7 +1977,8 @@
     "uploadConflict": "Conflicto de subida",
     "verifyingHost": "Verificando host",
     "waiting": "Esperando",
-    "waitingToOverwrite": "Esperando para sobrescribir"
+    "waitingToOverwrite": "Esperando para sobrescribir",
+    "windowsDrives": "Este equipo"
   },
   "terminal": {
     "actions": "Acciones del terminal",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1977,7 +1977,8 @@
     "uploadConflict": "Conflicto de subida",
     "verifyingHost": "Verificando host",
     "waiting": "Esperando",
-    "waitingToOverwrite": "Esperando para sobrescribir"
+    "waitingToOverwrite": "Esperando para sobrescribir",
+    "windowsDrives": "Este equipo"
   },
   "terminal": {
     "actions": "Acciones del terminal",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1977,7 +1977,8 @@
     "uploadConflict": "Conflit de téléversement",
     "verifyingHost": "Vérification de l'hôte",
     "waiting": "En attente",
-    "waitingToOverwrite": "En attente d'écrasement"
+    "waitingToOverwrite": "En attente d'écrasement",
+    "windowsDrives": "Ce PC"
   },
   "terminal": {
     "actions": "Actions du terminal",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -1977,7 +1977,8 @@
     "uploadConflict": "Konflik unggah",
     "verifyingHost": "Memverifikasi host",
     "waiting": "Menunggu",
-    "waitingToOverwrite": "Menunggu untuk menimpa"
+    "waitingToOverwrite": "Menunggu untuk menimpa",
+    "windowsDrives": "PC ini"
   },
   "terminal": {
     "actions": "Aksi terminal",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1977,7 +1977,8 @@
     "uploadConflict": "Conflitto caricamento",
     "verifyingHost": "Verifica host",
     "waiting": "In attesa",
-    "waitingToOverwrite": "In attesa di sovrascrivere"
+    "waitingToOverwrite": "In attesa di sovrascrivere",
+    "windowsDrives": "Questo PC"
   },
   "terminal": {
     "actions": "Azioni terminale",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1977,7 +1977,8 @@
     "uploadConflict": "アップロードの競合",
     "verifyingHost": "ホストを確認中",
     "waiting": "待機中",
-    "waitingToOverwrite": "上書き待ち"
+    "waitingToOverwrite": "上書き待ち",
+    "windowsDrives": "PC"
   },
   "terminal": {
     "actions": "ターミナル操作",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1977,7 +1977,8 @@
     "uploadConflict": "업로드 충돌",
     "verifyingHost": "호스트 확인 중",
     "waiting": "대기 중",
-    "waitingToOverwrite": "덮어쓰기 대기 중"
+    "waitingToOverwrite": "덮어쓰기 대기 중",
+    "windowsDrives": "내 PC"
   },
   "terminal": {
     "actions": "터미널 작업",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1977,7 +1977,8 @@
     "uploadConflict": "Conflito de envio",
     "verifyingHost": "Verificando host",
     "waiting": "Aguardando",
-    "waitingToOverwrite": "Aguardando para sobrescrever"
+    "waitingToOverwrite": "Aguardando para sobrescrever",
+    "windowsDrives": "Este computador"
   },
   "terminal": {
     "actions": "Ações do terminal",

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -1977,7 +1977,8 @@
     "uploadConflict": "ข้อขัดแย้งการอัปโหลด",
     "verifyingHost": "กำลังตรวจสอบโฮสต์",
     "waiting": "กำลังรอ",
-    "waitingToOverwrite": "กำลังรอเขียนทับ"
+    "waitingToOverwrite": "กำลังรอเขียนทับ",
+    "windowsDrives": "พีซีเครื่องนี้"
   },
   "terminal": {
     "actions": "การทำงานเทอร์มินัล",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -1977,7 +1977,8 @@
     "uploadConflict": "Upload conflict",
     "verifyingHost": "Verifying host",
     "waiting": "Waiting",
-    "waitingToOverwrite": "Đang chờ ghi đè"
+    "waitingToOverwrite": "Đang chờ ghi đè",
+    "windowsDrives": "PC này"
   },
   "terminal": {
     "actions": "Terminal actions",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1977,7 +1977,8 @@
     "uploadConflict": "上传冲突",
     "verifyingHost": "正在验证主机",
     "waiting": "等待中",
-    "waitingToOverwrite": "等待覆盖"
+    "waitingToOverwrite": "等待覆盖",
+    "windowsDrives": "此电脑"
   },
   "terminal": {
     "actions": "终端操作",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1977,7 +1977,8 @@
     "uploadConflict": "上傳衝突",
     "verifyingHost": "正在驗證主機",
     "waiting": "等待中",
-    "waitingToOverwrite": "等待覆寫"
+    "waitingToOverwrite": "等待覆寫",
+    "windowsDrives": "本機"
   },
   "terminal": {
     "actions": "終端機動作",

--- a/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
+++ b/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
@@ -39,6 +39,7 @@ import type {
 } from "./types";
 
 const TRANSFER_HISTORY_STATES: TransferRecord["state"][] = ["canceled", "done", "failed"];
+const WINDOWS_DRIVES_PATH = "__KKTERM_WINDOWS_DRIVES__";
 
 export function SftpWorkspace({
   isActive,
@@ -275,16 +276,24 @@ export function SftpWorkspace({
     await loadRemoteDirectory(joinRemotePath(remotePath, ".."));
   };
 
+  const isLocalDrivePicker = localPath === WINDOWS_DRIVES_PATH;
+
   const refreshLocalDirectory = async () => {
     await loadLocalDirectory(localPath || undefined);
   };
 
   const openLocalFolder = async (folderName: string) => {
-    await loadLocalDirectory(joinLocalPath(localPath, folderName));
+    await loadLocalDirectory(
+      isLocalDrivePicker ? folderName : joinLocalPath(localPath, folderName),
+    );
   };
 
   const openLocalParent = async () => {
-    await loadLocalDirectory(joinLocalPath(localPath, ".."));
+    await loadLocalDirectory(
+      isLocalDrivePicker || isWindowsDriveRoot(localPath)
+        ? WINDOWS_DRIVES_PATH
+        : joinLocalPath(localPath, ".."),
+    );
   };
 
   const setTransferState = (id: string, patch: Partial<TransferRecord>) => {
@@ -480,6 +489,9 @@ export function SftpWorkspace({
         ? localFiles.filter((file) => names.includes(file.name))
         : remoteFiles.filter((file) => names.includes(file.name));
     if (!sessionId || selected.length === 0 || !localPath || !isTauriRuntime()) {
+      return;
+    }
+    if (direction === "upload" && isLocalDrivePicker) {
       return;
     }
 
@@ -695,7 +707,9 @@ export function SftpWorkspace({
       return;
     }
 
-    handleDownload(names);
+    if (!isLocalDrivePicker) {
+      handleDownload(names);
+    }
   };
 
   const handleOpenContextMenu = (
@@ -764,7 +778,11 @@ export function SftpWorkspace({
     }
 
     const path =
-      side === "local" ? joinLocalPath(localPath, entry.name) : joinRemotePath(remotePath, entry.name);
+      side === "local"
+        ? isLocalDrivePicker
+          ? entry.name
+          : joinLocalPath(localPath, entry.name)
+        : joinRemotePath(remotePath, entry.name);
     let remoteProperties: SftpPathProperties | undefined;
     if (side === "remote") {
       const sessionId = sessionIdRef.current;
@@ -897,7 +915,7 @@ export function SftpWorkspace({
           <button
             className="toolbar-button"
             data-tutorial-id="sftp.upload"
-            disabled={!isConnected || selectedLocalFiles.length === 0}
+            disabled={!isConnected || isLocalDrivePicker || selectedLocalFiles.length === 0}
             onClick={() => handleUpload()}
             type="button"
           >
@@ -907,7 +925,9 @@ export function SftpWorkspace({
           <button
             className="toolbar-button"
             data-tutorial-id="sftp.download"
-            disabled={!isConnected || selectedRemoteFiles.length === 0 || !localPath}
+            disabled={
+              !isConnected || selectedRemoteFiles.length === 0 || !localPath || isLocalDrivePicker
+            }
             onClick={() => handleDownload()}
             type="button"
           >
@@ -937,7 +957,7 @@ export function SftpWorkspace({
         <FilePane
           side="local"
           title={t("sftp.local")}
-          path={localPath || localStatus || t("sftp.localFiles")}
+          path={isLocalDrivePicker ? t("sftp.windowsDrives") : localPath || localStatus || t("sftp.localFiles")}
           files={localFiles}
           isLoading={isLocalLoading}
           status={localStatus}
@@ -947,7 +967,9 @@ export function SftpWorkspace({
           onOpenFolder={openLocalFolder}
           onSelectionChange={setSelectedLocalNames}
           onContextMenuRequest={handleOpenContextMenu}
-          onDropTransfer={isConnected && !isTransferring ? handleDropTransfer : undefined}
+          onDropTransfer={
+            isConnected && !isTransferring && !isLocalDrivePicker ? handleDropTransfer : undefined
+          }
         />
         <FilePane
           side="remote"
@@ -1054,6 +1076,10 @@ export function SftpWorkspace({
       ) : null}
     </section>
   );
+}
+
+function isWindowsDriveRoot(path: string) {
+  return /^[A-Za-z]:[\\/]?$/.test(path.trim());
 }
 
 function localEntryToFileEntry(entry: LocalDirectoryEntry): FileEntry {


### PR DESCRIPTION
### Motivation
- Windows SFTP local browsing could not navigate between drive roots (opening parent of a drive root should show available drives). 
- Remote listings on Unix could present symlinks to directories as plain symlinks, preventing users from entering targets that are directories.

### Description
- Backend: add `WINDOWS_DRIVES_PATH` and support `list_local_directory` returning a drive-picker via `list_windows_drives()`, plus `requests_parent_directory()` and `is_windows_drive_root()` helpers to detect when to show the drive picker. 
- Backend: change `read_directory` to call a new helper `remote_listing_kind()` that resolves symlink targets and treats symlinks that point to directories as `folder` entries so they are openable. 
- Frontend: add `WINDOWS_DRIVES_PATH` and `isLocalDrivePicker` handling in `SftpWorkspace.tsx`, show the localized `sftp.windowsDrives` label when listing drives, disable upload/download and drag-drop actions while the drive picker is shown, and route open/parent actions to the drive list accordingly. 
- i18n/docs: add `sftp.windowsDrives` English and localized strings and update `docs/manual/07-sftp.md` to document drive-picker and symlink-directory behavior.

### Testing
- Ran `npx tsc --noEmit` to validate TypeScript changes, which succeeded. 
- Ran `rustfmt --edition 2021 src-tauri/src/sftp.rs` to format Rust changes, which completed successfully. 
- Ran the SFTP popup unit test `node tests/sftp-toolbar-popup.test.mjs`, which passed. 
- Ran `git diff --check` (lint-style check) which reported no new whitespace/patch issues. 
- Note: `cargo test --manifest-path src-tauri/Cargo.toml sftp --lib` could not complete in this environment due to a missing system `glib-2.0` dependency, and the full `npm run check` run is blocked in this container by an unrelated Node runtime compatibility issue in existing tests; these pre-existing environment limitations are unchanged by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e8c7423f4832f85e4885e6453716c)