### PR TITLE
[codex] add desktop wallpaper controls

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,6 +28,8 @@ The main app window close path stays native and free of frontend hooks. Do not a
 
 The single sanctioned exception is the minimize-to-tray diversion in `app_tray.rs`: a native, synchronous Rust-side `WindowEvent::CloseRequested` arm inside the existing `on_window_event` handler. It calls `api.prevent_close()` and hides the window **only when minimize-to-tray is enabled**; when disabled the close request is untouched and quits natively. The handler does no async work, and the tray "Exit" item (`app.exit(0)`) bypasses `CloseRequested` so a guaranteed quit path always exists.
 
+The tray `app.trayWallpaper` submenu is a Windows desktop integration surface, not a Dashboard Module. `app.trayWallpaperSet` restores the main window and opens the app-owned `DesktopWallpaperPicker`, which reuses `SharedBackgroundPopover` so Dashboard Views, terminal Connection backgrounds, and desktop wallpaper share the same presets, media import path, fit/dim controls, and dynamic background registry. `app.trayWallpaperClear` destroys the WorkerW-hosted wallpaper WebView and persists `desktopWallpaperEnabled=false` while preserving the last selected `desktopWallpaperBackground` for the next Set action. The native host lives in `src-tauri/src/desktop_wallpaper.rs`; it creates a frameless WebView behind desktop icons via the Windows WorkerW/Progman path, overscans the virtual screen bounds to avoid edge leakage, restores persisted wallpaper state on app startup, and emits pause state when a foreground window is maximized or covers a monitor so animated/video backgrounds can stop rendering under fullscreen work.
+
 Automatic database backups follow the same rule: they run during startup or explicit Settings actions, never during app-window close. Backup files are KKTerm settings ZIPs with the same structure as manual exports, so Import Settings can restore them directly.
 
 ### Command Boundary
@@ -381,6 +383,8 @@ Workspace chrome layout is global state. Connection-specific live context may ch
 - `src/app/app.css` — app shell, Activity Rail, rail tooltips, panel resize chrome, and Tutorial overlay styling.
 - `src/app/ActivityRail.tsx` — Activity Rail rendering, connected Connection shortcuts, pinned Connection actions, native rail Connection context menu, connected Connection drag ordering, and Don't Sleep control.
 - `src/app/RailTooltip.tsx` — shared app-owned Activity Rail tooltip surface, including the Windows native tooltip bridge that can draw over HWND-backed RDP ActiveX and WebView2 surfaces; use this instead of browser-native `title` tooltips for rail icon labels.
+- `src/app/DesktopWallpaperPicker.tsx` — app-owned tray-launched wallpaper picker. Reuses `SharedBackgroundPopover` and persists through the desktop wallpaper Tauri commands.
+- `src/app/WallpaperHost.tsx` — renderer for the hidden desktop wallpaper WebView. Loads persisted `desktopWallpaperBackground`, renders preset/media/dynamic backgrounds, and pauses dynamic/video motion from native pause events.
 - `src/app/workspaceChromeLayout.tsx` — global Workspace chrome panel widths/collapse state, panel resize handles, layout reset, and localStorage persistence for the Connection panel and AI Assistant Panel.
 - `src/app/appShellEffects.ts` — app-shell effects for frontend launch timing, host usage polling, global context-menu suppression, and app-shell CSS variables/color scheme.
 - `src/modules/workspace/connections/ConnectionSidebar.tsx` — connection tree orchestration: search, drag/drop, CRUD command handlers, folder rows, native Quick Connect/Add Connection/tree/Tab context menus, Connection dialog request assembly, and modal wiring.
@@ -417,6 +421,7 @@ Workspace chrome layout is global state. Connection-specific live context may ch
 - `src/modules/dashboard/edit/CatalogOverlay.tsx` — "Add widget" modal with search, Built-in/AI Created source tabs, and thumbnail cards.
 - `src/modules/dashboard/edit/CustomizePopover.tsx` — per-instance editor: preset row, accent palette, icon picker, title input, collapsible Advanced section per kind.
 - `src/modules/dashboard/edit/SharedBackgroundPopover.tsx` — shared background picker datasource and UI for Dashboard Views and terminal Connection backgrounds. Keep background preset/dynamic/media/fit/dim additions here or in the registries it consumes so both surfaces show the same list.
+- `src-tauri/src/desktop_wallpaper.rs` — Windows WorkerW desktop wallpaper host, startup restore, edge-overscanned wallpaper window placement, Clear handling, and pause-state monitoring for maximized/fullscreen foreground windows.
 - `src/modules/dashboard/motion.tsx` — centralized motion wrappers for Dashboard surfaces; per the motion rule above.
 - `src/modules/workspace/connections/terminal/TerminalWorkspace.tsx` — terminal workspace, split layout view, pane host, tmux session tag/popover, terminal context menu, SSH tmux inspection helpers.
 - `src/modules/workspace/connections/terminal/renderer.ts` — renderer abstraction and xterm/WebGL renderer implementation.

--- a/docs/manual/01-getting-started.md
+++ b/docs/manual/01-getting-started.md
@@ -2,9 +2,9 @@
 
 ## AI grep hints
 
-- Keys: `app.connections`, `app.settings`, `app.aiAssistant`, `app.dontSleep`, `app.trayExit`
-- Topics: first launch, what KKTerm is, system tray, "Don't Sleep" mode, primary navigation
-- Synonyms users may type: "open the app", "left bar icons", "tray icon", "keep awake", "prevent sleep"
+- Keys: `app.connections`, `app.settings`, `app.aiAssistant`, `app.dontSleep`, `app.trayExit`, `app.trayWallpaper`
+- Topics: first launch, what KKTerm is, system tray, "Don't Sleep" mode, desktop wallpaper, primary navigation
+- Synonyms users may type: "open the app", "left bar icons", "tray icon", "keep awake", "prevent sleep", "wallpaper", "live wallpaper"
 
 ## What KKTerm is
 
@@ -48,10 +48,11 @@ Hover tooltips on rail icons are rendered by the shared `RailTooltip` (`src/app/
 
 ## System tray
 
-KKTerm registers a Windows tray icon with recent Connections plus two controls:
+KKTerm registers a Windows tray icon with recent Connections plus app controls:
 
 - Recent Connections — selecting a Connection restores the window, switches to the Workspace Module, and opens or focuses that Connection's Tab.
 - `app.trayDontSleep` — toggles the same state as the in-app "Don't Sleep" mode (see below).
+- `app.trayWallpaper` — `app.trayWallpaperSet` opens the shared background picker for the Windows desktop wallpaper host; `app.trayWallpaperClear` destroys the wallpaper window and returns wallpaper handling to Windows.
 - `app.trayExit` — exits the app unconditionally. This path bypasses the close-to-tray diversion.
 
 ## Closing the window

--- a/src-tauri/src/app_tray.rs
+++ b/src-tauri/src/app_tray.rs
@@ -2,9 +2,7 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde::Deserialize;
-use tauri::menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem};
-#[cfg(debug_assertions)]
-use tauri::menu::Submenu;
+use tauri::menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu};
 use tauri::tray::{MouseButton, TrayIconBuilder, TrayIconEvent};
 use tauri::{Emitter, Manager};
 
@@ -15,9 +13,7 @@ const TRAY_ID: &str = "kkterm-main";
 const DONT_SLEEP_ITEM_ID: &str = "kkterm-tray-dont-sleep";
 const EXIT_ITEM_ID: &str = "kkterm-tray-exit";
 const RECENT_ITEM_PREFIX: &str = "kkterm-tray-recent:";
-#[cfg(debug_assertions)]
 const WALLPAPER_SET_ITEM_ID: &str = "kkterm-tray-wallpaper-set";
-#[cfg(debug_assertions)]
 const WALLPAPER_CLEAR_ITEM_ID: &str = "kkterm-tray-wallpaper-clear";
 
 #[derive(Clone, Deserialize)]
@@ -32,6 +28,9 @@ pub struct TrayRecentConnection {
 pub struct TrayMenuSnapshot {
     pub recent_connections: Vec<TrayRecentConnection>,
     pub dont_sleep_label: String,
+    pub wallpaper_label: String,
+    pub wallpaper_set_label: String,
+    pub wallpaper_clear_label: String,
     pub exit_label: String,
 }
 
@@ -162,23 +161,33 @@ fn build_menu<R: tauri::Runtime>(
     menu.append(&dont_sleep)
         .map_err(|error| error.to_string())?;
 
-    #[cfg(debug_assertions)]
-    {
-        menu.append(&PredefinedMenuItem::separator(app).map_err(|error| error.to_string())?)
-            .map_err(|error| error.to_string())?;
+    menu.append(&PredefinedMenuItem::separator(app).map_err(|error| error.to_string())?)
+        .map_err(|error| error.to_string())?;
 
-        let wallpaper = Submenu::new(app, "Wallpaper", true).map_err(|error| error.to_string())?;
-        let set = MenuItem::with_id(app, WALLPAPER_SET_ITEM_ID, "Set", true, None::<&str>)
-            .map_err(|error| error.to_string())?;
-        let clear = MenuItem::with_id(app, WALLPAPER_CLEAR_ITEM_ID, "Clear", true, None::<&str>)
-            .map_err(|error| error.to_string())?;
-        wallpaper.append(&set).map_err(|error| error.to_string())?;
-        wallpaper
-            .append(&clear)
-            .map_err(|error| error.to_string())?;
-        menu.append(&wallpaper)
-            .map_err(|error| error.to_string())?;
-    }
+    let wallpaper =
+        Submenu::new(app, &snapshot.wallpaper_label, true).map_err(|error| error.to_string())?;
+    let set = MenuItem::with_id(
+        app,
+        WALLPAPER_SET_ITEM_ID,
+        &snapshot.wallpaper_set_label,
+        true,
+        None::<&str>,
+    )
+    .map_err(|error| error.to_string())?;
+    let clear = MenuItem::with_id(
+        app,
+        WALLPAPER_CLEAR_ITEM_ID,
+        &snapshot.wallpaper_clear_label,
+        true,
+        None::<&str>,
+    )
+    .map_err(|error| error.to_string())?;
+    wallpaper.append(&set).map_err(|error| error.to_string())?;
+    wallpaper
+        .append(&clear)
+        .map_err(|error| error.to_string())?;
+    menu.append(&wallpaper)
+        .map_err(|error| error.to_string())?;
 
     menu.append(&PredefinedMenuItem::separator(app).map_err(|error| error.to_string())?)
         .map_err(|error| error.to_string())?;
@@ -203,27 +212,35 @@ fn handle_menu_event<R: tauri::Runtime>(app: &tauri::AppHandle<R>, id: &str) {
         return;
     }
 
-    #[cfg(debug_assertions)]
-    {
-        if id == WALLPAPER_SET_ITEM_ID {
-            if let Err(error) = crate::desktop_wallpaper::set_debug_wallpaper(app) {
-                eprintln!("failed to set debug wallpaper: {error}");
-            }
-            return;
-        }
+    if id == WALLPAPER_SET_ITEM_ID {
+        restore_main_window(app);
+        let _ = app.emit(crate::desktop_wallpaper::WALLPAPER_PICKER_EVENT, ());
+        return;
+    }
 
-        if id == WALLPAPER_CLEAR_ITEM_ID {
-            if let Err(error) = crate::desktop_wallpaper::clear_debug_wallpaper(app) {
-                eprintln!("failed to clear debug wallpaper: {error}");
-            }
-            return;
+    if id == WALLPAPER_CLEAR_ITEM_ID {
+        if let Err(error) = clear_desktop_wallpaper(app) {
+            eprintln!("failed to clear desktop wallpaper: {error}");
         }
+        return;
     }
 
     if let Some(connection_id) = id.strip_prefix(RECENT_ITEM_PREFIX) {
         restore_main_window(app);
         let _ = app.emit("kkterm://tray-open-connection", connection_id.to_string());
     }
+}
+
+fn clear_desktop_wallpaper<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> Result<(), String> {
+    crate::desktop_wallpaper::clear_wallpaper(app)?;
+    let Some(storage) = app.try_state::<crate::storage::Storage>() else {
+        return Ok(());
+    };
+    let saved = storage.update_desktop_wallpaper_enabled(false)?;
+    let _ = app.emit(crate::desktop_wallpaper::WALLPAPER_SETTINGS_EVENT, saved);
+    Ok(())
 }
 
 fn toggle_dont_sleep<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {

--- a/src-tauri/src/desktop_wallpaper.rs
+++ b/src-tauri/src/desktop_wallpaper.rs
@@ -1,22 +1,40 @@
+use std::sync::Once;
+
+pub(crate) const WALLPAPER_PICKER_EVENT: &str = "kkterm://desktop-wallpaper-pick";
+pub(crate) const WALLPAPER_SETTINGS_EVENT: &str = "kkterm://desktop-wallpaper-settings";
+pub(crate) const WALLPAPER_PAUSED_EVENT: &str = "kkterm://desktop-wallpaper-paused";
+
+static PAUSE_MONITOR: Once = Once::new();
+
 #[cfg(target_os = "windows")]
 mod platform {
-    use tauri::{Manager, Runtime, WebviewWindowBuilder};
+    use std::{mem, thread, time::Duration};
+
+    use tauri::{Emitter, Manager, Runtime, WebviewWindowBuilder};
     use windows::{
-        core::{w, BOOL, PCWSTR},
         Win32::{
             Foundation::{HWND, LPARAM, POINT, RECT, WPARAM},
-            Graphics::Gdi::MapWindowPoints,
+            Graphics::Gdi::{
+                GetMonitorInfoW, MapWindowPoints, MonitorFromWindow, MONITORINFO,
+                MONITOR_DEFAULTTONEAREST,
+            },
             UI::WindowsAndMessaging::{
-                EnumWindows, FindWindowExW, FindWindowW, GetSystemMetrics, SendMessageTimeoutW,
-                SetParent, SetWindowPos, ShowWindow, SMTO_NORMAL, SM_CXVIRTUALSCREEN,
-                SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SWP_NOACTIVATE,
-                SWP_NOZORDER, SW_SHOWNOACTIVATE,
+                EnumWindows, FindWindowExW, FindWindowW, GetClassNameW, GetForegroundWindow,
+                GetSystemMetrics, GetWindowRect, IsZoomed, SendMessageTimeoutW, SetParent,
+                SetWindowPos, ShowWindow, SMTO_NORMAL, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN,
+                SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SWP_NOACTIVATE, SWP_NOZORDER,
+                SW_SHOWNOACTIVATE,
             },
         },
+        core::{w, BOOL, PCWSTR},
     };
 
-    const WALLPAPER_WINDOW_LABEL: &str = "kkterm-debug-wallpaper";
+    use super::{WALLPAPER_PAUSED_EVENT, WALLPAPER_SETTINGS_EVENT};
+
+    const WALLPAPER_WINDOW_LABEL: &str = "kkterm-wallpaper";
     const WALLPAPER_ROUTE: &str = "index.html#/wallpaper";
+    const WALLPAPER_OVERSCAN_PX: i32 = 4;
+    const PAUSE_POLL_INTERVAL: Duration = Duration::from_millis(1000);
 
     struct WorkerSearch {
         workerw: HWND,
@@ -25,7 +43,7 @@ mod platform {
     pub fn set<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), String> {
         clear(app)?;
 
-        let bounds = virtual_screen_bounds();
+        let bounds = expanded_virtual_screen_bounds();
         let window = WebviewWindowBuilder::new(
             app,
             WALLPAPER_WINDOW_LABEL,
@@ -51,6 +69,7 @@ mod platform {
         let hwnd = HWND(handle.0);
         attach_wallpaper_window(hwnd, bounds)?;
         let _ = window.show();
+        let _ = app.emit(WALLPAPER_SETTINGS_EVENT, ());
         Ok(())
     }
 
@@ -60,7 +79,23 @@ mod platform {
                 .destroy()
                 .map_err(|error| format!("failed to destroy wallpaper window: {error}"))?;
         }
+        let _ = app.emit(WALLPAPER_PAUSED_EVENT, false);
+        let _ = app.emit(WALLPAPER_SETTINGS_EVENT, ());
         Ok(())
+    }
+
+    pub fn start_pause_monitor<R: Runtime>(app: tauri::AppHandle<R>) {
+        thread::spawn(move || {
+            let mut last_paused = false;
+            loop {
+                thread::sleep(PAUSE_POLL_INTERVAL);
+                let paused = should_pause_wallpaper(&app);
+                if paused != last_paused {
+                    last_paused = paused;
+                    let _ = app.emit(WALLPAPER_PAUSED_EVENT, paused);
+                }
+            }
+        });
     }
 
     fn attach_wallpaper_window(hwnd: HWND, bounds: RECT) -> Result<(), String> {
@@ -71,8 +106,8 @@ mod platform {
                 None,
                 bounds.left,
                 bounds.top,
-                (bounds.right - bounds.left).max(1),
-                (bounds.bottom - bounds.top).max(1),
+                rect_width(bounds),
+                rect_height(bounds),
                 SWP_NOACTIVATE,
             )
             .map_err(|error| format!("failed to position wallpaper window: {error}"))?;
@@ -96,8 +131,8 @@ mod platform {
                 None,
                 points[0].x,
                 points[0].y,
-                (bounds.right - bounds.left).max(1),
-                (bounds.bottom - bounds.top).max(1),
+                (points[1].x - points[0].x).max(1),
+                (points[1].y - points[0].y).max(1),
                 SWP_NOACTIVATE | SWP_NOZORDER,
             )
             .map_err(|error| format!("failed to resize attached wallpaper window: {error}"))?;
@@ -143,7 +178,10 @@ mod platform {
             workerw: HWND(std::ptr::null_mut()),
         };
         unsafe {
-            let _ = EnumWindows(Some(enum_windows_for_workerw), LPARAM(&mut search as *mut _ as isize));
+            let _ = EnumWindows(
+                Some(enum_windows_for_workerw),
+                LPARAM(&mut search as *mut _ as isize),
+            );
         }
         if search.workerw.0.is_null() {
             None
@@ -153,14 +191,75 @@ mod platform {
     }
 
     unsafe extern "system" fn enum_windows_for_workerw(hwnd: HWND, lparam: LPARAM) -> BOOL {
-        let shell = FindWindowExW(Some(hwnd), None, w!("SHELLDLL_DefView"), PCWSTR::null())
-            .unwrap_or_else(|_| HWND(std::ptr::null_mut()));
+        let shell = unsafe {
+            FindWindowExW(Some(hwnd), None, w!("SHELLDLL_DefView"), PCWSTR::null())
+                .unwrap_or_else(|_| HWND(std::ptr::null_mut()))
+        };
         if !shell.0.is_null() {
-            let search = &mut *(lparam.0 as *mut WorkerSearch);
-            search.workerw = FindWindowExW(None, Some(hwnd), w!("WorkerW"), PCWSTR::null())
-                .unwrap_or_else(|_| HWND(std::ptr::null_mut()));
+            let search = unsafe { &mut *(lparam.0 as *mut WorkerSearch) };
+            search.workerw = unsafe {
+                FindWindowExW(None, Some(hwnd), w!("WorkerW"), PCWSTR::null())
+                    .unwrap_or_else(|_| HWND(std::ptr::null_mut()))
+            };
         }
         true.into()
+    }
+
+    fn should_pause_wallpaper<R: Runtime>(app: &tauri::AppHandle<R>) -> bool {
+        if app.get_webview_window(WALLPAPER_WINDOW_LABEL).is_none() {
+            return false;
+        }
+
+        let hwnd = unsafe { GetForegroundWindow() };
+        if hwnd.0.is_null() || is_desktop_shell_window(hwnd) {
+            return false;
+        }
+
+        if unsafe { IsZoomed(hwnd).as_bool() } {
+            return true;
+        }
+
+        let mut rect = RECT::default();
+        if unsafe { GetWindowRect(hwnd, &mut rect) }.is_err() {
+            return false;
+        }
+
+        let monitor = unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) };
+        if monitor.0.is_null() {
+            return false;
+        }
+        let mut info = MONITORINFO {
+            cbSize: mem::size_of::<MONITORINFO>() as u32,
+            ..Default::default()
+        };
+        if !unsafe { GetMonitorInfoW(monitor, &mut info).as_bool() } {
+            return false;
+        }
+
+        rect_covers(rect, info.rcMonitor, 2)
+    }
+
+    fn is_desktop_shell_window(hwnd: HWND) -> bool {
+        let mut class_name = [0u16; 128];
+        let length = unsafe { GetClassNameW(hwnd, &mut class_name) };
+        if length <= 0 {
+            return false;
+        }
+        let name = String::from_utf16_lossy(&class_name[..length as usize]);
+        matches!(
+            name.as_str(),
+            "Progman" | "WorkerW" | "SHELLDLL_DefView" | "Shell_TrayWnd"
+        )
+    }
+
+    fn expanded_virtual_screen_bounds() -> RECT {
+        let bounds = virtual_screen_bounds();
+        RECT {
+            left: bounds.left - WALLPAPER_OVERSCAN_PX,
+            top: bounds.top - WALLPAPER_OVERSCAN_PX,
+            right: bounds.right + WALLPAPER_OVERSCAN_PX,
+            bottom: bounds.bottom + WALLPAPER_OVERSCAN_PX,
+        }
     }
 
     fn virtual_screen_bounds() -> RECT {
@@ -175,6 +274,21 @@ mod platform {
             }
         }
     }
+
+    fn rect_covers(rect: RECT, target: RECT, tolerance: i32) -> bool {
+        rect.left <= target.left + tolerance
+            && rect.top <= target.top + tolerance
+            && rect.right >= target.right - tolerance
+            && rect.bottom >= target.bottom - tolerance
+    }
+
+    fn rect_width(rect: RECT) -> i32 {
+        (rect.right - rect.left).max(1)
+    }
+
+    fn rect_height(rect: RECT) -> i32 {
+        (rect.bottom - rect.top).max(1)
+    }
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -186,19 +300,18 @@ mod platform {
     pub fn clear<R: tauri::Runtime>(_app: &tauri::AppHandle<R>) -> Result<(), String> {
         Ok(())
     }
+
+    pub fn start_pause_monitor<R: tauri::Runtime>(_app: tauri::AppHandle<R>) {}
 }
 
-pub(crate) fn set_debug_wallpaper<R: tauri::Runtime>(
-    app: &tauri::AppHandle<R>,
-) -> Result<(), String> {
-    if !cfg!(debug_assertions) {
-        return Err("debug wallpaper is only available in debug builds".to_string());
-    }
+pub(crate) fn set_wallpaper<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> Result<(), String> {
     platform::set(app)
 }
 
-pub(crate) fn clear_debug_wallpaper<R: tauri::Runtime>(
-    app: &tauri::AppHandle<R>,
-) -> Result<(), String> {
+pub(crate) fn clear_wallpaper<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> Result<(), String> {
     platform::clear(app)
+}
+
+pub(crate) fn start_pause_monitor<R: tauri::Runtime>(app: tauri::AppHandle<R>) {
+    PAUSE_MONITOR.call_once(|| platform::start_pause_monitor(app));
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,7 +10,6 @@ mod dashboard_ids;
 mod dashboard_storage;
 mod dashboard_validation;
 mod debug_heartbeat;
-#[cfg(debug_assertions)]
 mod desktop_wallpaper;
 mod diagnostics;
 mod favicon;
@@ -48,7 +47,7 @@ mod windows_local_pty;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 use tauri_plugin_opener::OpenerExt;
 
 #[derive(Deserialize)]
@@ -703,6 +702,35 @@ fn update_general_settings(
         eprintln!("failed to apply saved Don't Sleep setting: {error}");
     }
     webviews.set_clipboard_read_allowed(saved.allow_clipboard_read());
+    Ok(saved)
+}
+
+#[tauri::command]
+fn set_desktop_wallpaper(
+    app: tauri::AppHandle,
+    storage: tauri::State<'_, storage::Storage>,
+    background: dashboard_storage::DashboardBackground,
+) -> Result<storage::GeneralSettings, String> {
+    background
+        .validate()
+        .map_err(|error| format!("desktop wallpaper background is invalid: {error:?}"))?;
+    let saved = storage.update_desktop_wallpaper_settings(true, Some(background))?;
+    if let Err(error) = desktop_wallpaper::set_wallpaper(&app) {
+        let _ = storage.update_desktop_wallpaper_enabled(false);
+        return Err(error);
+    }
+    let _ = app.emit(desktop_wallpaper::WALLPAPER_SETTINGS_EVENT, saved.clone());
+    Ok(saved)
+}
+
+#[tauri::command]
+fn clear_desktop_wallpaper(
+    app: tauri::AppHandle,
+    storage: tauri::State<'_, storage::Storage>,
+) -> Result<storage::GeneralSettings, String> {
+    desktop_wallpaper::clear_wallpaper(&app)?;
+    let saved = storage.update_desktop_wallpaper_enabled(false)?;
+    let _ = app.emit(desktop_wallpaper::WALLPAPER_SETTINGS_EVENT, saved.clone());
     Ok(saved)
 }
 
@@ -2683,6 +2711,14 @@ pub fn run() {
             app.manage(std::sync::Arc::new(watchdog::WatchdogRegistry::new()));
             app.manage(std::sync::Arc::new(watchdog::SessionActivityTracker::new()));
             app.manage(installer::InstallerRuntime::new());
+            desktop_wallpaper::start_pause_monitor(app.handle().clone());
+            if general_settings.desktop_wallpaper_enabled()
+                && general_settings.desktop_wallpaper_background().is_some()
+            {
+                if let Err(error) = desktop_wallpaper::set_wallpaper(app.handle()) {
+                    eprintln!("failed to restore desktop wallpaper: {error}");
+                }
+            }
             mcp_bridge::start_if_enabled(
                 app.handle().clone(),
                 mcp_bridge_dir,
@@ -2770,6 +2806,8 @@ pub fn run() {
             clear_url_data_partition,
             get_general_settings,
             update_general_settings,
+            set_desktop_wallpaper,
+            clear_desktop_wallpaper,
             get_app_launcher_settings,
             update_app_launcher_settings,
             get_dashboard_settings,

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -268,6 +268,10 @@ pub struct GeneralSettings {
     #[serde(default)]
     rdp_webview_stability: bool,
     #[serde(default)]
+    desktop_wallpaper_enabled: bool,
+    #[serde(default)]
+    desktop_wallpaper_background: Option<crate::dashboard_storage::DashboardBackground>,
+    #[serde(default)]
     last_backup_at: Option<String>,
 }
 
@@ -298,6 +302,16 @@ impl GeneralSettings {
 
     pub(crate) fn rdp_webview_stability(&self) -> bool {
         self.rdp_webview_stability
+    }
+
+    pub(crate) fn desktop_wallpaper_enabled(&self) -> bool {
+        self.desktop_wallpaper_enabled
+    }
+
+    pub(crate) fn desktop_wallpaper_background(
+        &self,
+    ) -> Option<crate::dashboard_storage::DashboardBackground> {
+        self.desktop_wallpaper_background.clone()
     }
 }
 
@@ -1347,6 +1361,26 @@ impl Storage {
     pub fn update_dont_sleep_enabled(&self, enabled: bool) -> Result<GeneralSettings, String> {
         let mut settings = self.general_settings()?;
         settings.dont_sleep_enabled = enabled;
+        self.update_general_settings(settings)
+    }
+
+    pub fn update_desktop_wallpaper_settings(
+        &self,
+        enabled: bool,
+        background: Option<crate::dashboard_storage::DashboardBackground>,
+    ) -> Result<GeneralSettings, String> {
+        let mut settings = self.general_settings()?;
+        settings.desktop_wallpaper_enabled = enabled;
+        settings.desktop_wallpaper_background = background;
+        self.update_general_settings(settings)
+    }
+
+    pub fn update_desktop_wallpaper_enabled(
+        &self,
+        enabled: bool,
+    ) -> Result<GeneralSettings, String> {
+        let mut settings = self.general_settings()?;
+        settings.desktop_wallpaper_enabled = enabled;
         self.update_general_settings(settings)
     }
 
@@ -4609,6 +4643,8 @@ fn default_general_settings() -> GeneralSettings {
         status_bar_monitor_interval_seconds: default_status_bar_monitor_interval_seconds(),
         advanced_debugging_enabled: false,
         rdp_webview_stability: false,
+        desktop_wallpaper_enabled: false,
+        desktop_wallpaper_background: None,
         last_backup_at: None,
     }
 }
@@ -5049,6 +5085,11 @@ fn validate_general_settings(mut settings: GeneralSettings) -> Result<GeneralSet
         3_600 | 86_400 | 604_800 | 2_592_000 => settings.installer_check_interval_seconds,
         _ => default_installer_check_interval_seconds(),
     };
+    if let Some(background) = &settings.desktop_wallpaper_background {
+        background
+            .validate()
+            .map_err(|error| format!("desktop wallpaper background is invalid: {error:?}"))?;
+    }
     Ok(settings)
 }
 
@@ -6796,6 +6837,8 @@ mod tests {
         assert_eq!(defaults.status_bar_monitor_interval_seconds, 5);
         assert!(!defaults.advanced_debugging_enabled);
         assert!(!defaults.rdp_webview_stability);
+        assert!(!defaults.desktop_wallpaper_enabled);
+        assert!(defaults.desktop_wallpaper_background.is_none());
         assert!(defaults.last_backup_at.is_none());
 
         let updated = storage
@@ -6824,6 +6867,12 @@ mod tests {
                 status_bar_monitor_interval_seconds: 30,
                 advanced_debugging_enabled: true,
                 rdp_webview_stability: true,
+                desktop_wallpaper_enabled: true,
+                desktop_wallpaper_background: Some(
+                    crate::dashboard_storage::DashboardBackground::Dynamic {
+                        dynamic: "aurora".to_string(),
+                    },
+                ),
                 last_backup_at: None,
             })
             .expect("general settings update");
@@ -6849,6 +6898,13 @@ mod tests {
         assert_eq!(updated.status_bar_monitor_interval_seconds, 30);
         assert!(updated.advanced_debugging_enabled);
         assert!(updated.rdp_webview_stability);
+        assert!(updated.desktop_wallpaper_enabled);
+        assert_eq!(
+            updated.desktop_wallpaper_background,
+            Some(crate::dashboard_storage::DashboardBackground::Dynamic {
+                dynamic: "aurora".to_string(),
+            })
+        );
 
         let reloaded = storage.general_settings().expect("general settings reload");
         assert!(!reloaded.auto_backup_enabled);
@@ -6869,7 +6925,41 @@ mod tests {
         assert_eq!(reloaded.status_bar_monitor_interval_seconds, 30);
         assert!(reloaded.advanced_debugging_enabled);
         assert!(reloaded.rdp_webview_stability);
+        assert!(reloaded.desktop_wallpaper_enabled);
+        assert_eq!(
+            reloaded.desktop_wallpaper_background,
+            Some(crate::dashboard_storage::DashboardBackground::Dynamic {
+                dynamic: "aurora".to_string(),
+            })
+        );
         assert!(reloaded.last_backup_at.is_none());
+    }
+
+    #[test]
+    fn desktop_wallpaper_settings_preserve_selection_when_disabled() {
+        let storage = Storage::open(temp_db_path("desktop-wallpaper-settings"))
+            .expect("storage opens");
+
+        let background = crate::dashboard_storage::DashboardBackground::Dynamic {
+            dynamic: "aurora".to_string(),
+        };
+        let enabled = storage
+            .update_desktop_wallpaper_settings(true, Some(background.clone()))
+            .expect("desktop wallpaper enables");
+        assert!(enabled.desktop_wallpaper_enabled);
+        assert_eq!(enabled.desktop_wallpaper_background, Some(background.clone()));
+
+        let disabled = storage
+            .update_desktop_wallpaper_enabled(false)
+            .expect("desktop wallpaper disables");
+        assert!(!disabled.desktop_wallpaper_enabled);
+        assert_eq!(disabled.desktop_wallpaper_background, Some(background.clone()));
+
+        let reloaded = storage
+            .general_settings()
+            .expect("desktop wallpaper settings reload");
+        assert!(!reloaded.desktop_wallpaper_enabled);
+        assert_eq!(reloaded.desktop_wallpaper_background, Some(background));
     }
 
     #[test]
@@ -7132,6 +7222,8 @@ mod tests {
                 status_bar_monitor_interval_seconds: 15,
                 advanced_debugging_enabled: true,
                 rdp_webview_stability: false,
+                desktop_wallpaper_enabled: false,
+                desktop_wallpaper_background: None,
                 last_backup_at: None,
             })
             .expect("general settings update");
@@ -7159,6 +7251,8 @@ mod tests {
                 status_bar_monitor_interval_seconds: 5,
                 advanced_debugging_enabled: false,
                 rdp_webview_stability: false,
+                desktop_wallpaper_enabled: false,
+                desktop_wallpaper_background: None,
                 last_backup_at: None,
             })
             .expect("general settings changes after export");

--- a/src/App.css
+++ b/src/App.css
@@ -33,3 +33,68 @@
   bottom: 0;
   left: 0;
 }
+
+.kk-wallpaper-layer {
+  position: absolute;
+  inset: 0;
+}
+
+.kk-wallpaper-media::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: var(--kk-wallpaper-dim-color, transparent);
+}
+
+.kk-wallpaper-media video {
+  width: 100%;
+  height: 100%;
+}
+
+.desktop-wallpaper-picker {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(6, 8, 12, 0.42);
+}
+
+.desktop-wallpaper-picker-panel {
+  position: relative;
+  width: min(680px, calc(100vw - 48px));
+  max-height: calc(100vh - 48px);
+}
+
+.desktop-wallpaper-picker-popover {
+  position: static;
+  width: 100%;
+  max-height: calc(100vh - 48px);
+  overflow: auto;
+}
+
+.desktop-wallpaper-picker-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 1;
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.desktop-wallpaper-picker-error {
+  margin: 10px 0 0;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in srgb, var(--color-danger, #f87171) 48%, transparent);
+  border-radius: 6px;
+  color: var(--color-danger, #f87171);
+  background: color-mix(in srgb, var(--color-danger, #f87171) 12%, transparent);
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import type { AssistantPageContext } from "./ai/AssistantPanel";
 import { ActivityRail } from "./app/ActivityRail";
 import type { ActivePage } from "./app/ActivityRail";
 import { AppUpdatePrompt } from "./app/AppUpdatePrompt";
+import { DesktopWallpaperPicker } from "./app/DesktopWallpaperPicker";
 import { TitleBar } from "./app/TitleBar";
 import {
   findTutorialTargetElement,
@@ -292,6 +293,7 @@ function App() {
         />
       ) : null}
       <AppUpdatePrompt key="app-update-prompt" settingsReady={generalSettingsReady} />
+      <DesktopWallpaperPicker key="desktop-wallpaper-picker" />
       </div>
     </div>
   );

--- a/src/app-defaults.ts
+++ b/src/app-defaults.ts
@@ -40,6 +40,8 @@ export const defaultGeneralSettings: GeneralSettings = {
   statusBarMonitorIntervalSeconds: 5,
   advancedDebuggingEnabled: false,
   rdpWebviewStability: false,
+  desktopWallpaperEnabled: false,
+  desktopWallpaperBackground: null,
   lastBackupAt: null,
 };
 

--- a/src/app/DesktopWallpaperPicker.tsx
+++ b/src/app/DesktopWallpaperPicker.tsx
@@ -1,0 +1,97 @@
+import { listen } from "@tauri-apps/api/event";
+import { useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import { invokeCommand, isTauriRuntime } from "../lib/tauri";
+import { SharedBackgroundPopover } from "../modules/dashboard/edit/SharedBackgroundPopover";
+import { loadBackgroundImage } from "../modules/dashboard/state/persistence";
+import type { DashboardBackground } from "../modules/dashboard/types";
+import { useWorkspaceStore } from "../store";
+import type { GeneralSettings } from "../types";
+
+const WALLPAPER_PICKER_EVENT = "kkterm://desktop-wallpaper-pick";
+const WALLPAPER_SETTINGS_EVENT = "kkterm://desktop-wallpaper-settings";
+
+export function DesktopWallpaperPicker() {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState("");
+  const generalSettings = useWorkspaceStore((state) => state.generalSettings);
+  const setGeneralSettings = useWorkspaceStore((state) => state.setGeneralSettings);
+  const background = generalSettings.desktopWallpaperBackground ?? null;
+
+  const refreshSettings = useCallback(async () => {
+    if (!isTauriRuntime()) return;
+    const settings = await invokeCommand("get_general_settings", undefined);
+    setGeneralSettings(settings);
+  }, [setGeneralSettings]);
+
+  useEffect(() => {
+    if (!isTauriRuntime()) return;
+    const unlistenPicker = listen(WALLPAPER_PICKER_EVENT, () => {
+      setError("");
+      setOpen(true);
+    });
+    const unlistenSettings = listen<GeneralSettings | null>(
+      WALLPAPER_SETTINGS_EVENT,
+      (event) => {
+        if (event.payload && typeof event.payload === "object") {
+          setGeneralSettings(event.payload);
+        } else {
+          void refreshSettings();
+        }
+      },
+    );
+    return () => {
+      void unlistenPicker.then((unlisten) => unlisten());
+      void unlistenSettings.then((unlisten) => unlisten());
+    };
+  }, [refreshSettings, setGeneralSettings]);
+
+  async function applyBackground(nextBackground: DashboardBackground | null) {
+    setError("");
+    try {
+      const saved = nextBackground
+        ? await invokeCommand("set_desktop_wallpaper", { background: nextBackground })
+        : await invokeCommand("clear_desktop_wallpaper", undefined);
+      setGeneralSettings(saved);
+    } catch (updateError) {
+      setError(updateError instanceof Error ? updateError.message : String(updateError));
+    }
+  }
+
+  if (!open) return null;
+
+  return createPortal(
+    <div className="desktop-wallpaper-picker" role="presentation">
+      <div
+        className="desktop-wallpaper-picker-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label={t("app.wallpaperPickerTitle")}
+      >
+        <button
+          className="desktop-wallpaper-picker-close"
+          type="button"
+          aria-label={t("app.titlebar.close")}
+          onClick={() => setOpen(false)}
+        >
+          &times;
+        </button>
+        <SharedBackgroundPopover
+          background={background}
+          titleKey="app.wallpaperPickerTitle"
+          defaultHintKey="app.wallpaperPickerDefaultHint"
+          className="desktop-wallpaper-picker-popover"
+          onBackgroundChange={applyBackground}
+          onLoadBackgroundImage={async (file) => {
+            await loadBackgroundImage(file);
+          }}
+          onClose={() => setOpen(false)}
+        />
+        {error ? <p className="desktop-wallpaper-picker-error">{error}</p> : null}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/app/WallpaperHost.tsx
+++ b/src/app/WallpaperHost.tsx
@@ -1,14 +1,159 @@
+import { listen } from "@tauri-apps/api/event";
+import { useEffect, useState, type CSSProperties } from "react";
 import "../App.css";
-import { DashboardDynamicBackground, DYNAMIC_BACKGROUNDS } from "../modules/dashboard/registry/dynamicBackgrounds";
+import { invokeCommand, isTauriRuntime } from "../lib/tauri";
+import { resolveBackgroundPreset } from "../modules/dashboard/registry/backgroundPresets";
+import { DashboardDynamicBackground } from "../modules/dashboard/registry/dynamicBackgrounds";
+import { loadBackgroundImage } from "../modules/dashboard/state/persistence";
+import type { BackgroundFit, DashboardBackground } from "../modules/dashboard/types";
+import type { GeneralSettings } from "../types";
 
-const DEFAULT_WALLPAPER_DYNAMIC_ID = DYNAMIC_BACKGROUNDS[0]?.id ?? "";
+const WALLPAPER_SETTINGS_EVENT = "kkterm://desktop-wallpaper-settings";
+const WALLPAPER_PAUSED_EVENT = "kkterm://desktop-wallpaper-paused";
 
 export function WallpaperHost() {
+  const [background, setBackground] = useState<DashboardBackground | null>(null);
+  const [paused, setPaused] = useState(false);
+
+  useEffect(() => {
+    void loadWallpaperSettings().then(setBackground);
+    if (!isTauriRuntime()) return;
+    const unlistenSettings = listen<GeneralSettings | null>(
+      WALLPAPER_SETTINGS_EVENT,
+      (event) => {
+        if (event.payload && typeof event.payload === "object") {
+          setBackground(event.payload.desktopWallpaperBackground ?? null);
+        } else {
+          void loadWallpaperSettings().then(setBackground);
+        }
+      },
+    );
+    const unlistenPaused = listen<boolean>(WALLPAPER_PAUSED_EVENT, (event) => {
+      setPaused(Boolean(event.payload));
+    });
+    return () => {
+      void unlistenSettings.then((unlisten) => unlisten());
+      void unlistenPaused.then((unlisten) => unlisten());
+    };
+  }, []);
+
   return (
     <main className="kk-wallpaper-host" aria-hidden="true">
-      {DEFAULT_WALLPAPER_DYNAMIC_ID ? (
-        <DashboardDynamicBackground active={true} id={DEFAULT_WALLPAPER_DYNAMIC_ID} />
-      ) : null}
+      <WallpaperBackgroundLayer active={!paused} background={background} />
     </main>
   );
+}
+
+function WallpaperBackgroundLayer({
+  active,
+  background,
+}: {
+  active: boolean;
+  background: DashboardBackground | null;
+}) {
+  const [mediaDataUrl, setMediaDataUrl] = useState("");
+  const mediaFile = background?.kind === "image" || background?.kind === "video" ? background.file : "";
+
+  useEffect(() => {
+    let cancelled = false;
+    setMediaDataUrl("");
+    if (!mediaFile) return;
+    void loadBackgroundImage(mediaFile).then((dataUrl) => {
+      if (!cancelled) setMediaDataUrl(dataUrl);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [mediaFile]);
+
+  if (!background) return null;
+
+  if (background.kind === "preset") {
+    return (
+      <div
+        className="kk-wallpaper-layer"
+        style={{ background: resolveBackgroundPreset(background.preset).css }}
+      />
+    );
+  }
+
+  if (background.kind === "dynamic") {
+    return <DashboardDynamicBackground active={active} id={background.dynamic} />;
+  }
+
+  if (background.kind === "image" && mediaDataUrl) {
+    const style: CSSProperties = {
+      backgroundImage: `url("${mediaDataUrl}")`,
+      ...backgroundFitStyle(background.fit),
+    };
+    const dim = dimColor(background.dim);
+    if (dim) {
+      (style as Record<string, string>)["--kk-wallpaper-dim-color"] = dim;
+    }
+    return <div className="kk-wallpaper-layer kk-wallpaper-media" style={style} />;
+  }
+
+  if (background.kind === "video" && mediaDataUrl && active) {
+    const dim = dimColor(background.dim);
+    const style = dim ? ({ "--kk-wallpaper-dim-color": dim } as CSSProperties) : undefined;
+    return (
+      <div className="kk-wallpaper-layer kk-wallpaper-media" style={style}>
+        <video
+          aria-hidden="true"
+          autoPlay
+          loop
+          muted
+          playsInline
+          src={mediaDataUrl}
+          style={videoFitStyle(background.fit)}
+        />
+      </div>
+    );
+  }
+
+  return null;
+}
+
+async function loadWallpaperSettings() {
+  if (!isTauriRuntime()) return null;
+  const settings = await invokeCommand("get_general_settings", undefined);
+  return settings.desktopWallpaperBackground ?? null;
+}
+
+function backgroundFitStyle(fit: BackgroundFit): CSSProperties {
+  switch (fit) {
+    case "fill":
+      return { backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center" };
+    case "fit":
+      return { backgroundSize: "contain", backgroundRepeat: "no-repeat", backgroundPosition: "center" };
+    case "stretch":
+      return { backgroundSize: "100% 100%", backgroundRepeat: "no-repeat" };
+    case "tile":
+      return { backgroundSize: "auto", backgroundRepeat: "repeat" };
+    case "center":
+      return { backgroundSize: "auto", backgroundRepeat: "no-repeat", backgroundPosition: "center" };
+  }
+}
+
+function videoFitStyle(fit: BackgroundFit): CSSProperties {
+  switch (fit) {
+    case "fill":
+      return { objectFit: "cover" };
+    case "fit":
+      return { objectFit: "contain" };
+    case "stretch":
+      return { objectFit: "fill" };
+    case "tile":
+      return { objectFit: "cover" };
+    case "center":
+      return { objectFit: "none" };
+  }
+}
+
+function dimColor(dim: number): string | undefined {
+  if (dim === 0) return undefined;
+  const alpha = Math.min(Math.abs(dim), 100) / 100;
+  return dim < 0
+    ? `rgba(0, 0, 0, ${alpha})`
+    : `rgba(255, 255, 255, ${alpha})`;
 }

--- a/src/app/trayMenu.ts
+++ b/src/app/trayMenu.ts
@@ -10,7 +10,13 @@ const TRAY_RECENT_LIMIT = 3;
  */
 export async function pushTrayMenu(
   recentConnections: Connection[],
-  labels: { dontSleep: string; exit: string },
+  labels: {
+    dontSleep: string;
+    wallpaper: string;
+    wallpaperSet: string;
+    wallpaperClear: string;
+    exit: string;
+  },
 ) {
   if (!isTauriRuntime()) {
     return;
@@ -23,6 +29,9 @@ export async function pushTrayMenu(
           .slice(0, TRAY_RECENT_LIMIT)
           .map((connection) => ({ id: connection.id, label: connection.name })),
         dontSleepLabel: labels.dontSleep,
+        wallpaperLabel: labels.wallpaper,
+        wallpaperSetLabel: labels.wallpaperSet,
+        wallpaperClearLabel: labels.wallpaperClear,
         exitLabel: labels.exit,
       },
     });

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -549,7 +549,12 @@
     "resizeConnections": "Verbindungen-Spalte skalieren",
     "settings": "Einstellungen",
     "trayDontSleep": "Nicht schlafen",
+    "trayWallpaper": "Hintergrundbild",
+    "trayWallpaperSet": "Festlegen",
+    "trayWallpaperClear": "Löschen",
     "trayExit": "Beenden",
+    "wallpaperPickerTitle": "Hintergrundbild festlegen",
+    "wallpaperPickerDefaultHint": "Live-Hintergrundbild löschen und wieder die Windows-Hintergrundverwaltung verwenden.",
     "manual": "Handbuch",
     "dontSleepStatusEnabled": "Nicht schlafen aktiviert",
     "titlebar": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -19,7 +19,12 @@
     "openConnectedConnection": "Open {{name}}",
     "openPinnedConnection": "Open pinned Connection {{name}}",
     "trayDontSleep": "Don't Sleep",
+    "trayWallpaper": "Wallpaper",
+    "trayWallpaperSet": "Set",
+    "trayWallpaperClear": "Clear",
     "trayExit": "Exit",
+    "wallpaperPickerTitle": "Set Wallpaper",
+    "wallpaperPickerDefaultHint": "Clear the live wallpaper and return to Windows wallpaper handling.",
     "titlebar": {
       "minimize": "Minimize",
       "maximize": "Maximize",

--- a/src/i18n/locales/es-MX.json
+++ b/src/i18n/locales/es-MX.json
@@ -549,7 +549,12 @@
     "resizeConnections": "Redimensionar columna de Conexiones",
     "settings": "Configuración",
     "trayDontSleep": "No dormir",
+    "trayWallpaper": "Fondo de pantalla",
+    "trayWallpaperSet": "Establecer",
+    "trayWallpaperClear": "Borrar",
     "trayExit": "Salir",
+    "wallpaperPickerTitle": "Establecer fondo de pantalla",
+    "wallpaperPickerDefaultHint": "Borra el fondo animado y vuelve a la gestión de fondos de Windows.",
     "manual": "Manual",
     "dontSleepStatusEnabled": "No suspender activado",
     "titlebar": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -549,7 +549,12 @@
     "resizeConnections": "Redimensionar columna Conexiones",
     "settings": "Ajustes",
     "trayDontSleep": "No dormir",
+    "trayWallpaper": "Fondo de pantalla",
+    "trayWallpaperSet": "Establecer",
+    "trayWallpaperClear": "Borrar",
     "trayExit": "Salir",
+    "wallpaperPickerTitle": "Establecer fondo de pantalla",
+    "wallpaperPickerDefaultHint": "Borra el fondo animado y vuelve a la gestión de fondos de Windows.",
     "manual": "Manual",
     "dontSleepStatusEnabled": "No suspender activado",
     "titlebar": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -549,7 +549,12 @@
     "resizeConnections": "Redimensionner la colonne Connexions",
     "settings": "Paramètres",
     "trayDontSleep": "Ne pas mettre en veille",
+    "trayWallpaper": "Fond d’écran",
+    "trayWallpaperSet": "Définir",
+    "trayWallpaperClear": "Effacer",
     "trayExit": "Quitter",
+    "wallpaperPickerTitle": "Définir le fond d’écran",
+    "wallpaperPickerDefaultHint": "Efface le fond d’écran animé et revient à la gestion du fond d’écran par Windows.",
     "manual": "Manuel",
     "dontSleepStatusEnabled": "Mode Ne pas dormir activé",
     "titlebar": {

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -549,7 +549,12 @@
     "resizeConnections": "Ubah ukuran kolom Koneksi",
     "settings": "Pengaturan",
     "trayDontSleep": "Jangan Tidur",
+    "trayWallpaper": "Wallpaper",
+    "trayWallpaperSet": "Atur",
+    "trayWallpaperClear": "Hapus",
     "trayExit": "Keluar",
+    "wallpaperPickerTitle": "Atur Wallpaper",
+    "wallpaperPickerDefaultHint": "Hapus wallpaper live dan kembalikan penanganan wallpaper ke Windows.",
     "manual": "Panduan",
     "dontSleepStatusEnabled": "Jangan Tidur Aktif",
     "titlebar": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -549,7 +549,12 @@
     "resizeConnections": "Ridimensiona colonna Connessioni",
     "settings": "Impostazioni",
     "trayDontSleep": "Non sospendere",
+    "trayWallpaper": "Sfondo",
+    "trayWallpaperSet": "Imposta",
+    "trayWallpaperClear": "Cancella",
     "trayExit": "Esci",
+    "wallpaperPickerTitle": "Imposta sfondo",
+    "wallpaperPickerDefaultHint": "Cancella lo sfondo animato e torna alla gestione dello sfondo di Windows.",
     "manual": "Manuale",
     "dontSleepStatusEnabled": "Non sospendere attivo",
     "titlebar": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -549,7 +549,12 @@
     "resizeConnections": "接続列のサイズを変更",
     "settings": "設定",
     "trayDontSleep": "スリープしない",
+    "trayWallpaper": "壁紙",
+    "trayWallpaperSet": "設定",
+    "trayWallpaperClear": "クリア",
     "trayExit": "終了",
+    "wallpaperPickerTitle": "壁紙を設定",
+    "wallpaperPickerDefaultHint": "ライブ壁紙をクリアして、Windows の壁紙管理に戻します。",
     "manual": "マニュアル",
     "dontSleepStatusEnabled": "スリープ防止が有効",
     "titlebar": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -549,7 +549,12 @@
     "resizeConnections": "연결 열 크기 조정",
     "settings": "설정",
     "trayDontSleep": "절전 해제",
+    "trayWallpaper": "배경 화면",
+    "trayWallpaperSet": "설정",
+    "trayWallpaperClear": "지우기",
     "trayExit": "종료",
+    "wallpaperPickerTitle": "배경 화면 설정",
+    "wallpaperPickerDefaultHint": "라이브 배경 화면을 지우고 Windows 배경 화면 관리로 되돌립니다.",
     "manual": "매뉴얼",
     "dontSleepStatusEnabled": "절전 방지 활성화됨",
     "titlebar": {

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -549,7 +549,12 @@
     "resizeConnections": "Redimensionar coluna de Conexões",
     "settings": "Configurações",
     "trayDontSleep": "Não suspender",
+    "trayWallpaper": "Papel de parede",
+    "trayWallpaperSet": "Definir",
+    "trayWallpaperClear": "Limpar",
     "trayExit": "Sair",
+    "wallpaperPickerTitle": "Definir papel de parede",
+    "wallpaperPickerDefaultHint": "Limpa o papel de parede animado e volta para o gerenciamento de papel de parede do Windows.",
     "manual": "Manual",
     "dontSleepStatusEnabled": "Não suspender ativado",
     "titlebar": {

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -549,7 +549,12 @@
     "resizeConnections": "ปรับขนาดคอลัมน์การเชื่อมต่อ",
     "settings": "การตั้งค่า",
     "trayDontSleep": "ไม่พักเครื่อง",
+    "trayWallpaper": "วอลเปเปอร์",
+    "trayWallpaperSet": "ตั้งค่า",
+    "trayWallpaperClear": "ล้าง",
     "trayExit": "ออก",
+    "wallpaperPickerTitle": "ตั้งค่าวอลเปเปอร์",
+    "wallpaperPickerDefaultHint": "ล้างวอลเปเปอร์สดและกลับไปให้ Windows จัดการวอลเปเปอร์",
     "manual": "คู่มือ",
     "dontSleepStatusEnabled": "เปิดใช้งานไม่ให้พักเครื่อง",
     "titlebar": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -549,7 +549,12 @@
     "resizeConnections": "Đổi kích thước cột Kết nối",
     "settings": "Settings",
     "trayDontSleep": "Không ngủ",
+    "trayWallpaper": "Hình nền",
+    "trayWallpaperSet": "Đặt",
+    "trayWallpaperClear": "Xóa",
     "trayExit": "Thoát",
+    "wallpaperPickerTitle": "Đặt hình nền",
+    "wallpaperPickerDefaultHint": "Xóa hình nền động và trả lại việc xử lý hình nền cho Windows.",
     "manual": "Hướng dẫn",
     "dontSleepStatusEnabled": "Đã bật Không ngủ",
     "titlebar": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -549,7 +549,12 @@
     "resizeConnections": "调整连接列宽度",
     "settings": "设置",
     "trayDontSleep": "禁止休眠",
+    "trayWallpaper": "壁纸",
+    "trayWallpaperSet": "设置",
+    "trayWallpaperClear": "清除",
     "trayExit": "退出",
+    "wallpaperPickerTitle": "设置壁纸",
+    "wallpaperPickerDefaultHint": "清除动态壁纸，并交还给 Windows 处理壁纸。",
     "manual": "手册",
     "dontSleepStatusEnabled": "防止睡眠已启用",
     "titlebar": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -549,7 +549,12 @@
     "resizeConnections": "調整連線欄寬度",
     "settings": "設定",
     "trayDontSleep": "禁止休眠",
+    "trayWallpaper": "桌布",
+    "trayWallpaperSet": "設定",
+    "trayWallpaperClear": "清除",
     "trayExit": "結束",
+    "wallpaperPickerTitle": "設定桌布",
+    "wallpaperPickerDefaultHint": "清除動態桌布，並交還給 Windows 處理桌布。",
     "manual": "手冊",
     "dontSleepStatusEnabled": "防止睡眠已啟用",
     "titlebar": {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -402,6 +402,9 @@ export interface TrayRecentConnection {
 export interface TrayMenuSnapshot {
   recentConnections: TrayRecentConnection[];
   dontSleepLabel: string;
+  wallpaperLabel: string;
+  wallpaperSetLabel: string;
+  wallpaperClearLabel: string;
   exitLabel: string;
 }
 
@@ -899,6 +902,14 @@ type CommandMap = {
   };
   update_general_settings: {
     args: { request: GeneralSettings };
+    result: GeneralSettings;
+  };
+  set_desktop_wallpaper: {
+    args: { background: DashboardBackground };
+    result: GeneralSettings;
+  };
+  clear_desktop_wallpaper: {
+    args: undefined;
     result: GeneralSettings;
   };
   get_app_launcher_settings: {

--- a/src/modules/workspace/connections/ConnectionSidebar.tsx
+++ b/src/modules/workspace/connections/ConnectionSidebar.tsx
@@ -1144,6 +1144,9 @@ export function ConnectionSidebar({
   useEffect(() => {
     void pushTrayMenu(recentConnections, {
       dontSleep: t("app.trayDontSleep"),
+      wallpaper: t("app.trayWallpaper"),
+      wallpaperSet: t("app.trayWallpaperSet"),
+      wallpaperClear: t("app.trayWallpaperClear"),
       exit: t("app.trayExit"),
     });
     // recentConnections is intentionally read fresh; we only resync when the

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,6 +218,8 @@ export interface GeneralSettings {
   statusBarMonitorIntervalSeconds: number;
   advancedDebuggingEnabled: boolean;
   rdpWebviewStability: boolean;
+  desktopWallpaperEnabled: boolean;
+  desktopWallpaperBackground?: DashboardBackground | null;
   lastBackupAt?: string | null;
 }
 


### PR DESCRIPTION
## Summary

- Promote the tray Wallpaper submenu to release builds with localized `Wallpaper -> Set / Clear` labels.
- Add a tray-launched desktop wallpaper picker that reuses the shared Dashboard/terminal background picker and persists the selected background in general settings.
- Update the WorkerW wallpaper host to load the persisted background, overscan the virtual screen to avoid edge gaps, restore on startup, and pause dynamic/video rendering when a maximized or fullscreen foreground window covers the desktop.
- Update docs and locale files for the new tray wallpaper surface.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml desktop_wallpaper_settings_preserve_selection_when_disabled` passes.
- `cargo check --manifest-path src-tauri/Cargo.toml` passes.
- `npm run i18n:check` passes.
- `npm run build` passes.
- `cargo test --manifest-path src-tauri/Cargo.toml` passes: 567 passed, 2 ignored.
- `npm run check` currently fails at unrelated `tests/installer-stepper-legacy-log.test.mjs` with: `Queued installs must move the dialog to the currently running package before starting it.` The failing assertion scans Installer Helper files that this PR does not touch; the command stops there before reaching `tsc`.