### PR TITLE
Lazy-mount dashboard views to avoid mounting all views at once

### DIFF
--- a/src/modules/dashboard/DashboardPage.tsx
+++ b/src/modules/dashboard/DashboardPage.tsx
@@ -108,6 +108,7 @@ export function DashboardPage({
   const [tabGradientPicker, setTabGradientPicker] = useState<{ viewId: string; rect: DOMRect } | null>(null);
   const [backgroundOpen, setBackgroundOpen] = useState(false);
   const [mcpServers, setMcpServers] = useState<McpServer[]>([]);
+  const [mountedViewIds, setMountedViewIds] = useState<Set<string>>(() => new Set());
   const appliedLandingPref = useRef(false);
   const viewDragRef = useRef<{
     id: string;
@@ -162,6 +163,15 @@ export function DashboardPage({
   }, [editMode, toggleEditMode]);
 
   const activeView = views.find((v) => v.id === activeViewId) ?? views[0];
+
+  useEffect(() => {
+    if (!activeView) return;
+    setMountedViewIds((current) => {
+      if (current.has(activeView.id)) return current;
+      return new Set(current).add(activeView.id);
+    });
+  }, [activeView]);
+
   const customizeInstance =
     customize ? instances.find((instance) => instance.id === customize.instance.id) : null;
   const viewInstances = useMemo(
@@ -489,6 +499,8 @@ export function DashboardPage({
       <div className="dw-canvas-stack">
         {views.map((view) => {
           const isActiveView = view.id === activeView.id;
+          const shouldMountView = isActiveView || mountedViewIds.has(view.id);
+          if (!shouldMountView) return null;
           const cachedViewInstances = instances.filter((instance) => instance.viewId === view.id);
           return (
             <div


### PR DESCRIPTION
### Motivation
- Prevent mounting every dashboard view on initial render to reduce work and preserve per-view state only for views that have been shown.
- Ensure previously-activated views remain mounted so their UI state is preserved when switching back.

### Description
- Added a `mountedViewIds` state set and an effect that adds the `activeView.id` to the set whenever a view becomes active.
- Changed the views rendering loop to only mount a view if it is currently active or if its id exists in `mountedViewIds`.
- Kept existing behavior of marking active vs cached views via CSS classes and preserved the existing canvas/background/component props.
- Changes are implemented in `src/modules/dashboard/DashboardPage.tsx`.

### Testing
- Ran the automated test suite with `yarn test` and the dashboard component tests, and they all passed.
- Verified that switching views mounts the view when first activated and that returning to previously-activated views preserves their mounted state via existing component tests, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20048c3068832f98076f12188ab95f)