### PR TITLE
Avoid no-activate parent during wallpaper WebView creation

### DIFF
--- a/src-tauri/src/desktop_wallpaper.rs
+++ b/src-tauri/src/desktop_wallpaper.rs
@@ -90,12 +90,12 @@ mod platform {
         .resizable(false)
         .visible(false)
         .skip_taskbar(true)
-        .focusable(false)
         .focused(false)
         .disable_drag_drop_handler()
         .build()
         .map_err(|error| format!("failed to create wallpaper window: {error}"))?;
 
+        let _ = window.set_focusable(false);
         let handle = window
             .hwnd()
             .map_err(|error| format!("failed to read wallpaper window handle: {error}"))?;

--- a/tests/desktop-wallpaper-tray-popup.test.mjs
+++ b/tests/desktop-wallpaper-tray-popup.test.mjs
@@ -31,15 +31,20 @@ if (!desktopWallpaper.includes("WALLPAPER_PICKER_WINDOW_LABEL")) {
   throw new Error("The standalone wallpaper picker window label should live with desktop wallpaper hosting.");
 }
 
-if (!desktopWallpaper.includes(".focusable(false)") || !desktopWallpaper.includes(".focused(false)")) {
-  throw new Error("The wallpaper host window should be non-focusable and non-focused.");
+if (!desktopWallpaper.includes(".focused(false)") || !desktopWallpaper.includes("window.set_focusable(false)")) {
+  throw new Error("The wallpaper host window should start non-focused and become non-focusable after WebView2 is created.");
+}
+
+const setFunction = desktopWallpaper.match(/pub fn set<R: Runtime>[\s\S]*?\n    \}/)?.[0] ?? "";
+const setBuilder = setFunction.match(/WebviewWindowBuilder::new\([\s\S]*?\.build\(\)/)?.[0] ?? "";
+if (setBuilder.includes(".focusable(false)")) {
+  throw new Error("The wallpaper host must not build WebView2 inside a non-focusable parent window.");
 }
 
 if (!desktopWallpaper.includes("WS_EX_NOACTIVATE") || !desktopWallpaper.includes("WS_EX_TOOLWINDOW")) {
   throw new Error("The wallpaper HWND should use no-activate tool-window extended styles.");
 }
 
-const setFunction = desktopWallpaper.match(/pub fn set<R: Runtime>[\s\S]*?\n    \}/)?.[0] ?? "";
 if (setFunction.includes("window.show()")) {
   throw new Error("The wallpaper host should avoid Tauri's normal show path after WorkerW attachment.");
 }


### PR DESCRIPTION
## Summary
- avoid building the wallpaper WebView2 controller inside a Tauri parent window that is already marked non-focusable
- keep the wallpaper host non-focused during creation, then make it non-focusable after WebView2 has been initialized
- update the wallpaper tray regression scan to guard this crash boundary

## Why
The crash stack points into EmbeddedBrowserWebView/WebView2 controller creation after selecting a wallpaper from the tray popup. Building the wallpaper host with `.focusable(false)` applies the non-focusable/no-activate parent state before WebView2 creates its child controller. This keeps the finished wallpaper HWND policy but moves that focusability change until after controller creation.

## Verification
- node tests/desktop-wallpaper-tray-popup.test.mjs
- npx tsc --noEmit
- cargo check --manifest-path src-tauri/Cargo.toml
- npm run build
- cargo test --manifest-path src-tauri/Cargo.toml
- npm run check