### PR TITLE
Fix duplicate Activity Rail tooltips

### DIFF
--- a/src/app/RailTooltip.tsx
+++ b/src/app/RailTooltip.tsx
@@ -9,7 +9,7 @@ export function RailTooltip({ label }: { label: string }) {
   const labelRef = useRef(label);
   const showTimerRef = useRef<number | null>(null);
   const hoverTokenRef = useRef(0);
-  const [nativeActive, setNativeActive] = useState(false);
+  const [nativeTooltipSuppressed, setNativeTooltipSuppressed] = useState(false);
 
   useEffect(() => {
     labelRef.current = label;
@@ -33,7 +33,7 @@ export function RailTooltip({ label }: { label: string }) {
     function hideNativeTooltip() {
       clearShowTimer();
       hoverTokenRef.current += 1;
-      setNativeActive(false);
+      setNativeTooltipSuppressed(false);
       void invokeCommand("hide_native_tooltip").catch(() => {
         // CSS tooltips remain the fallback if the native helper is unavailable.
       });
@@ -43,6 +43,7 @@ export function RailTooltip({ label }: { label: string }) {
       clearShowTimer();
       const hoverToken = hoverTokenRef.current + 1;
       hoverTokenRef.current = hoverToken;
+      setNativeTooltipSuppressed(true);
       showTimerRef.current = window.setTimeout(() => {
         const bounds = tooltipOwner.getBoundingClientRect();
         const x = bounds.right + RAIL_TOOLTIP_OFFSET_PX;
@@ -59,11 +60,11 @@ export function RailTooltip({ label }: { label: string }) {
               void invokeCommand("hide_native_tooltip");
               return;
             }
-            setNativeActive(shown);
+            setNativeTooltipSuppressed(shown);
           })
           .catch(() => {
             if (hoverTokenRef.current === hoverToken) {
-              setNativeActive(false);
+              setNativeTooltipSuppressed(false);
             }
           });
       }, RAIL_TOOLTIP_DELAY_MS);
@@ -86,7 +87,7 @@ export function RailTooltip({ label }: { label: string }) {
   return (
     <span
       ref={tooltipRef}
-      className={`rail-tooltip ${nativeActive ? "native-active" : ""}`}
+      className={`rail-tooltip ${nativeTooltipSuppressed ? "native-suppressed" : ""}`}
       role="tooltip"
     >
       {label}

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -296,7 +296,7 @@
   transition-delay: 650ms;
 }
 
-.rail-tooltip.native-active {
+.rail-tooltip.native-suppressed {
   opacity: 0;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent both the app-owned CSS tooltip and the Tauri native tooltip from showing simultaneously for Activity Rail icons by suppressing the CSS tooltip while the native path is pending or active.

### Description
- Add a `nativeTooltipSuppressed` state in `src/app/RailTooltip.tsx` and toggle a `native-suppressed` class to hide the CSS tooltip when the native tooltip is scheduled or shown, and update `src/app/app.css` to make `.rail-tooltip.native-suppressed` keep the CSS tooltip hidden while preserving the CSS tooltip as the fallback if the native helper does not show.

### Testing
- Ran `npx tsc --noEmit` which succeeded, ran `git diff --check` which succeeded, and attempted `npm run check` which failed due to an existing Node iterator compatibility issue in `tests/tutorial-target-navigation.test.mjs` (the failure is unrelated to this tooltip change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eb029c438832f83cc4285a7e3bc3f)