### PR TITLE
Derive Debug for SSH host key preview

### DIFF
--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -114,7 +114,7 @@ pub struct TrustSshHostKeyRequest {
     replace: bool,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SshHostKeyPreview {
     host: String,


### PR DESCRIPTION
### Motivation
- Ensure the Tauri command return type meets the compile-time `std::fmt::Debug` bound by deriving `Debug` for the SSH host-key preview structure.

### Description
- Add `Debug` to the derives for `SshHostKeyPreview` in `src-tauri/src/ssh.rs` (`#[derive(Debug, Serialize)]`).

### Testing
- Ran `git diff --check` and `rustfmt --edition 2021 src-tauri/src/ssh.rs` successfully; attempted `cargo check --manifest-path src-tauri/Cargo.toml` but it was blocked by a missing system dependency (`glib-2.0` / missing `glib-2.0.pc` for `pkg-config`) in the Linux environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20fe83a8dc832f9ed857bad5afc52f)