### PR TITLE
Add RDP connection state to resize debug logs

### DIFF
--- a/src-tauri/src/rdp.rs
+++ b/src-tauri/src/rdp.rs
@@ -2041,6 +2041,7 @@ mod platform {
         display_settings: RdpDisplaySettings,
         force: bool,
     ) -> bool {
+        let connection_state = get_property_i32(&session.dispatch, "Connected").unwrap_or(-1);
         if !force
             && !should_resize_remote_desktop(
                 session.desktop_width,
@@ -2058,6 +2059,8 @@ mod platform {
                 &json!({
                     "reason": "unchanged",
                     "force": force,
+                    "connectionState": connection_state,
+                    "connectionStateLabel": rdp_connection_state_label(connection_state),
                     "desktopWidth": display_settings.desktop_width,
                     "desktopHeight": display_settings.desktop_height,
                     "physicalWidth": display_settings.physical_width,
@@ -2079,6 +2082,8 @@ mod platform {
                         "error": error,
                         "force": force,
                         "failures": session.dynamic_resize_failures,
+                        "connectionState": connection_state,
+                        "connectionStateLabel": rdp_connection_state_label(connection_state),
                         "desktopWidth": display_settings.desktop_width,
                         "desktopHeight": display_settings.desktop_height,
                         "physicalWidth": display_settings.physical_width,
@@ -2095,6 +2100,8 @@ mod platform {
                 "display.resize.recovered",
                 &json!({
                     "previousFailures": session.dynamic_resize_failures,
+                    "connectionState": connection_state,
+                    "connectionStateLabel": rdp_connection_state_label(connection_state),
                     "desktopWidth": display_settings.desktop_width,
                     "desktopHeight": display_settings.desktop_height,
                     "physicalWidth": display_settings.physical_width,
@@ -2114,6 +2121,8 @@ mod platform {
             &json!({
                 "method": resize_method,
                 "force": force,
+                "connectionState": connection_state,
+                "connectionStateLabel": rdp_connection_state_label(connection_state),
                 "desktopWidth": display_settings.desktop_width,
                 "desktopHeight": display_settings.desktop_height,
                 "physicalWidth": display_settings.physical_width,

--- a/tests/rdp-display-sync.test.mjs
+++ b/tests/rdp-display-sync.test.mjs
@@ -36,3 +36,24 @@ test("remote desktop runtime session ids stay within backend limits", async () =
     "backend session ids should not include variable-length tab ids",
   );
 });
+
+test("RDP display resize debug events include connection state", async () => {
+  const rdpSource = await readFile(new URL("../src-tauri/src/rdp.rs", import.meta.url), "utf8");
+  const syncFunction = rdpSource.match(
+    /fn sync_remote_desktop_size\([\s\S]*?\n    #\[allow\(clippy::too_many_arguments\)\]/,
+  )?.[0];
+
+  assert.ok(syncFunction, "sync_remote_desktop_size function should exist");
+  for (const eventName of [
+    "display.resize.skipped",
+    "display.resize.error",
+    "display.resize.recovered",
+    "display.resize.ok",
+  ]) {
+    const eventIndex = syncFunction.indexOf(`"${eventName}"`);
+    assert.notEqual(eventIndex, -1, `${eventName} should be logged`);
+    const eventBlock = syncFunction.slice(eventIndex, syncFunction.indexOf("}),", eventIndex));
+    assert.match(eventBlock, /"connectionState": connection_state/);
+    assert.match(eventBlock, /"connectionStateLabel": rdp_connection_state_label\(connection_state\)/);
+  }
+});


### PR DESCRIPTION
## Summary
- Include the current RDP ActiveX connection state in resize-related debug events
- Add a regression test to ensure the resize log payload keeps the state fields

## Testing
- `node tests/rdp-display-sync.test.mjs`
- `cargo test --manifest-path src-tauri/Cargo.toml rdp --lib`