### PR TITLE
fix(terminal): don't let a reactivation-focused button block focus restore

### DIFF
--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -2983,9 +2983,14 @@ function shouldPreserveTerminalWorkspaceFocus() {
     return false;
   }
 
+  // Only yield to surfaces the user is genuinely working in: the assistant
+  // panel or an editable input (e.g. a dialog field). After an OS window
+  // switch, document.activeElement reflects Chromium's automatic focus
+  // restoration, not a user action — a non-terminal *button* (e.g. the
+  // connection tree's open button) landing focus is never intent, so it must
+  // not block restoring focus to the terminal the user was using.
   return activeElement.closest(".assistant-panel") !== null ||
-    isEditableElement(activeElement) ||
-    isFocusableElement(activeElement);
+    isEditableElement(activeElement);
 }
 
 function isEditableElement(element: HTMLElement) {


### PR DESCRIPTION
## New, clearer signal

Your repro (type in terminal → Alt-Tab away → Alt-Tab back → terminal won't take keys until clicked) plus this log exposed a **logic bug in my own guard**, distinct from the native-focus question:

```
restore:window-activated  activeElement=button.connection-open  hasFocus=true
```

On reactivation, `document.activeElement` was **`button.connection-open`** (the connection tree), and the restore **bailed early** — there's no matching `restored:` line.

## Root cause

`shouldPreserveTerminalWorkspaceFocus()` treated *any* focusable element outside the terminal (including a plain button) as "the user intentionally focused this — don't steal it." But after an OS window switch, `document.activeElement` reflects **Chromium's automatic focus restoration, not a user action** — you were in another app and clicked nothing in KKTerm. A non-terminal button landing focus is never intent, yet the guard honored it and skipped the restore. Earlier runs happened to land `activeElement` on the textarea and slipped past; this run landed on a button and got blocked.

## Fix

Preserve focus only for surfaces the user is genuinely working in — the **assistant panel** or an **editable input** (e.g. a dialog field) — and stop yielding to arbitrary buttons. The restore then moves DOM focus back to the terminal textarea (a real focus move off the button) and re-asserts native window focus (#267).

One-line change in the guard; `tsc --noEmit` passes. Builds on #267 (now in `main`).

## To verify
Repeat your exact repro, then check `ui.debug.log`: you should now see `restored:window-activated`, and — without clicking — `input-after-activation:keydown:…` when you type. If you instead still see no keydown (input dead despite `restored:`), then the button-guard wasn't the last blocker and the native keyboard-focus path needs the raw Win32 `SetFocus` escalation, which I'll wire next.

(Can't build Tauri in this Linux container — verified by typecheck; needs your Windows build.)

https://claude.ai/code/session_01Kww2P9kNeBAD4jCSmARe9F

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kww2P9kNeBAD4jCSmARe9F)_