### PR TITLE
Fix tutorial navigation test match iterator handling

### DIFF
--- a/tests/tutorial-target-navigation.test.mjs
+++ b/tests/tutorial-target-navigation.test.mjs
@@ -23,7 +23,7 @@ const anchorIds = new Set(
     [
       ...source.matchAll(/data-tutorial-id=["']([^"']+)["']/g),
       ...source.matchAll(/dataTutorialId=["']([^"']+)["']/g),
-      ...source.matchAll(/data-tutorial-id=\{([^}]+)\}/g).flatMap((match) =>
+      ...Array.from(source.matchAll(/data-tutorial-id=\{([^}]+)\}/g)).flatMap((match) =>
         [...match[1].matchAll(/["']([a-z][a-zA-Z0-9]*\.[a-zA-Z0-9.-]+)["']/g)],
       ),
     ].map((match) => match[1]),


### PR DESCRIPTION
### Motivation
- The tutorial navigation validation test failed on some Node versions because `String.prototype.matchAll()` returns an iterator that does not implement array methods, causing `TypeError: source.matchAll.flatMap is not a function`.

### Description
- Convert the `matchAll()` iterator to an array with `Array.from(...)` before calling `flatMap()` in `tests/tutorial-target-navigation.test.mjs` to make the test compatible with older Node runtimes.

### Testing
- Ran `node tests/tutorial-target-navigation.test.mjs` which passed; ran the full `npm run check` suite which also completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f6833c570832fa689666f18c054fd)