### PR TITLE
Improve SFTP path controls: autocomplete, recent paths, and inline-toolbar behavior

### DIFF
--- a/docs/localization_todo/sftp.recentPathsAria.md
+++ b/docs/localization_todo/sftp.recentPathsAria.md
@@ -1,0 +1,16 @@
+# sftp.recentPathsAria
+
+- **English value**: `Open recent {{pane}} paths`
+- **Namespace**: `sftp`
+- **File/component**: `src/modules/workspace/connections/sftp/SftpFilePane.tsx`
+- **UI role**: `button | tooltip`
+- **User flow**: `Users see this on the Local and Remote path row in the SFTP/FTP file browser. Pressing the icon opens a short menu of recently visited paths for that pane.`
+- **Tone**: `concise/neutral`
+- **Placeholders**: `{{pane}} — localized pane name supplied by the component, such as local or remote; the token must survive unchanged.`
+- **Context/meaning**: `Recent paths are filesystem folders the user previously opened in this file browser pane, not recent Connections or recent Sessions.`
+- **Domain notes**: `SFTP/FTP are technical protocol names and typically stay English. Local means the user's machine; Remote means the connected server.`
+
+<!--
+Filename: sftp.recentPathsAria.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/manual/07-sftp.md
+++ b/docs/manual/07-sftp.md
@@ -28,7 +28,7 @@ Startup states:
 
 Two columns:
 
-Each pane path is editable: type a local or remote path into the path field and press Enter to navigate. Press Escape or leave the field without Enter to keep the current path. The path input accessibility label is `sftp.pathInputAria`.
+Each pane header keeps the pane label and editable path field on one row. Type a local or remote path into the expanding path field and press Enter to navigate. Press Escape or leave the field without Enter to keep the current path. Folder-name autocomplete suggests folders from the current listing and inserts the selected folder path with a trailing slash. The recent-path icon (`sftp.recentPathsAria`) opens up to the last five visited paths for that local or remote pane. The path input accessibility label is `sftp.pathInputAria`.
 
 - **Local** (`sftp.local`, `sftp.localFiles`) — loading state `sftp.loadingLocal`. On Windows, opening the parent of a drive root shows the drive picker path label `sftp.windowsDrives`, where double-clicking a drive opens that drive root.
 - **Remote** (`sftp.remote`) — empty state `sftp.noFiles`, loading `sftp.loading`.
@@ -56,7 +56,7 @@ Double-click affordance hint: `sftp.doubleClickToOpen`, `sftp.doubleClickToOpenF
 
 ## Transferring files
 
-Use drag/drop between panes or the explicit toolbar buttons `sftp.upload` and `sftp.download`. The terminal column also exposes a `sftp.terminal` action that reopens the parent SSH terminal in the originating Pane.
+Use drag/drop between panes or the explicit toolbar buttons `sftp.upload` and `sftp.download`. Standalone SFTP panes expose a `sftp.terminal` action that reopens the parent SSH terminal in the originating Pane; SFTP popups opened from an active SSH terminal omit that action because closing the popup returns to the parent terminal. Inline SFTP popups also omit the screenshot toolbar action, while standalone SFTP panes keep the screenshot target `sftp.screenshotTarget`.
 
 Tutorial targets: `sftp.upload`, `sftp.download`, `sftp.terminal`.
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2034,7 +2034,8 @@
     "fileTypeLabel": "{{ext}} file",
     "targetExistsDetail": "The target {{kind}} already exists. Choose whether to overwrite {{name}}.",
     "windowsDrives": "This PC",
-    "pathInputAria": "Enter {{pane}} path"
+    "pathInputAria": "Enter {{pane}} path",
+    "recentPathsAria": "Open recent {{pane}} paths"
   },
   "webview": {
     "goBack": "Go back",

--- a/src/modules/workspace/connections/sftp/SftpFilePane.tsx
+++ b/src/modules/workspace/connections/sftp/SftpFilePane.tsx
@@ -1,5 +1,5 @@
-import { ArrowDown, ChevronDown, FolderPlus, Pencil, RefreshCw, Trash2 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { ArrowDown, ChevronDown, FolderPlus, History, Pencil, RefreshCw, Trash2 } from "lucide-react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import type { DragEvent as ReactDragEvent, KeyboardEvent, MouseEvent as ReactMouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import i18next from "../../../../i18n/config";
@@ -22,6 +22,7 @@ export function FilePane({
   onDeleteSelected,
   onOpenFolder,
   onPathSubmit,
+  recentPaths = [],
   onSelectionChange,
   onContextMenuRequest,
   onDropTransfer,
@@ -41,6 +42,7 @@ export function FilePane({
   onDeleteSelected?: () => void;
   onOpenFolder?: (folderName: string) => void;
   onPathSubmit?: (path: string) => void | Promise<void>;
+  recentPaths?: string[];
   onSelectionChange?: (fileNames: string[]) => void;
   onContextMenuRequest?: (
     side: FilePaneSide,
@@ -51,12 +53,14 @@ export function FilePane({
   renameRequest?: { side: FilePaneSide; name: string; requestId: number };
 }) {
   const { t } = useTranslation();
+  const pathSuggestionsId = useId();
   const renameInputRef = useRef<HTMLInputElement | null>(null);
   const renameCanceledRef = useRef(false);
   const lastSelectedNameRef = useRef<string | null>(null);
   const [editingName, setEditingName] = useState<string | null>(null);
   const [renameDraft, setRenameDraft] = useState("");
   const [pathDraft, setPathDraft] = useState(path);
+  const [recentMenuOpen, setRecentMenuOpen] = useState(false);
   const [sortKey, setSortKey] = useState<FileSortKey>("name");
   const [isDropTarget, setIsDropTarget] = useState(false);
   const hasMutationActions = Boolean(onCreateFolder || onRenameSelected || onDeleteSelected);
@@ -66,6 +70,10 @@ export function FilePane({
   );
   const sortedFiles = useMemo(() => sortFileEntries(files, sortKey), [files, sortKey]);
   const nextSortKey: FileSortKey = sortKey === "name" ? "date" : "name";
+  const pathSuggestions = useMemo(
+    () => buildFolderPathSuggestions({ side, currentPath: path, draft: pathDraft, files }),
+    [files, path, pathDraft, side],
+  );
 
   useEffect(() => {
     setPathDraft(path);
@@ -180,6 +188,7 @@ export function FilePane({
       return;
     }
 
+    setRecentMenuOpen(false);
     await onPathSubmit?.(nextPath);
   }
 
@@ -231,33 +240,75 @@ export function FilePane({
   return (
     <article
       className="file-pane"
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setRecentMenuOpen(false);
+        }
+      }}
       data-tutorial-id={side === "local" ? "sftp.localPane" : "sftp.remotePane"}
     >
       <header>
-        <div>
+        <div className="file-pane-path-row">
           <strong>{title}</strong>
-          <input
-            aria-label={t("sftp.pathInputAria", { pane: title.toLowerCase() })}
-            className="file-pane-path-input"
-            disabled={!onPathSubmit || isLoading}
-            onBlur={() => setPathDraft(path)}
-            onChange={(event) => setPathDraft(event.currentTarget.value)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter") {
-                event.preventDefault();
-                const nextPath = event.currentTarget.value;
-                void commitPathDraft(nextPath);
-                event.currentTarget.blur();
-              }
-              if (event.key === "Escape") {
-                event.preventDefault();
-                setPathDraft(path);
-                event.currentTarget.blur();
-              }
-            }}
-            spellCheck={false}
-            value={pathDraft}
-          />
+          <div className="file-pane-path-control">
+            <input
+              aria-label={t("sftp.pathInputAria", { pane: title.toLowerCase() })}
+              className="file-pane-path-input"
+              disabled={!onPathSubmit || isLoading}
+              list={pathSuggestions.length > 0 ? pathSuggestionsId : undefined}
+              onBlur={() => setPathDraft(path)}
+              onChange={(event) => setPathDraft(event.currentTarget.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  const nextPath = event.currentTarget.value;
+                  void commitPathDraft(nextPath);
+                  event.currentTarget.blur();
+                }
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  setPathDraft(path);
+                  setRecentMenuOpen(false);
+                  event.currentTarget.blur();
+                }
+              }}
+              spellCheck={false}
+              value={pathDraft}
+            />
+            {pathSuggestions.length > 0 ? (
+              <datalist id={pathSuggestionsId}>
+                {pathSuggestions.map((suggestion) => (
+                  <option key={suggestion} value={suggestion} />
+                ))}
+              </datalist>
+            ) : null}
+            <button
+              aria-expanded={recentMenuOpen}
+              aria-label={t("sftp.recentPathsAria", { pane: title.toLowerCase() })}
+              className="icon-button file-pane-recent-button"
+              disabled={recentPaths.length === 0 || isLoading || !onPathSubmit}
+              onClick={() => setRecentMenuOpen((open) => !open)}
+              title={t("sftp.recentPathsAria", { pane: title.toLowerCase() })}
+              type="button"
+            >
+              <History size={14} />
+            </button>
+            {recentMenuOpen && recentPaths.length > 0 ? (
+              <div className="file-pane-recent-menu" role="menu">
+                {recentPaths.map((recentPath) => (
+                  <button
+                    key={recentPath}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => void commitPathDraft(recentPath)}
+                    role="menuitem"
+                    type="button"
+                  >
+                    {recentPath}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
         </div>
         <div className="file-pane-actions">
           <button
@@ -460,4 +511,49 @@ function sortFileEntries(files: FileEntry[], sortKey: FileSortKey) {
 
 function fileSortLabel(sortKey: FileSortKey) {
   return sortKey === "name" ? i18next.t("sftp.name") : i18next.t("sftp.date");
+}
+
+
+function buildFolderPathSuggestions({
+  side,
+  currentPath,
+  draft,
+  files,
+}: {
+  side: FilePaneSide;
+  currentPath: string;
+  draft: string;
+  files: FileEntry[];
+}) {
+  const folders = files.filter((file) => file.kind === "folder");
+  if (folders.length === 0 || (side === "local" && !/[\\/]/.test(currentPath))) {
+    return [];
+  }
+
+  const separator = pathSeparatorFor(side, currentPath || draft);
+  const splitPattern = side === "local" ? /[\\/]/ : /\//;
+  const parts = draft.split(splitPattern);
+  const typedName = parts[parts.length - 1] ?? "";
+  const typedParent = parts.length > 1 ? draft.slice(0, draft.length - typedName.length) : "";
+  const parentPath = typedParent || appendPathSeparator(currentPath, separator);
+  const normalizedTypedName = typedName.toLocaleLowerCase();
+
+  return folders
+    .filter((folder) => folder.name.toLocaleLowerCase().startsWith(normalizedTypedName))
+    .slice(0, 8)
+    .map((folder) => `${parentPath}${folder.name}${separator}`);
+}
+
+function pathSeparatorFor(side: FilePaneSide, path: string) {
+  return side === "local" && path.includes("\\") ? "\\" : "/";
+}
+
+function appendPathSeparator(path: string, separator: string) {
+  if (!path) {
+    return "";
+  }
+  if (path.endsWith("/") || path.endsWith("\\")) {
+    return path;
+  }
+  return `${path}${separator}`;
 }

--- a/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
+++ b/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
@@ -40,15 +40,19 @@ import type {
 
 const TRANSFER_HISTORY_STATES: TransferRecord["state"][] = ["canceled", "done", "failed"];
 const WINDOWS_DRIVES_PATH = "__KKTERM_WINDOWS_DRIVES__";
+const FILE_BROWSER_RECENT_PATHS_STORAGE_KEY = "kkterm.fileBrowserRecentPaths.v1";
+const RECENT_PATH_LIMIT = 5;
 
 export function SftpWorkspace({
   isActive,
   tab,
   commands: commandsProp,
+  inline = false,
 }: {
   isActive: boolean;
   tab: WorkspaceTab;
   commands?: FileBrowserCommands;
+  inline?: boolean;
 }) {
   const { t } = useTranslation();
   const openTerminalHere = useWorkspaceStore((state) => state.openTerminalHere);
@@ -62,6 +66,10 @@ export function SftpWorkspace({
   const [localFiles, setLocalFiles] = useState<FileEntry[]>([]);
   const [remotePath, setRemotePath] = useState(".");
   const [remoteFiles, setRemoteFiles] = useState<FileEntry[]>([]);
+  const [recentLocalPaths, setRecentLocalPaths] = useState<string[]>(() => readRecentPaths("local"));
+  const [recentRemotePaths, setRecentRemotePaths] = useState<string[]>(() =>
+    readRecentPaths("remote", connection?.id),
+  );
   const [status, setStatus] = useState(t("sftp.connecting"));
   const [localStatus, setLocalStatus] = useState("");
   const [isLocalLoading, setIsLocalLoading] = useState(false);
@@ -139,6 +147,20 @@ export function SftpWorkspace({
     };
   }, [commands]);
 
+  useEffect(() => {
+    setRecentRemotePaths(readRecentPaths("remote", connection?.id));
+  }, [connection?.id]);
+
+  const rememberLocalPath = (path: string) => {
+    const nextPaths = writeRecentPaths("local", path);
+    setRecentLocalPaths(nextPaths);
+  };
+
+  const rememberRemotePath = (path: string) => {
+    const nextPaths = writeRecentPaths("remote", path, connection?.id);
+    setRecentRemotePaths(nextPaths);
+  };
+
   const loadLocalDirectory = async (path?: string) => {
     if (!isTauriRuntime()) {
       setLocalStatus(t("sftp.tauriUnavailable"));
@@ -154,6 +176,7 @@ export function SftpWorkspace({
       });
       setLocalPath(result.path);
       setLocalFiles(result.entries.map(localEntryToFileEntry));
+      rememberLocalPath(result.path);
       setSelectedLocalNames([]);
       setLocalStatus("");
     } catch (error) {
@@ -213,6 +236,7 @@ export function SftpWorkspace({
         markConnectionSessionStarted(connection.id);
         setRemotePath(result.path);
         setRemoteFiles(result.entries.map(remoteEntryToFileEntry));
+        rememberRemotePath(result.path);
         setSelectedRemoteNames([]);
         setStatus(t("sftp.connected"));
       } catch (error) {
@@ -259,6 +283,7 @@ export function SftpWorkspace({
       const result = await commands.listDirectory({ sessionId, path });
       setRemotePath(result.path);
       setRemoteFiles(result.entries.map(remoteEntryToFileEntry));
+      rememberRemotePath(result.path);
       setSelectedRemoteNames([]);
       setStatus(t("sftp.connected"));
     } catch (error) {
@@ -934,21 +959,25 @@ export function SftpWorkspace({
             <Download size={15} />
             {t("sftp.download")}
           </button>
-          <button
-            className="toolbar-button"
-            data-tutorial-id="sftp.terminal"
-            disabled={!isConnected}
-            onClick={handleOpenTerminalHere}
-            type="button"
-          >
-            <Terminal size={15} />
-            {t("sftp.terminal")}
-          </button>
-          <ScreenshotMenu
-            dataTutorialId="workspace.screenshotMenu"
-            targetLabel={t("sftp.screenshotTarget", { title: tab.title })}
-            targetRef={workspaceRef}
-          />
+          {!inline && commands?.capabilities.openTerminalHere ? (
+            <button
+              className="toolbar-button"
+              data-tutorial-id="sftp.terminal"
+              disabled={!isConnected}
+              onClick={handleOpenTerminalHere}
+              type="button"
+            >
+              <Terminal size={15} />
+              {t("sftp.terminal")}
+            </button>
+          ) : null}
+          {!inline ? (
+            <ScreenshotMenu
+              dataTutorialId="workspace.screenshotMenu"
+              targetLabel={t("sftp.screenshotTarget", { title: tab.title })}
+              targetRef={workspaceRef}
+            />
+          ) : null}
         
         </div>
       </div>
@@ -966,6 +995,7 @@ export function SftpWorkspace({
           onGoUp={openLocalParent}
           onOpenFolder={openLocalFolder}
           onPathSubmit={(path) => void loadLocalDirectory(path)}
+          recentPaths={recentLocalPaths}
           onSelectionChange={setSelectedLocalNames}
           onContextMenuRequest={handleOpenContextMenu}
           onDropTransfer={
@@ -987,6 +1017,7 @@ export function SftpWorkspace({
           onDeleteSelected={isConnected && !isTransferring ? handleDeleteRemotePath : undefined}
           onOpenFolder={openRemoteFolder}
           onPathSubmit={(path) => void loadRemoteDirectory(path)}
+          recentPaths={recentRemotePaths}
           onSelectionChange={setSelectedRemoteNames}
           onContextMenuRequest={handleOpenContextMenu}
           onDropTransfer={isConnected && !isTransferring ? handleDropTransfer : undefined}
@@ -1083,6 +1114,80 @@ export function SftpWorkspace({
 function isWindowsDriveRoot(path: string) {
   return /^[A-Za-z]:[\\/]?$/.test(path.trim());
 }
+
+
+function readRecentPaths(side: FilePaneSide, connectionId?: string) {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const state = JSON.parse(
+      window.localStorage.getItem(FILE_BROWSER_RECENT_PATHS_STORAGE_KEY) || "{}",
+    ) as RecentFileBrowserPaths;
+    if (side === "local") {
+      return normalizeRecentPaths(state.local);
+    }
+
+    return normalizeRecentPaths(state.remote?.[remoteRecentPathKey(connectionId)]);
+  } catch {
+    return [];
+  }
+}
+
+function writeRecentPaths(side: FilePaneSide, path: string, connectionId?: string) {
+  const trimmedPath = path.trim();
+  if (!trimmedPath || trimmedPath === WINDOWS_DRIVES_PATH || typeof window === "undefined") {
+    return readRecentPaths(side, connectionId);
+  }
+
+  let state: RecentFileBrowserPaths = {};
+  try {
+    state = JSON.parse(
+      window.localStorage.getItem(FILE_BROWSER_RECENT_PATHS_STORAGE_KEY) || "{}",
+    ) as RecentFileBrowserPaths;
+  } catch {
+    state = {};
+  }
+
+  const currentPaths = side === "local"
+    ? normalizeRecentPaths(state.local)
+    : normalizeRecentPaths(state.remote?.[remoteRecentPathKey(connectionId)]);
+  const nextPaths = [
+    trimmedPath,
+    ...currentPaths.filter((entry) => entry !== trimmedPath),
+  ].slice(0, RECENT_PATH_LIMIT);
+
+  if (side === "local") {
+    state = { ...state, local: nextPaths };
+  } else {
+    state = {
+      ...state,
+      remote: {
+        ...(state.remote ?? {}),
+        [remoteRecentPathKey(connectionId)]: nextPaths,
+      },
+    };
+  }
+
+  window.localStorage.setItem(FILE_BROWSER_RECENT_PATHS_STORAGE_KEY, JSON.stringify(state));
+  return nextPaths;
+}
+
+function normalizeRecentPaths(paths: unknown) {
+  return Array.isArray(paths)
+    ? paths.filter((path): path is string => typeof path === "string" && path.length > 0).slice(0, RECENT_PATH_LIMIT)
+    : [];
+}
+
+function remoteRecentPathKey(connectionId?: string) {
+  return connectionId || "default";
+}
+
+type RecentFileBrowserPaths = {
+  local?: string[];
+  remote?: Record<string, string[]>;
+};
 
 function localEntryToFileEntry(entry: LocalDirectoryEntry): FileEntry {
   return {

--- a/src/modules/workspace/connections/sftp/sftp.css
+++ b/src/modules/workspace/connections/sftp/sftp.css
@@ -47,16 +47,33 @@
 }
 
 .file-pane header {
+  display: flex;
+  gap: 8px;
+  align-items: center;
   padding: 0 10px 0 12px;
   border-bottom: 1px solid var(--border);
 }
 
-.file-pane header > div:first-child {
-  display: grid;
-  gap: 3px;
+.file-pane-path-row {
+  display: flex;
+  flex: 1 1 auto;
+  gap: 8px;
+  align-items: center;
   min-width: 0;
 }
 
+.file-pane-path-row strong {
+  flex: 0 0 auto;
+}
+
+.file-pane-path-control {
+  position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  gap: 4px;
+  align-items: center;
+  min-width: 0;
+}
 
 .file-pane-path-input {
   width: 100%;
@@ -82,6 +99,44 @@
 
 .file-pane-path-input:disabled {
   opacity: 1;
+}
+
+.file-pane-recent-button {
+  flex: 0 0 auto;
+}
+
+.file-pane-recent-menu {
+  position: absolute;
+  top: calc(100% + 5px);
+  right: 0;
+  z-index: 40;
+  display: grid;
+  width: min(360px, 80vw);
+  max-width: 100%;
+  padding: 4px;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  box-shadow: var(--shadow);
+}
+
+.file-pane-recent-menu button {
+  min-width: 0;
+  padding: 6px 8px;
+  color: var(--text);
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-pane-recent-menu button:hover,
+.file-pane-recent-menu button:focus-visible {
+  background: var(--surface-muted);
+  outline: none;
 }
 
 .file-pane-actions {

--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -291,7 +291,7 @@ export function TerminalWorkspace({
               </button>
             </header>
             <div className="sftp-popup-dialog-body">
-              <SftpWorkspace isActive={true} tab={sftpDialogTab} />
+              <SftpWorkspace isActive={true} tab={sftpDialogTab} inline />
             </div>
           </section>
         </div>,


### PR DESCRIPTION
### Motivation
- For SFTP opened from an active SSH terminal the toolbar Terminal button is redundant and the screenshot action is of limited value, so inline popups should be lighter weight. 
- The SFTP Local/Remote path controls needed to be more compact and usable: path label and input should share one row and the path input should expand. 
- Typing paths should be faster with folder-name suggestions and easy access to recently used paths.

### Description
- Hide the Terminal and Screenshot toolbar actions when `SftpWorkspace` is rendered inline (popup from an SSH terminal) while preserving them for standalone SFTP/FTP tabs by adding an `inline` prop and gating toolbar rendering. 
- Rework the pane header so the pane label and the path input appear on the same row and the path input grows to fill available space, with CSS updates in `sftp.css`. 
- Add folder autocomplete for the path input (suggestions populated from the current listing and inserting a trailing separator), implemented with a small suggestion helper (`buildFolderPathSuggestions`) and a `datalist` usage in `SftpFilePane.tsx`. 
- Add per-pane recent-paths (local and remote) persisted in `localStorage` (key `kkterm.fileBrowserRecentPaths.v1`) with a cap of 5 entries, a recent-paths button and popup menu next to the path input, and wiring to remember paths after successful navigation. 
- Wire the new `recentPaths` prop through `SftpWorkspace` → `SftpFilePane`, update `TerminalWorkspace` to open the SFTP popup as inline by passing `inline`, and keep standalone FTP routing unchanged via `fileBrowserCommandsFor`. 
- Add a new English i18n key `sftp.recentPathsAria` and a `docs/localization_todo/` entry for translation tracking, and update `docs/manual/07-sftp.md` to document the UI changes. 

### Testing
- Ran the full frontend check suite with `npm run check` (this includes the repository JS tests); the suite completed and all tests passed. 
- Ran the TypeScript compiler check `npx tsc --noEmit` and it completed without errors. 
- Verified the SFTP toolbar/popup tests (including `tests/sftp-toolbar-popup.test.mjs`) as part of the check run and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21316b74ac832fa921cc6418e6d5e6)