### PR TITLE
Revert Win32 WebView2 focus-restore (#269 + #270)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -191,8 +191,7 @@ fn focus_main_window(app: tauri::AppHandle) {
 #[cfg(target_os = "windows")]
 fn focus_webview_content_hwnd(window: &tauri::WebviewWindow) {
     use windows::Win32::Foundation::HWND;
-    use windows::Win32::UI::Input::KeyboardAndMouse::SetFocus;
-    use windows::Win32::UI::WindowsAndMessaging::{GW_CHILD, GetWindow};
+    use windows::Win32::UI::WindowsAndMessaging::{GW_CHILD, GetWindow, SetFocus};
 
     let root = match window.hwnd() {
         Ok(handle) => HWND(handle.0 as *mut _),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -167,54 +167,16 @@ fn ui_debug_log(event: String, payload: serde_json::Value) {
 }
 
 // Restore native keyboard focus to the main window after the OS hands it back.
-// Diagnostics confirmed: document.hasFocus() is true and the xterm textarea is
-// document.activeElement, yet WM_KEYDOWN never arrives until the user clicks.
-// The Win32 keyboard-focus HWND is not the WebView2 content child window.
-// window.set_focus() (SetForegroundWindow on the frame) is necessary but not
-// sufficient — it wakes the outer window but leaves the content HWND without
-// keyboard focus. Walking to the deepest child HWND and calling SetFocus there
-// replicates what a physical click does and routes WM_KEYDOWN to the renderer.
+// Diagnostics proved the WebView2 content keeps DOM focus (document.hasFocus()
+// is true, the xterm textarea is active) yet keyboard input is dropped until a
+// physical click — i.e. the Win32 keyboard focus is not on the webview content
+// HWND. The JS webview MoveFocus (getCurrentWebview().setFocus) runs but does
+// not fix it; the window-level set_focus used by the tray-restore path does
+// route keyboard focus into the content, so reuse it here.
 #[tauri::command]
 fn focus_main_window(app: tauri::AppHandle) {
     if let Some(window) = app.get_webview_window(window_state::MAIN_WINDOW_LABEL) {
         let _ = window.set_focus();
-        #[cfg(target_os = "windows")]
-        focus_webview_content_hwnd(&window);
-    }
-}
-
-// Walk the Win32 child-window chain from the main frame HWND down to the
-// deepest descendant — Chrome_RenderWidgetHostHWND in a typical WebView2
-// hierarchy — and call SetFocus on it. This is synchronous and happens within
-// the same Tauri command invocation as set_focus(), so there is no IPC
-// round-trip gap that could let focus drift before the WebView2 step runs.
-#[cfg(target_os = "windows")]
-fn focus_webview_content_hwnd(window: &tauri::WebviewWindow) {
-    use windows::Win32::Foundation::HWND;
-    use windows::Win32::UI::WindowsAndMessaging::{GW_CHILD, GetWindow, SetFocus};
-
-    let root = match window.hwnd() {
-        Ok(handle) => HWND(handle.0 as *mut _),
-        Err(_) => return,
-    };
-    unsafe {
-        let mut hwnd = root;
-        let mut depth = 0u32;
-        loop {
-            match GetWindow(hwnd, GW_CHILD) {
-                Ok(child) => {
-                    hwnd = child;
-                    depth += 1;
-                }
-                Err(_) => break,
-            }
-            if depth >= 8 {
-                break;
-            }
-        }
-        if depth > 0 {
-            let _ = SetFocus(Some(hwnd));
-        }
     }
 }
 

--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -14,7 +14,7 @@ import type { FormEvent, KeyboardEvent, MouseEvent as ReactMouseEvent, PointerEv
 import { useTranslation } from "react-i18next";
 import i18next from "../../../../i18n/config";
 import { ariaInvalid, dialogButtonAria, menuButtonAria } from "../../../../lib/aria";
-import { focusMainWindow, invokeCommand, isTauriRuntime, listenMainWindowFocusChanged, logUiDebug, saveTextFile, type RemoteLoopbackPort, type TerminalOutput, type TerminalRecordingEntry, type TerminalRecordingInfo, type TmuxSession } from "../../../../lib/tauri";
+import { focusCurrentWebview, focusMainWindow, invokeCommand, isTauriRuntime, listenMainWindowFocusChanged, logUiDebug, saveTextFile, type RemoteLoopbackPort, type TerminalOutput, type TerminalRecordingEntry, type TerminalRecordingInfo, type TmuxSession } from "../../../../lib/tauri";
 import { defaultTerminalSettings } from "../../../../app-defaults";
 import { forgetTmuxSessionId, useWorkspaceStore } from "../../../../store";
 import { createTerminalRenderer, type TerminalDimensions, type TerminalRenderer } from "./renderer";
@@ -248,14 +248,16 @@ export function TerminalWorkspace({
     // (the WebView2 input routing was dead until the click), which the
     // hasFocus/activeElement signals cannot distinguish.
     inputProbeArmedRef.current = true;
-    // The diagnostic confirmed the xterm textarea keeps DOM focus across an OS
+    // The diagnostic proved the xterm textarea keeps DOM focus across an OS
     // window switch (document.activeElement and document.hasFocus stay true),
-    // yet WM_KEYDOWN never arrives — the Win32 keyboard-focus HWND is not the
-    // WebView2 content child. focusMainWindow now synchronously calls SetFocus
-    // on the deepest child HWND (Chrome_RenderWidgetHostHWND) after the frame
-    // set_focus(), routing keyboard input without an extra IPC round-trip.
+    // yet keyboard input is dropped until a physical click — the Win32 keyboard
+    // focus is off the webview content HWND. A JS terminal.focus() and the
+    // WebView2 MoveFocus (focusCurrentWebview) both run without fixing it, so
+    // re-assert focus at the window level (what a click does) and then route it
+    // into the content.
     if (isTauriRuntime()) {
       void focusMainWindow()
+        .then(() => focusCurrentWebview())
         .catch(() => undefined)
         .finally(() => logTerminalFocusDiagnostic(`restored:${reason}`));
     }
@@ -1563,10 +1565,12 @@ function TerminalPaneView({
     // A freshly opened terminal holds DOM focus on its textarea but the
     // WebView2 content does not yet own OS keyboard focus (especially right
     // after a connection dialog closes), so the first keystroke is otherwise
-    // dropped until the user clicks. focusMainWindow now handles both the
-    // frame-level set_focus and the content HWND SetFocus in one native call.
+    // dropped until the user clicks. Route native focus into the webview once
+    // when this pane is the active, focused one.
     if (isActive && isFocused && isTauriRuntime()) {
-      void focusMainWindow().catch(() => undefined);
+      void focusMainWindow()
+        .then(() => focusCurrentWebview())
+        .catch(() => undefined);
     }
     terminal.attachCustomKeyEventHandler((event) => {
       // xterm.js emits a bare CR for Shift+Enter, indistinguishable from a


### PR DESCRIPTION
@
## Summary

Reverts the Win32 `SetFocus` focus-restoration change because it made Alt-Tab focus behavior worse.

This undoes both:
- **#270** — the `SetFocus` import-path fix (compile fix)
- **#269** — the actual behavioral change: native walk of the WebView2 child-window chain calling Win32 `SetFocus`, plus removal of the JS `focusCurrentWebview()` call

After this revert:
- `focus_main_window` is back to just `window.set_focus()`
- `TerminalWorkspace.tsx` again calls `focusCurrentWebview()` on the window-activation and session-start paths
- No dangling Win32 imports; tree compiles as before #269

## Why

Reverting #270 alone would reintroduce the `E0432` compile error and keep the regressed behavior, so both PRs are reverted together as one unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@