### PR TITLE
Add debug wallpaper tray prototype

### DIFF
--- a/src-tauri/src/app_tray.rs
+++ b/src-tauri/src/app_tray.rs
@@ -3,6 +3,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde::Deserialize;
 use tauri::menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem};
+#[cfg(debug_assertions)]
+use tauri::menu::Submenu;
 use tauri::tray::{MouseButton, TrayIconBuilder, TrayIconEvent};
 use tauri::{Emitter, Manager};
 
@@ -13,6 +15,10 @@ const TRAY_ID: &str = "kkterm-main";
 const DONT_SLEEP_ITEM_ID: &str = "kkterm-tray-dont-sleep";
 const EXIT_ITEM_ID: &str = "kkterm-tray-exit";
 const RECENT_ITEM_PREFIX: &str = "kkterm-tray-recent:";
+#[cfg(debug_assertions)]
+const WALLPAPER_SET_ITEM_ID: &str = "kkterm-tray-wallpaper-set";
+#[cfg(debug_assertions)]
+const WALLPAPER_CLEAR_ITEM_ID: &str = "kkterm-tray-wallpaper-clear";
 
 #[derive(Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -156,6 +162,24 @@ fn build_menu<R: tauri::Runtime>(
     menu.append(&dont_sleep)
         .map_err(|error| error.to_string())?;
 
+    #[cfg(debug_assertions)]
+    {
+        menu.append(&PredefinedMenuItem::separator(app).map_err(|error| error.to_string())?)
+            .map_err(|error| error.to_string())?;
+
+        let wallpaper = Submenu::new(app, "Wallpaper", true).map_err(|error| error.to_string())?;
+        let set = MenuItem::with_id(app, WALLPAPER_SET_ITEM_ID, "Set", true, None::<&str>)
+            .map_err(|error| error.to_string())?;
+        let clear = MenuItem::with_id(app, WALLPAPER_CLEAR_ITEM_ID, "Clear", true, None::<&str>)
+            .map_err(|error| error.to_string())?;
+        wallpaper.append(&set).map_err(|error| error.to_string())?;
+        wallpaper
+            .append(&clear)
+            .map_err(|error| error.to_string())?;
+        menu.append(&wallpaper)
+            .map_err(|error| error.to_string())?;
+    }
+
     menu.append(&PredefinedMenuItem::separator(app).map_err(|error| error.to_string())?)
         .map_err(|error| error.to_string())?;
 
@@ -177,6 +201,23 @@ fn handle_menu_event<R: tauri::Runtime>(app: &tauri::AppHandle<R>, id: &str) {
     if id == DONT_SLEEP_ITEM_ID {
         toggle_dont_sleep(app);
         return;
+    }
+
+    #[cfg(debug_assertions)]
+    {
+        if id == WALLPAPER_SET_ITEM_ID {
+            if let Err(error) = crate::desktop_wallpaper::set_debug_wallpaper(app) {
+                eprintln!("failed to set debug wallpaper: {error}");
+            }
+            return;
+        }
+
+        if id == WALLPAPER_CLEAR_ITEM_ID {
+            if let Err(error) = crate::desktop_wallpaper::clear_debug_wallpaper(app) {
+                eprintln!("failed to clear debug wallpaper: {error}");
+            }
+            return;
+        }
     }
 
     if let Some(connection_id) = id.strip_prefix(RECENT_ITEM_PREFIX) {

--- a/src-tauri/src/desktop_wallpaper.rs
+++ b/src-tauri/src/desktop_wallpaper.rs
@@ -1,0 +1,204 @@
+#[cfg(target_os = "windows")]
+mod platform {
+    use tauri::{Manager, Runtime, WebviewWindowBuilder};
+    use windows::{
+        core::{w, BOOL, PCWSTR},
+        Win32::{
+            Foundation::{HWND, LPARAM, POINT, RECT, WPARAM},
+            Graphics::Gdi::MapWindowPoints,
+            UI::WindowsAndMessaging::{
+                EnumWindows, FindWindowExW, FindWindowW, GetSystemMetrics, SendMessageTimeoutW,
+                SetParent, SetWindowPos, ShowWindow, SMTO_NORMAL, SM_CXVIRTUALSCREEN,
+                SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SWP_NOACTIVATE,
+                SWP_NOZORDER, SW_SHOWNOACTIVATE,
+            },
+        },
+    };
+
+    const WALLPAPER_WINDOW_LABEL: &str = "kkterm-debug-wallpaper";
+    const WALLPAPER_ROUTE: &str = "index.html#/wallpaper";
+
+    struct WorkerSearch {
+        workerw: HWND,
+    }
+
+    pub fn set<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), String> {
+        clear(app)?;
+
+        let bounds = virtual_screen_bounds();
+        let window = WebviewWindowBuilder::new(
+            app,
+            WALLPAPER_WINDOW_LABEL,
+            tauri::WebviewUrl::App(WALLPAPER_ROUTE.into()),
+        )
+        .title("KKTerm Wallpaper")
+        .position(bounds.left as f64, bounds.top as f64)
+        .inner_size(
+            (bounds.right - bounds.left).max(1) as f64,
+            (bounds.bottom - bounds.top).max(1) as f64,
+        )
+        .decorations(false)
+        .resizable(false)
+        .visible(false)
+        .skip_taskbar(true)
+        .disable_drag_drop_handler()
+        .build()
+        .map_err(|error| format!("failed to create wallpaper window: {error}"))?;
+
+        let handle = window
+            .hwnd()
+            .map_err(|error| format!("failed to read wallpaper window handle: {error}"))?;
+        let hwnd = HWND(handle.0);
+        attach_wallpaper_window(hwnd, bounds)?;
+        let _ = window.show();
+        Ok(())
+    }
+
+    pub fn clear<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), String> {
+        if let Some(window) = app.get_webview_window(WALLPAPER_WINDOW_LABEL) {
+            window
+                .destroy()
+                .map_err(|error| format!("failed to destroy wallpaper window: {error}"))?;
+        }
+        Ok(())
+    }
+
+    fn attach_wallpaper_window(hwnd: HWND, bounds: RECT) -> Result<(), String> {
+        let workerw = find_wallpaper_workerw()?;
+        unsafe {
+            SetWindowPos(
+                hwnd,
+                None,
+                bounds.left,
+                bounds.top,
+                (bounds.right - bounds.left).max(1),
+                (bounds.bottom - bounds.top).max(1),
+                SWP_NOACTIVATE,
+            )
+            .map_err(|error| format!("failed to position wallpaper window: {error}"))?;
+
+            SetParent(hwnd, Some(workerw))
+                .map_err(|error| format!("failed to attach wallpaper window to WorkerW: {error}"))?;
+
+            let mut points = [
+                POINT {
+                    x: bounds.left,
+                    y: bounds.top,
+                },
+                POINT {
+                    x: bounds.right,
+                    y: bounds.bottom,
+                },
+            ];
+            let _ = MapWindowPoints(None, Some(workerw), &mut points);
+            SetWindowPos(
+                hwnd,
+                None,
+                points[0].x,
+                points[0].y,
+                (bounds.right - bounds.left).max(1),
+                (bounds.bottom - bounds.top).max(1),
+                SWP_NOACTIVATE | SWP_NOZORDER,
+            )
+            .map_err(|error| format!("failed to resize attached wallpaper window: {error}"))?;
+            let _ = ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+        }
+        Ok(())
+    }
+
+    fn find_wallpaper_workerw() -> Result<HWND, String> {
+        let progman = unsafe { FindWindowW(w!("Progman"), PCWSTR::null()) }
+            .map_err(|error| format!("desktop Progman window was not found: {error}"))?;
+        if progman.0.is_null() {
+            return Err("desktop Progman window was not found".to_string());
+        }
+
+        unsafe {
+            SendMessageTimeoutW(
+                progman,
+                0x052c,
+                WPARAM(0x0d),
+                LPARAM(0x01),
+                SMTO_NORMAL,
+                1000,
+                None,
+            );
+        }
+
+        if let Some(workerw) = find_workerw_after_shell_view() {
+            return Ok(workerw);
+        }
+
+        let workerw = unsafe { FindWindowExW(Some(progman), None, w!("WorkerW"), PCWSTR::null()) }
+            .unwrap_or_else(|_| HWND(std::ptr::null_mut()));
+        if !workerw.0.is_null() {
+            return Ok(workerw);
+        }
+
+        Ok(progman)
+    }
+
+    fn find_workerw_after_shell_view() -> Option<HWND> {
+        let mut search = WorkerSearch {
+            workerw: HWND(std::ptr::null_mut()),
+        };
+        unsafe {
+            let _ = EnumWindows(Some(enum_windows_for_workerw), LPARAM(&mut search as *mut _ as isize));
+        }
+        if search.workerw.0.is_null() {
+            None
+        } else {
+            Some(search.workerw)
+        }
+    }
+
+    unsafe extern "system" fn enum_windows_for_workerw(hwnd: HWND, lparam: LPARAM) -> BOOL {
+        let shell = FindWindowExW(Some(hwnd), None, w!("SHELLDLL_DefView"), PCWSTR::null())
+            .unwrap_or_else(|_| HWND(std::ptr::null_mut()));
+        if !shell.0.is_null() {
+            let search = &mut *(lparam.0 as *mut WorkerSearch);
+            search.workerw = FindWindowExW(None, Some(hwnd), w!("WorkerW"), PCWSTR::null())
+                .unwrap_or_else(|_| HWND(std::ptr::null_mut()));
+        }
+        true.into()
+    }
+
+    fn virtual_screen_bounds() -> RECT {
+        unsafe {
+            let left = GetSystemMetrics(SM_XVIRTUALSCREEN);
+            let top = GetSystemMetrics(SM_YVIRTUALSCREEN);
+            RECT {
+                left,
+                top,
+                right: left + GetSystemMetrics(SM_CXVIRTUALSCREEN).max(1),
+                bottom: top + GetSystemMetrics(SM_CYVIRTUALSCREEN).max(1),
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+mod platform {
+    pub fn set<R: tauri::Runtime>(_app: &tauri::AppHandle<R>) -> Result<(), String> {
+        Err("desktop wallpaper hosting is only available on Windows".to_string())
+    }
+
+    pub fn clear<R: tauri::Runtime>(_app: &tauri::AppHandle<R>) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+pub(crate) fn set_debug_wallpaper<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> Result<(), String> {
+    if !cfg!(debug_assertions) {
+        return Err("debug wallpaper is only available in debug builds".to_string());
+    }
+    platform::set(app)
+}
+
+pub(crate) fn clear_debug_wallpaper<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> Result<(), String> {
+    platform::clear(app)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,8 @@ mod dashboard_ids;
 mod dashboard_storage;
 mod dashboard_validation;
 mod debug_heartbeat;
+#[cfg(debug_assertions)]
+mod desktop_wallpaper;
 mod diagnostics;
 mod favicon;
 mod ftp;

--- a/src/App.css
+++ b/src/App.css
@@ -15,3 +15,21 @@
 @import "./manual/manual.css";
 @import "./modules/dashboard/widgets/builtin/ai-coding-usage/ai-coding-usage.css";
 @import "./watchdog/watchdog.css";
+
+.kk-wallpaper-host {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+  background: #05070f;
+}
+
+.kk-wallpaper-host .dw-canvas-bg {
+  position: absolute;
+  inset: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}

--- a/src/app/WallpaperHost.tsx
+++ b/src/app/WallpaperHost.tsx
@@ -1,0 +1,14 @@
+import "../App.css";
+import { DashboardDynamicBackground, DYNAMIC_BACKGROUNDS } from "../modules/dashboard/registry/dynamicBackgrounds";
+
+const DEFAULT_WALLPAPER_DYNAMIC_ID = DYNAMIC_BACKGROUNDS[0]?.id ?? "";
+
+export function WallpaperHost() {
+  return (
+    <main className="kk-wallpaper-host" aria-hidden="true">
+      {DEFAULT_WALLPAPER_DYNAMIC_ID ? (
+        <DashboardDynamicBackground active={true} id={DEFAULT_WALLPAPER_DYNAMIC_ID} />
+      ) : null}
+    </main>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { WallpaperHost } from "./app/WallpaperHost";
 import { ensureI18nReady } from "./i18n/config";
 
 ensureI18nReady().then(() => {
+  const Root = window.location.hash === "#/wallpaper" ? WallpaperHost : App;
   ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>
-      <App />
+      <Root />
     </React.StrictMode>,
   );
 });


### PR DESCRIPTION
## Summary
- add a debug-only tray submenu: Wallpaper -> Set/Clear
- create a Windows WorkerW-hosted Tauri WebView wallpaper prototype
- render a minimal `#/wallpaper` host using the existing Dashboard dynamic background registry

## Verification
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo check --manifest-path src-tauri/Cargo.toml --release

## Notes
- `npm run check` did not complete locally: existing `installer-stepper-legacy-log.test.mjs` assertion failed before TypeScript ran.
- Standalone local TypeScript could not run in this worktree because `node_modules` does not contain the project-local TypeScript binary.
- The actual WorkerW desktop behavior still needs a debug Tauri runtime smoke test.