### PR TITLE
Move downloads badge into README badge row

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -4,8 +4,6 @@
 
 <h1 align="center">KKTerm</h1>
 
-![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
-
 <p align="center">
   <strong>Der native Windows-Admin-Workspace, den das KI-Tools-Zeitalter zu bauen vergessen hat — Terminals, SSH, SFTP, RDP/VNC, Dashboards und eine KI, die deine eigenen Tool-Widgets baut.</strong>
 </p>
@@ -28,6 +26,9 @@
   </a>
   <a href="https://github.com/ryantsai/KKTerm/network/members">
     <img src="https://img.shields.io/github/forks/ryantsai/KKTerm?style=for-the-badge&logo=github&color=8a63d2" alt="GitHub forks" />
+  </a>
+  <a href="https://github.com/ryantsai/KKTerm/releases">
+    <img src="https://img.shields.io/github/downloads/ryantsai/KKTerm/total?style=for-the-badge&logo=github&color=0969da" alt="GitHub downloads" />
   </a>
   <a href="https://github.com/ryantsai/KKTerm/issues">
     <img src="https://img.shields.io/github/issues/ryantsai/KKTerm?style=for-the-badge&logo=github&color=2ea043" alt="Open issues" />

--- a/README.es-MX.md
+++ b/README.es-MX.md
@@ -4,8 +4,6 @@
 
 <h1 align="center">KKTerm</h1>
 
-![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
-
 <p align="center">
   <strong>El workspace de administración nativo para Windows que la era de las herramientas de IA se olvidó de construir — terminales, SSH, SFTP, RDP/VNC, dashboards, y una IA que crea tus propios widgets de herramientas.</strong>
 </p>
@@ -28,6 +26,9 @@
   </a>
   <a href="https://github.com/ryantsai/KKTerm/network/members">
     <img src="https://img.shields.io/github/forks/ryantsai/KKTerm?style=for-the-badge&logo=github&color=8a63d2" alt="GitHub forks" />
+  </a>
+  <a href="https://github.com/ryantsai/KKTerm/releases">
+    <img src="https://img.shields.io/github/downloads/ryantsai/KKTerm/total?style=for-the-badge&logo=github&color=0969da" alt="GitHub downloads" />
   </a>
   <a href="https://github.com/ryantsai/KKTerm/issues">
     <img src="https://img.shields.io/github/issues/ryantsai/KKTerm?style=for-the-badge&logo=github&color=2ea043" alt="Open issues" />

--- a/README.es.md
+++ b/README.es.md
@@ -4,8 +4,6 @@
 
 <h1 align="center">KKTerm</h1>
 
-![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
-
 <p align="center">
   <strong>El espacio de trabajo nativo para administradores Windows que la era de la IA se olvidó de construir — terminales, SSH, SFTP, RDP/VNC, dashboards, y una IA que crea tus propios widgets de herramientas.</strong>
 </p>
@@ -28,6 +26,9 @@
   </a>
   <a href="https://github.com/ryantsai/KKTerm/network/members">
     <img src="https://img.shields.io/github/forks/ryantsai/KKTerm?style=for-the-badge&logo=github&color=8a63d2" alt="GitHub forks" />
+  </a>
+  <a href="https://github.com/ryantsai/KKTerm/releases">
+    <img src="https://img.shields.io/github/downloads/ryantsai/KKTerm/total?style=for-the-badge&logo=github&color=0969da" alt="GitHub downloads" />
   </a>
   <a href="https://github.com/ryantsai/KKTerm/issues">
     <img src="https://img.shields.io/github/issues/ryantsai/KKTerm?style=for-the-badge&logo=github&color=2ea043" alt="Open issues" />

--- a/README.fr.md
+++ b/README.fr.md
@@ -4,8 +4,6 @@
 
 <h1 align="center">KKTerm</h1>
 
-![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
-
 <p align="center">
   <strong>L'espace de travail d'administration Windows natif que l'ère des outils IA a oublié de construire — terminaux, SSH, SFTP, RDP/VNC, dashboards, et une IA qui construit tes propres Widgets d'outils.</strong>
 </p>
@@ -28,6 +26,9 @@
   </a>
   <a href="https://github.com/ryantsai/KKTerm/network/members">
     <img src="https://img.shields.io/github/forks/ryantsai/KKTerm?style=for-the-badge&logo=github&color=8a63d2" alt="GitHub forks" />
+  </a>
+  <a href="https://github.com/ryantsai/KKTerm/releases">
+    <img src="https://img.shields.io/github/downloads/ryantsai/KKTerm/total?style=for-the-badge&logo=github&color=0969da" alt="GitHub downloads" />
   </a>
   <a href="https://github.com/ryantsai/KKTerm/issues">
     <img src="https://img.shields.io/github/issues/ryantsai/KKTerm?style=for-the-badge&logo=github&color=2ea043" alt="Open issues" />

--- a/README.id.md
+++ b/README.id.md
@@ -4,8 +4,6 @@
 
 <h1 align="center">KKTerm</h1>
 
-![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
-
 <p align="center">
   <strong>Workspace admin Windows native yang lupa dibangun oleh era AI-tools — terminal, SSH, SFTP, RDP/VNC, dashboard, dan AI yang membangun widget tool milikmu sendiri.</strong>
 </p>
@@ -28,6 +26,9 @@
   </a>
   <a href="https://github.com/ryantsai/KKTerm/network/members">
     <img src="https://img.shields.io/github/forks/ryantsai/KKTerm?style=for-the-badge&logo=github&color=8a63d2" alt="GitHub forks" />
+  </a>
+  <a href="https://github.com/ryantsai/KKTerm/releases">
+    <img src="https://img.shields.io/github/downloads/ryantsai/KKTerm/total?style=for-the-badge&logo=github&color=0969da" alt="GitHub downloads" />
   </a>
   <a href="https://github.com/ryantsai/KKTerm/issues">
     <img src="https://img.shields.io/github/issues/ryantsai/KKTerm?style=for-the-badge&logo=github&color=2ea043" alt="Open issues" />

--- a/README.it.md
+++ b/README.it.md
@@ -4,8 +4,6 @@
 
 <h1 align="center">KKTerm</h1>
 
-![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
-
 <p align="center">
   <strong>Il workspace di amministrazione nativo per Windows che l'era degli AI-tool si è dimenticata di costruire — terminali, SSH, SFTP, RDP/VNC, dashboard, e un'AI che costruisce i tuoi widget-strumento.</strong>
 </p>
@@ -28,6 +26,9 @@
   </a>
   <a href="https://github.com/ryantsai/KKTerm/network/members">
     <img src="https://img.shields.io/github/forks/ryantsai/KKTerm?style=for-the-badge&logo=github&color=8a63d2" alt="GitHub forks" />
+  </a>
+  <a href="https://github.com/ryantsai/KKTerm/releases">
+    <img src="https://img.shields.io/github/downloads/ryantsai/KKTerm/total?style=for-the-badge&logo=github&color=0969da" alt="GitHub downloads" />
   </a>
   <a href="https://github.com/ryantsai/KKTerm/issues">
     <img src="https://img.shields.io/github/issues/ryantsai/KKTerm?style=for-the-badge&logo=github&color=2ea043" alt="Open issues" />

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,8 +4,6 @@
 
 <h1 align="center">KKTerm</h1>
 
-![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
-
 <p align="center">
   <strong>ターミナル、SSH、SFTP、RDP/VNC、Dashboard、そして自分専用のツールWidgetを作るAI——AIツール時代に誰も作らなかった、Windowsネイティブの管理者向けワークスペース。</strong>
 </p>
@@ -28,6 +26,9 @@
   </a>
   <a href="https://github.com/ryantsai/KKTerm/network/members">
     <img src="https://img.shields.io/github/forks/ryantsai/KKTerm?style=for-the-badge&logo=github&color=8a63d2" alt="GitHub forks" />
+  </a>
+  <a href="https://github.com/ryantsai/KKTerm/releases">
+    <img src="https://img.shields.io/github/downloads/ryantsai/KKTerm/total?style=for-the-badge&logo=github&color=0969da" alt="GitHub downloads" />
   </a>
   <a href="https://github.com/ryantsai/KKTerm/issues">
     <img src="https://img.shields.io/github/issues/ryantsai/KKTerm?style=for-the-badge&logo=github&color=2ea043" alt="Open issues" />

--- a/README.ko.md
+++ b/README.ko.md
@@ -4,8 +4,6 @@
 
 <h1 align="center">KKTerm</h1>
 
-![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
-
 <p align="center">
   <strong>AI 도구 시대가 깜빡 잊고 만들지 않은, 진짜 Windows 네이티브 관리자 Workspace — 터미널, SSH, SFTP, RDP/VNC, Dashboard, 그리고 나만의 도구 Widget을 만들어 주는 AI.</strong>
 </p>
@@ -28,6 +26,9 @@
   </a>
   <a href="https://github.com/ryantsai/KKTerm/network/members">
     <img src="https://img.shields.io/github/forks/ryantsai/KKTerm?style=for-the-badge&logo=github&color=8a63d2" alt="GitHub forks" />
+  </a>
+  <a href="https://github.com/ryantsai/KKTerm/releases">
+    <img src="https://img.shields.io/github/downloads/ryantsai/KKTerm/total?style=for-the-badge&logo=github&color=0969da" alt="GitHub downloads" />
   </a>
   <a href="https://github.com/ryantsai/KKTerm/issues">
     <img src="https://img.shields.io/github/issues/ryantsai/KKTerm?style=for-the-badge&logo=github&color=2ea043" alt="Open issues" />

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 <h1 align="center">KKTerm</h1>
 
-![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
-
 <p align="center">
   <strong>The native Windows admin workspace the AI-tools era forgot to build — terminals, SSH, SFTP, RDP/VNC, dashboards, and an AI that builds your own tool widgets.</strong>
 </p>
@@ -28,6 +26,9 @@
   </a>
   <a href="https://github.com/ryantsai/KKTerm/network/members">
     <img src="https://img.shields.io/github/forks/ryantsai/KKTerm?style=for-the-badge&logo=github&color=8a63d2" alt="GitHub forks" />
+  </a>
+  <a href="https://github.com/ryantsai/KKTerm/releases">
+    <img src="https://img.shields.io/github/downloads/ryantsai/KKTerm/total?style=for-the-badge&logo=github&color=0969da" alt="GitHub downloads" />
   </a>
   <a href="https://github.com/ryantsai/KKTerm/issues">
     <img src="https://img.shields.io/github/issues/ryantsai/KKTerm?style=for-the-badge&logo=github&color=2ea043" alt="Open issues" />

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -4,8 +4,6 @@
 
 <h1 align="center">KKTerm</h1>
 
-![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
-
 <p align="center">
   <strong>O workspace nativo para administradores Windows que a era das ferramentas de IA esqueceu de criar — terminais, SSH, SFTP, RDP/VNC, dashboards, e uma IA que cria seus próprios widgets de ferramentas.</strong>
 </p>
@@ -28,6 +26,9 @@
   </a>
   <a href="https://github.com/ryantsai/KKTerm/network/members">
     <img src="https://img.shields.io/github/forks/ryantsai/KKTerm?style=for-the-badge&logo=github&color=8a63d2" alt="GitHub forks" />
+  </a>
+  <a href="https://github.com/ryantsai/KKTerm/releases">
+    <img src="https://img.shields.io/github/downloads/ryantsai/KKTerm/total?style=for-the-badge&logo=github&color=0969da" alt="GitHub downloads" />
   </a>
   <a href="https://github.com/ryantsai/KKTerm/issues">
     <img src="https://img.shields.io/github/issues/ryantsai/KKTerm?style=for-the-badge&logo=github&color=2ea043" alt="Open issues" />

--- a/README.th.md
+++ b/README.th.md
@@ -4,8 +4,6 @@
 
 <h1 align="center">KKTerm</h1>
 
-![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
-
 <p align="center">
   <strong>Workspace สำหรับแอดมิน Windows แบบ native ที่ยุค AI tools ลืมสร้าง — terminal, SSH, SFTP, RDP/VNC, dashboard, และ AI ที่สร้าง widget เครื่องมือของคุณเอง</strong>
 </p>
@@ -28,6 +26,9 @@
   </a>
   <a href="https://github.com/ryantsai/KKTerm/network/members">
     <img src="https://img.shields.io/github/forks/ryantsai/KKTerm?style=for-the-badge&logo=github&color=8a63d2" alt="GitHub forks" />
+  </a>
+  <a href="https://github.com/ryantsai/KKTerm/releases">
+    <img src="https://img.shields.io/github/downloads/ryantsai/KKTerm/total?style=for-the-badge&logo=github&color=0969da" alt="GitHub downloads" />
   </a>
   <a href="https://github.com/ryantsai/KKTerm/issues">
     <img src="https://img.shields.io/github/issues/ryantsai/KKTerm?style=for-the-badge&logo=github&color=2ea043" alt="Open issues" />

--- a/README.vi.md
+++ b/README.vi.md
@@ -4,8 +4,6 @@
 
 <h1 align="center">KKTerm</h1>
 
-![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
-
 <p align="center">
   <strong>Không gian quản trị Windows native mà kỷ nguyên AI-tools đã quên xây — terminal, SSH, SFTP, RDP/VNC, dashboard, và một AI build các widget công cụ của riêng bạn.</strong>
 </p>
@@ -28,6 +26,9 @@
   </a>
   <a href="https://github.com/ryantsai/KKTerm/network/members">
     <img src="https://img.shields.io/github/forks/ryantsai/KKTerm?style=for-the-badge&logo=github&color=8a63d2" alt="GitHub forks" />
+  </a>
+  <a href="https://github.com/ryantsai/KKTerm/releases">
+    <img src="https://img.shields.io/github/downloads/ryantsai/KKTerm/total?style=for-the-badge&logo=github&color=0969da" alt="GitHub downloads" />
   </a>
   <a href="https://github.com/ryantsai/KKTerm/issues">
     <img src="https://img.shields.io/github/issues/ryantsai/KKTerm?style=for-the-badge&logo=github&color=2ea043" alt="Open issues" />

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,8 +4,6 @@
 
 <h1 align="center">KKTerm</h1>
 
-![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
-
 <p align="center">
   <strong>AI 工具时代忘记打造的原生 Windows 管理工作台——终端、SSH、SFTP、RDP/VNC、Dashboard，以及一个能为你打造专属工具 Widget 的 AI。</strong>
 </p>
@@ -28,6 +26,9 @@
   </a>
   <a href="https://github.com/ryantsai/KKTerm/network/members">
     <img src="https://img.shields.io/github/forks/ryantsai/KKTerm?style=for-the-badge&logo=github&color=8a63d2" alt="GitHub forks" />
+  </a>
+  <a href="https://github.com/ryantsai/KKTerm/releases">
+    <img src="https://img.shields.io/github/downloads/ryantsai/KKTerm/total?style=for-the-badge&logo=github&color=0969da" alt="GitHub downloads" />
   </a>
   <a href="https://github.com/ryantsai/KKTerm/issues">
     <img src="https://img.shields.io/github/issues/ryantsai/KKTerm?style=for-the-badge&logo=github&color=2ea043" alt="Open issues" />

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -4,8 +4,6 @@
 
 <h1 align="center">KKTerm</h1>
 
-![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)
-
 <p align="center">
   <strong>AI 工具當道的年代裡沒人想動手寫的那款 Windows 原生管理工作區 — 終端機、SSH、SFTP、RDP/VNC、Dashboard，加上一個能幫你打造專屬工具 Widget 的 AI。</strong>
 </p>
@@ -28,6 +26,9 @@
   </a>
   <a href="https://github.com/ryantsai/KKTerm/network/members">
     <img src="https://img.shields.io/github/forks/ryantsai/KKTerm?style=for-the-badge&logo=github&color=8a63d2" alt="GitHub forks" />
+  </a>
+  <a href="https://github.com/ryantsai/KKTerm/releases">
+    <img src="https://img.shields.io/github/downloads/ryantsai/KKTerm/total?style=for-the-badge&logo=github&color=0969da" alt="GitHub downloads" />
   </a>
   <a href="https://github.com/ryantsai/KKTerm/issues">
     <img src="https://img.shields.io/github/issues/ryantsai/KKTerm?style=for-the-badge&logo=github&color=2ea043" alt="Open issues" />


### PR DESCRIPTION
### Motivation
- Keep the downloads count visually consistent with other repository badges by placing it inside the badge label row instead of as a standalone header image. 
- Ensure the localized README files all present the same badge layout and link the downloads badge to the releases page.

### Description
- Removed the standalone `![Downloads](https://img.shields.io/github/downloads/ryantsai/KKTerm/total)` badge from the top of the root `README.md` and each localized `README.*.md` file. 
- Inserted a `for-the-badge` downloads badge linking to `https://github.com/ryantsai/KKTerm/releases` into the existing badge row (between forks and issues) using the same style used for stars/forks/issues. 
- Applied the change across the root `README.md` plus all localized root READMEs (14 files updated).

### Testing
- Ran `rg -n "!\[Downloads\]" README.md README.*.md` and confirmed the standalone top-of-file downloads badge was removed. 
- Executed a `python3` verification script that checks each root README contains the `for-the-badge` downloads badge and confirmed it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23c8142200832f979915d43ded53a6)