### PR TITLE
docs: sync release and roadmap status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to KKTerm are documented here.
 
+## v0.1.54
+
 ## Highlights
 - App update download & installation is now supported in KKTerm (with user-facing update status prompts). Like a good terminal session, it tells you what’s happening—before it happens.
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4,7 +4,7 @@
 
 Administrators, developers, and operators often juggle separate tools for local terminals, SSH sessions, SFTP transfers, saved host lists, and AI-assisted command work. Existing tools either feel dated and Windows-only, focus narrowly on terminal emulation, or carry heavyweight runtime and UI costs that make them feel slow.
 
-KKTerm is intended to be a fast, professional desktop workspace for personal/local infrastructure administration. The first version should provide the core experience users expect from a modern MobaXterm/RDCMan/VSCode-inspired tool without taking on team sync, RDP, VNC, or cloud services too early.
+KKTerm is intended to be a fast, professional desktop workspace for personal/local infrastructure administration. The first version provides the core experience users expect from a modern MobaXterm/RDCMan/VSCode-inspired tool, including terminal, file-transfer, URL, RDP, and VNC workflows, while keeping team sync and managed cloud services out of scope.
 
 ## Solution
 
@@ -89,10 +89,10 @@ High-level product decisions that are not duplicated elsewhere:
 - Product name: **KKTerm**. Primary acceptance platform: Windows. Follow-on: macOS and Linux on the same architecture.
 - Current protocols: local terminal, SSH terminal, Telnet terminal, Serial terminal, SFTP launched from SSH, FTP/FTPS, URL (WebView2), RDP (ActiveX), and VNC (`vnc-rs`).
 - License: MIT. Dependencies should be MIT/Apache-2.0/BSD/MPL-style; avoid GPL in the core runtime.
-- Privacy: no telemetry or automatic crash upload in v0.1. Update checks (v0.2) are described separately from telemetry.
+- Privacy: no telemetry or automatic crash upload in v0.1. Update checks and user-mediated installer handoff are described separately from telemetry.
 - AI model: typed assistant tool calling with permission boundaries. Prompt is the default mode for mutating tools; Allow All is an explicit user setting for automatic execution of enabled tools. CLI agent integrations remain suggest-only/ask-before-execute where possible.
 
-The full stack, frontend source map, storage/secrets boundaries, command-runtime rules, RDP overlay model, Settings layout, and Activity Rail layout live in `docs/ARCHITECTURE.md`. Standalone decision records (SSH transport, security/privacy, extension platform, etc.) live in `docs/ADR/`. Performance budgets and the measurement runbook live in `docs/PERFORMANCE.md`. Distribution, packaging scripts, and the v0.2 updater scope live in `docs/RELEASE.md`.
+The full stack, frontend source map, storage/secrets boundaries, command-runtime rules, RDP overlay model, Settings layout, and Activity Rail layout live in `docs/ARCHITECTURE.md`. Standalone decision records (SSH transport, security/privacy, extension platform, etc.) live in `docs/ADR/`. Performance budgets and the measurement runbook live in `docs/PERFORMANCE.md`. Distribution, packaging scripts, update checks, and the installer download/install flow live in `docs/RELEASE.md`.
 
 ## Testing Decisions
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,7 +4,7 @@
 
 Quick snapshot as of June 2, 2026:
 
-All core connection types, terminal features, SFTP/FTP, RDP/VNC, AI Assistant tool calling, Dashboard Module redesign, Installer Helper, and UI customization are implemented and shipping. The app metadata is currently at v0.1.52 and releasing continuously.
+All core connection types, terminal features, SFTP/FTP, RDP/VNC, AI Assistant tool calling, Dashboard Module redesign, Installer Helper, and UI customization are implemented and shipping. The app metadata is currently at v0.1.54 and releasing continuously.
 
 Release validation gates are documented in `AGENTS.md` and `docs/RELEASE.md`; run the full suite before significant code changes or release publication. Previous packaging validation passed for `npm run package:installer` and `npm run smoke:installer`.
 
@@ -88,6 +88,7 @@ For operational measurement records see `docs/PERFORMANCE.md`. For packaging and
 - [x] Saved Connection tools: list/create/open/update/delete.
 - [x] Live Session tools: terminal buffer reads, terminal input, RDP/VNC screenshots and input, SFTP/FTP browser list/create-folder/rename/delete actions.
 - [x] Review-only extension draft mode.
+- [x] MCP (Model Context Protocol) server support for external agent integration.
 - [x] Language output setting: follow UI language or a specific language.
 - [x] Claude Code CLI and Codex CLI path configuration (constrained to suggest-only/ask-before-execute where possible).
 - [x] Command planning safety tests.
@@ -138,7 +139,6 @@ For operational measurement records see `docs/PERFORMANCE.md`. For packaging and
 - [ ] Expanded AI orchestration: import Connection entries from multiple formats, monitor Connections, rename/reorganize layouts, optionally relay interactions through Telegram/WhatsApp/LINE integrations.
 - [ ] AI reference to previous session text buffers via RAG/agentic search.
 - [ ] Voice input for AI Assistant with local model support.
-- [x] MCP (Model Context Protocol) server support for external agent integration.
 
 ### Dashboard & Modules
 

--- a/docs/releases/v0.1.54.md
+++ b/docs/releases/v0.1.54.md
@@ -1,3 +1,5 @@
+# KKTerm v0.1.54
+
 ## Highlights
 - App update download & installation is now supported in KKTerm (with user-facing update status prompts). Like a good terminal session, it tells you what’s happening—before it happens.
 


### PR DESCRIPTION
### Motivation
- Ensure documentation accurately reflects the current code/release state by updating product scope, roadmap version, and release artifacts so readers and automation see a consistent story.
- Fix small drift where MCP support and updater/install wording and the v0.1.54 release headings were not reflected in the shipped docs.

### Description
- Clarified PRD scope and update-check/install wording in `docs/PRD.md` to reflect that RDP/VNC and the installer/update handoff are in-scope and to describe update checks/installer handoff behavior.
- Updated `docs/ROADMAP.md` to reference `v0.1.54` and moved MCP support into the implemented section, and added `v0.1.54` headings to `CHANGELOG.md` and `docs/releases/v0.1.54.md` so release files match the package version.

### Testing
- Ran `npm run i18n:check` and it reported all locale files match `en.json` (2091 keys) so localization structure is intact.
- Ran the repository check suite via `npm run check` and all automated tests passed.
- Ran targeted Python checks that validate release/version alignment and markdown link resolution and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f6b822220832fb3b2b04649744f94)