### PR TITLE
Add fallback to replace a changed SSH host key

### DIFF
--- a/docs/manual/06-ssh-and-tmux.md
+++ b/docs/manual/06-ssh-and-tmux.md
@@ -8,12 +8,19 @@
 
 ## Host key trust
 
-When connecting to an SSH host, the user sees `terminal.verifyingHostKey`. If the host key does not match a previously trusted key, KKTerm shows an app-owned dialog:
+When connecting to an SSH host, the user sees `terminal.verifyingHostKey`. Host-key verification runs before authentication regardless of the auth method (password, key file, or agent).
 
-- Title: `terminal.sshHostKeyChanged`
-- Body: `terminal.sshHostKeyChangedDetail` (long form) or `terminal.sshHostKeyChangeDetail`
-- Trust action: `terminal.trustHostKey`
+For a host that has never been trusted, KKTerm shows an app-owned dialog:
+
+- Trust action title: `terminal.trustHostKey`
 - Untrusted state status: `terminal.hostKeyNotTrusted`
+
+If the host key no longer matches a previously trusted key, KKTerm shows a stronger warning dialog instead of failing outright:
+
+- Title: `terminal.replaceChangedHostKeyTitle`
+- Body: `terminal.replaceChangedHostKeyWarning`
+
+Confirming this dialog replaces the stored trusted key (the conflicting entry in KKTerm's `ssh_known_hosts` file is removed and the new key is learned); cancelling aborts with `terminal.hostKeyNotTrusted`. This is the fallback path for legitimate key rotation (server reinstall, rotated host keys). `terminal.sshHostKeyChanged`, `terminal.sshHostKeyChangedDetail`, and `terminal.sshHostKeyChangeDetail` remain for descriptive messaging.
 
 This is not a `window.confirm`. Users explicitly approve the new key; the trusted key set is persisted with the Connection's metadata.
 

--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -110,6 +110,8 @@ pub struct TrustSshHostKeyRequest {
     host: String,
     port: Option<u16>,
     public_key: String,
+    #[serde(default)]
+    replace: bool,
 }
 
 #[derive(Serialize)]
@@ -367,9 +369,12 @@ pub fn trust_host_key(
                 .map_err(|error| format!("failed to trust SSH host key: {error}"))?;
         }
         HostKeyTrustStatus::Changed { line } => {
-            return Err(format!(
-                "refusing to replace changed SSH host key at known-hosts line {line}"
-            ));
+            if !request.replace {
+                return Err(format!(
+                    "refusing to replace changed SSH host key at known-hosts line {line}"
+                ));
+            }
+            replace_changed_host_key(&host, port, &key, &known_hosts_path)?;
         }
     }
 
@@ -383,6 +388,39 @@ pub fn trust_host_key(
             .map_err(|error| format!("failed to encode SSH host key: {error}"))?,
         status: "trusted".to_string(),
     })
+}
+
+fn replace_changed_host_key(
+    host: &str,
+    port: u16,
+    key: &russh::keys::ssh_key::PublicKey,
+    known_hosts_path: &PathBuf,
+) -> Result<(), String> {
+    // Drop every stale entry that conflicts with the new key (there can be more
+    // than one, e.g. one per algorithm) before learning the rotated key.
+    while let HostKeyTrustStatus::Changed { line } =
+        host_key_status(host, port, key, known_hosts_path)?
+    {
+        remove_known_hosts_line(known_hosts_path, line)?;
+    }
+    russh::keys::known_hosts::learn_known_hosts_path(host, port, key, known_hosts_path)
+        .map_err(|error| format!("failed to trust SSH host key: {error}"))
+}
+
+fn remove_known_hosts_line(known_hosts_path: &PathBuf, line: usize) -> Result<(), String> {
+    let contents = std::fs::read_to_string(known_hosts_path)
+        .map_err(|error| format!("failed to read SSH known hosts: {error}"))?;
+    let mut lines: Vec<&str> = contents.lines().collect();
+    if line == 0 || line > lines.len() {
+        return Err(format!("SSH known-hosts line {line} is out of range"));
+    }
+    lines.remove(line - 1);
+    let mut rebuilt = lines.join("\n");
+    if !rebuilt.is_empty() {
+        rebuilt.push('\n');
+    }
+    std::fs::write(known_hosts_path, rebuilt)
+        .map_err(|error| format!("failed to update SSH known hosts: {error}"))
 }
 
 pub(crate) fn run_remote_command(request: NativeSshCommandRequest) -> Result<String, String> {
@@ -1186,6 +1224,64 @@ mod tests {
             host_key_status("localhost", 2222, &changed_key, &path).expect("status loads"),
             HostKeyTrustStatus::Changed { line: 2 }
         );
+    }
+
+    #[test]
+    fn trust_host_key_replaces_changed_entry_when_requested() {
+        let path = temp_known_hosts_path("replace");
+        let original = russh::keys::ssh_key::PublicKey::from_openssh(
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJdD7y3aLq454yWBdwLWbieU1ebz9/cu7/QEXn9OIeZJ",
+        )
+        .expect("original host key parses");
+        russh::keys::known_hosts::learn_known_hosts_path("localhost", 2222, &original, &path)
+            .expect("original host key is trusted");
+
+        let rotated = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA6rWI3G1sz07DnfFlrouTcysQlj2P+jpNSOEWD9OJ3X";
+        let preview = trust_host_key(
+            path.clone(),
+            TrustSshHostKeyRequest {
+                host: "localhost".to_string(),
+                port: Some(2222),
+                public_key: rotated.to_string(),
+                replace: true,
+            },
+        )
+        .expect("changed host key is replaced when replace is requested");
+        assert_eq!(preview.status, "trusted");
+
+        let rotated_key =
+            russh::keys::ssh_key::PublicKey::from_openssh(rotated).expect("rotated host key parses");
+        assert_eq!(
+            host_key_status("localhost", 2222, &rotated_key, &path).expect("status loads"),
+            HostKeyTrustStatus::Trusted
+        );
+        assert_eq!(
+            host_key_status("localhost", 2222, &original, &path).expect("status loads"),
+            HostKeyTrustStatus::Changed { line: 1 }
+        );
+    }
+
+    #[test]
+    fn trust_host_key_refuses_changed_entry_without_replace() {
+        let path = temp_known_hosts_path("refuse");
+        let original = russh::keys::ssh_key::PublicKey::from_openssh(
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJdD7y3aLq454yWBdwLWbieU1ebz9/cu7/QEXn9OIeZJ",
+        )
+        .expect("original host key parses");
+        russh::keys::known_hosts::learn_known_hosts_path("localhost", 2222, &original, &path)
+            .expect("original host key is trusted");
+
+        let error = trust_host_key(
+            path,
+            TrustSshHostKeyRequest {
+                host: "localhost".to_string(),
+                port: Some(2222),
+                public_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA6rWI3G1sz07DnfFlrouTcysQlj2P+jpNSOEWD9OJ3X".to_string(),
+                replace: false,
+            },
+        )
+        .expect_err("changed host key is refused without replace");
+        assert!(error.contains("refusing to replace changed SSH host key"));
     }
 
     #[test]

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2099,6 +2099,8 @@
     "sshHostKeyChanged": "SSH-Host-Schlüssel für",
     "sshHostKeyChangedDetail": "hat sich geändert! Dies könnte auf einen Man-in-the-Middle-Angriff hindeuten.",
     "sshHostKeyChangeDetail": "SSH-Host-Schlüssel für {{host}} hat sich geändert. Vorgelegter {{algorithm}} {{fingerprint}}.",
+    "replaceChangedHostKeyTitle": "SSH-Host-Schlüssel geändert",
+    "replaceChangedHostKeyWarning": "Der SSH-Host-Schlüssel für {{host}} hat sich geändert und legt nun {{algorithm}} {{fingerprint}} vor. Das bedeutet meist, dass der Server neu installiert wurde oder seinen Schlüssel gewechselt hat, kann aber auch auf einen Man-in-the-Middle-Angriff hindeuten. Ersetzen Sie den vertrauenswürdigen Schlüssel nur, wenn Sie diese Änderung erwartet haben.",
     "sshPortForwardOpened": "SSH-Port-Weiterleitung für entfernten Port {{port}} geöffnet.",
     "sshPortRedirect": "SSH-Port-Weiterleitung",
     "starting": "Starte",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1546,6 +1546,8 @@
     "sshHostKeyChanged": "SSH host key for",
     "sshHostKeyChangedDetail": "has changed! This could indicate a man-in-the-middle attack.",
     "sshHostKeyChangeDetail": "SSH host key for {{host}} changed. Presented {{algorithm}} {{fingerprint}}.",
+    "replaceChangedHostKeyTitle": "SSH host key changed",
+    "replaceChangedHostKeyWarning": "The SSH host key for {{host}} has changed, and now presents {{algorithm}} {{fingerprint}}. This usually means the server was reinstalled or rotated its key, but it can also indicate a man-in-the-middle attack. Only replace the trusted key if you expected this change.",
     "trustHostKey": "Trust SSH host key for",
     "hostKeyNotTrusted": "SSH host key was not trusted.",
     "selectKeyFile": "Select SSH key file",

--- a/src/i18n/locales/es-MX.json
+++ b/src/i18n/locales/es-MX.json
@@ -2099,6 +2099,8 @@
     "sshHostKeyChanged": "La clave del host SSH para",
     "sshHostKeyChangedDetail": "¡ha cambiado! Esto podría indicar un ataque de intermediario.",
     "sshHostKeyChangeDetail": "La clave de host SSH para {{host}} cambió. Se presentó {{algorithm}} {{fingerprint}}.",
+    "replaceChangedHostKeyTitle": "La clave del host SSH cambió",
+    "replaceChangedHostKeyWarning": "La clave del host SSH para {{host}} cambió y ahora presenta {{algorithm}} {{fingerprint}}. Esto suele significar que el servidor se reinstaló o rotó su clave, pero también puede indicar un ataque de intermediario. Reemplaza la clave de confianza solo si esperabas este cambio.",
     "sshPortForwardOpened": "Redirección de puerto SSH abierta para el puerto remoto {{port}}.",
     "sshPortRedirect": "Redirección de puerto SSH",
     "starting": "Iniciando",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2099,6 +2099,8 @@
     "sshHostKeyChanged": "La clave de host SSH para",
     "sshHostKeyChangedDetail": "ha cambiado. Esto podría indicar un ataque de intermediario.",
     "sshHostKeyChangeDetail": "La clave de host SSH para {{host}} ha cambiado. Se presentó {{algorithm}} {{fingerprint}}.",
+    "replaceChangedHostKeyTitle": "Clave de host SSH cambiada",
+    "replaceChangedHostKeyWarning": "La clave de host SSH para {{host}} ha cambiado y ahora presenta {{algorithm}} {{fingerprint}}. Esto suele significar que el servidor se reinstaló o rotó su clave, pero también puede indicar un ataque de intermediario. Reemplace la clave de confianza solo si esperaba este cambio.",
     "sshPortForwardOpened": "Redirección de puerto SSH abierta para el puerto remoto {{port}}.",
     "sshPortRedirect": "Redirección de puerto SSH",
     "starting": "Iniciando",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2099,6 +2099,8 @@
     "sshHostKeyChanged": "La clé d'hôte SSH pour",
     "sshHostKeyChangedDetail": "a changé ! Cela pourrait indiquer une attaque de l'homme du milieu.",
     "sshHostKeyChangeDetail": "Clé d'hôte SSH pour {{host}} modifiée. Présentée {{algorithm}} {{fingerprint}}.",
+    "replaceChangedHostKeyTitle": "Clé d'hôte SSH modifiée",
+    "replaceChangedHostKeyWarning": "La clé d'hôte SSH pour {{host}} a changé et présente désormais {{algorithm}} {{fingerprint}}. Cela signifie généralement que le serveur a été réinstallé ou a renouvelé sa clé, mais cela peut aussi indiquer une attaque de l'intercepteur. Ne remplacez la clé approuvée que si vous attendiez ce changement.",
     "sshPortForwardOpened": "Redirection de port SSH ouverte pour le port distant {{port}}.",
     "sshPortRedirect": "Redirection de port SSH",
     "starting": "Démarrage",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -2099,6 +2099,8 @@
     "sshHostKeyChanged": "Kunci host SSH untuk",
     "sshHostKeyChangedDetail": "telah berubah! Ini bisa menunjukkan serangan man-in-the-middle.",
     "sshHostKeyChangeDetail": "Kunci host SSH untuk {{host}} berubah. Disajikan {{algorithm}} {{fingerprint}}.",
+    "replaceChangedHostKeyTitle": "Kunci host SSH berubah",
+    "replaceChangedHostKeyWarning": "Kunci host SSH untuk {{host}} telah berubah dan kini menyajikan {{algorithm}} {{fingerprint}}. Ini biasanya berarti server diinstal ulang atau merotasi kuncinya, tetapi juga bisa menandakan serangan man-in-the-middle. Ganti kunci tepercaya hanya jika Anda memang mengharapkan perubahan ini.",
     "sshPortForwardOpened": "Pengalihan port SSH dibuka untuk port jarak jauh {{port}}.",
     "sshPortRedirect": "Pengalihan port SSH",
     "starting": "Memulai",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -2099,6 +2099,8 @@
     "sshHostKeyChanged": "La chiave host SSH per",
     "sshHostKeyChangedDetail": "è cambiata! Questo potrebbe indicare un attacco man-in-the-middle.",
     "sshHostKeyChangeDetail": "Chiave host SSH per {{host}} cambiata. Presentata {{algorithm}} {{fingerprint}}.",
+    "replaceChangedHostKeyTitle": "Chiave host SSH cambiata",
+    "replaceChangedHostKeyWarning": "La chiave host SSH per {{host}} è cambiata e ora presenta {{algorithm}} {{fingerprint}}. Di solito significa che il server è stato reinstallato o ha ruotato la chiave, ma può anche indicare un attacco man-in-the-middle. Sostituisci la chiave attendibile solo se ti aspettavi questo cambiamento.",
     "sshPortForwardOpened": "Reindirizzamento porta SSH aperto per la porta remota {{port}}.",
     "sshPortRedirect": "Reindirizzamento porta SSH",
     "starting": "Avvio",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2099,6 +2099,8 @@
     "sshHostKeyChanged": "SSHホストキーが変更されました：",
     "sshHostKeyChangedDetail": "が変更されました！中間者攻撃の可能性があります。",
     "sshHostKeyChangeDetail": "{{host}}のSSHホストキーが変更されました。提示された{{algorithm}} {{fingerprint}}。",
+    "replaceChangedHostKeyTitle": "SSHホストキーが変更されました",
+    "replaceChangedHostKeyWarning": "{{host}}のSSHホストキーが変更され、現在は{{algorithm}} {{fingerprint}}が提示されています。通常はサーバーの再インストールやキーのローテーションを意味しますが、中間者攻撃の可能性もあります。この変更が想定どおりの場合のみ、信頼済みキーを置き換えてください。",
     "sshPortForwardOpened": "リモートポート {{port}} の SSH ポートリダイレクトを開きました。",
     "sshPortRedirect": "SSH ポートリダイレクト",
     "starting": "起動中",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -2099,6 +2099,8 @@
     "sshHostKeyChanged": "SSH 호스트 키 변경됨:",
     "sshHostKeyChangedDetail": "이(가) 변경되었습니다! 중간자 공격일 수 있습니다.",
     "sshHostKeyChangeDetail": "{{host}}의 SSH 호스트 키가 변경되었습니다. 제시된 {{algorithm}} {{fingerprint}}。",
+    "replaceChangedHostKeyTitle": "SSH 호스트 키가 변경됨",
+    "replaceChangedHostKeyWarning": "{{host}}의 SSH 호스트 키가 변경되어 이제 {{algorithm}} {{fingerprint}}을(를) 제시합니다. 보통 서버가 재설치되었거나 키를 교체한 경우이지만, 중간자 공격을 의미할 수도 있습니다. 이 변경이 예상된 경우에만 신뢰할 수 있는 키를 교체하세요.",
     "sshPortForwardOpened": "원격 포트 {{port}}에 대한 SSH 포트 리다이렉트가 열렸습니다.",
     "sshPortRedirect": "SSH 포트 리다이렉트",
     "starting": "시작 중",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2099,6 +2099,8 @@
     "sshHostKeyChanged": "A chave do host SSH para",
     "sshHostKeyChangedDetail": "mudou! Isso pode indicar um ataque de intermediário.",
     "sshHostKeyChangeDetail": "A chave do host SSH para {{host}} mudou. Apresentada {{algorithm}} {{fingerprint}}.",
+    "replaceChangedHostKeyTitle": "Chave do host SSH alterada",
+    "replaceChangedHostKeyWarning": "A chave do host SSH para {{host}} mudou e agora apresenta {{algorithm}} {{fingerprint}}. Isso geralmente significa que o servidor foi reinstalado ou rotacionou a chave, mas também pode indicar um ataque man-in-the-middle. Substitua a chave confiável apenas se você esperava essa mudança.",
     "sshPortForwardOpened": "Redirecionamento de porta SSH aberto para a porta remota {{port}}.",
     "sshPortRedirect": "Redirecionamento de porta SSH",
     "starting": "Iniciando",

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -2099,6 +2099,8 @@
     "sshHostKeyChanged": "คีย์โฮสต์ SSH สำหรับ",
     "sshHostKeyChangedDetail": "เปลี่ยนแปลงแล้ว! นี่อาจเป็นการโจมตีแบบ man-in-the-middle",
     "sshHostKeyChangeDetail": "คีย์โฮสต์ SSH สำหรับ {{host}} เปลี่ยนไป แสดง {{algorithm}} {{fingerprint}}",
+    "replaceChangedHostKeyTitle": "คีย์โฮสต์ SSH เปลี่ยนไป",
+    "replaceChangedHostKeyWarning": "คีย์โฮสต์ SSH สำหรับ {{host}} เปลี่ยนไป และตอนนี้แสดง {{algorithm}} {{fingerprint}} โดยทั่วไปหมายความว่าเซิร์ฟเวอร์ถูกติดตั้งใหม่หรือหมุนเวียนคีย์ แต่ก็อาจบ่งชี้การโจมตีแบบ man-in-the-middle ได้เช่นกัน ให้แทนที่คีย์ที่เชื่อถือเฉพาะเมื่อคุณคาดหวังการเปลี่ยนแปลงนี้",
     "sshPortForwardOpened": "เปิดการเปลี่ยนเส้นทางพอร์ต SSH สำหรับพอร์ตระยะไกล {{port}} แล้ว",
     "sshPortRedirect": "การเปลี่ยนเส้นทางพอร์ต SSH",
     "starting": "กำลังเริ่มต้น",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -2099,6 +2099,8 @@
     "sshHostKeyChanged": "SSH host key for",
     "sshHostKeyChangedDetail": "has changed! This could indicate a man-in-the-middle attack.",
     "sshHostKeyChangeDetail": "Khóa máy chủ SSH cho {{host}} đã thay đổi. Trình bày {{algorithm}} {{fingerprint}}.",
+    "replaceChangedHostKeyTitle": "Khóa máy chủ SSH đã thay đổi",
+    "replaceChangedHostKeyWarning": "Khóa máy chủ SSH cho {{host}} đã thay đổi và hiện trình bày {{algorithm}} {{fingerprint}}. Điều này thường có nghĩa là máy chủ đã được cài đặt lại hoặc xoay vòng khóa, nhưng cũng có thể là dấu hiệu của một cuộc tấn công xen giữa (man-in-the-middle). Chỉ thay thế khóa tin cậy nếu bạn dự kiến sự thay đổi này.",
     "sshPortForwardOpened": "Đã mở chuyển hướng cổng SSH cho cổng từ xa {{port}}.",
     "sshPortRedirect": "Chuyển hướng cổng SSH",
     "starting": "Starting",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2099,6 +2099,8 @@
     "sshHostKeyChanged": "SSH 主机密钥",
     "sshHostKeyChangedDetail": "已变更！这可能表示有中间人攻击。",
     "sshHostKeyChangeDetail": "{{host}} 的 SSH 主机密钥已更改。提供了 {{algorithm}} {{fingerprint}}。",
+    "replaceChangedHostKeyTitle": "SSH 主机密钥已更改",
+    "replaceChangedHostKeyWarning": "{{host}} 的 SSH 主机密钥已更改，现在提供 {{algorithm}} {{fingerprint}}。这通常表示服务器已重新安装或轮换了密钥，但也可能意味着存在中间人攻击。仅在你预期此更改时才替换受信任的密钥。",
     "sshPortForwardOpened": "已为远程端口 {{port}} 打开 SSH 端口重定向。",
     "sshPortRedirect": "SSH 端口重定向",
     "starting": "正在启动",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2099,6 +2099,8 @@
     "sshHostKeyChanged": "SSH 主機金鑰",
     "sshHostKeyChangedDetail": "已變更！這可能表示有中間人攻擊。",
     "sshHostKeyChangeDetail": "{{host}} 的 SSH 主機金鑰已變更。提供了 {{algorithm}} {{fingerprint}}。",
+    "replaceChangedHostKeyTitle": "SSH 主機金鑰已變更",
+    "replaceChangedHostKeyWarning": "{{host}} 的 SSH 主機金鑰已變更，現在提供 {{algorithm}} {{fingerprint}}。這通常表示伺服器已重新安裝或輪換金鑰，但也可能代表發生中間人攻擊。只有在您預期此變更時，才取代受信任的金鑰。",
     "sshPortForwardOpened": "已為遠端連接埠 {{port}} 開啟 SSH 連接埠重新導向。",
     "sshPortRedirect": "SSH 連接埠重新導向",
     "starting": "正在啟動",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1293,7 +1293,9 @@ type CommandMap = {
     result: SshHostKeyPreview;
   };
   trust_ssh_host_key: {
-    args: { request: { host: string; port?: number; publicKey: string } };
+    args: {
+      request: { host: string; port?: number; publicKey: string; replace?: boolean };
+    };
     result: SshHostKeyPreview;
   };
   store_secret: {

--- a/src/modules/workspace/connections/utils.tsx
+++ b/src/modules/workspace/connections/utils.tsx
@@ -242,13 +242,30 @@ export async function confirmTrustedSshHostKey(preview: SshHostKeyPreview) {
   }
 
   if (preview.status === "changed") {
-    throw new Error(
-      i18next.t("terminal.sshHostKeyChangeDetail", {
+    const shouldReplace = await confirmNativeDialog(
+      i18next.t("terminal.replaceChangedHostKeyWarning", {
         host: `${preview.host}:${preview.port}`,
         algorithm: preview.algorithm,
         fingerprint: preview.fingerprint,
       }),
+      {
+        kind: "warning",
+        title: i18next.t("terminal.replaceChangedHostKeyTitle"),
+      },
     );
+    if (shouldReplace !== true) {
+      throw new Error(i18next.t("terminal.hostKeyNotTrusted"));
+    }
+
+    await invokeCommand("trust_ssh_host_key", {
+      request: {
+        host: preview.host,
+        port: preview.port,
+        publicKey: preview.publicKey,
+        replace: true,
+      },
+    });
+    return;
   }
 
   const shouldTrust = await confirmNativeDialog(


### PR DESCRIPTION
When a remote host key no longer matched the trusted one, both the
frontend and backend hard-stopped with no remediation: confirmTrustedSshHostKey
threw immediately and trust_host_key refused to replace a changed key.
A legitimate key rotation (server reinstall, rotated host keys) bricked
the connection regardless of auth method, with no in-app recovery.

Now the "changed" case shows a strong warning dialog explaining the
possible man-in-the-middle risk and, on explicit confirmation, replaces
the stored key: the backend removes the conflicting known-hosts entries
and learns the rotated key via a new opt-in `replace` flag on
trust_ssh_host_key. Adds Rust tests for the replace and refuse paths,
new localized strings across all locales, and updates the SSH manual.