### PR TITLE
fix: correct SetFocus import path for Win32 WebView2 focus restore

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -191,7 +191,8 @@ fn focus_main_window(app: tauri::AppHandle) {
 #[cfg(target_os = "windows")]
 fn focus_webview_content_hwnd(window: &tauri::WebviewWindow) {
     use windows::Win32::Foundation::HWND;
-    use windows::Win32::UI::WindowsAndMessaging::{GW_CHILD, GetWindow, SetFocus};
+    use windows::Win32::UI::Input::KeyboardAndMouse::SetFocus;
+    use windows::Win32::UI::WindowsAndMessaging::{GW_CHILD, GetWindow};
 
     let root = match window.hwnd() {
         Ok(handle) => HWND(handle.0 as *mut _),


### PR DESCRIPTION
## Summary

- Fixes compile error introduced in the previous PR: `SetFocus` was incorrectly imported from `Win32::UI::WindowsAndMessaging` — it lives in `Win32::UI::Input::KeyboardAndMouse` in the `windows` 0.62 crate
- Calls Win32 `SetFocus` on the deepest WebView2 child HWND (`Chrome_RenderWidgetHostHWND`) synchronously within the same `focus_main_window` Tauri command, so keyboard input is restored to the terminal after Alt-Tab without an IPC round-trip gap

## Test plan

- [ ] Build succeeds on Windows (no `E0432` compile error)
- [ ] Alt-Tab away from KKTerm and back — terminal pane accepts keyboard input immediately without clicking

https://claude.ai/code/session_01Kww2P9kNeBAD4jCSmARe9F

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kww2P9kNeBAD4jCSmARe9F)_