### PR TITLE
feat(arm64): release pipeline + arch-aware installer paths for Windows on Arm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      include_arm64:
+        description: "Also build and publish the native Windows on Arm (ARM64) installer"
+        required: false
+        default: false
+        type: boolean
       skip_ai_release_notes:
         description: "Use deterministic release notes without OpenAI"
         required: false
@@ -78,5 +83,6 @@ jobs:
           if ("${{ inputs.skip_build }}" -eq "true") { $releaseArgs += "-SkipBuild" }
           if ("${{ inputs.skip_smoke }}" -eq "true") { $releaseArgs += "-SkipSmoke" }
           if ("${{ inputs.skip_ai_release_notes }}" -eq "true") { $releaseArgs += "-SkipAiReleaseNotes" }
+          if ("${{ inputs.include_arm64 }}" -eq "true") { $releaseArgs += "-IncludeArm64" }
           if ("${{ inputs.dry_run }}" -eq "true") { $releaseArgs += "-DryRun" }
           powershell -NoProfile -ExecutionPolicy Bypass @releaseArgs

--- a/docs/windows-arm-compatibility.md
+++ b/docs/windows-arm-compatibility.md
@@ -20,6 +20,22 @@ npm run package:installer:arm64 -- -ToolchainOnly    # just check/install toolch
 The output is `artifacts/kkterm-<version>-windows-arm64-setup.exe` plus a
 `.sha256` checksum, matching the x64 packaging script's conventions.
 
+## Releasing an ARM64 build
+
+The release pipeline publishes x64 by default. To also build and attach the
+native ARM64 installer to the GitHub release, opt in:
+
+- **Workflow:** run the **Release** workflow with the `include_arm64` input set
+  to `true`.
+- **Local:** `pwsh scripts/release-github.ps1 -IncludeArm64` (combine with the
+  usual `-Draft` / `-Prerelease` / `-DryRun` switches as needed).
+
+When enabled, the release builds the ARM64 installer with
+`package:installer:arm64 -InstallMissing` (which provisions the cross-build
+toolchain on the runner) and appends
+`kkterm-<version>-windows-arm64-setup.exe` plus its `.sha256` to the release
+assets next to the x64 artifacts.
+
 ## Required toolchain (detected & optionally downloaded by the script)
 
 `scripts/package-installer-arm64.ps1` detects each piece and, with
@@ -70,34 +86,42 @@ All of these use OS-provided APIs that exist natively on ARM64 Windows:
   template). It runs fine under x86 emulation on ARM64 and installs the native
   ARM64 binaries. This is expected and not a defect.
 
-## Features that are NOT fully ARM64-aware (gaps to be aware of)
+## Per-feature ARM64 awareness in feature code
 
-These do not block a build but degrade on ARM64 and are worth a follow-up. They
-are **data/path** issues, not architectural blockers:
+The packaging work above makes a native build; the following data/path paths
+make that build behave natively rather than under emulation.
 
-1. **Installer Helper catalog is x64-pinned.** `installer/catalog.v1.json` has
-   ~20 `downloadInstaller` URLs hardcoded to x64 builds (VS Code `win32-x64`,
-   Cursor `x64`, 7-Zip `x64`, Notepad++ `x64`, PowerToys `x64`, Everything
-   `x64`, ShareX `x64`, Bruno `x64`, Claude `win32/x64`, `rustup` `x86_64`,
-   …). On ARM64 these install x64 apps that run under emulation; several
-   (PowerToys, Everything, VS Code, 7-Zip) have native ARM64 builds that aren't
-   offered. The `winget` providers (52 entries) generally auto-select the ARM64
-   build, so winget-backed entries are fine — the gap is the
-   `downloadInstaller` fallbacks.
+### Addressed
 
-2. **AI coding-usage detection misses ARM64 Codex.**
-   `src-tauri/src/ai_coding_usage.rs` hardcodes the Codex CLI path segment
-   `bin/windows-x86_64/codex.exe`; on ARM64 the binary lives under
-   `windows-arm64`, so usage detection would not find it.
+1. **Installer Helper `downloadInstaller` fallbacks are now arch-aware.** The
+   `downloadInstaller` provider schema accepts optional `arm64Url` /
+   `arm64FileName` fields. On a native ARM64 build (`cfg!(target_arch =
+   "aarch64")`), `Provider::download_target` prefers the ARM64 asset and
+   otherwise falls back to the default x64 asset (which still runs under
+   emulation). `installer/catalog.v1.json` populates native ARM64 downloads for
+   the entries with deterministic vendor URL schemes: **GitHub CLI**
+   (`gh_*_windows_arm64.msi`), **VS Code** (`win32-arm64-user`), and **rustup**
+   (`win.rustup.rs/aarch64`). The `winget` providers (52 entries) already
+   auto-select the ARM64 build. Remaining x64-only `downloadInstaller` entries
+   (Cursor, 7-Zip, Notepad++, PowerToys, Everything, ShareX, Bruno, Claude, …)
+   keep working under emulation and can adopt the same two fields when a native
+   ARM64 URL is confirmed.
 
-3. **App-detection registry roots are x64-only.**
-   `src-tauri/src/installer/detect.rs` scans `ARP\Machine\X64` /
-   `ARP\User\X64`; ARM64-native installs that register under an `ARM64` ARP
-   root may not be detected.
+2. **AI coding-usage detection finds ARM64 Codex.**
+   `src-tauri/src/ai_coding_usage.rs` probes the Codex VS Code extension's
+   per-arch `bin/` folder, preferring `windows-arm64` on an ARM64 build and
+   falling back to `windows-x86_64` (and vice versa on x64).
 
-These are intentionally left out of the build-enablement change so the
-packaging work stays surgical; they can be addressed when ARM64 becomes a
-shipped target.
+### Remaining (non-blocking)
+
+3. **App-detection registry views.**
+   `src-tauri/src/installer/detect.rs` enumerates the native 64-bit registry
+   view via `KEY_WOW64_64KEY` (which resolves to the ARM64 view on Windows on
+   Arm) plus the 32-bit WOW view, and matches catalog entries on the bare
+   uninstall subkey, so native ARM64 installs are still detected. The synthetic
+   `ARP\Machine\X64` / `ARP\User\X64` labels are cosmetic; x64 apps installed
+   under emulation that register in a separate emulated view are the only
+   edge case left to verify on real ARM64 hardware.
 
 ## Diagnostics
 

--- a/installer/catalog.v1.json
+++ b/installer/catalog.v1.json
@@ -29,7 +29,7 @@
         "displayNames": ["GitHub CLI"]
       },
       "provider": { "kind": "winget", "id": "GitHub.cli" },
-      "downloadProvider": { "kind": "downloadInstaller", "url": "https://github.com/cli/cli/releases/download/v2.93.0/gh_2.93.0_windows_amd64.msi", "fileName": "gh_2.93.0_windows_amd64.msi" },
+      "downloadProvider": { "kind": "downloadInstaller", "url": "https://github.com/cli/cli/releases/download/v2.93.0/gh_2.93.0_windows_amd64.msi", "fileName": "gh_2.93.0_windows_amd64.msi", "arm64Url": "https://github.com/cli/cli/releases/download/v2.93.0/gh_2.93.0_windows_arm64.msi", "arm64FileName": "gh_2.93.0_windows_arm64.msi" },
       "options": ["provider", "scope", "version"]
     },
     {
@@ -60,7 +60,7 @@
         "displayNamePrefixes": ["Microsoft Visual Studio Code"]
       },
       "provider": { "kind": "winget", "id": "Microsoft.VisualStudioCode" },
-      "downloadProvider": { "kind": "downloadInstaller", "url": "https://update.code.visualstudio.com/latest/win32-x64-user/stable", "fileName": "VSCodeUserSetup-x64.exe" },
+      "downloadProvider": { "kind": "downloadInstaller", "url": "https://update.code.visualstudio.com/latest/win32-x64-user/stable", "fileName": "VSCodeUserSetup-x64.exe", "arm64Url": "https://update.code.visualstudio.com/latest/win32-arm64-user/stable", "arm64FileName": "VSCodeUserSetup-arm64.exe" },
       "options": ["provider", "scope", "version", "location"]
     },
     {
@@ -368,7 +368,7 @@
         "displayNamePrefixes": ["Rustup"]
       },
       "provider": { "kind": "winget", "id": "Rustlang.Rustup" },
-      "downloadProvider": { "kind": "downloadInstaller", "url": "https://win.rustup.rs/x86_64", "fileName": "rustup-init.exe" },
+      "downloadProvider": { "kind": "downloadInstaller", "url": "https://win.rustup.rs/x86_64", "fileName": "rustup-init.exe", "arm64Url": "https://win.rustup.rs/aarch64", "arm64FileName": "rustup-init.exe" },
       "options": ["provider", "scope", "version"]
     },
     {

--- a/scripts/release-github.ps1
+++ b/scripts/release-github.ps1
@@ -8,7 +8,8 @@ param(
     [switch]$SkipBuild,
     [switch]$SkipSmoke,
     [switch]$SkipAiReleaseNotes,
-    [switch]$AllowDirty
+    [switch]$AllowDirty,
+    [switch]$IncludeArm64
 )
 
 $ErrorActionPreference = "Stop"
@@ -158,6 +159,14 @@ try {
     # $LatestJson = Join-Path $ResolvedOutputDir "latest.json"
     $ReleaseAssets = @($InstallerExe, $InstallerSha)
 
+    # Optional native Windows on Arm (ARM64) installer, published alongside x64.
+    $Arm64Triple = "windows-arm64"
+    $Arm64InstallerExe = Join-Path $ResolvedOutputDir "kkterm-$NextVersion-$Arm64Triple-setup.exe"
+    $Arm64InstallerSha = "$Arm64InstallerExe.sha256"
+    if ($IncludeArm64) {
+        $ReleaseAssets += @($Arm64InstallerExe, $Arm64InstallerSha)
+    }
+
     Write-Host "Current version: $CurrentVersion"
     Write-Host "Next version:    $NextVersion"
     Write-Host "Release tag:     $TagName"
@@ -223,6 +232,12 @@ try {
 
     if (-not $SkipBuild) {
         Invoke-Checked -FilePath "npm" -ArgumentList @("run", "package:installer") -Action "Build installer package"
+        if ($IncludeArm64) {
+            # `--` forwards -InstallMissing to the ARM64 packaging script so the
+            # cross-build toolchain (aarch64 Rust target, ARM64 MSVC tools, CMake,
+            # NASM) is provisioned on the runner before building.
+            Invoke-Checked -FilePath "npm" -ArgumentList @("run", "package:installer:arm64", "--", "-InstallMissing") -Action "Build ARM64 installer package"
+        }
     }
 
     # TODO(updates): Restore latest.json generation when the Tauri updater is
@@ -327,9 +342,10 @@ try {
     $GhArgs = @(
         "release",
         "create",
-        $TagName,
-        $InstallerExe,
-        $InstallerSha,
+        $TagName
+    )
+    $GhArgs += $ReleaseAssets
+    $GhArgs += @(
         "--title",
         "KKTerm $TagName",
         "--notes-file",

--- a/src-tauri/src/ai_coding_usage.rs
+++ b/src-tauri/src/ai_coding_usage.rs
@@ -1132,7 +1132,7 @@ fn codex_vscode_extension_candidates() -> Vec<PathBuf> {
     let Ok(entries) = std::fs::read_dir(extensions) else {
         return Vec::new();
     };
-    let mut paths = entries
+    let mut extension_dirs = entries
         .filter_map(Result::ok)
         .map(|entry| entry.path())
         .filter(|path| {
@@ -1140,11 +1140,34 @@ fn codex_vscode_extension_candidates() -> Vec<PathBuf> {
                 .and_then(OsStr::to_str)
                 .is_some_and(|name| name.starts_with("openai.chatgpt-"))
         })
-        .map(|path| path.join("bin").join("windows-x86_64").join("codex.exe"))
         .collect::<Vec<_>>();
-    paths.sort();
-    paths.reverse();
-    paths
+    // Newest extension version first.
+    extension_dirs.sort();
+    extension_dirs.reverse();
+    // The VS Code Codex extension ships a per-architecture binary. Probe the
+    // native-arch folder first so a Windows on Arm host finds windows-arm64,
+    // then fall back to the x64 build (which runs under emulation).
+    extension_dirs
+        .into_iter()
+        .flat_map(|path| {
+            codex_extension_arch_dirs()
+                .iter()
+                .map(move |arch| path.join("bin").join(arch).join("codex.exe"))
+        })
+        .collect()
+}
+
+/// Architecture subfolders under the Codex VS Code extension's `bin/`, ordered
+/// by preference for the running build's native architecture.
+fn codex_extension_arch_dirs() -> &'static [&'static str] {
+    #[cfg(target_arch = "aarch64")]
+    {
+        &["windows-arm64", "windows-x86_64"]
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        &["windows-x86_64", "windows-arm64"]
+    }
 }
 
 fn run_command(
@@ -1521,6 +1544,17 @@ mod tests {
     fn provider_labels_are_stable() {
         assert_eq!(AiCodingUsageProvider::Codex.label(), "Codex");
         assert_eq!(AiCodingUsageProvider::ClaudeCode.label(), "Claude Code");
+    }
+
+    #[test]
+    fn codex_extension_arch_dirs_cover_both_targets_native_first() {
+        let dirs = codex_extension_arch_dirs();
+        assert!(dirs.contains(&"windows-x86_64"));
+        assert!(dirs.contains(&"windows-arm64"));
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(dirs.first(), Some(&"windows-arm64"));
+        #[cfg(not(target_arch = "aarch64"))]
+        assert_eq!(dirs.first(), Some(&"windows-x86_64"));
     }
 
     #[test]

--- a/src-tauri/src/installer/install.rs
+++ b/src-tauri/src/installer/install.rs
@@ -103,7 +103,10 @@ fn install_recipe_by_provider(
         Provider::Winget { id } => install_winget(&recipe.id, id, &options, cancel, emit),
         Provider::Npm { pkg } => install_npm(&recipe.id, pkg, &options, cancel, emit),
         Provider::UvPip { package } => install_uv_pip(&recipe.id, package, &options, cancel, emit),
-        Provider::DownloadInstaller { url, file_name } => {
+        provider @ Provider::DownloadInstaller { .. } => {
+            let (url, file_name) = provider
+                .download_target(super::schema::prefer_native_arm64())
+                .expect("DownloadInstaller provider resolves a download target");
             install_download_installer(&recipe.id, url, file_name, cancel, emit)
         }
         Provider::GithubRelease {

--- a/src-tauri/src/installer/schema.rs
+++ b/src-tauri/src/installer/schema.rs
@@ -134,11 +134,25 @@ pub enum Provider {
         package: String,
     },
     DownloadInstaller {
-        /// Canonical vendor URL for a desktop installer.
+        /// Canonical vendor URL for a desktop installer (x64 by default).
         url: String,
         /// Stable local filename used for the temp download.
         #[serde(rename = "fileName")]
         file_name: String,
+        /// Optional native ARM64 (`aarch64-pc-windows-msvc`) installer URL.
+        /// When present and KKTerm is running on Windows on Arm, this is
+        /// preferred over `url`, which otherwise installs an x64 build that runs
+        /// under emulation. Requires `arm64FileName` to be set as well.
+        #[serde(default, rename = "arm64Url", skip_serializing_if = "Option::is_none")]
+        arm64_url: Option<String>,
+        /// Local filename for the ARM64 download. Ignored unless `arm64Url` is
+        /// also set.
+        #[serde(
+            default,
+            rename = "arm64FileName",
+            skip_serializing_if = "Option::is_none"
+        )]
+        arm64_file_name: Option<String>,
     },
     GithubRelease {
         /// "owner/repo".
@@ -169,6 +183,40 @@ pub enum Provider {
         /// Ordered recipe ids. Already-installed steps are skipped.
         steps: Vec<String>,
     },
+}
+
+impl Provider {
+    /// For a [`Provider::DownloadInstaller`], return the architecture-appropriate
+    /// `(url, file_name)`. When `prefer_arm64` is set and the recipe carries a
+    /// native ARM64 asset, that asset wins; otherwise the default (x64) asset is
+    /// used, which runs under emulation on Windows on Arm. Returns `None` for
+    /// non-download providers.
+    pub fn download_target(&self, prefer_arm64: bool) -> Option<(&str, &str)> {
+        match self {
+            Provider::DownloadInstaller {
+                url,
+                file_name,
+                arm64_url,
+                arm64_file_name,
+            } => {
+                if prefer_arm64 {
+                    if let (Some(arm_url), Some(arm_file)) =
+                        (arm64_url.as_deref(), arm64_file_name.as_deref())
+                    {
+                        return Some((arm_url, arm_file));
+                    }
+                }
+                Some((url.as_str(), file_name.as_str()))
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Whether the running build is native Windows on Arm (`aarch64`). Used to pick
+/// ARM64 installer assets when the catalog offers them.
+pub const fn prefer_native_arm64() -> bool {
+    cfg!(target_arch = "aarch64")
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -598,7 +646,7 @@ mod tests {
         assert!(antigravity.needs.is_empty());
         assert!(matches!(
             &antigravity.provider,
-            Provider::DownloadInstaller { url, file_name }
+            Provider::DownloadInstaller { url, file_name, .. }
                 if url == "https://antigravity.google/cli/install.cmd"
                     && file_name == "antigravity-cli-install.cmd"
         ));
@@ -659,5 +707,96 @@ mod tests {
             recipes: vec![leaf_a, leaf_b, bundle],
         };
         assert!(catalog.validate().is_ok());
+    }
+
+    #[test]
+    fn download_target_prefers_arm64_asset_when_offered() {
+        let provider = Provider::DownloadInstaller {
+            url: "https://example.com/app-x64.exe".into(),
+            file_name: "app-x64.exe".into(),
+            arm64_url: Some("https://example.com/app-arm64.exe".into()),
+            arm64_file_name: Some("app-arm64.exe".into()),
+        };
+
+        assert_eq!(
+            provider.download_target(true),
+            Some(("https://example.com/app-arm64.exe", "app-arm64.exe"))
+        );
+        assert_eq!(
+            provider.download_target(false),
+            Some(("https://example.com/app-x64.exe", "app-x64.exe"))
+        );
+    }
+
+    #[test]
+    fn download_target_falls_back_to_default_without_arm64_asset() {
+        let provider = Provider::DownloadInstaller {
+            url: "https://example.com/app-x64.exe".into(),
+            file_name: "app-x64.exe".into(),
+            arm64_url: None,
+            arm64_file_name: None,
+        };
+
+        assert_eq!(
+            provider.download_target(true),
+            Some(("https://example.com/app-x64.exe", "app-x64.exe"))
+        );
+        // A bare arm64Url without a matching file name is ignored.
+        let provider = Provider::DownloadInstaller {
+            url: "https://example.com/app-x64.exe".into(),
+            file_name: "app-x64.exe".into(),
+            arm64_url: Some("https://example.com/app-arm64.exe".into()),
+            arm64_file_name: None,
+        };
+        assert_eq!(
+            provider.download_target(true),
+            Some(("https://example.com/app-x64.exe", "app-x64.exe"))
+        );
+    }
+
+    #[test]
+    fn download_target_is_none_for_non_download_providers() {
+        assert_eq!(
+            Provider::Winget { id: "X".into() }.download_target(true),
+            None
+        );
+    }
+
+    #[test]
+    fn shipped_catalog_offers_native_arm64_downloads() {
+        let json = include_str!("../../../installer/catalog.v1.json");
+        let catalog: Catalog =
+            serde_json::from_str(json).expect("shipped catalog JSON should parse");
+
+        // Recipes whose download fallback has a deterministic native ARM64 asset.
+        let arm64_ready = [
+            ("github-cli", "gh_2.93.0_windows_arm64.msi"),
+            ("vscode", "win32-arm64-user"),
+            ("rustup", "aarch64"),
+        ];
+        for (id, marker) in arm64_ready {
+            let recipe = catalog
+                .recipes
+                .iter()
+                .find(|recipe| recipe.id == id)
+                .unwrap_or_else(|| panic!("catalog should include {id}"));
+            let provider = recipe
+                .download_provider
+                .as_ref()
+                .unwrap_or_else(|| panic!("{id} should have a download provider"));
+            let (url, _) = provider
+                .download_target(true)
+                .unwrap_or_else(|| panic!("{id} download provider should resolve"));
+            assert!(
+                url.contains(marker),
+                "{id} ARM64 download URL should contain {marker}, got {url}"
+            );
+            // The x64 path must not regress to the ARM64 asset.
+            let (x64_url, _) = provider.download_target(false).unwrap();
+            assert!(
+                !x64_url.contains(marker),
+                "{id} x64 download URL should not contain {marker}, got {x64_url}"
+            );
+        }
     }
 }

--- a/tests/release-github-script.test.mjs
+++ b/tests/release-github-script.test.mjs
@@ -33,3 +33,20 @@ test("release script writes version files as utf8 without bom", () => {
 test("release script stages Cargo.lock with Rust version files", () => {
   assert.match(script, /"src-tauri\/Cargo\.toml", "src-tauri\/Cargo\.lock"/);
 });
+
+test("release script can also build and publish the ARM64 installer", () => {
+  // Opt-in switch keeps the default x64-only release unchanged.
+  assert.match(script, /\[switch\]\$IncludeArm64/);
+  // ARM64 build provisions its toolchain via the dedicated packaging script.
+  assert.match(
+    script,
+    /"run", "package:installer:arm64", "--", "-InstallMissing"/,
+  );
+  // ARM64 assets follow the windows-arm64 naming convention and are appended
+  // to the release asset list only when requested.
+  assert.match(script, /kkterm-\$NextVersion-\$Arm64Triple-setup\.exe/);
+  assert.match(script, /if \(\$IncludeArm64\) \{\s*\$ReleaseAssets \+= /);
+  // The GitHub upload args are built from the asset list, not hardcoded, so the
+  // ARM64 artifacts ride along when present.
+  assert.match(script, /\$GhArgs \+= \$ReleaseAssets/);
+});


### PR DESCRIPTION
Builds on the ARM64 packaging script by closing the feature-code gaps the
compatibility review flagged, so a native aarch64 build behaves natively
rather than under emulation:

- Release pipeline: add opt-in `-IncludeArm64` to scripts/release-github.ps1
  and an `include_arm64` Release workflow input. When set, the release also
  builds the ARM64 installer (provisioning the cross-build toolchain via
  package:installer:arm64 -InstallMissing) and attaches the
  windows-arm64 setup.exe + .sha256 next to the x64 artifacts. Default
  releases stay x64-only and unchanged.

- Installer Helper downloads: add optional arm64Url/arm64FileName to the
  downloadInstaller provider and Provider::download_target, which prefers the
  native ARM64 asset on aarch64 builds and otherwise falls back to x64. Populate
  native ARM64 downloads for entries with deterministic vendor URL schemes:
  GitHub CLI, VS Code, and rustup. winget-backed entries already auto-select
  ARM64.

- AI coding-usage: probe the Codex VS Code extension's per-arch bin/ folder,
  preferring windows-arm64 on aarch64 and falling back to windows-x86_64.

- Docs: refresh windows-arm-compatibility.md (release steps + addressed vs.
  remaining feature-code items).

Tests: schema selector + arch-aware catalog assertions, codex arch-dir helper,
and release-script coverage.