### PR TITLE
Avoid blocking UI during MCP bridge startup

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -57,12 +57,12 @@ Module namespaces in this build:
   `\\.\pipe\kkterm-mcp-<token-prefix>`. The pipe name is published in the
   bridge descriptor file (see below) along with a per-launch bearer token.
 - **Bridge descriptor file:** `%APPDATA%\com.kkterm.app\mcp-bridge.json`.
-  Written when KKTerm.exe starts with the bridge enabled, removed on the
-  next start before a new descriptor is written. Stale files cause clients
-  to fail with `app_not_running`. On Windows, KKTerm uses `whoami` to resolve
-  the current user SID, then `icacls` to remove inherited ACLs and grant only
-  that SID full control before publishing the descriptor; if that hardening
-  fails, the bridge does not start.
+  Written in a background startup thread when KKTerm.exe starts with the bridge
+  enabled, removed on the next start before a new descriptor is written. Stale
+  files cause clients to fail with `app_not_running`. On Windows, KKTerm uses
+  hidden `whoami` and `icacls` child processes to resolve the current user SID,
+  remove inherited ACLs, and grant only that SID full control before publishing
+  the descriptor; if that hardening fails, the bridge does not start.
 - **Auth:** the first framed line `kkterm-cli` sends on the pipe is the
   bearer token from the descriptor file. KKTerm.exe responds with
   `{"ok":true}` on success and closes the connection on mismatch.
@@ -74,9 +74,11 @@ the descriptor ACL step: `whoami /user /fo csv /nh` provides the current
 process user SID, and `icacls <path> /inheritance:r /grant:r *<SID>:(F)`
 replaces inherited grants with full control for that SID only. `icacls.exe`
 and `whoami.exe` are present on supported Windows installations, this keeps
-the Rust code small, and the hardening runs once at bridge startup rather
-than on a hot path. The bridge fails closed and deletes the descriptor if
-these tools cannot be run or return an error.
+the Rust code small, and the hardening runs once in a background bridge startup
+thread rather than blocking the app startup path or a hot path. Both child
+processes are launched with `CREATE_NO_WINDOW` so they do not flash console
+windows. The bridge fails closed and deletes the descriptor if these tools
+cannot be run or return an error.
 
 A direct Win32 API implementation was considered for this hardening. It would
 avoid spawning `whoami` and `icacls`, but it requires enabling additional

--- a/src-tauri/src/mcp_bridge.rs
+++ b/src-tauri/src/mcp_bridge.rs
@@ -14,6 +14,9 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+#[cfg(target_os = "windows")]
+use std::process::Command;
+
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -85,10 +88,12 @@ fn restrict_bridge_info_permissions(path: &Path) -> std::io::Result<()> {
 fn restrict_file_to_current_user(path: &Path) -> std::io::Result<()> {
     let sid = current_windows_user_sid()?;
     let grant_arg = format!("*{sid}:(F)");
-    let output = std::process::Command::new("icacls")
-        .arg(path)
-        .args(["/inheritance:r", "/grant:r", &grant_arg])
-        .output()?;
+    let output = no_window(Command::new("icacls").arg(path).args([
+        "/inheritance:r",
+        "/grant:r",
+        &grant_arg,
+    ]))
+    .output()?;
     if output.status.success() {
         Ok(())
     } else {
@@ -104,9 +109,7 @@ fn restrict_file_to_current_user(path: &Path) -> std::io::Result<()> {
 
 #[cfg(target_os = "windows")]
 fn current_windows_user_sid() -> std::io::Result<String> {
-    let output = std::process::Command::new("whoami")
-        .args(["/user", "/fo", "csv", "/nh"])
-        .output()?;
+    let output = no_window(Command::new("whoami").args(["/user", "/fo", "csv", "/nh"])).output()?;
     if !output.status.success() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::PermissionDenied,
@@ -170,48 +173,75 @@ pub fn start_if_enabled(
 
     #[cfg(target_os = "windows")]
     {
-        let token = random_token();
-        let pipe_name = format!(r"\\.\pipe\kkterm-mcp-{}", &token[..16]);
-        let pid = std::process::id();
-        let info = BridgeInfo {
-            version: BRIDGE_INFO_VERSION,
-            pipe_name: pipe_name.clone(),
-            token: token.clone(),
-            pid,
-        };
-        if let Err(error) = write_bridge_info(&info_path, &info) {
-            crate::logging::mcp_debug(
-                "bridge.info_write_failed",
-                &json!({"error": error.to_string()}),
-            );
-            eprintln!("kkterm built-in MCP server: failed to write bridge info: {error}");
-            return;
-        }
-        crate::logging::mcp_debug(
-            "bridge.started",
-            &json!({
-                "pipeName": pipe_name.clone(),
-                "pid": pid,
-                "allowAllDangerous": allow_all_dangerous,
-                "bridgeInfoPath": info_path,
-            }),
-        );
-
-        let ctx = Arc::new(BridgeContext {
-            app,
-            token,
-            allow_all_dangerous,
-        });
-        tauri::async_runtime::spawn(async move {
-            if let Err(error) = run_named_pipe_server(ctx, pipe_name).await {
+        std::thread::Builder::new()
+            .name("kkterm-mcp-bridge-startup".to_string())
+            .spawn(move || {
+                start_windows_bridge(app, info_path, allow_all_dangerous);
+            })
+            .unwrap_or_else(|error| {
                 crate::logging::mcp_debug(
-                    "bridge.server_stopped",
+                    "bridge.startup_thread_failed",
                     &json!({"error": error.to_string()}),
                 );
-                eprintln!("kkterm built-in MCP server stopped: {error}");
-            }
-        });
+                eprintln!("kkterm built-in MCP server: failed to spawn startup thread: {error}");
+            });
     }
+}
+
+#[cfg(target_os = "windows")]
+fn start_windows_bridge(app: AppHandle, info_path: PathBuf, allow_all_dangerous: bool) {
+    let token = random_token();
+    let pipe_name = format!(r"\\.\pipe\kkterm-mcp-{}", &token[..16]);
+    let pid = std::process::id();
+    let info = BridgeInfo {
+        version: BRIDGE_INFO_VERSION,
+        pipe_name: pipe_name.clone(),
+        token: token.clone(),
+        pid,
+    };
+    if let Err(error) = write_bridge_info(&info_path, &info) {
+        crate::logging::mcp_debug(
+            "bridge.info_write_failed",
+            &json!({"error": error.to_string()}),
+        );
+        eprintln!("kkterm built-in MCP server: failed to write bridge info: {error}");
+        return;
+    }
+    crate::logging::mcp_debug(
+        "bridge.started",
+        &json!({
+            "pipeName": pipe_name.clone(),
+            "pid": pid,
+            "allowAllDangerous": allow_all_dangerous,
+            "bridgeInfoPath": info_path,
+        }),
+    );
+
+    let ctx = Arc::new(BridgeContext {
+        app,
+        token,
+        allow_all_dangerous,
+    });
+    tauri::async_runtime::spawn(async move {
+        if let Err(error) = run_named_pipe_server(ctx, pipe_name).await {
+            crate::logging::mcp_debug(
+                "bridge.server_stopped",
+                &json!({"error": error.to_string()}),
+            );
+            eprintln!("kkterm built-in MCP server stopped: {error}");
+        }
+    });
+}
+
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+#[cfg(target_os = "windows")]
+fn no_window(command: &mut Command) -> &mut Command {
+    use std::os::windows::process::CommandExt;
+
+    command.creation_flags(CREATE_NO_WINDOW);
+    command
 }
 
 struct BridgeContext {


### PR DESCRIPTION
### Motivation
- The MCP bridge startup currently runs Windows `whoami`/`icacls` synchronously during app setup which can open a console window and block UI startup. The change moves that work off the Tauri setup path and hides helper console windows.

### Description
- Start the Windows MCP bridge descriptor/ACL work on a dedicated background thread (`start_windows_bridge`) instead of doing it inline in `start_if_enabled` in `src-tauri/src/mcp_bridge.rs`.
- Add a `no_window` helper that applies `CREATE_NO_WINDOW` to spawned `whoami` / `icacls` child processes and use it where the descriptor ACL step runs, preventing visible console flashes.
- Keep the previous fail-closed behaviour: the descriptor is only published on success and the named-pipe server is launched asynchronously after descriptor creation and hardening.
- Update `docs/MCP.md` to document the background startup thread and the hidden `whoami`/`icacls` helper processes.

### Testing
- Ran `rustfmt --edition 2021 src-tauri/src/mcp_bridge.rs` and formatting completed successfully. (succeeded)
- Ran `git diff --check` to validate no whitespace/errors in diffs. (succeeded)
- Ran `cargo check --manifest-path src-tauri/Cargo.toml` in this environment but it failed due to a missing system `glib-2.0` pkg-config dependency required by the build. (blocked/failure due to environment)
- Ran `cargo check --manifest-path src-tauri/Cargo.toml --target x86_64-pc-windows-gnu` to validate Windows cross-build but it failed due to the missing cross-compiler `x86_64-w64-mingw32-gcc` in this environment. (blocked/failure due to environment)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fdfcdc41c832f9c3b70b3958dda57)