### PR TITLE
Add double-click header toggle for Connections and AI Assistant panels

### DIFF
--- a/docs/manual/02-app-layout.md
+++ b/docs/manual/02-app-layout.md
@@ -28,7 +28,7 @@ Non-Workspace pages (Dashboard and Settings) stay inset from the 48 px rail so i
 
 Resizable. Collapsed/expanded state persists across launches. See [03-connections.md](03-connections.md) for the tree itself. When `settings.hideTopTabButtons` is enabled, this panel also becomes the primary Tab navigator by showing Child Connection Tabs under parent Connections.
 
-- Toggle: custom title-bar `app.connections` icon or Workspace icon on the Activity Rail
+- Toggle: custom title-bar `app.connections` icon or Workspace icon on the Activity Rail. Double-clicking the panel title row, including the blank space beside `connections.title`, performs the same hide/show action.
 - Resize handle: `app.resizeConnections`
 
 Tutorial target: `app.connectionsResize`.
@@ -46,7 +46,7 @@ Accessibility label: `workspace.workspaceSurface`. Per-Connection-kind labels us
 Resizable, collapsible. State is app-wide — the same width and collapsed state apply across Workspace, Dashboard, Settings, and all Tabs.
 
 - Title: `ai.title`
-- Toggle: custom title-bar `app.aiAssistant` icon
+- Toggle: custom title-bar `app.aiAssistant` icon. Double-clicking the panel title row, including the blank space beside `ai.title`, performs the same hide/show action.
 - Resize handle: `app.resizeAiAssistant`
 
 Tutorial target: `app.aiAssistantResize`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -220,6 +220,7 @@ function App() {
       <div key="workspace-page" className="workspace-page" {...ariaHidden(activePage !== "workspace")}>
         <ConnectionSidebar
           onExternalOpenConnection={() => navigateToPage("workspace")}
+          onTogglePanel={toggleConnectionPanel}
         />
         {connectionPanelLayout.collapsed ? (
           <div className="connection-collapsed-separator" aria-hidden="true" />
@@ -252,6 +253,7 @@ function App() {
         onOpenDashboard={openDashboardPage}
         onOpenSettings={() => navigateToPage("settings")}
         onOpenWorkspace={() => navigateToPage("workspace")}
+        onTogglePanel={toggleAiPanel}
         onTutorialRequest={handleTutorialRequest}
         pageContext={assistantPageContext()}
       />

--- a/src/ai/AssistantPanel.tsx
+++ b/src/ai/AssistantPanel.tsx
@@ -831,6 +831,7 @@ export function AssistantPanel({
   onOpenDashboard,
   onOpenSettings,
   onOpenWorkspace,
+  onTogglePanel,
   onTutorialRequest,
   pageContext,
 }: {
@@ -838,6 +839,7 @@ export function AssistantPanel({
   onOpenDashboard: (viewId?: string) => void;
   onOpenSettings: () => void;
   onOpenWorkspace: () => void;
+  onTogglePanel?: () => void;
   onTutorialRequest: (
     request: TutorialHighlightRequest,
   ) => Promise<{ ok: boolean; error?: string }>;
@@ -2615,6 +2617,13 @@ export function AssistantPanel({
     insertTextIntoComposer(textarea, "");
   }
 
+  function handleTopbarDoubleClick(event: MouseEvent<HTMLElement>) {
+    if ((event.target as HTMLElement).closest("button, a, input, textarea, select")) {
+      return;
+    }
+    onTogglePanel?.();
+  }
+
   function selectedAssistantPanelText(panel: HTMLElement) {
     const selection = window.getSelection();
     if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
@@ -2879,7 +2888,7 @@ export function AssistantPanel({
       className="assistant-panel"
       onContextMenu={(event) => void handleAssistantPanelContextMenu(event)}
     >
-      <div className="assistant-topbar">
+      <div className="assistant-topbar" onDoubleClick={handleTopbarDoubleClick}>
         <h2>{t("ai.title")}</h2>
         <button
           aria-label={t("ai.refresh")}

--- a/src/modules/workspace/connections/ConnectionSidebar.tsx
+++ b/src/modules/workspace/connections/ConnectionSidebar.tsx
@@ -168,8 +168,10 @@ function isTerminalWorkspacePane(pane: WorkspacePane): pane is WorkspacePane & {
 
 export function ConnectionSidebar({
   onExternalOpenConnection,
+  onTogglePanel,
 }: {
   onExternalOpenConnection?: () => void;
+  onTogglePanel?: () => void;
 }) {
   const { i18n, t } = useTranslation();
   const query = useWorkspaceStore((state) => state.query);
@@ -1938,9 +1940,16 @@ export function ConnectionSidebar({
 
   const dragDisabled = isTreeFiltered || showAllConnections || Boolean(inlineRenameTarget);
 
+  function handleHeaderDoubleClick(event: ReactMouseEvent<HTMLElement>) {
+    if ((event.target as HTMLElement).closest("button, a, input, textarea, select")) {
+      return;
+    }
+    onTogglePanel?.();
+  }
+
   return (
     <aside className="connection-sidebar" data-tutorial-id="connections.panel">
-      <div className="sidebar-header">
+      <div className="sidebar-header" onDoubleClick={handleHeaderDoubleClick}>
         <div>
           <h1>{t("connections.title")}</h1>
         </div>


### PR DESCRIPTION
### Motivation
- Make the sidebar and assistant panel easier to hide/show by enabling double-click on the panel title/header row (blank/title area), matching the existing titlebar toggle behavior while ignoring interactive controls.

### Description
- Add an optional `onTogglePanel` prop to `ConnectionSidebar` and `AssistantPanel` and implement `handleHeaderDoubleClick` / `handleTopbarDoubleClick` that ignore clicks originating inside interactive controls and call the provided toggle.
- Wire the panel toggles from `App.tsx` by passing `toggleConnectionPanel` into `ConnectionSidebar` and `toggleAiPanel` into `AssistantPanel` so double-click invokes the same collapse/expand logic as the titlebar buttons.
- Update `docs/manual/02-app-layout.md` to document the new double-click hide/show shortcut for both panels.

### Testing
- Ran `npm run check` (frontend tests, lint/tsc checks and various unit tests) and the check suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fa155f6b8832f885eb71ff9e21120)