### PR TITLE
Open Windows Task Manager from status metrics and persist AI usage backoff

### DIFF
--- a/src-tauri/src/ai_coding_usage.rs
+++ b/src-tauri/src/ai_coding_usage.rs
@@ -476,20 +476,22 @@ fn save_provider_error(
     provider: AiCodingUsageProvider,
     error: &str,
 ) -> Result<(), String> {
+    let now = now_rfc3339()?;
     let scrubbed = scrub_provider_error(error);
     connection
         .execute(
             "INSERT INTO ai_coding_usage_accounts
-                (provider, account_label, account_email, auth_state, last_error, created_at, updated_at)
-             VALUES (?1, NULL, NULL, 'error', ?2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                (provider, account_label, account_email, auth_state, last_refresh_at, last_error, created_at, updated_at)
+             VALUES (?1, NULL, NULL, 'error', ?2, ?3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
              ON CONFLICT(provider) DO UPDATE SET
                 auth_state = CASE
                     WHEN auth_state = 'connected' THEN auth_state
                     ELSE 'error'
                 END,
+                last_refresh_at = excluded.last_refresh_at,
                 last_error = excluded.last_error,
                 updated_at = CURRENT_TIMESTAMP",
-            params![provider.as_str(), scrubbed],
+            params![provider.as_str(), now, scrubbed],
         )
         .map_err(|error| format!("failed to save usage error: {error}"))?;
     Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1318,6 +1318,25 @@ fn get_system_performance_counters(
 }
 
 #[tauri::command]
+fn open_windows_task_manager() -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("taskmgr.exe")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map(|_| ())
+            .map_err(|error| format!("failed to open Windows Task Manager: {error}"))
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        Err("Windows Task Manager is only available on Windows.".to_string())
+    }
+}
+
+#[tauri::command]
 fn create_diagnostics_bundle(
     app: tauri::AppHandle,
     performance: tauri::State<'_, performance::PerformanceMonitor>,
@@ -2883,6 +2902,7 @@ pub fn run() {
             get_performance_snapshot,
             get_host_usage_snapshot,
             get_system_performance_counters,
+            open_windows_task_manager,
             create_diagnostics_bundle,
             get_dont_sleep_enabled,
             set_dont_sleep_enabled,

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1190,6 +1190,10 @@ type CommandMap = {
     args: undefined;
     result: SystemPerformanceCountersSnapshot;
   };
+  open_windows_task_manager: {
+    args: undefined;
+    result: void;
+  };
   create_diagnostics_bundle: {
     args: undefined;
     result: DiagnosticsBundle;

--- a/src/modules/workspace/StatusBar.tsx
+++ b/src/modules/workspace/StatusBar.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { AiCodingUsageStatusBar } from "../dashboard/widgets/builtin/ai-coding-usage/AiCodingUsageStatusBar";
+import { invokeCommand, isTauriRuntime } from "../../lib/tauri";
 import { useWorkspaceStore } from "../../store";
 import { WatchdogStatusBar } from "../../watchdog/WatchdogStatusBar";
 
@@ -145,8 +146,20 @@ function AssistantWorkingStatusButton({
 function WorkspaceHostMetrics({ t }: { t: (key: string) => string }) {
   const hostUsage = useWorkspaceStore((state) => state.performanceMetrics.hostUsage);
 
+  function openTaskManager() {
+    if (!isTauriRuntime()) {
+      return;
+    }
+    void invokeCommand("open_windows_task_manager").catch(() => undefined);
+  }
+
   return (
-    <div className="host-metrics" aria-label={t("workspace.hostUsage")} data-tutorial-id="workspace.hostUsage">
+    <div
+      className="host-metrics"
+      aria-label={t("workspace.hostUsage")}
+      data-tutorial-id="workspace.hostUsage"
+      onDoubleClick={openTaskManager}
+    >
       <Metric
         icon={<Cpu size={13} />}
         label={t("workspace.cpu")}


### PR DESCRIPTION
### Motivation
- Provide a quick, platform-appropriate way for users to inspect host processes by opening Task Manager from the status-bar performance metrics via a double-click.
- Ensure AI coding usage refresh/backoff intervals survive app restarts so providers (notably Claude) are not retried immediately after relaunch and trigger rate-limit problems.

### Description
- Added a fire-and-forget Tauri command `open_windows_task_manager` that spawns `taskmgr.exe` with stdio detached and registered it in the native command map (`src-tauri/src/lib.rs` and `src/lib/tauri.ts`).
- Wired the frontend host metrics container to call the new command on double-click so double-clicking the CPU/RAM/network area opens Task Manager (`src/modules/workspace/StatusBar.tsx`).
- Updated AI coding usage persistence so `save_provider_error` writes `last_refresh_at` along with the error, allowing existing frontend refresh/backoff logic to respect retry intervals after app relaunch (`src-tauri/src/ai_coding_usage.rs`).

### Testing
- Ran `npm run check` and the repository frontend checks completed successfully.
- Ran `node tests/ai-coding-usage-refresh-policy.test.mjs` and `node tests/ai-coding-usage-display.test.mjs` and both test suites passed.
- Ran `git diff --check` with no issues reported.
- Attempted `cargo check --manifest-path src-tauri/Cargo.toml`, which failed in this CI environment due to a missing system library (`glib-2.0` / pkg-config) and not because of the code changes, so native Rust build verification was blocked by the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20cf29202c832fa04057fd94507ca5)