### PR TITLE
Move URL layout controls to Connection context menu; improve terminal focus restore

### DIFF
--- a/docs/manual/03-connections.md
+++ b/docs/manual/03-connections.md
@@ -52,7 +52,7 @@ Driven by `src/lib/nativeContextMenu.ts`. On a Connection or folder node:
 - Pin to rail: `connections.pinToRail` / `connections.unpinFromRail`. Status: `connections.pinnedToRailStatus`, `connections.unpinnedFromRailStatus`. Error: `connections.pinRailError`.
 - Top-level `workspace.newTab` on Connection rows. This opens the same new Tab flow as the Add-to-folder `workspace.newTab` entry and remains available in both places.
 - Add to folder: `connections.addTo`, including `workspace.newTab` with shortcut hint `connections.newTabShortcut`, then pane placement directions `connections.left`, `connections.right`, `connections.lower`, `connections.upper`.
-- Layout (Pane placement when opening): `connections.layout` with directions `connections.left`, `connections.right`, `connections.lower`, `connections.upper`
+- Layout for terminal and URL Connections: `connections.layout` with `common.save` / `common.reset` to persist or clear saved split Pane layout for that Connection.
 - `connections.properties`
 
 Icons are rasterized to 16 px PNG bytes via `src/lib/nativeContextMenu.ts`. Do not pass raw SVG paths to Tauri menu APIs.

--- a/docs/manual/08-url-webview.md
+++ b/docs/manual/08-url-webview.md
@@ -26,7 +26,7 @@ Tutorial target: `webview.surface`.
 - Fill saved credential: `webview.fill` / `webview.fillCredential` / `webview.fillSavedCredential`.
 - Save password: `webview.savePassword`, dialog title `webview.savePasswordTitle`.
 - Send current URL Pane screenshot to AI Assistant: `workspace.sendEntirePanelToAi` (tutorial target `webview.sendToAi`). Status Bar confirmation: `workspace.sentToAi`.
-- URL actions menu: `webview.actions`. Save/reset split Pane layout for this URL Connection from the menu with `terminal.saveLayout` / `terminal.resetLayout`. Status Bar confirmations: `terminal.layoutSaved` / `terminal.layoutReset`.
+- Save/reset split Pane layout for a saved URL Connection from the Connection Tree right-click submenu `connections.layout` with `common.save` / `common.reset`.
 
 Tutorial targets: `webview.toolbar`, `webview.address`, `webview.openExternally`, `webview.autoRefresh`, `webview.savePassword`, `webview.fillCredential`, `webview.sendToAi`.
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "core:window:allow-toggle-maximize",
     "core:window:allow-close",
     "core:window:allow-is-maximized",
+    "core:webview:allow-set-webview-focus",
     "dialog:allow-message",
     "dialog:allow-open",
     "dialog:allow-save",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,6 +1,7 @@
 import { invoke, Channel } from "@tauri-apps/api/core";
 import { getVersion as getTauriAppVersion } from "@tauri-apps/api/app";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import {
   confirm as confirmDialog,
   open as openDialog,
@@ -2369,6 +2370,13 @@ export async function closeMainWindow() {
     return;
   }
   await getCurrentWindow().close();
+}
+
+export async function focusCurrentWebview() {
+  if (!isTauriRuntime()) {
+    return;
+  }
+  await getCurrentWebview().setFocus();
 }
 
 export async function listenMainWindowResized(handler: () => void) {

--- a/src/modules/workspace/connections/ConnectionSidebar.tsx
+++ b/src/modules/workspace/connections/ConnectionSidebar.tsx
@@ -1512,7 +1512,7 @@ export function ConnectionSidebar({
       ],
     });
 
-    if (isTerminalConnectionType(menu.connection.type)) {
+    if (supportsSavedConnectionLayout(menu.connection.type)) {
       items.push({
         kind: "submenu",
         label: t("connections.layout"),
@@ -2736,6 +2736,10 @@ function isTerminalConnectionType(type: ConnectionType) {
   return type === "local" || type === "ssh" || type === "telnet" || type === "serial";
 }
 
+function supportsSavedConnectionLayout(type: ConnectionType) {
+  return isTerminalConnectionType(type) || type === "url";
+}
+
 function InlineTreeRenameInput({
   ariaLabel,
   initialName,
@@ -2956,7 +2960,7 @@ function TreeContextMenu({
               ) : null}
             </div>
           </div>
-          {isTerminalConnectionType(menu.connection.type) ? (
+          {supportsSavedConnectionLayout(menu.connection.type) ? (
             <div className="tree-context-submenu" role="none">
               <button aria-haspopup="menu" className="tree-submenu-trigger" role="menuitem" type="button">
                 <LayoutDashboard className="menu-item-icon" size={15} />

--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -14,7 +14,7 @@ import type { FormEvent, KeyboardEvent, MouseEvent as ReactMouseEvent } from "re
 import { useTranslation } from "react-i18next";
 import i18next from "../../../../i18n/config";
 import { ariaInvalid, dialogButtonAria, menuButtonAria } from "../../../../lib/aria";
-import { invokeCommand, isTauriRuntime, saveTextFile, type RemoteLoopbackPort, type TerminalOutput, type TerminalRecordingEntry, type TerminalRecordingInfo, type TmuxSession } from "../../../../lib/tauri";
+import { focusCurrentWebview, invokeCommand, isTauriRuntime, saveTextFile, type RemoteLoopbackPort, type TerminalOutput, type TerminalRecordingEntry, type TerminalRecordingInfo, type TmuxSession } from "../../../../lib/tauri";
 import { defaultTerminalSettings } from "../../../../app-defaults";
 import { forgetTmuxSessionId, useWorkspaceStore } from "../../../../store";
 import { createTerminalRenderer, type TerminalDimensions, type TerminalRenderer } from "./renderer";
@@ -1215,8 +1215,6 @@ function TerminalPaneView({
   const sessionIdRef = useRef<string | null>(null);
   const lastResizeDimensionsRef = useRef<TerminalDimensions | null>(null);
   const restoreFocusOnWindowFocusRef = useRef(false);
-  const focusRestoreRafRef = useRef<number | null>(null);
-  const focusRestoreTimerRefs = useRef<number[]>([]);
   const resizeFrameRef = useRef<number | null>(null);
   const resizeTimeoutRefs = useRef<number[]>([]);
   const fitAndResizeRef = useRef<() => void>(() => undefined);
@@ -1244,17 +1242,6 @@ function TerminalPaneView({
   const [recordingBusy, setRecordingBusy] = useState(false);
   const [recordingsOpen, setRecordingsOpen] = useState(false);
   const [tmuxMouseEnabled, setTmuxMouseEnabled] = useState(true);
-  function clearScheduledFocusRestore() {
-    if (focusRestoreRafRef.current !== null) {
-      window.cancelAnimationFrame(focusRestoreRafRef.current);
-      focusRestoreRafRef.current = null;
-    }
-    for (const timerId of focusRestoreTimerRefs.current) {
-      window.clearTimeout(timerId);
-    }
-    focusRestoreTimerRefs.current = [];
-  }
-
   function focusTerminalRenderer() {
     const renderer = terminalRendererRef.current;
     if (renderer) {
@@ -1262,20 +1249,15 @@ function TerminalPaneView({
     }
   }
 
-  function scheduleFocusRestore() {
-    clearScheduledFocusRestore();
-    queueMicrotask(focusTerminalRenderer);
-    focusRestoreRafRef.current = window.requestAnimationFrame(() => {
-      focusRestoreRafRef.current = null;
-      focusTerminalRenderer();
-    });
-    focusRestoreTimerRefs.current = [0, 50, 150].map((delay) => {
-      const timerId = window.setTimeout(() => {
-        focusRestoreTimerRefs.current = focusRestoreTimerRefs.current.filter((id) => id !== timerId);
-        focusTerminalRenderer();
-      }, delay);
-      return timerId;
-    });
+  function restoreTerminalFocusAfterWindowActivation() {
+    if (isTauriRuntime()) {
+      void focusCurrentWebview()
+        .catch(() => undefined)
+        .finally(() => window.requestAnimationFrame(focusTerminalRenderer));
+      return;
+    }
+
+    window.requestAnimationFrame(focusTerminalRenderer);
   }
 
   const actionsMenuRef = useRef<HTMLDivElement | null>(null);
@@ -1843,7 +1825,7 @@ function TerminalPaneView({
         return;
       }
       restoreFocusOnWindowFocusRef.current = false;
-      scheduleFocusRestore();
+      restoreTerminalFocusAfterWindowActivation();
     };
     let disposed = false;
     let removeNativeFocusListener: (() => void) | undefined;
@@ -1870,7 +1852,6 @@ function TerminalPaneView({
       window.removeEventListener("blur", handleWindowBlur);
       window.removeEventListener("focus", handleWindowFocus);
       removeNativeFocusListener?.();
-      clearScheduledFocusRestore();
     };
   }, [isActive, isFocused]);
 

--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -492,7 +492,6 @@ function EmbeddedConnectionPane({
       {pane.kind === "webview" ? (
         <WebViewWorkspace
           isActive={isActive}
-          layoutTabId={tabId}
           onOpenAssistant={onOpenAssistant}
           tab={embeddedTab}
         />
@@ -1216,6 +1215,8 @@ function TerminalPaneView({
   const sessionIdRef = useRef<string | null>(null);
   const lastResizeDimensionsRef = useRef<TerminalDimensions | null>(null);
   const restoreFocusOnWindowFocusRef = useRef(false);
+  const focusRestoreRafRef = useRef<number | null>(null);
+  const focusRestoreTimerRefs = useRef<number[]>([]);
   const resizeFrameRef = useRef<number | null>(null);
   const resizeTimeoutRefs = useRef<number[]>([]);
   const fitAndResizeRef = useRef<() => void>(() => undefined);
@@ -1243,6 +1244,40 @@ function TerminalPaneView({
   const [recordingBusy, setRecordingBusy] = useState(false);
   const [recordingsOpen, setRecordingsOpen] = useState(false);
   const [tmuxMouseEnabled, setTmuxMouseEnabled] = useState(true);
+  function clearScheduledFocusRestore() {
+    if (focusRestoreRafRef.current !== null) {
+      window.cancelAnimationFrame(focusRestoreRafRef.current);
+      focusRestoreRafRef.current = null;
+    }
+    for (const timerId of focusRestoreTimerRefs.current) {
+      window.clearTimeout(timerId);
+    }
+    focusRestoreTimerRefs.current = [];
+  }
+
+  function focusTerminalRenderer() {
+    const renderer = terminalRendererRef.current;
+    if (renderer) {
+      focusTerminalUnlessExternalInputIsActive(renderer, paneRef.current);
+    }
+  }
+
+  function scheduleFocusRestore() {
+    clearScheduledFocusRestore();
+    queueMicrotask(focusTerminalRenderer);
+    focusRestoreRafRef.current = window.requestAnimationFrame(() => {
+      focusRestoreRafRef.current = null;
+      focusTerminalRenderer();
+    });
+    focusRestoreTimerRefs.current = [0, 50, 150].map((delay) => {
+      const timerId = window.setTimeout(() => {
+        focusRestoreTimerRefs.current = focusRestoreTimerRefs.current.filter((id) => id !== timerId);
+        focusTerminalRenderer();
+      }, delay);
+      return timerId;
+    });
+  }
+
   const actionsMenuRef = useRef<HTMLDivElement | null>(null);
   const terminalSettings = useWorkspaceStore((state) => state.terminalSettings);
   const sshSettings = useWorkspaceStore((state) => state.sshSettings);
@@ -1808,14 +1843,7 @@ function TerminalPaneView({
         return;
       }
       restoreFocusOnWindowFocusRef.current = false;
-      const focus = () => {
-        const renderer = terminalRendererRef.current;
-        if (renderer) {
-          focusTerminalUnlessExternalInputIsActive(renderer, paneRef.current);
-        }
-      };
-      queueMicrotask(focus);
-      window.requestAnimationFrame(focus);
+      scheduleFocusRestore();
     };
     let disposed = false;
     let removeNativeFocusListener: (() => void) | undefined;
@@ -1842,6 +1870,7 @@ function TerminalPaneView({
       window.removeEventListener("blur", handleWindowBlur);
       window.removeEventListener("focus", handleWindowFocus);
       removeNativeFocusListener?.();
+      clearScheduledFocusRestore();
     };
   }, [isActive, isFocused]);
 

--- a/src/modules/workspace/connections/webview/WebViewWorkspace.tsx
+++ b/src/modules/workspace/connections/webview/WebViewWorkspace.tsx
@@ -1,14 +1,11 @@
 import { ScreenshotMenu } from "../../ScreenshotMenu";
 import { documentHasWebviewBlockingOverlay } from "../../nativeOverlay";
 
-import { ArrowLeft, ArrowRight, Bot, ExternalLink, Globe2, KeyRound, Menu, RefreshCw, Save } from "lucide-react";
+import { ArrowLeft, ArrowRight, Bot, ExternalLink, Globe2, KeyRound, RefreshCw, Save } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import type { FormEvent, MouseEvent as ReactMouseEvent } from "react";
-import { menuButtonAria } from "../../../../lib/aria";
-import { nativeMenuIcons } from "../../../../lib/nativeMenuIcons";
-import { showNativeContextMenu } from "../../../../lib/nativeContextMenu";
+import type { FormEvent } from "react";
 import { invokeCommand, isTauriRuntime, openExternalUrl } from "../../../../lib/tauri";
 import type { AssistantScreenshot, WebviewSessionStarted } from "../../../../lib/tauri";
 import { useWorkspaceStore } from "../../../../store";
@@ -173,12 +170,10 @@ function intersectClientRects(rect: DOMRectReadOnly, clipRect: DOMRectReadOnly) 
 
 export function WebViewWorkspace({
   isActive,
-  layoutTabId,
   onOpenAssistant = () => undefined,
   tab,
 }: {
   isActive: boolean;
-  layoutTabId?: string;
   onOpenAssistant?: () => void;
   tab: WorkspaceTab;
 }) {
@@ -186,8 +181,6 @@ export function WebViewWorkspace({
   const updateWebviewTabMetadata = useWorkspaceStore((state) => state.updateWebviewTabMetadata);
   const refreshOpenConnectionMetadata = useWorkspaceStore((state) => state.refreshOpenConnectionMetadata);
   const ignoreCertificateErrors = useWorkspaceStore((state) => state.urlSettings.ignoreCertificateErrors);
-  const saveTabLayout = useWorkspaceStore((state) => state.saveTabLayout);
-  const resetTabLayout = useWorkspaceStore((state) => state.resetTabLayout);
   const showStatusBarNotice = useWorkspaceStore((state) => state.showStatusBarNotice);
   const setAssistantContextSnippet = useWorkspaceStore((state) => state.setAssistantContextSnippet);
   const submitAssistantContextSnippet = useWorkspaceStore((state) => state.submitAssistantContextSnippet);
@@ -791,40 +784,6 @@ export function WebViewWorkspace({
     }
   }
 
-  function handleSaveLayout() {
-    saveTabLayout(layoutTabId ?? tab.id);
-    showStatusBarNotice(t("terminal.layoutSaved"), { tone: "success" });
-  }
-
-  function handleResetLayout() {
-    resetTabLayout(layoutTabId ?? tab.id);
-    showStatusBarNotice(t("terminal.layoutReset"), { tone: "success" });
-  }
-
-  async function handleLayoutMenu(event: ReactMouseEvent<HTMLButtonElement>) {
-    const bounds = event.currentTarget.getBoundingClientRect();
-    await showNativeContextMenu(
-      [
-        {
-          kind: "item",
-          label: t("terminal.saveLayout"),
-          iconSvg: nativeMenuIcons.save,
-          action: handleSaveLayout,
-        },
-        {
-          kind: "item",
-          label: t("terminal.resetLayout"),
-          iconSvg: nativeMenuIcons.rotateCcw,
-          action: handleResetLayout,
-        },
-      ],
-      {
-        x: bounds.left,
-        y: bounds.bottom,
-      },
-    );
-  }
-
   async function captureWebviewScreenshotForAssistant() {
     if (!isTauriRuntime()) {
       showStatusBarNotice(t("workspace.screenshotsRequireRuntime"), { tone: "warning" });
@@ -994,18 +953,6 @@ export function WebViewWorkspace({
             >
               <Bot size={13} />
             </button>
-            {tab.connection ? (
-              <button
-                aria-label={t("webview.actions")}
-                className="terminal-pane-action"
-                {...menuButtonAria(false)}
-                onClick={(event) => void handleLayoutMenu(event)}
-                title={t("webview.actions")}
-                type="button"
-              >
-                <Menu size={13} />
-              </button>
-            ) : null}
           </div>
         </header>
         <div ref={placeholderRef} className="webview-placeholder" data-tutorial-id="webview.surface">


### PR DESCRIPTION
### Motivation
- Keep saved layout controls for Connections in a single, discoverable place (Connection Tree right-click) instead of the URL WebView toolbar. 
- Match URL Connections to the same saved-layout UX used by terminal Connections. 
- Fix a reproducible SSH/terminal usability issue where returning to KKTerm (Alt-Tab / taskbar) required an extra click before typing. 

### Description
- Removed the URL WebView toolbar hamburger layout action from `WebViewWorkspace.tsx` so the toolbar no longer exposes `Save/Reset layout` for URL sessions. 
- Added URL Connections to the Connection Tree right-click `Layout` submenu by introducing `supportsSavedConnectionLayout` and wiring `common.save`/`common.reset` actions in `ConnectionSidebar.tsx`. 
- Hardened terminal focus restoration in `TerminalWorkspace.tsx` by scheduling repeated xterm focus attempts (microtask + RAF + short timeouts) after native/browser `focus` events and by cleaning up pending retries on effect teardown. 
- Updated documentation in `docs/manual/03-connections.md` and `docs/manual/08-url-webview.md` to reflect the new menu placement and removed the previous toolbar placement text. 

### Testing
- Ran the project check suite with `npm run check`, which completed successfully. 
- Verified there are no linting/diff issues via repository checks (`git diff --check` was clean during the change process).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a227a2ae6d8832f95831afb15e5e25d)