### PR TITLE
fix(terminal): restore OS focus to webview, stop focus-restore loop

### DIFF
--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -227,33 +227,33 @@ export function TerminalWorkspace({
     return defaultFontSize;
   }
 
-  function restoreFocusedTerminalPane() {
-    const renderer = focusedPaneId ? getPaneRenderer(focusedPaneId) : undefined;
-    if (!renderer || shouldPreserveTerminalWorkspaceFocus()) {
+  const lastFocusRestoreRef = useRef(0);
+  function restoreFocusedTerminalPane(reason: string) {
+    logTerminalFocusDiagnostic(`restore:${reason}`);
+    if (shouldPreserveTerminalWorkspaceFocus()) {
       return;
     }
-    logTerminalFocusDiagnostic("restore:before");
-    // On Windows/WebView2 the xterm textarea usually stays as
-    // document.activeElement while KKTerm is in the background, so a bare
-    // terminal.focus() short-circuits (the element is "already focused") and
-    // the native input chain is never re-established when we return. Re-assert
-    // focus at the OS webview level first, then force the textarea to actually
-    // re-acquire focus by blurring before focusing.
-    const reassert = () => {
-      if (shouldPreserveTerminalWorkspaceFocus()) {
-        return;
-      }
-      renderer.blur();
-      renderer.focus();
-      logTerminalFocusDiagnostic("restore:after");
-    };
+    // Re-entrancy guard: a single activation must not be able to spin. Native
+    // focus calls below can re-emit focus signals on some WebView2 builds.
+    const now = Date.now();
+    if (now - lastFocusRestoreRef.current < 300) {
+      return;
+    }
+    lastFocusRestoreRef.current = now;
+    // The diagnostic showed the xterm textarea keeps DOM focus across an OS
+    // window switch (document.activeElement never leaves it), so a JS
+    // terminal.focus() is a no-op. What is missing is OS-level keyboard focus
+    // on the WebView2 content, which only a native webview focus restores.
     if (isTauriRuntime()) {
       void focusCurrentWebview()
         .catch(() => undefined)
-        .finally(() => window.requestAnimationFrame(reassert));
-      return;
+        .finally(() => logTerminalFocusDiagnostic(`restored:${reason}`));
     }
-    reassert();
+    // Cover the case where DOM focus did leave the terminal (e.g. a title-bar
+    // drag parked it on <body>): re-focus the pane's textarea. This is a no-op
+    // when it already holds focus, so it cannot re-enter the native path.
+    const renderer = focusedPaneId ? getPaneRenderer(focusedPaneId) : undefined;
+    renderer?.focus();
   }
 
   useEffect(() => {
@@ -261,26 +261,26 @@ export function TerminalWorkspace({
       return;
     }
 
-    const scheduleRestore = () => {
-      window.setTimeout(restoreFocusedTerminalPane, 80);
-      window.setTimeout(restoreFocusedTerminalPane, 180);
-    };
+    // Restore terminal input focus when the OS hands the window back to us, or
+    // after a title-bar drag. We deliberately do NOT listen to the DOM window
+    // "focus" event: focusing the webview natively re-fires it, which would
+    // spin the restore into a feedback loop.
     const handleTitlebarPointerUp = (event: PointerEvent) => {
       const target = event.target instanceof HTMLElement ? event.target : null;
       if (!target?.closest(".app-titlebar") || target.closest("button")) {
         return;
       }
-      scheduleRestore();
+      restoreFocusedTerminalPane("titlebar");
     };
+    const handleWindowFocus = () => restoreFocusedTerminalPane("window-focus");
     let disposed = false;
     let removeNativeFocusListener: (() => void) | undefined;
 
-    window.addEventListener("focus", scheduleRestore);
     document.addEventListener("pointerup", handleTitlebarPointerUp, true);
     if (isTauriRuntime()) {
       void listenMainWindowFocusChanged((focused) => {
         if (focused) {
-          scheduleRestore();
+          restoreFocusedTerminalPane("window-activated");
         }
       }).then((unlisten) => {
         if (disposed) {
@@ -289,12 +289,14 @@ export function TerminalWorkspace({
           removeNativeFocusListener = unlisten;
         }
       });
+    } else {
+      window.addEventListener("focus", handleWindowFocus);
     }
 
     return () => {
       disposed = true;
-      window.removeEventListener("focus", scheduleRestore);
       document.removeEventListener("pointerup", handleTitlebarPointerUp, true);
+      window.removeEventListener("focus", handleWindowFocus);
       removeNativeFocusListener?.();
     };
   }, [focusedPaneId, isActive]);
@@ -1510,6 +1512,14 @@ function TerminalPaneView({
     terminal.open(element);
     terminal.fit();
     focusTerminalUnlessExternalInputIsActive(terminal, paneRef.current);
+    // A freshly opened terminal holds DOM focus on its textarea but the
+    // WebView2 content does not yet own OS keyboard focus (especially right
+    // after a connection dialog closes), so the first keystroke is otherwise
+    // dropped until the user clicks. Route native focus into the webview once
+    // when this pane is the active, focused one.
+    if (isActive && isFocused && isTauriRuntime()) {
+      void focusCurrentWebview().catch(() => undefined);
+    }
     terminal.attachCustomKeyEventHandler((event) => {
       // xterm.js emits a bare CR for Shift+Enter, indistinguishable from a
       // plain Enter, so Node.js TUIs running inside local PowerShell/cmd/WSL


### PR DESCRIPTION
Follow-up to #264. The `ui.debug.log` trace added there revealed that the previous focus-restore approach was both aiming at the wrong layer and spinning in a feedback loop.

## What the trace proved
- `document.activeElement` is **always** the xterm textarea — the DOM focus is never lost, so every `terminal.focus()`/`blur()` call was a no-op chasing the wrong thing.
- `document.hasFocus()` (OS-level keyboard focus on the WebView2 content) is the value that's actually wrong, and it only recovers on a physical click → this is a native WebView2 focus-routing issue, not a DOM one.
- The restore fired **hundreds of times per activation**: re-focusing the webview re-fires the DOM `window` `focus` event, which the `window.addEventListener("focus", …)` listener turned back into another restore. The `hasFocus` true/false thrashing in the log is that fight.

## Changes
- **Break the loop**: drop the DOM `window` `focus` listener and the `blur()/focus()` dance. Restore now triggers only from the native window-activated event and title-bar drag, with a 300ms re-entrancy guard.
- **Fix the right layer**: route native OS focus into the webview (`focusCurrentWebview`); the textarea `.focus()` remains only as a no-op fallback for the title-bar-drag case where DOM focus genuinely moved to `<body>`.
- **Connect-needs-a-click**: focus the webview natively when a terminal session starts on the active/focused pane, so the first keystroke lands without an extra click after connecting.

## Verification
- `tsc --noEmit` passes.
- The Tauri app can't be built in the CI Linux container (missing GTK), so this needs a Windows build to confirm. Watch `ui.debug.log`: `restored:window-activated` with `hasFocus:true` and working input = fixed. If `hasFocus` stays `false`, the webview-level `MoveFocus` is insufficient and the next step is to escalate the focus call into the native `WindowEvent::Focused(true)` handler in `lib.rs`.

https://claude.ai/code/session_01Kww2P9kNeBAD4jCSmARe9F

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kww2P9kNeBAD4jCSmARe9F)_