### PR TITLE
Handle rejected SSH X11 forwarding status in SSH panes

### DIFF
--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -195,6 +195,8 @@ pub struct TerminalSessionStarted {
     session_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     terminal_ready_ms: Option<u128>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    x11_forwarding_status: Option<ssh::NativeSshX11ForwardingStatus>,
 }
 
 impl TerminalSessionStarted {
@@ -737,6 +739,7 @@ impl SessionManager {
             return Ok(TerminalSessionStarted {
                 session_id,
                 terminal_ready_ms: None,
+                x11_forwarding_status: None,
             });
         }
 
@@ -772,6 +775,7 @@ impl SessionManager {
             return Ok(TerminalSessionStarted {
                 session_id,
                 terminal_ready_ms: None,
+                x11_forwarding_status: None,
             });
         }
 
@@ -802,6 +806,7 @@ impl SessionManager {
             ) {
                 Ok(session) => {
                     let terminal_ready_ms = session.terminal_ready_ms();
+                    let x11_forwarding_status = session.x11_forwarding_status();
                     self.sessions
                         .lock()
                         .map_err(|_| "terminal session lock is poisoned".to_string())?
@@ -814,6 +819,7 @@ impl SessionManager {
                     return Ok(TerminalSessionStarted {
                         session_id,
                         terminal_ready_ms: Some(terminal_ready_ms),
+                        x11_forwarding_status,
                     });
                 }
                 Err(error) if should_fallback_to_interactive_ssh(&error) => {
@@ -871,6 +877,7 @@ impl SessionManager {
             return Ok(TerminalSessionStarted {
                 session_id,
                 terminal_ready_ms: None,
+                x11_forwarding_status: None,
             });
         }
 
@@ -931,6 +938,7 @@ impl SessionManager {
         Ok(TerminalSessionStarted {
             session_id,
             terminal_ready_ms: None,
+            x11_forwarding_status: None,
         })
     }
 

--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -44,11 +44,16 @@ pub struct NativeSshTerminal {
     control: mpsc::UnboundedSender<SshTerminalControl>,
     worker: Option<JoinHandle<()>>,
     terminal_ready_ms: u128,
+    x11_forwarding_status: Option<NativeSshX11ForwardingStatus>,
 }
 
 impl NativeSshTerminal {
     pub fn terminal_ready_ms(&self) -> u128 {
         self.terminal_ready_ms
+    }
+
+    pub fn x11_forwarding_status(&self) -> Option<NativeSshX11ForwardingStatus> {
+        self.x11_forwarding_status
     }
 }
 
@@ -75,6 +80,15 @@ pub struct NativeSshTerminalRequest {
 pub struct NativeSshX11Forwarding {
     pub display: u16,
 }
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum NativeSshX11ForwardingStatus {
+    Enabled,
+    Rejected,
+}
+
+type NativeSshReadyResult = (u128, Option<NativeSshX11ForwardingStatus>);
 
 #[derive(Clone)]
 pub(crate) struct NativeSshConnectionRequest {
@@ -310,10 +324,11 @@ pub fn start_native_terminal(
         .recv_timeout(Duration::from_secs(15))
         .map_err(|_| "timed out while starting native SSH session".to_string())?
     {
-        Ok(terminal_ready_ms) => Ok(NativeSshTerminal {
+        Ok((terminal_ready_ms, x11_forwarding_status)) => Ok(NativeSshTerminal {
             control: control_tx,
             worker: Some(worker),
             terminal_ready_ms,
+            x11_forwarding_status,
         }),
         Err(error) => {
             let _ = worker.join();
@@ -558,7 +573,7 @@ fn run_native_terminal_thread(
     app: AppHandle,
     request: NativeSshTerminalRequest,
     control_rx: mpsc::UnboundedReceiver<SshTerminalControl>,
-    ready_tx: std_mpsc::SyncSender<Result<u128, String>>,
+    ready_tx: std_mpsc::SyncSender<Result<NativeSshReadyResult, String>>,
 ) -> Result<(), String> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -577,7 +592,7 @@ async fn run_native_terminal(
     app: AppHandle,
     request: NativeSshTerminalRequest,
     mut control_rx: mpsc::UnboundedReceiver<SshTerminalControl>,
-    ready_tx: std_mpsc::SyncSender<Result<u128, String>>,
+    ready_tx: std_mpsc::SyncSender<Result<NativeSshReadyResult, String>>,
 ) -> Result<(), String> {
     let current_request = request;
     let mut ready_tx = Some(ready_tx);
@@ -624,7 +639,7 @@ async fn run_native_terminal_once(
     app: &AppHandle,
     request: &NativeSshTerminalRequest,
     control_rx: &mut mpsc::UnboundedReceiver<SshTerminalControl>,
-    ready_tx: Option<std_mpsc::SyncSender<Result<u128, String>>>,
+    ready_tx: Option<std_mpsc::SyncSender<Result<NativeSshReadyResult, String>>>,
     startup_timeout: Duration,
 ) -> Result<TerminalRunOutcome, String> {
     let startup = async {
@@ -655,12 +670,21 @@ async fn run_native_terminal_once(
             )
             .await
             .map_err(|error| format!("failed to allocate SSH PTY: {error}"))?;
-        if request.x11_forwarding.is_some() {
-            channel
+        let x11_forwarding_status = if request.x11_forwarding.is_some() {
+            let status = match channel
                 .request_x11(false, false, "MIT-MAGIC-COOKIE-1", x11_auth_cookie(), 0)
                 .await
-                .map_err(|error| format!("failed to request SSH X11 forwarding: {error}"))?;
-        }
+            {
+                Ok(()) => NativeSshX11ForwardingStatus::Enabled,
+                Err(error) => {
+                    eprintln!("SSH X11 forwarding request rejected: {error}");
+                    NativeSshX11ForwardingStatus::Rejected
+                }
+            };
+            Some(status)
+        } else {
+            None
+        };
         channel
             .request_shell(false)
             .await
@@ -672,15 +696,15 @@ async fn run_native_terminal_once(
                 .map_err(|error| format!("failed to initialize SSH shell: {error}"))?;
         }
 
-        Ok::<_, String>((session, channel, ready_start.elapsed().as_millis()))
+        Ok::<_, String>((session, channel, ready_start.elapsed().as_millis(), x11_forwarding_status))
     };
 
-    let (session, mut channel, terminal_ready_ms) = tokio::time::timeout(startup_timeout, startup)
+    let (session, mut channel, terminal_ready_ms, x11_forwarding_status) = tokio::time::timeout(startup_timeout, startup)
         .await
         .map_err(|_| "timed out while starting native SSH session".to_string())??;
 
     if let Some(ready_tx) = ready_tx {
-        let _ = ready_tx.send(Ok(terminal_ready_ms));
+        let _ = ready_tx.send(Ok((terminal_ready_ms, x11_forwarding_status)));
     }
 
     loop {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -123,6 +123,7 @@ export interface StartTerminalSessionRequest {
 export interface TerminalSessionStarted {
   sessionId: string;
   terminalReadyMs?: number;
+  x11ForwardingStatus?: "enabled" | "rejected";
 }
 
 export interface TerminalOutput {

--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -6,7 +6,7 @@ import { ScreenshotMenu } from "../../ScreenshotMenu";
 import { RemoteDesktopWorkspace } from "../remote-desktop/RemoteDesktopWorkspace";
 import { SftpWorkspace } from "../sftp/SftpWorkspace";
 import { WebViewWorkspace } from "../webview/WebViewWorkspace";
-import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Bot, Check, FileText, FolderOpen, Mouse, ChevronRight, Circle, ClipboardPaste, Columns2, Copy, Globe2, Menu, Network, PanelBottom, Pencil, RefreshCw, Save, Search, SplitSquareHorizontal, Square, Type, X } from "lucide-react";
+import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Bot, Check, FileText, Folder, FolderOpen, Mouse, ChevronRight, Circle, ClipboardPaste, Copy, Globe2, Menu, Network, PanelBottom, Pencil, RefreshCw, Save, Search, SplitSquareHorizontal, Square, Type, X } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
@@ -504,11 +504,13 @@ function TmuxSessionTag({
   onMouseModeChange,
   sessionId,
   tabId,
+  x11ForwardingStatus,
 }: {
   connection: Connection;
   onMouseModeChange: (enabled: boolean) => void;
   sessionId?: string;
   tabId: string;
+  x11ForwardingStatus: "disabled" | "enabled" | "rejected";
 }) {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -773,7 +775,12 @@ function TmuxSessionTag({
           title={t("terminal.showTmux")}
           type="button"
         >
-          tmux {sessionId}
+          <X
+            aria-hidden="true"
+            className={`tmux-x11-indicator ${x11ForwardingStatus}`}
+            size={12}
+          />
+          <span>tmux {sessionId}</span>
         </button>
       </div>
       {open ? (
@@ -1205,6 +1212,9 @@ function TerminalPaneView({
   const actionsMenuRef = useRef<HTMLDivElement | null>(null);
   const terminalSettings = useWorkspaceStore((state) => state.terminalSettings);
   const sshSettings = useWorkspaceStore((state) => state.sshSettings);
+  const x11ForwardingStatus = pane.x11ForwardingStatus ?? (
+    pane.connection?.type === "ssh" && sshSettings.managedXServerEnabled ? "enabled" : "disabled"
+  );
   const setAssistantContextSnippet = useWorkspaceStore(
     (state) => state.setAssistantContextSnippet,
   );
@@ -1225,6 +1235,7 @@ function TerminalPaneView({
   const updateOpenConnectionTerminalAppearance = useWorkspaceStore((state) => state.updateOpenConnectionTerminalAppearance);
   const updateOpenTerminalPaneAppearance = useWorkspaceStore((state) => state.updateOpenTerminalPaneAppearance);
   const updateOpenTerminalPaneBackground = useWorkspaceStore((state) => state.updateOpenTerminalPaneBackground);
+  const updateOpenTerminalPaneX11ForwardingStatus = useWorkspaceStore((state) => state.updateOpenTerminalPaneX11ForwardingStatus);
   const showStatusBarNotice = useWorkspaceStore((state) => state.showStatusBarNotice);
   const { t } = useTranslation();
   const terminalOpacity =
@@ -1623,6 +1634,13 @@ function TerminalPaneView({
           });
         }
         sessionIdRef.current = result.sessionId;
+        if (connection.type === "ssh") {
+          updateOpenTerminalPaneX11ForwardingStatus(
+            tabId,
+            pane.id,
+            result.x11ForwardingStatus ?? x11ForwardingStatus,
+          );
+        }
         sessionStarted = true;
         const startupInput = localStartupInputFor(connection);
         if (startupInput) {
@@ -2071,6 +2089,7 @@ function TerminalPaneView({
               onMouseModeChange={setTmuxMouseEnabled}
               sessionId={pane.tmuxSessionId}
               tabId={tabId}
+              x11ForwardingStatus={x11ForwardingStatus}
             />
           ) : null}
           {recordingInfo ? <span className="terminal-recording-status">{t("terminal.recording")}</span> : null}
@@ -2087,15 +2106,14 @@ function TerminalPaneView({
           </button>
           {isSshPane && showSftpButton ? (
             <button
-              className="terminal-pane-action terminal-pane-action-text"
+              className="terminal-pane-action"
               aria-label={t("terminal.openSftp")}
               data-tutorial-id="terminal.openSftp"
               onClick={handleOpenSftp}
-              title={t("terminal.openSftp")}
+              title={t("terminal.sftp")}
               type="button"
             >
-              <Columns2 size={13} />
-              <span>{t("terminal.sftp")}</span>
+              <Folder size={13} />
             </button>
           ) : null}
           <button

--- a/src/modules/workspace/connections/terminal/terminal.css
+++ b/src/modules/workspace/connections/terminal/terminal.css
@@ -300,6 +300,9 @@
 }
 
 .tmux-session-tag {
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
   max-width: 220px;
   height: 24px;
   padding: 0 8px;
@@ -313,6 +316,31 @@
   border: 1px solid rgba(86, 166, 255, 0.28);
   border-radius: 5px;
   cursor: pointer;
+}
+
+.tmux-session-tag span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tmux-x11-indicator {
+  flex: 0 0 auto;
+}
+
+.tmux-x11-indicator.disabled {
+  color: #7f8a98;
+  opacity: 0.45;
+}
+
+.tmux-x11-indicator.enabled {
+  color: #5ee787;
+  opacity: 0.62;
+}
+
+.tmux-x11-indicator.rejected {
+  color: #ff6b6b;
+  opacity: 0.72;
 }
 
 .tmux-session-edit-button {

--- a/src/store.ts
+++ b/src/store.ts
@@ -913,6 +913,11 @@ interface WorkspaceState {
   updateOpenConnectionTerminalAppearance: (connectionId: string, appearance: Pick<Connection, "terminalOpacity" | "terminalBackground">) => void;
   updateOpenTerminalPaneAppearance: (tabId: string, paneId: string, appearance: Pick<Connection, "terminalOpacity" | "terminalBackground">) => void;
   updateOpenTerminalPaneBackground: (tabId: string, paneId: string, terminalBackground: TerminalPane["terminalBackground"]) => void;
+  updateOpenTerminalPaneX11ForwardingStatus: (
+    tabId: string,
+    paneId: string,
+    status: TerminalPane["x11ForwardingStatus"],
+  ) => void;
   markConnectionSessionStarted: (connectionId: string) => void;
   markConnectionSessionEnded: (connectionId: string) => void;
   closeAllTabs: () => void;
@@ -2356,6 +2361,24 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
           }
         }
         return nextTab;
+      }),
+    }));
+  },
+  updateOpenTerminalPaneX11ForwardingStatus: (tabId, paneId, status) => {
+    set((state) => ({
+      tabs: state.tabs.map((tab) => {
+        if (tab.id !== tabId || tab.kind !== "terminal") {
+          return tab;
+        }
+        let changed = false;
+        const panes = tab.panes.map((pane) => {
+          if (!isTerminalPane(pane) || pane.id !== paneId || pane.x11ForwardingStatus === status) {
+            return pane;
+          }
+          changed = true;
+          return { ...pane, x11ForwardingStatus: status };
+        });
+        return changed ? { ...tab, panes } : tab;
       }),
     }));
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,6 +128,7 @@ export interface TerminalPane {
   connection?: Connection;
   terminalBackground?: DashboardBackground | null;
   tmuxSessionId?: string;
+  x11ForwardingStatus?: "disabled" | "enabled" | "rejected";
 }
 
 export interface UrlPane {

--- a/tests/sftp-toolbar-popup.test.mjs
+++ b/tests/sftp-toolbar-popup.test.mjs
@@ -40,6 +40,29 @@ test("SSH pane toolbar SFTP button opens an in-place popup instead of a workspac
   );
 });
 
+test("SSH pane toolbar SFTP action is icon-only with a native SFTP tooltip", async () => {
+  const terminalSource = await readFile(
+    new URL("../src/modules/workspace/connections/terminal/TerminalWorkspace.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    terminalSource,
+    /import \{[^}]*Folder[^}]*\} from "lucide-react";/,
+    "the SSH toolbar SFTP action should use the folder icon",
+  );
+  assert.match(
+    terminalSource,
+    /title=\{t\("terminal\.sftp"\)\}[\s\S]*?<Folder size=\{13\} \/>/,
+    "the native browser tooltip should read SFTP while the button body stays icon-only",
+  );
+  assert.doesNotMatch(
+    terminalSource,
+    /<Folder size=\{13\} \/>\s*<span>\{t\("terminal\.sftp"\)\}<\/span>/,
+    "the SSH toolbar should not render visible SFTP text beside the folder icon",
+  );
+});
+
 test("SFTP popup uses the selected app color scheme outside the app shell", async () => {
   const shellEffectsSource = await readFile(
     new URL("../src/app/appShellEffects.ts", import.meta.url),

--- a/tests/ssh-x11-forwarding.test.mjs
+++ b/tests/ssh-x11-forwarding.test.mjs
@@ -22,3 +22,89 @@ test("managed X server enables SSH X11 forwarding before shell startup", async (
   assert.match(sessionsSource, /NativeSshX11Forwarding/);
   assert.match(sessionsSource, /x11_forwarding:\s+managed_x_server_display\s+\.map/s);
 });
+
+test("remote X11 forwarding rejection keeps SSH shell open and reports rejected status", async () => {
+  const sshSource = await readFile(new URL("../src-tauri/src/ssh.rs", import.meta.url), "utf8");
+  const sessionsSource = await readFile(
+    new URL("../src-tauri/src/sessions.rs", import.meta.url),
+    "utf8",
+  );
+  const tauriSource = await readFile(new URL("../src/lib/tauri.ts", import.meta.url), "utf8");
+  const terminalSource = await readFile(
+    new URL("../src/modules/workspace/connections/terminal/TerminalWorkspace.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    sshSource,
+    /pub enum NativeSshX11ForwardingStatus \{\s*Enabled,\s*Rejected,\s*\}/s,
+    "native SSH startup should expose whether requested X11 forwarding was accepted or rejected",
+  );
+  assert.match(
+    sshSource,
+    /match channel\s+\.request_x11[\s\S]*?\.await\s*\{\s*Ok\(\(\)\) => NativeSshX11ForwardingStatus::Enabled,\s*Err\(error\) => \{/s,
+    "X11 request failure should be handled locally instead of aborting shell startup",
+  );
+  assert.match(
+    sshSource,
+    /eprintln!\("SSH X11 forwarding request rejected: \{error\}"\);\s*NativeSshX11ForwardingStatus::Rejected/s,
+    "X11 request rejection should be reported as rejected",
+  );
+  assert.match(
+    sessionsSource,
+    /let x11_forwarding_status = session\.x11_forwarding_status\(\);[\s\S]*?x11_forwarding_status,/s,
+    "session startup result should carry the native SSH X11 forwarding status",
+  );
+  assert.match(
+    tauriSource,
+    /x11ForwardingStatus\?: "enabled" \| "rejected";/,
+    "frontend command type should expose X11 forwarding status",
+  );
+  assert.match(
+    terminalSource,
+    /updateOpenTerminalPaneX11ForwardingStatus\(\s*tabId,\s*pane\.id,\s*result\.x11ForwardingStatus \?\? x11ForwardingStatus,\s*\)/s,
+    "frontend should store rejected X11 status from startup result for the Pane toolbar",
+  );
+});
+
+test("SSH tmux toolbar tag shows dim X11 forwarding state", async () => {
+  const terminalSource = await readFile(
+    new URL("../src/modules/workspace/connections/terminal/TerminalWorkspace.tsx", import.meta.url),
+    "utf8",
+  );
+  const terminalStyles = await readFile(
+    new URL("../src/modules/workspace/connections/terminal/terminal.css", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    terminalSource,
+    /const x11ForwardingStatus = pane\.x11ForwardingStatus \?\? \(\s*pane\.connection\?\.type === "ssh" && sshSettings\.managedXServerEnabled \? "enabled" : "disabled"\s*\);/s,
+    "the toolbar indicator should snapshot whether the SSH Session started with X11 forwarding enabled",
+  );
+  assert.match(
+    terminalSource,
+    /className=\{`tmux-x11-indicator \$\{x11ForwardingStatus\}`\}/,
+    "the tmux tag should render a conditional X11 indicator before its label",
+  );
+  assert.match(
+    terminalSource,
+    /<span>tmux \{sessionId\}<\/span>/,
+    "the X11 indicator should sit to the left of the tmux session label",
+  );
+  assert.match(
+    terminalStyles,
+    /\.tmux-x11-indicator\.disabled\s*\{[^}]*color:\s*#7f8a98;[^}]*opacity:\s*0\.45;/s,
+    "disabled X11 forwarding should render as dim grey",
+  );
+  assert.match(
+    terminalStyles,
+    /\.tmux-x11-indicator\.enabled\s*\{[^}]*color:\s*#5ee787;[^}]*opacity:\s*0\.62;/s,
+    "enabled X11 forwarding should render as a subtle dim green",
+  );
+  assert.match(
+    terminalStyles,
+    /\.tmux-x11-indicator\.rejected\s*\{[^}]*color:\s*#ff6b6b;[^}]*opacity:\s*0\.72;/s,
+    "rejected X11 forwarding should render as dim red",
+  );
+});


### PR DESCRIPTION
## Summary
- Keep SSH terminal startup alive when X11 forwarding is rejected by the remote host.
- Propagate the X11 forwarding result into terminal panes so the tmux toolbar indicator can render disabled, enabled, or rejected states.
- Keep the SSH toolbar SFTP action icon-only with a folder icon and native SFTP tooltip.

## Testing
- `node tests/ssh-x11-forwarding.test.mjs`
- `node tests/sftp-toolbar-popup.test.mjs`
- `cargo check --manifest-path src-tauri/Cargo.toml`