### PR TITLE
SFTP: editable path input and terminal focus restore after popup

### DIFF
--- a/docs/manual/07-sftp.md
+++ b/docs/manual/07-sftp.md
@@ -28,6 +28,8 @@ Startup states:
 
 Two columns:
 
+Each pane path is editable: type a local or remote path into the path field and press Enter to navigate. Press Escape or leave the field without Enter to keep the current path. The path input accessibility label is `sftp.pathInputAria`.
+
 - **Local** (`sftp.local`, `sftp.localFiles`) — loading state `sftp.loadingLocal`. On Windows, opening the parent of a drive root shows the drive picker path label `sftp.windowsDrives`, where double-clicking a drive opens that drive root.
 - **Remote** (`sftp.remote`) — empty state `sftp.noFiles`, loading `sftp.loading`.
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2023,7 +2023,8 @@
     "verifyingHost": "Host überprüfen",
     "waiting": "Warten",
     "waitingToOverwrite": "Warten auf Überschreiben",
-    "windowsDrives": "Dieser PC"
+    "windowsDrives": "Dieser PC",
+    "pathInputAria": "{{pane}}-Pfad eingeben"
   },
   "terminal": {
     "actions": "Terminalaktionen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2028,7 +2028,8 @@
     "renameFileAria": "Rename {{name}}",
     "fileTypeLabel": "{{ext}} file",
     "targetExistsDetail": "The target {{kind}} already exists. Choose whether to overwrite {{name}}.",
-    "windowsDrives": "This PC"
+    "windowsDrives": "This PC",
+    "pathInputAria": "Enter {{pane}} path"
   },
   "webview": {
     "goBack": "Go back",

--- a/src/i18n/locales/es-MX.json
+++ b/src/i18n/locales/es-MX.json
@@ -2023,7 +2023,8 @@
     "verifyingHost": "Verificando host",
     "waiting": "Esperando",
     "waitingToOverwrite": "Esperando para sobrescribir",
-    "windowsDrives": "Este equipo"
+    "windowsDrives": "Este equipo",
+    "pathInputAria": "Ingresa la ruta de {{pane}}"
   },
   "terminal": {
     "actions": "Acciones del terminal",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2023,7 +2023,8 @@
     "verifyingHost": "Verificando host",
     "waiting": "Esperando",
     "waitingToOverwrite": "Esperando para sobrescribir",
-    "windowsDrives": "Este equipo"
+    "windowsDrives": "Este equipo",
+    "pathInputAria": "Introduce la ruta de {{pane}}"
   },
   "terminal": {
     "actions": "Acciones del terminal",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2023,7 +2023,8 @@
     "verifyingHost": "Vérification de l'hôte",
     "waiting": "En attente",
     "waitingToOverwrite": "En attente d'écrasement",
-    "windowsDrives": "Ce PC"
+    "windowsDrives": "Ce PC",
+    "pathInputAria": "Saisir le chemin {{pane}}"
   },
   "terminal": {
     "actions": "Actions du terminal",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -2023,7 +2023,8 @@
     "verifyingHost": "Memverifikasi host",
     "waiting": "Menunggu",
     "waitingToOverwrite": "Menunggu untuk menimpa",
-    "windowsDrives": "PC ini"
+    "windowsDrives": "PC ini",
+    "pathInputAria": "Masukkan jalur {{pane}}"
   },
   "terminal": {
     "actions": "Aksi terminal",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -2023,7 +2023,8 @@
     "verifyingHost": "Verifica host",
     "waiting": "In attesa",
     "waitingToOverwrite": "In attesa di sovrascrivere",
-    "windowsDrives": "Questo PC"
+    "windowsDrives": "Questo PC",
+    "pathInputAria": "Inserisci il percorso {{pane}}"
   },
   "terminal": {
     "actions": "Azioni terminale",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2023,7 +2023,8 @@
     "verifyingHost": "ホストを確認中",
     "waiting": "待機中",
     "waitingToOverwrite": "上書き待ち",
-    "windowsDrives": "PC"
+    "windowsDrives": "PC",
+    "pathInputAria": "{{pane}}のパスを入力"
   },
   "terminal": {
     "actions": "ターミナル操作",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -2023,7 +2023,8 @@
     "verifyingHost": "호스트 확인 중",
     "waiting": "대기 중",
     "waitingToOverwrite": "덮어쓰기 대기 중",
-    "windowsDrives": "내 PC"
+    "windowsDrives": "내 PC",
+    "pathInputAria": "{{pane}} 경로 입력"
   },
   "terminal": {
     "actions": "터미널 작업",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2023,7 +2023,8 @@
     "verifyingHost": "Verificando host",
     "waiting": "Aguardando",
     "waitingToOverwrite": "Aguardando para sobrescrever",
-    "windowsDrives": "Este computador"
+    "windowsDrives": "Este computador",
+    "pathInputAria": "Insira o caminho de {{pane}}"
   },
   "terminal": {
     "actions": "Ações do terminal",

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -2023,7 +2023,8 @@
     "verifyingHost": "กำลังตรวจสอบโฮสต์",
     "waiting": "กำลังรอ",
     "waitingToOverwrite": "กำลังรอเขียนทับ",
-    "windowsDrives": "พีซีเครื่องนี้"
+    "windowsDrives": "พีซีเครื่องนี้",
+    "pathInputAria": "ป้อนเส้นทาง {{pane}}"
   },
   "terminal": {
     "actions": "การทำงานเทอร์มินัล",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -2023,7 +2023,8 @@
     "verifyingHost": "Verifying host",
     "waiting": "Waiting",
     "waitingToOverwrite": "Đang chờ ghi đè",
-    "windowsDrives": "PC này"
+    "windowsDrives": "PC này",
+    "pathInputAria": "Nhập đường dẫn {{pane}}"
   },
   "terminal": {
     "actions": "Terminal actions",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2023,7 +2023,8 @@
     "verifyingHost": "正在验证主机",
     "waiting": "等待中",
     "waitingToOverwrite": "等待覆盖",
-    "windowsDrives": "此电脑"
+    "windowsDrives": "此电脑",
+    "pathInputAria": "输入{{pane}}路径"
   },
   "terminal": {
     "actions": "终端操作",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2023,7 +2023,8 @@
     "verifyingHost": "正在驗證主機",
     "waiting": "等待中",
     "waitingToOverwrite": "等待覆寫",
-    "windowsDrives": "本機"
+    "windowsDrives": "本機",
+    "pathInputAria": "輸入{{pane}}路徑"
   },
   "terminal": {
     "actions": "終端機動作",

--- a/src/modules/workspace/connections/sftp/SftpFilePane.tsx
+++ b/src/modules/workspace/connections/sftp/SftpFilePane.tsx
@@ -21,6 +21,7 @@ export function FilePane({
   onRenameSelected,
   onDeleteSelected,
   onOpenFolder,
+  onPathSubmit,
   onSelectionChange,
   onContextMenuRequest,
   onDropTransfer,
@@ -39,6 +40,7 @@ export function FilePane({
   onRenameSelected?: (currentName: string, newName: string) => void | Promise<void>;
   onDeleteSelected?: () => void;
   onOpenFolder?: (folderName: string) => void;
+  onPathSubmit?: (path: string) => void | Promise<void>;
   onSelectionChange?: (fileNames: string[]) => void;
   onContextMenuRequest?: (
     side: FilePaneSide,
@@ -54,6 +56,7 @@ export function FilePane({
   const lastSelectedNameRef = useRef<string | null>(null);
   const [editingName, setEditingName] = useState<string | null>(null);
   const [renameDraft, setRenameDraft] = useState("");
+  const [pathDraft, setPathDraft] = useState(path);
   const [sortKey, setSortKey] = useState<FileSortKey>("name");
   const [isDropTarget, setIsDropTarget] = useState(false);
   const hasMutationActions = Boolean(onCreateFolder || onRenameSelected || onDeleteSelected);
@@ -63,6 +66,10 @@ export function FilePane({
   );
   const sortedFiles = useMemo(() => sortFileEntries(files, sortKey), [files, sortKey]);
   const nextSortKey: FileSortKey = sortKey === "name" ? "date" : "name";
+
+  useEffect(() => {
+    setPathDraft(path);
+  }, [path]);
 
   useEffect(() => {
     if (!editingName) {
@@ -166,6 +173,16 @@ export function FilePane({
     setRenameDraft("");
   }
 
+  async function commitPathDraft(value = pathDraft) {
+    const nextPath = value.trim();
+    if (!nextPath || nextPath === path || isLoading) {
+      setPathDraft(path);
+      return;
+    }
+
+    await onPathSubmit?.(nextPath);
+  }
+
   function dragPayloadFor(fileName: string) {
     return selectedNames.includes(fileName) ? selectedNames : [fileName];
   }
@@ -219,7 +236,28 @@ export function FilePane({
       <header>
         <div>
           <strong>{title}</strong>
-          <span>{path}</span>
+          <input
+            aria-label={t("sftp.pathInputAria", { pane: title.toLowerCase() })}
+            className="file-pane-path-input"
+            disabled={!onPathSubmit || isLoading}
+            onBlur={() => setPathDraft(path)}
+            onChange={(event) => setPathDraft(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                const nextPath = event.currentTarget.value;
+                void commitPathDraft(nextPath);
+                event.currentTarget.blur();
+              }
+              if (event.key === "Escape") {
+                event.preventDefault();
+                setPathDraft(path);
+                event.currentTarget.blur();
+              }
+            }}
+            spellCheck={false}
+            value={pathDraft}
+          />
         </div>
         <div className="file-pane-actions">
           <button

--- a/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
+++ b/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
@@ -965,6 +965,7 @@ export function SftpWorkspace({
           onRefresh={refreshLocalDirectory}
           onGoUp={openLocalParent}
           onOpenFolder={openLocalFolder}
+          onPathSubmit={(path) => void loadLocalDirectory(path)}
           onSelectionChange={setSelectedLocalNames}
           onContextMenuRequest={handleOpenContextMenu}
           onDropTransfer={
@@ -985,6 +986,7 @@ export function SftpWorkspace({
           onRenameSelected={isConnected && !isTransferring ? handleRenameRemotePath : undefined}
           onDeleteSelected={isConnected && !isTransferring ? handleDeleteRemotePath : undefined}
           onOpenFolder={openRemoteFolder}
+          onPathSubmit={(path) => void loadRemoteDirectory(path)}
           onSelectionChange={setSelectedRemoteNames}
           onContextMenuRequest={handleOpenContextMenu}
           onDropTransfer={isConnected && !isTransferring ? handleDropTransfer : undefined}

--- a/src/modules/workspace/connections/sftp/sftp.css
+++ b/src/modules/workspace/connections/sftp/sftp.css
@@ -57,6 +57,33 @@
   min-width: 0;
 }
 
+
+.file-pane-path-input {
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  color: var(--text-muted);
+  background: transparent;
+  border: 0;
+  outline: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font: inherit;
+}
+
+.file-pane-path-input:focus {
+  padding: 1px 5px;
+  color: var(--text);
+  background: var(--surface-muted);
+  border-radius: 4px;
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.file-pane-path-input:disabled {
+  opacity: 1;
+}
+
 .file-pane-actions {
   display: flex;
   flex: 0 0 auto;

--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -96,6 +96,7 @@ export function TerminalWorkspace({
     generalSettings.separateSplitTerminalBackgrounds &&
     tab.panes.filter(isTerminalPane).length > 1;
   const [sftpDialogConnection, setSftpDialogConnection] = useState<Connection | null>(null);
+  const sftpFocusRestorePaneIdRef = useRef<string | null>(null);
   const { t } = useTranslation();
   const defaultFontSize = defaultTerminalSettings.fontSize;
   const canSplit = allowPaneLayoutControls && tab.panes.some((pane) => pane.connection);
@@ -142,13 +143,33 @@ export function TerminalWorkspace({
 
     const handleKeyDown = (event: globalThis.KeyboardEvent) => {
       if (event.key === "Escape") {
-        setSftpDialogConnection(null);
+        closeSftpDialog();
       }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [sftpDialogConnection]);
+
+  function focusTerminalPaneAfterDialogClose(paneId: string) {
+    const focus = () => getPaneRenderer(paneId)?.focus();
+    queueMicrotask(focus);
+    window.requestAnimationFrame(focus);
+  }
+
+  function closeSftpDialog() {
+    const restorePaneId = sftpFocusRestorePaneIdRef.current;
+    sftpFocusRestorePaneIdRef.current = null;
+    setSftpDialogConnection(null);
+    if (restorePaneId) {
+      focusTerminalPaneAfterDialogClose(restorePaneId);
+    }
+  }
+
+  function openSftpDialog(connection: Connection, paneId: string) {
+    sftpFocusRestorePaneIdRef.current = paneId === focusedPaneId ? paneId : null;
+    setSftpDialogConnection(connection);
+  }
 
   function handleSplit(paneId: string, direction: "right" | "left" | "down" | "up") {
     setFocusedPane(tab.id, paneId);
@@ -238,7 +259,7 @@ export function TerminalWorkspace({
             canSplit={canSplit}
             usePaneTerminalBackgrounds={usePaneTerminalBackgrounds}
             onFontChange={handleFontChange}
-            onOpenSftp={(connection) => setSftpDialogConnection(connection)}
+            onOpenSftp={openSftpDialog}
             onSaveBuffer={(paneId) => void handleSaveBuffer(paneId)}
             showSftpButton={showSftpButton}
             onSplit={handleSplit}
@@ -263,7 +284,7 @@ export function TerminalWorkspace({
               <button
                 aria-label={t("common.close")}
                 className="connection-dialog-close"
-                onClick={() => setSftpDialogConnection(null)}
+                onClick={closeSftpDialog}
                 type="button"
               >
                 <X size={15} />
@@ -310,7 +331,7 @@ function TerminalLayoutView({
   canSplit: boolean;
   usePaneTerminalBackgrounds: boolean;
   onFontChange: (delta: number | "reset") => void;
-  onOpenSftp: (connection: Connection) => void;
+  onOpenSftp: (connection: Connection, paneId: string) => void;
   onSaveBuffer: (paneId: string) => void;
   showSftpButton: boolean;
   onSplit: (paneId: string, direction: "right" | "left" | "down" | "up") => void;
@@ -1140,7 +1161,7 @@ function TerminalPaneView({
   canClosePane: boolean;
   onFontChange: (delta: number | "reset") => void;
   usePaneTerminalBackgrounds: boolean;
-  onOpenSftp: (connection: Connection) => void;
+  onOpenSftp: (connection: Connection, paneId: string) => void;
   onSaveBuffer: (paneId: string) => void;
   showSftpButton: boolean;
   onSplit: (paneId: string, direction: "right" | "left" | "down" | "up") => void;
@@ -1153,6 +1174,7 @@ function TerminalPaneView({
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const sessionIdRef = useRef<string | null>(null);
   const lastResizeDimensionsRef = useRef<TerminalDimensions | null>(null);
+  const restoreFocusOnWindowFocusRef = useRef(false);
   const resizeFrameRef = useRef<number | null>(null);
   const resizeTimeoutRefs = useRef<number[]>([]);
   const fitAndResizeRef = useRef<() => void>(() => undefined);
@@ -1716,6 +1738,38 @@ function TerminalPaneView({
     return () => window.cancelAnimationFrame(frame);
   }, [isActive]);
 
+  useEffect(() => {
+    if (!isActive || !isFocused) {
+      restoreFocusOnWindowFocusRef.current = false;
+      return;
+    }
+
+    const handleWindowBlur = () => {
+      restoreFocusOnWindowFocusRef.current = !shouldPreserveExternalFocus(paneRef.current);
+    };
+    const handleWindowFocus = () => {
+      if (!restoreFocusOnWindowFocusRef.current) {
+        return;
+      }
+      restoreFocusOnWindowFocusRef.current = false;
+      const focus = () => {
+        const renderer = terminalRendererRef.current;
+        if (renderer) {
+          focusTerminalUnlessExternalInputIsActive(renderer, paneRef.current);
+        }
+      };
+      queueMicrotask(focus);
+      window.requestAnimationFrame(focus);
+    };
+
+    window.addEventListener("blur", handleWindowBlur);
+    window.addEventListener("focus", handleWindowFocus);
+    return () => {
+      window.removeEventListener("blur", handleWindowBlur);
+      window.removeEventListener("focus", handleWindowFocus);
+    };
+  }, [isActive, isFocused]);
+
 
   useEffect(() => {
     if (searchOpen) {
@@ -1942,7 +1996,7 @@ function TerminalPaneView({
     if (pane.connection?.type !== "ssh") {
       return;
     }
-    onOpenSftp(pane.connection);
+    onOpenSftp(pane.connection, pane.id);
   }
 
   function handleSplit(direction: "right" | "left" | "down" | "up") {

--- a/tests/sftp-toolbar-popup.test.mjs
+++ b/tests/sftp-toolbar-popup.test.mjs
@@ -20,8 +20,13 @@ test("SSH pane toolbar SFTP button opens an in-place popup instead of a workspac
   );
   assert.match(
     terminalSource,
-    /onOpenSftp=\{\(connection\) => setSftpDialogConnection\(connection\)\}/,
-    "clicking the SSH toolbar SFTP action should open the popup, not dispatch to a tab opener",
+    /onOpenSftp=\{openSftpDialog\}/,
+    "clicking the SSH toolbar SFTP action should open the popup through TerminalWorkspace, not dispatch to a tab opener",
+  );
+  assert.match(
+    terminalSource,
+    /sftpFocusRestorePaneIdRef/,
+    "the SFTP popup should remember the originating terminal pane for focus restore",
   );
   assert.match(
     terminalSource,


### PR DESCRIPTION
### Motivation
- Let users type a local or remote path directly into each SFTP pane and navigate by pressing Enter, matching common file-browser workflows.
- When the SFTP toolbar popup is opened from a terminal pane (or when switching away and back to the app), restore input focus to the terminal pane that was focused before the popup/switch so typing resumes where the user expects.

### Description
- Add an editable path field to `FilePane` with keyboard handling that navigates on `Enter`, cancels on `Escape`/blur, and exposes `onPathSubmit`; wired to the SFTP workspace to call `loadLocalDirectory` / `loadRemoteDirectory` for local/remote panes (`src/modules/workspace/connections/sftp/SftpFilePane.tsx`, `SftpWorkspace.tsx`).
- Add compact focused styling for the path input (`src/modules/workspace/connections/sftp/sftp.css`).
- Implement focus-restore for the SFTP popup: remember the originating terminal pane id when opening the dialog and focus that pane after the dialog closes (`src/modules/workspace/connections/terminal/TerminalWorkspace.tsx`).
- Restore terminal input when the app regains OS focus after an app switch (unless an external UI element had focus) by tracking blur/focus and re-focusing the terminal renderer (`src/modules/workspace/connections/terminal/TerminalWorkspace.tsx`).
- Add i18n key `sftp.pathInputAria` and populate it across locale files, and update the SFTP manual to document the editable path field (`src/i18n/locales/*.json`, `docs/manual/07-sftp.md`).
- Update the SFTP toolbar popup test to assert the new open/close/focus behavior (`tests/sftp-toolbar-popup.test.mjs`).

### Testing
- Ran `npm run i18n:check` and it passed with all locale files matching `en.json` (2131 keys). ✅
- Ran the project checks with `npm run check`; after updating the test to match the new focus-restoration behavior the full check suite passed. ✅
- Ran `git diff --check` to verify no trailing whitespace/issues; it reported clean. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20e5945964832faac3e91711f6ec21)