### PR TITLE
Fix assistant screenshot region overlay

### DIFF
--- a/src/ai/AssistantPanel.tsx
+++ b/src/ai/AssistantPanel.tsx
@@ -30,6 +30,7 @@ import {
   X,
 } from "lucide-react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import type {
   ChangeEvent,
   ClipboardEvent,
@@ -3338,23 +3339,26 @@ export function AssistantPanel({
           </button>
         </div>
       </form>
-      {screenshotRegionState ? (
-        <div
-          aria-label={t("workspace.selectRegion")}
-          className="screenshot-region-overlay"
-          onKeyDown={handleScreenshotRegionKeyDown}
-          onPointerDown={handleScreenshotRegionPointerDown}
-          onPointerMove={handleScreenshotRegionPointerMove}
-          onPointerUp={handleScreenshotRegionPointerUp}
-          role="application"
-          tabIndex={-1}
-        >
-          <div className="screenshot-region-target" ref={regionTargetRef} />
-          {screenshotSelectionRect ? (
-            <div className="screenshot-region-selection" ref={regionSelectionRef} />
-          ) : null}
-        </div>
-      ) : null}
+      {screenshotRegionState
+        ? createPortal(
+            <div
+              aria-label={t("workspace.selectRegion")}
+              className="screenshot-region-overlay"
+              onKeyDown={handleScreenshotRegionKeyDown}
+              onPointerDown={handleScreenshotRegionPointerDown}
+              onPointerMove={handleScreenshotRegionPointerMove}
+              onPointerUp={handleScreenshotRegionPointerUp}
+              role="application"
+              tabIndex={-1}
+            >
+              <div className="screenshot-region-target" ref={regionTargetRef} />
+              {screenshotSelectionRect ? (
+                <div className="screenshot-region-selection" ref={regionSelectionRef} />
+              ) : null}
+            </div>,
+            document.body,
+          )
+        : null}
     </aside>
   );
 }


### PR DESCRIPTION
### Motivation
- The AI Assistant screenshot region picker overlay was confined to the assistant panel and could not cover the app viewport due to layout/containment; the overlay must be able to sit above the whole app so region selection works correctly.

### Description
- Render the assistant screenshot-region overlay through a React portal attached to `document.body` instead of rendering it as a child of the Assistant panel by using `createPortal` in `src/ai/AssistantPanel.tsx`.
- Add `createPortal` import and update the conditional overlay rendering to mount the overlay into `document.body` so fixed positioning is no longer constrained by panel containment.
- Change touches only `src/ai/AssistantPanel.tsx` (small, focused change).

### Testing
- Ran `node tests/assistant-add-menu-order.test.mjs` and it passed successfully.
- Ran `npx tsc --noEmit` (TypeScript compile check) and it succeeded locally.
- Ran the full `npm run check`; it did not complete due to an unrelated test (`tests/tutorial-target-navigation.test.mjs`) invoking `.flatMap()` on the `matchAll()` iterator under the Node.js runtime in the test environment (Node v20.20.2), which is a runtime / test-suite compatibility issue and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eb011860c832fb0f7b9290552355d)