### PR TITLE
fix(terminal): restore keyboard focus via window-level set_focus

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -166,6 +166,20 @@ fn ui_debug_log(event: String, payload: serde_json::Value) {
     logging::ui_debug(&event, &payload);
 }
 
+// Restore native keyboard focus to the main window after the OS hands it back.
+// Diagnostics proved the WebView2 content keeps DOM focus (document.hasFocus()
+// is true, the xterm textarea is active) yet keyboard input is dropped until a
+// physical click — i.e. the Win32 keyboard focus is not on the webview content
+// HWND. The JS webview MoveFocus (getCurrentWebview().setFocus) runs but does
+// not fix it; the window-level set_focus used by the tray-restore path does
+// route keyboard focus into the content, so reuse it here.
+#[tauri::command]
+fn focus_main_window(app: tauri::AppHandle) {
+    if let Some(window) = app.get_webview_window(window_state::MAIN_WINDOW_LABEL) {
+        let _ = window.set_focus();
+    }
+}
+
 #[tauri::command]
 fn get_custom_fonts_folder() -> Result<String, String> {
     let folder = custom_fonts_folder()?;
@@ -2856,6 +2870,7 @@ pub fn run() {
             app_updates::download_and_install_app_update,
             debug_frontend_heartbeat,
             ui_debug_log,
+            focus_main_window,
             show_native_tooltip,
             hide_native_tooltip,
             list_connection_tree,

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -803,6 +803,10 @@ type CommandMap = {
     args: { event: string; payload: Record<string, unknown> };
     result: void;
   };
+  focus_main_window: {
+    args: undefined;
+    result: void;
+  };
   show_native_tooltip: {
     args: {
       request: {
@@ -2392,6 +2396,17 @@ export async function focusCurrentWebview() {
     return;
   }
   await getCurrentWebview().setFocus();
+}
+
+// Window-level native focus. Unlike focusCurrentWebview (WebView2 MoveFocus),
+// this routes Win32 keyboard focus back onto the webview content HWND, which is
+// what a physical click does and what the WebView2 MoveFocus call fails to do
+// after the OS reactivates the window.
+export async function focusMainWindow() {
+  if (!isTauriRuntime()) {
+    return;
+  }
+  await invokeCommand("focus_main_window");
 }
 
 export async function listenMainWindowResized(handler: () => void) {

--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -14,7 +14,7 @@ import type { FormEvent, KeyboardEvent, MouseEvent as ReactMouseEvent, PointerEv
 import { useTranslation } from "react-i18next";
 import i18next from "../../../../i18n/config";
 import { ariaInvalid, dialogButtonAria, menuButtonAria } from "../../../../lib/aria";
-import { focusCurrentWebview, invokeCommand, isTauriRuntime, listenMainWindowFocusChanged, logUiDebug, saveTextFile, type RemoteLoopbackPort, type TerminalOutput, type TerminalRecordingEntry, type TerminalRecordingInfo, type TmuxSession } from "../../../../lib/tauri";
+import { focusCurrentWebview, focusMainWindow, invokeCommand, isTauriRuntime, listenMainWindowFocusChanged, logUiDebug, saveTextFile, type RemoteLoopbackPort, type TerminalOutput, type TerminalRecordingEntry, type TerminalRecordingInfo, type TmuxSession } from "../../../../lib/tauri";
 import { defaultTerminalSettings } from "../../../../app-defaults";
 import { forgetTmuxSessionId, useWorkspaceStore } from "../../../../store";
 import { createTerminalRenderer, type TerminalDimensions, type TerminalRenderer } from "./renderer";
@@ -248,12 +248,16 @@ export function TerminalWorkspace({
     // (the WebView2 input routing was dead until the click), which the
     // hasFocus/activeElement signals cannot distinguish.
     inputProbeArmedRef.current = true;
-    // The diagnostic showed the xterm textarea keeps DOM focus across an OS
-    // window switch (document.activeElement never leaves it), so a JS
-    // terminal.focus() is a no-op. What is missing is OS-level keyboard focus
-    // on the WebView2 content, which only a native webview focus restores.
+    // The diagnostic proved the xterm textarea keeps DOM focus across an OS
+    // window switch (document.activeElement and document.hasFocus stay true),
+    // yet keyboard input is dropped until a physical click — the Win32 keyboard
+    // focus is off the webview content HWND. A JS terminal.focus() and the
+    // WebView2 MoveFocus (focusCurrentWebview) both run without fixing it, so
+    // re-assert focus at the window level (what a click does) and then route it
+    // into the content.
     if (isTauriRuntime()) {
-      void focusCurrentWebview()
+      void focusMainWindow()
+        .then(() => focusCurrentWebview())
         .catch(() => undefined)
         .finally(() => logTerminalFocusDiagnostic(`restored:${reason}`));
     }
@@ -1554,7 +1558,9 @@ function TerminalPaneView({
     // dropped until the user clicks. Route native focus into the webview once
     // when this pane is the active, focused one.
     if (isActive && isFocused && isTauriRuntime()) {
-      void focusCurrentWebview().catch(() => undefined);
+      void focusMainWindow()
+        .then(() => focusCurrentWebview())
+        .catch(() => undefined);
     }
     terminal.attachCustomKeyEventHandler((event) => {
       // xterm.js emits a bare CR for Shift+Enter, indistinguishable from a


### PR DESCRIPTION
## The confirmed diagnosis

The probe (PR #266) gave us the decisive signal. After the OS reactivates the window:
- **Mouse works**: `pointerdown` fires on in-webview elements (you clicked the title-bar Close button).
- **Keyboard is dead**: no `keydown` ever fires — you typed and nothing happened.
- Yet `document.hasFocus()` is `true` and `activeElement` is the xterm textarea.

That split — pointer in, keyboard out, despite the document reporting focused — is the textbook Windows symptom of **the Win32 keyboard focus not being on the WebView2 content HWND**. It explains why every JS attempt failed: `terminal.focus()` is a no-op (textarea already active) and the WebView2 `MoveFocus` (`getCurrentWebview().setFocus()`) runs but doesn't move the OS keyboard focus.

## The fix

Use the **window-level** `set_focus()` — the same call the tray-restore path (`app_tray.rs`) already uses to bring the window back with working keyboard focus — instead of the webview-level `MoveFocus` that doesn't stick.

- New `focus_main_window` command → `get_webview_window(MAIN).set_focus()`.
- `focusMainWindow()` wrapper, called (then the webview MoveFocus, sequenced) from:
  - the terminal focus-restore on window activation, and
  - terminal session start (fixes the "click required after connecting" case).
- Scoped to when a terminal pane is the active, focused surface, so URL-pane child WebView2s are untouched.

The probe stays in, so the same `ui.debug.log` line confirms the result: after Alt-Tab, type without clicking → `input-after-activation:keydown:…` means it's fixed.

## Verification
`tsc --noEmit` passes. The Rust mirrors the existing, proven tray-restore `set_focus()` call. The Tauri app can't be built in the CI Linux container (missing GTK), so this needs a Windows build to confirm — please re-run the type-without-clicking test once built.

If keyboard is *still* dead after this, the only remaining lever is raw Win32 `SetFocus` on the WebView2 child HWND, which I'll wire next.

https://claude.ai/code/session_01Kww2P9kNeBAD4jCSmARe9F

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kww2P9kNeBAD4jCSmARe9F)_