### PR TITLE
Fix host-key replace test to expect line 2 after rotation

### DIFF
--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -1255,9 +1255,12 @@ mod tests {
             host_key_status("localhost", 2222, &rotated_key, &path).expect("status loads"),
             HostKeyTrustStatus::Trusted
         );
+        // `learn_known_hosts_path` always emits a leading newline when the file
+        // does not already end in one (an empty file included), so the rotated
+        // key lands on line 2. The original key now reports as changed there.
         assert_eq!(
             host_key_status("localhost", 2222, &original, &path).expect("status loads"),
-            HostKeyTrustStatus::Changed { line: 1 }
+            HostKeyTrustStatus::Changed { line: 2 }
         );
     }
 


### PR DESCRIPTION
`learn_known_hosts_path` writes a leading newline whenever the
known-hosts file does not already end in one (an empty file included),
so a learned entry lands on line 2. The replace test asserted the
rotated key would occupy line 1, an expectation that was never exercised
because these host-key tests did not compile until Debug was derived for
SshHostKeyPreview.

Align the assertion with the actual, consistent behavior already
codified by host_key_status_reports_unknown_trusted_and_changed.