### PR TITLE
ci: align Release workflow with both-arch build script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,6 @@ on:
         required: false
         default: false
         type: boolean
-      include_arm64:
-        description: "Also build and publish the native Windows on Arm (ARM64) installer"
-        required: false
-        default: false
-        type: boolean
       skip_ai_release_notes:
         description: "Use deterministic release notes without OpenAI"
         required: false
@@ -77,12 +72,14 @@ jobs:
       - name: Publish release
         shell: pwsh
         run: |
-          $releaseArgs = @("-File", "scripts/release-github.ps1")
+          # Use the both-arch wrapper so CI/CD always builds and publishes the
+          # x64 and ARM64 installers together, matching the local
+          # `npm run release:github:both-arch` path.
+          $releaseArgs = @("-File", "scripts/release-github-both-arch.ps1")
           if ("${{ inputs.draft }}" -eq "true") { $releaseArgs += "-Draft" }
           if ("${{ inputs.prerelease }}" -eq "true") { $releaseArgs += "-Prerelease" }
           if ("${{ inputs.skip_build }}" -eq "true") { $releaseArgs += "-SkipBuild" }
           if ("${{ inputs.skip_smoke }}" -eq "true") { $releaseArgs += "-SkipSmoke" }
           if ("${{ inputs.skip_ai_release_notes }}" -eq "true") { $releaseArgs += "-SkipAiReleaseNotes" }
-          if ("${{ inputs.include_arm64 }}" -eq "true") { $releaseArgs += "-IncludeArm64" }
           if ("${{ inputs.dry_run }}" -eq "true") { $releaseArgs += "-DryRun" }
           powershell -NoProfile -ExecutionPolicy Bypass @releaseArgs

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -95,7 +95,7 @@ $env:OPENAI_API_KEY = "sk-..."
 npm run release:github
 ```
 
-GitHub Actions uses the same script through the manual **Release** workflow. Store the API key as the repository secret `OPENAI_API_KEY`; the workflow exposes it to the script as the same environment variable. Use the workflow inputs to mark a release as draft/prerelease, skip the installer build or smoke test, disable AI notes, or run a dry preview.
+GitHub Actions uses the same scripts through the manual **Release** workflow. The workflow invokes `scripts/release-github-both-arch.ps1` so a CI/CD release always builds and publishes the x64 **and** ARM64 installers together, matching the local `npm run release:github:both-arch` path (and the `Direct Downloads` section, which links both architecture assets). Store the API key as the repository secret `OPENAI_API_KEY`; the workflow exposes it to the script as the same environment variable. Use the workflow inputs to mark a release as draft/prerelease, skip the installer build or smoke test, disable AI notes, or run a dry preview.
 
 ## Known Limitations
 


### PR DESCRIPTION
The manual Release workflow called scripts/release-github.ps1 directly and
only produced the ARM64 installer when the opt-in include_arm64 input was
toggled (default false). The local GitHub release build script
(npm run release:github:both-arch -> scripts/release-github-both-arch.ps1)
always builds both x64 and ARM64. The release-notes generator also always
links both architecture assets, so a default workflow run published a
broken ARM64 download link.

Point the workflow at scripts/release-github-both-arch.ps1 so CI/CD always
builds and publishes the x64 and ARM64 installers together, and drop the
now-redundant include_arm64 input. Update docs/RELEASE.md to match.