### PR TITLE
Fix native tooltip PWSTR type mismatch

### DIFF
--- a/src-tauri/src/native_tooltip.rs
+++ b/src-tauri/src/native_tooltip.rs
@@ -11,16 +11,16 @@ mod platform {
     use super::NativeTooltipRequest;
     use std::sync::Mutex;
     use tauri::Manager;
+    use windows::core::PWSTR;
     use windows::Win32::Foundation::{HWND, LPARAM, RECT, WPARAM};
     use windows::Win32::UI::Controls::{
         TOOLTIPS_CLASSW, TTF_ABSOLUTE, TTF_TRACK, TTM_ADDTOOLW, TTM_SETMAXTIPWIDTH,
         TTM_TRACKACTIVATE, TTM_TRACKPOSITION, TTS_ALWAYSTIP, TTS_NOPREFIX, TTTOOLINFOW,
     };
     use windows::Win32::UI::WindowsAndMessaging::{
-        CreateWindowExW, DestroyWindow, SendMessageW, CW_USEDEFAULT, WINDOW_STYLE,
-        WS_EX_TOPMOST, WS_POPUP,
+        CreateWindowExW, DestroyWindow, SendMessageW, CW_USEDEFAULT, WINDOW_STYLE, WS_EX_TOPMOST,
+        WS_POPUP,
     };
-    use windows_core::PWSTR;
 
     #[derive(Default)]
     pub struct NativeTooltipState {


### PR DESCRIPTION
### Motivation
- Fix a Windows-only compile error where `TTTOOLINFOW.lpszText` expected the `PWSTR` type from the `windows` crate bindings but the code used a different `PWSTR` typedef, causing a type mismatch during CI builds.

### Description
- Use the `windows` crate re-exported type by changing the import to `use windows::core::PWSTR;` in `src-tauri/src/native_tooltip.rs`, keeping the UTF-16 buffer and tooltip flow unchanged.

### Testing
- Ran `rustfmt --check src-tauri/src/native_tooltip.rs` which succeeded.
- Ran `git diff --check` and `cargo tree --manifest-path src-tauri/Cargo.toml --target x86_64-pc-windows-msvc -i windows-strings@0.5.1` and the same for `windows-strings@0.4.2`, which succeeded and verified the dependency shape.
- Attempted `cargo check --manifest-path src-tauri/Cargo.toml` and `cargo check --manifest-path src-tauri/Cargo.toml --target x86_64-pc-windows-msvc --lib`, but these were blocked in the current Linux environment due to missing system packages (`glib-2.0.pc`) and missing MSVC C toolchain components (`lib.exe`) respectively.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e92cbeb2c832f90d2fb6fb6264ff0)