### PR TITLE
Refine Notes widget into a skeuomorphic sticky note

### DIFF
--- a/src/modules/dashboard/dashboard.css
+++ b/src/modules/dashboard/dashboard.css
@@ -3413,7 +3413,10 @@ button.dashboard-pill-dot:focus-visible {
   background: transparent;
   color: var(--note-ink);
   border-radius: 0;
-  filter: drop-shadow(0 1px 1px rgb(0 0 0 / 10%)) drop-shadow(0 8px 18px rgb(0 0 0 / 14%));
+  filter:
+    drop-shadow(0 1px 0 rgb(255 255 255 / 28%))
+    drop-shadow(0 2px 2px rgb(0 0 0 / 10%))
+    drop-shadow(0 12px 18px rgb(0 0 0 / 15%));
   transform: rotate(var(--note-rotation, -0.6deg));
   transform-origin: 50% 0;
   overflow: visible;
@@ -3427,9 +3430,18 @@ button.dashboard-pill-dot:focus-visible {
   inset: 0;
   z-index: 0;
   background:
-    linear-gradient(160deg, rgb(255 255 255 / 18%) 0%, rgb(0 0 0 / 0%) 35%),
+    linear-gradient(180deg, rgb(255 255 255 / 24%) 0 7%, rgb(150 100 0 / 7%) 7% 8%, transparent 18%),
+    radial-gradient(120% 80% at 18% 12%, rgb(255 255 255 / 20%) 0 22%, transparent 58%),
+    radial-gradient(110% 70% at 76% 88%, rgb(95 62 0 / 9%) 0 18%, transparent 62%),
+    repeating-linear-gradient(94deg, rgb(255 255 255 / 7%) 0 1px, transparent 1px 11px),
+    repeating-linear-gradient(3deg, rgb(77 54 0 / 4%) 0 1px, transparent 1px 15px),
     var(--note-paper);
-  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 4%);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 24%),
+    inset 0 -10px 18px -18px rgb(52 38 0 / 38%),
+    inset 10px 0 14px -18px rgb(255 255 255 / 62%),
+    inset -12px 0 16px -20px rgb(52 38 0 / 34%),
+    inset 0 0 0 1px rgb(52 38 0 / 7%);
   pointer-events: none;
 }
 
@@ -3444,14 +3456,16 @@ button.dashboard-pill-dot:focus-visible {
   width: var(--note-fold-curl-size);
   height: var(--note-fold-curl-size);
   background:
-    radial-gradient(110% 90% at 100% 0%, rgb(255 255 255 / 46%) 0 12%, transparent 50%),
-    radial-gradient(120% 100% at 100% 0%, var(--note-fold-under) 0 26%, var(--note-paper-edge) 46%, transparent 72%),
+    radial-gradient(115% 92% at 100% 0%, rgb(255 255 255 / 54%) 0 10%, transparent 48%),
+    radial-gradient(120% 100% at 100% 0%, var(--note-fold-under) 0 25%, var(--note-paper-edge) 45%, transparent 73%),
+    repeating-linear-gradient(28deg, rgb(255 255 255 / 7%) 0 1px, transparent 1px 7px),
     linear-gradient(45deg, var(--note-paper) 0%, var(--note-paper-edge) 100%);
   clip-path: polygon(0 0, 100% 0, 100% 100%, 94% 76%, 82% 55%, 63% 35%, 38% 17%, 15% 5%);
   border-bottom-left-radius: 88% 72%;
   box-shadow:
-    calc(0px - var(--note-fold-shadow-offset)) var(--note-fold-shadow-offset) var(--note-fold-shadow-blur) rgb(0 0 0 / 18%),
-    -9px 12px 18px -14px rgb(72 40 0 / calc(0.24 + var(--note-fold-depth-alpha)));
+    calc(0px - var(--note-fold-shadow-offset)) var(--note-fold-shadow-offset) var(--note-fold-shadow-blur) rgb(0 0 0 / 23%),
+    -6px 8px 10px -8px rgb(72 40 0 / calc(0.28 + var(--note-fold-depth-alpha))),
+    inset -1px 1px 1px rgb(255 255 255 / 25%);
   pointer-events: none;
 }
 
@@ -3484,15 +3498,17 @@ button.dashboard-pill-dot:focus-visible {
   left: 0;
   right: auto;
   background:
-    radial-gradient(110% 90% at 0% 0%, rgb(255 255 255 / 46%) 0 12%, transparent 50%),
+    radial-gradient(110% 90% at 0% 0%, rgb(255 255 255 / 54%) 0 12%, transparent 50%),
     radial-gradient(120% 100% at 0% 0%, var(--note-fold-under) 0 26%, var(--note-paper-edge) 46%, transparent 72%),
+    repeating-linear-gradient(332deg, rgb(255 255 255 / 7%) 0 1px, transparent 1px 7px),
     linear-gradient(315deg, var(--note-paper) 0%, var(--note-paper-edge) 100%);
   clip-path: polygon(0 0, 100% 0, 85% 5%, 62% 17%, 37% 35%, 18% 55%, 6% 76%, 0 100%);
   border-radius: 0 0 88% 0 / 0 0 72% 0;
   transform: translate(-6%, -6%);
   box-shadow:
-    var(--note-fold-shadow-offset) var(--note-fold-shadow-offset) var(--note-fold-shadow-blur) rgb(0 0 0 / 18%),
-    9px 12px 18px -14px rgb(72 40 0 / calc(0.24 + var(--note-fold-depth-alpha)));
+    var(--note-fold-shadow-offset) var(--note-fold-shadow-offset) var(--note-fold-shadow-blur) rgb(0 0 0 / 23%),
+    6px 8px 10px -8px rgb(72 40 0 / calc(0.28 + var(--note-fold-depth-alpha))),
+    inset 1px 1px 1px rgb(255 255 255 / 25%);
 }
 
 .dw-notes--fold-bottomRight::before {
@@ -3500,15 +3516,17 @@ button.dashboard-pill-dot:focus-visible {
   right: 0;
   bottom: 0;
   background:
-    radial-gradient(110% 90% at 100% 100%, rgb(255 255 255 / 46%) 0 12%, transparent 50%),
+    radial-gradient(110% 90% at 100% 100%, rgb(255 255 255 / 54%) 0 12%, transparent 50%),
     radial-gradient(120% 100% at 100% 100%, var(--note-fold-under) 0 26%, var(--note-paper-edge) 46%, transparent 72%),
+    repeating-linear-gradient(332deg, rgb(255 255 255 / 7%) 0 1px, transparent 1px 7px),
     linear-gradient(135deg, var(--note-paper) 0%, var(--note-paper-edge) 100%);
   clip-path: polygon(100% 0, 100% 100%, 0 100%, 6% 76%, 18% 55%, 37% 35%, 62% 17%, 85% 5%);
   border-radius: 88% 0 0 0 / 72% 0 0 0;
   transform: translate(6%, 6%);
   box-shadow:
-    calc(0px - var(--note-fold-shadow-offset)) calc(0px - var(--note-fold-shadow-offset)) var(--note-fold-shadow-blur) rgb(0 0 0 / 18%),
-    -9px -12px 18px -14px rgb(72 40 0 / calc(0.24 + var(--note-fold-depth-alpha)));
+    calc(0px - var(--note-fold-shadow-offset)) calc(0px - var(--note-fold-shadow-offset)) var(--note-fold-shadow-blur) rgb(0 0 0 / 23%),
+    -6px -8px 10px -8px rgb(72 40 0 / calc(0.28 + var(--note-fold-depth-alpha))),
+    inset -1px -1px 1px rgb(255 255 255 / 25%);
 }
 
 .dw-notes--fold-bottomLeft::before {
@@ -3517,15 +3535,17 @@ button.dashboard-pill-dot:focus-visible {
   right: auto;
   bottom: 0;
   background:
-    radial-gradient(110% 90% at 0% 100%, rgb(255 255 255 / 46%) 0 12%, transparent 50%),
+    radial-gradient(110% 90% at 0% 100%, rgb(255 255 255 / 54%) 0 12%, transparent 50%),
     radial-gradient(120% 100% at 0% 100%, var(--note-fold-under) 0 26%, var(--note-paper-edge) 46%, transparent 72%),
+    repeating-linear-gradient(28deg, rgb(255 255 255 / 7%) 0 1px, transparent 1px 7px),
     linear-gradient(225deg, var(--note-paper) 0%, var(--note-paper-edge) 100%);
   clip-path: polygon(0 0, 15% 5%, 38% 17%, 63% 35%, 82% 55%, 94% 76%, 100% 100%, 0 100%);
   border-radius: 0 88% 0 0 / 0 72% 0 0;
   transform: translate(-6%, 6%);
   box-shadow:
-    var(--note-fold-shadow-offset) calc(0px - var(--note-fold-shadow-offset)) var(--note-fold-shadow-blur) rgb(0 0 0 / 18%),
-    9px -12px 18px -14px rgb(72 40 0 / calc(0.24 + var(--note-fold-depth-alpha)));
+    var(--note-fold-shadow-offset) calc(0px - var(--note-fold-shadow-offset)) var(--note-fold-shadow-blur) rgb(0 0 0 / 23%),
+    6px -8px 10px -8px rgb(72 40 0 / calc(0.28 + var(--note-fold-depth-alpha))),
+    inset 1px -1px 1px rgb(255 255 255 / 25%);
 }
 
 .dw-notes-page-actions {
@@ -3571,7 +3591,8 @@ button.dashboard-pill-dot:focus-visible {
   font: inherit;
   font-size: 18px;
   line-height: 1.45;
-  letter-spacing: 0.1px;
+  letter-spacing: 0;
+  text-shadow: 0 1px 0 rgb(255 255 255 / 18%);
 }
 
 .dw-notes-text {
@@ -3720,12 +3741,9 @@ button.dashboard-pill-dot:focus-visible {
   z-index: 1;
   border-radius: inherit;
   background:
-    linear-gradient(160deg, rgb(255 255 255 / 18%) 0%, rgb(0 0 0 / 0%) 35%),
-    repeating-linear-gradient(
-      to bottom,
-      rgb(0 0 0 / 10%) 0 1px,
-      transparent 1px 28px
-    ),
+    linear-gradient(180deg, rgb(255 255 255 / 24%) 0 7%, rgb(150 100 0 / 7%) 7% 8%, transparent 18%),
+    repeating-linear-gradient(94deg, rgb(255 255 255 / 7%) 0 1px, transparent 1px 11px),
+    repeating-linear-gradient(3deg, rgb(77 54 0 / 4%) 0 1px, transparent 1px 15px),
     var(--note-paper);
   pointer-events: none;
   animation: dw-notes-paper-tear 220ms ease-in forwards;


### PR DESCRIPTION
## Summary
- Deepened the Dashboard Notes widget’s paper treatment with layered grain, stronger lift shadows, and more physical folded-corner shading.
- Preserved the current dynamic colors, proportions, rotation, and existing widget behavior.

## Testing
- `node tests/dashboard-notes-widget-options.test.mjs` passed.
- `git diff --check` passed.
- `npm run build` was not available in this worktree because `node_modules` is missing, so `tsc` could not run.
- Rendered browser QA was blocked by the in-app browser’s local URL policy, so I could not complete screenshot validation.