### PR TITLE
Route terminal paste through xterm handling

### DIFF
--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -2014,14 +2014,7 @@ function TerminalPaneView({
       return;
     }
 
-    const sessionId = sessionIdRef.current;
-    if (sessionId) {
-      await writeWithPasteConfirmation(text, (input) => {
-        void invokeCommand("write_terminal_input", {
-          request: { sessionId, data: encodeTerminalInput(input) },
-        });
-      });
-    }
+    terminalRendererRef.current?.paste(text);
     setContextMenu(null);
     terminalRendererRef.current?.focus();
   }

--- a/src/modules/workspace/connections/terminal/renderer.ts
+++ b/src/modules/workspace/connections/terminal/renderer.ts
@@ -55,6 +55,7 @@ export interface TerminalRenderer {
   open: (element: HTMLElement) => void;
   setWheelScrollbackOverride: (enabled: boolean, handler?: (lines: number) => void) => void;
   setBackgroundOpacity: (opacity: number) => void;
+  paste: (data: string) => void;
   write: (data: string) => void;
   writeln: (data: string) => void;
   setFontSize: (size: number) => void;
@@ -302,6 +303,10 @@ class XtermTerminalRenderer implements TerminalRenderer {
 
   write(data: string) {
     this.terminal.write(data);
+  }
+
+  paste(data: string) {
+    this.terminal.paste(data);
   }
 
   writeln(data: string) {

--- a/tests/terminal-paste-normalization.test.mjs
+++ b/tests/terminal-paste-normalization.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("terminal app-owned paste uses xterm paste transformations before writing to the session", async () => {
+  const rendererSource = await readFile(
+    new URL("../src/modules/workspace/connections/terminal/renderer.ts", import.meta.url),
+    "utf8",
+  );
+  const workspaceSource = await readFile(
+    new URL("../src/modules/workspace/connections/terminal/TerminalWorkspace.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(rendererSource, /paste: \(data: string\) => void/);
+  assert.match(rendererSource, /paste\(data: string\) \{\s*this\.terminal\.paste\(data\);\s*\}/s);
+
+  const pasteHandler =
+    workspaceSource.match(/async function handlePasteIntoTerminal\(\) \{([\s\S]*?)\n  \}/)?.[1] ?? "";
+  assert.match(pasteHandler, /terminalRendererRef\.current\?\.paste\(text\)/);
+  assert.doesNotMatch(pasteHandler, /write_terminal_input/);
+});


### PR DESCRIPTION
## Summary
- Route app-owned terminal paste actions through `xterm`'s `paste()` API instead of writing clipboard text directly to the PTY
- Add a renderer-level `paste()` method so xterm can apply its canonical paste transformations consistently
- Add a regression test covering the paste path

## Testing
- Added a unit test for the terminal paste path
- Validated the focused regression locally