### PR TITLE
Improve folder drag-and-drop behavior and add visible root drop target

### DIFF
--- a/docs/manual/03-connections.md
+++ b/docs/manual/03-connections.md
@@ -94,7 +94,7 @@ For saved Connections, the properties/Add Connection header includes Connection 
 
 ## Drag and drop
 
-Drag a Connection onto a folder to move it; drag onto another Connection to reorder. Folders can be nested. Order is persisted.
+Drag a Connection onto a folder to move it; drag onto another Connection to reorder. Folders can be nested: when dragging a folder over another folder, drop on the center of the row to make it a subfolder, or drop near the row edge to reorder it beside that folder. While a tree drag is active, a temporary `connections.root` drop target appears so Connections or folders can be moved back to the root even when the visible tree has no blank space. Order is persisted.
 
 ## Status badges
 

--- a/src/modules/workspace/connections/ConnectionSidebar.tsx
+++ b/src/modules/workspace/connections/ConnectionSidebar.tsx
@@ -1789,7 +1789,17 @@ export function ConnectionSidebar({
         const siblingParentFolderId = row.dataset.parentFolderId;
         const siblingFolderIndex = Number(row.dataset.folderIndex ?? 0);
         const bounds = row.getBoundingClientRect();
-        const insertAfter = pointerY > bounds.top + bounds.height / 2;
+        const offsetY = pointerY - bounds.top;
+        const edgeDropHeight = Math.min(8, bounds.height * 0.28);
+        if (offsetY >= edgeDropHeight && offsetY <= bounds.height - edgeDropHeight) {
+          return {
+            kind: "folder",
+            folderId,
+            targetIndex: Number(row.dataset.folderCount ?? 0),
+          } satisfies TreeDropTarget;
+        }
+
+        const insertAfter = offsetY > bounds.height / 2;
         if (siblingParentFolderId) {
           return {
             kind: "folder",
@@ -2194,6 +2204,17 @@ export function ConnectionSidebar({
                 onToggleFolder={isTreeFiltered ? undefined : handleToggleFolder}
               />
             ))}
+        {dragPreview ? (
+          <div
+            className={`tree-root-drop-target${dropTarget === "root" ? " drop-target" : ""}`}
+            data-connection-count={filteredTree.connections.length}
+            data-folder-count={filteredTree.folders.length}
+            data-tree-drop-kind="root"
+            role="presentation"
+          >
+            {t("connections.root")}
+          </div>
+        ) : null}
       </div>
 
       {treeContextMenu ? (

--- a/src/modules/workspace/connections/connections.css
+++ b/src/modules/workspace/connections/connections.css
@@ -300,10 +300,34 @@
 
 .tree-list.drop-target,
 .tree-folder-row.drop-target,
-.connection-row.drop-target {
+.connection-row.drop-target,
+.tree-root-drop-target.drop-target {
   background: var(--accent-soft);
   outline: 1px solid #8db5ff;
   outline-offset: -1px;
+}
+
+.tree-root-drop-target {
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  margin-top: 6px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 700;
+  background: var(--surface);
+  border: 1px dashed var(--border-strong);
+  border-radius: 6px;
+  backdrop-filter: blur(6px);
+}
+
+.tree-root-drop-target.drop-target {
+  color: var(--accent);
+  border-color: #8db5ff;
 }
 
 .tree-folder-row.dragging-source,


### PR DESCRIPTION
### Motivation
- Make folder drag-and-drop more intuitive by distinguishing dropping on the center of a folder to make it a subfolder versus dropping near edges to reorder it beside the folder.
- Allow users to move items back to the tree root even when the visible tree has no blank space by exposing a temporary root drop target while dragging.
- Document the refined drag behavior in the Connections manual and provide matching visual styling for the new drop target.

### Description
- Updated documentation in `docs/manual/03-connections.md` to describe the new center-vs-edge folder drop behavior and the temporary `connections.root` drop target.
- Modified `ConnectionSidebar.tsx` to compute `offsetY` and `edgeDropHeight`, treat center drops on folders as subfolder drops, preserve edge-based reordering logic using `insertAfter`, and render a sticky root drop target element when `dragPreview` is active.
- Added `tree-root-drop-target` CSS in `src/modules/workspace/connections/connections.css` with a `.drop-target` variant and adjusted existing selectors to style the new element consistently with other drop targets.

### Testing
- Ran project unit tests with `yarn test` and linters with `yarn lint`, and both completed successfully.
- Performed automated type checks with `yarn build` which succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fbcde0468832fb887566d968d816d)