### PR TITLE
Reduce workspace connection frame padding to 20%

### DIFF
--- a/src/modules/workspace/connections/remote-desktop/remote-desktop.css
+++ b/src/modules/workspace/connections/remote-desktop/remote-desktop.css
@@ -8,10 +8,6 @@
   background: #111318;
 }
 
-.remote-desktop-shell {
-  padding: 14px;
-}
-
 .remote-desktop-pane {
   grid-template-rows: 34px minmax(0, 1fr);
   width: 100%;

--- a/src/modules/workspace/connections/terminal/terminal.css
+++ b/src/modules/workspace/connections/terminal/terminal.css
@@ -4,7 +4,7 @@
   height: 100%;
   min-height: 0;
   overflow: hidden;
-  padding: 14px;
+  padding: 2.8px;
   background: var(--chrome-strong);
 }
 

--- a/src/modules/workspace/connections/webview/webview.css
+++ b/src/modules/workspace/connections/webview/webview.css
@@ -2,7 +2,6 @@
   box-sizing: border-box;
   min-width: 0;
   overflow: hidden;
-  padding: 14px;
 }
 
 .webview-pane {


### PR DESCRIPTION
### Motivation
- Shrink the shared frame (the space between the connection toolbar and the tab/button area) for all connection types by reducing the workspace container padding to 20% of its previous size so the UI uses less outer gutter and keeps behavior unchanged.

### Description
- Change the shared workspace container padding from `14px` to `2.8px` and remove duplicated `14px` overrides so terminal/SFTP, WebView, and remote-desktop workspaces inherit the single shared frame padding (files changed: `src/modules/workspace/connections/terminal/terminal.css`, `src/modules/workspace/connections/webview/webview.css`, `src/modules/workspace/connections/remote-desktop/remote-desktop.css`).

### Testing
- Ran `npm run check` (project test/check suite including `tsc --noEmit`) and it completed successfully with all checks passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20db876f50832f9f200e2369bc2c73)