### PR TITLE
Add GitHub downloads badge to README files

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -4,6 +4,8 @@
 
 <h1 align="center">KKTerm</h1>
 
+![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
+
 <p align="center">
   <strong>Der native Windows-Admin-Workspace, den das KI-Tools-Zeitalter zu bauen vergessen hat — Terminals, SSH, SFTP, RDP/VNC, Dashboards und eine KI, die deine eigenen Tool-Widgets baut.</strong>
 </p>

--- a/README.es-MX.md
+++ b/README.es-MX.md
@@ -4,6 +4,8 @@
 
 <h1 align="center">KKTerm</h1>
 
+![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
+
 <p align="center">
   <strong>El workspace de administración nativo para Windows que la era de las herramientas de IA se olvidó de construir — terminales, SSH, SFTP, RDP/VNC, dashboards, y una IA que crea tus propios widgets de herramientas.</strong>
 </p>

--- a/README.es.md
+++ b/README.es.md
@@ -4,6 +4,8 @@
 
 <h1 align="center">KKTerm</h1>
 
+![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
+
 <p align="center">
   <strong>El espacio de trabajo nativo para administradores Windows que la era de la IA se olvidó de construir — terminales, SSH, SFTP, RDP/VNC, dashboards, y una IA que crea tus propios widgets de herramientas.</strong>
 </p>

--- a/README.fr.md
+++ b/README.fr.md
@@ -4,6 +4,8 @@
 
 <h1 align="center">KKTerm</h1>
 
+![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
+
 <p align="center">
   <strong>L'espace de travail d'administration Windows natif que l'ère des outils IA a oublié de construire — terminaux, SSH, SFTP, RDP/VNC, dashboards, et une IA qui construit tes propres Widgets d'outils.</strong>
 </p>

--- a/README.id.md
+++ b/README.id.md
@@ -4,6 +4,8 @@
 
 <h1 align="center">KKTerm</h1>
 
+![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
+
 <p align="center">
   <strong>Workspace admin Windows native yang lupa dibangun oleh era AI-tools — terminal, SSH, SFTP, RDP/VNC, dashboard, dan AI yang membangun widget tool milikmu sendiri.</strong>
 </p>

--- a/README.it.md
+++ b/README.it.md
@@ -4,6 +4,8 @@
 
 <h1 align="center">KKTerm</h1>
 
+![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
+
 <p align="center">
   <strong>Il workspace di amministrazione nativo per Windows che l'era degli AI-tool si è dimenticata di costruire — terminali, SSH, SFTP, RDP/VNC, dashboard, e un'AI che costruisce i tuoi widget-strumento.</strong>
 </p>

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,6 +4,8 @@
 
 <h1 align="center">KKTerm</h1>
 
+![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
+
 <p align="center">
   <strong>ターミナル、SSH、SFTP、RDP/VNC、Dashboard、そして自分専用のツールWidgetを作るAI——AIツール時代に誰も作らなかった、Windowsネイティブの管理者向けワークスペース。</strong>
 </p>

--- a/README.ko.md
+++ b/README.ko.md
@@ -4,6 +4,8 @@
 
 <h1 align="center">KKTerm</h1>
 
+![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
+
 <p align="center">
   <strong>AI 도구 시대가 깜빡 잊고 만들지 않은, 진짜 Windows 네이티브 관리자 Workspace — 터미널, SSH, SFTP, RDP/VNC, Dashboard, 그리고 나만의 도구 Widget을 만들어 주는 AI.</strong>
 </p>

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 <h1 align="center">KKTerm</h1>
 
+![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
+
 <p align="center">
   <strong>The native Windows admin workspace the AI-tools era forgot to build — terminals, SSH, SFTP, RDP/VNC, dashboards, and an AI that builds your own tool widgets.</strong>
 </p>

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -4,6 +4,8 @@
 
 <h1 align="center">KKTerm</h1>
 
+![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
+
 <p align="center">
   <strong>O workspace nativo para administradores Windows que a era das ferramentas de IA esqueceu de criar — terminais, SSH, SFTP, RDP/VNC, dashboards, e uma IA que cria seus próprios widgets de ferramentas.</strong>
 </p>

--- a/README.th.md
+++ b/README.th.md
@@ -4,6 +4,8 @@
 
 <h1 align="center">KKTerm</h1>
 
+![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
+
 <p align="center">
   <strong>Workspace สำหรับแอดมิน Windows แบบ native ที่ยุค AI tools ลืมสร้าง — terminal, SSH, SFTP, RDP/VNC, dashboard, และ AI ที่สร้าง widget เครื่องมือของคุณเอง</strong>
 </p>

--- a/README.vi.md
+++ b/README.vi.md
@@ -4,6 +4,8 @@
 
 <h1 align="center">KKTerm</h1>
 
+![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
+
 <p align="center">
   <strong>Không gian quản trị Windows native mà kỷ nguyên AI-tools đã quên xây — terminal, SSH, SFTP, RDP/VNC, dashboard, và một AI build các widget công cụ của riêng bạn.</strong>
 </p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,6 +4,8 @@
 
 <h1 align="center">KKTerm</h1>
 
+![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
+
 <p align="center">
   <strong>AI 工具时代忘记打造的原生 Windows 管理工作台——终端、SSH、SFTP、RDP/VNC、Dashboard，以及一个能为你打造专属工具 Widget 的 AI。</strong>
 </p>

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -4,6 +4,8 @@
 
 <h1 align="center">KKTerm</h1>
 
+![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
+
 <p align="center">
   <strong>AI 工具當道的年代裡沒人想動手寫的那款 Windows 原生管理工作區 — 終端機、SSH、SFTP、RDP/VNC、Dashboard，加上一個能幫你打造專屬工具 Widget 的 AI。</strong>
 </p>

--- a/docs/localization_todo/README.md
+++ b/docs/localization_todo/README.md
@@ -1,5 +1,7 @@
 # Localization Backlog
 
+![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
+
 Each pending English string lives in its own file in this directory. One key per file. This replaces the previous single `docs/LOCALIZATION.md` so feature branches can add or remove pending strings without colliding.
 
 ## Filename Convention

--- a/src/assets/installer-icons/README.md
+++ b/src/assets/installer-icons/README.md
@@ -1,5 +1,7 @@
 # Installer Helper icon provenance
 
+![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
+
 These icons are bundled only for Installer Helper catalog tiles. Prefer SVGs
 from Simple Icons when available; otherwise use the smallest official or
 project-repository asset that remains legible at 40-46px.


### PR DESCRIPTION
### Motivation
- Surface repository download metrics consistently across all localized and nested README files. 
- Keep top-of-file branding uniform by adding the same downloads badge under the main title in each README.

### Description
- Inserted the GitHub downloads badge `![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)` immediately after the main `h1`/title in all top-level localized `README.*.md` files and in `docs/localization_todo/README.md` and `src/assets/installer-icons/README.md`.
- The change affects 16 files with 32 insertions total and keeps existing content and layout unchanged except for the new badge line.

### Testing
- Ran `git diff --stat` to verify files changed and insertion count, which reported 16 files changed and 32 insertions. 
- Ran `git diff --check` to ensure no trailing-whitespace or diff issues and it passed. 
- Verified badge presence across files with the `rg`/shell check that searches for the badge URL, and the script reported all target READMEs contain the badge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23b4d21d6c832f86b4171d92b2ec2e)