### PR TITLE
Fix terminal focus restore after app switch

### DIFF
--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -248,17 +248,23 @@ export function TerminalWorkspace({
     // (the WebView2 input routing was dead until the click), which the
     // hasFocus/activeElement signals cannot distinguish.
     inputProbeArmedRef.current = true;
-    const renderer = focusedPaneId ? getPaneRenderer(focusedPaneId) : undefined;
+    const focusRenderer = () => getPaneRenderer(focusedPaneId)?.focus();
+    // Cover the case where DOM focus did leave the terminal (e.g. a title-bar
+    // drag parked it on <body>): re-focus the pane's textarea. This is a no-op
+    // when it already holds focus. Schedule another pass for app activation,
+    // because WebView2 can ignore textarea focus until the webview receives
+    // native keyboard focus after an Alt+Tab return.
+    focusRenderer();
+    window.requestAnimationFrame(focusRenderer);
     if (isTauriRuntime()) {
       void focusMainWindow()
         .then(() => focusCurrentWebview())
         .catch(() => undefined)
-        .finally(() => logTerminalFocusDiagnostic(`restored:${reason}`));
+        .finally(() => {
+          window.requestAnimationFrame(focusRenderer);
+          logTerminalFocusDiagnostic(`restored:${reason}`);
+        });
     }
-    // Cover the case where DOM focus did leave the terminal (e.g. a title-bar
-    // drag parked it on <body>): re-focus the pane's textarea. This is a no-op
-    // when it already holds focus, so it cannot re-enter the native path.
-    renderer?.focus();
   }
 
   function describeProbeTarget(target: EventTarget | null) {
@@ -283,9 +289,15 @@ export function TerminalWorkspace({
       return;
     }
 
-    // Restore terminal input focus after a title-bar drag. The native app-window
-    // activation path is intentionally disabled: repeated WebView2/Win32 focus
-    // attempts can fight xterm's textarea and make the cursor flicker.
+    // Restore terminal input focus after native app activation and title-bar
+    // drags. Keep the actual restore gated by shouldPreserveTerminalWorkspaceFocus
+    // so dialogs, search fields, and the assistant are not stolen from the user.
+    const handleWindowFocus = () => restoreFocusedTerminalPane("window-focus");
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        restoreFocusedTerminalPane("visibility-visible");
+      }
+    };
     const handleTitlebarPointerUp = (event: PointerEvent) => {
       const target = event.target instanceof HTMLElement ? event.target : null;
       if (!target?.closest(".app-titlebar") || target.closest("button")) {
@@ -311,11 +323,15 @@ export function TerminalWorkspace({
       logTerminalFocusDiagnostic(`input-after-activation:pointerdown:${describeProbeTarget(event.target)}`);
     };
 
+    window.addEventListener("focus", handleWindowFocus);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
     document.addEventListener("pointerup", handleTitlebarPointerUp, true);
     document.addEventListener("keydown", handleProbeKeydown, true);
     document.addEventListener("pointerdown", handleProbePointerdown, true);
 
     return () => {
+      window.removeEventListener("focus", handleWindowFocus);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
       document.removeEventListener("pointerup", handleTitlebarPointerUp, true);
       document.removeEventListener("keydown", handleProbeKeydown, true);
       document.removeEventListener("pointerdown", handleProbePointerdown, true);

--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -40,6 +40,7 @@ type TerminalContextMenuState = {
 };
 
 const TMUX_MOUSE_MODE_EVENT = "kkterm:tmux-mouse-mode";
+const MAIN_WINDOW_FOCUS_CHANGED_EVENT = "kkterm://main-window-focus-changed";
 const terminalInputEncoder = new TextEncoder();
 
 function normalizeFilenamePart(value: string) {
@@ -229,6 +230,7 @@ export function TerminalWorkspace({
 
   const lastFocusRestoreRef = useRef(0);
   const inputProbeArmedRef = useRef(false);
+  const restoreFocusOnWindowFocusRef = useRef(false);
   function restoreFocusedTerminalPane(reason: string) {
     logTerminalFocusDiagnostic(`restore:${reason}`);
     if (shouldPreserveTerminalWorkspaceFocus()) {
@@ -289,13 +291,24 @@ export function TerminalWorkspace({
       return;
     }
 
-    // Restore terminal input focus after native app activation and title-bar
-    // drags. Keep the actual restore gated by shouldPreserveTerminalWorkspaceFocus
-    // so dialogs, search fields, and the assistant are not stolen from the user.
-    const handleWindowFocus = () => restoreFocusedTerminalPane("window-focus");
+    // Restore terminal input focus after native app activation only when the
+    // active terminal owned focus before the app blurred. Keep the xterm focus
+    // path pane-local instead of stealing focus on every window activation.
+    const handleWindowBlur = () => {
+      restoreFocusOnWindowFocusRef.current = shouldRestoreTerminalFocusAfterWindowBlur();
+    };
+    const handleWindowFocus = () => {
+      if (!restoreFocusOnWindowFocusRef.current) {
+        return;
+      }
+      restoreFocusOnWindowFocusRef.current = false;
+      restoreFocusedTerminalPane("window-focus");
+    };
     const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
-        restoreFocusedTerminalPane("visibility-visible");
+      if (document.visibilityState === "hidden") {
+        handleWindowBlur();
+      } else if (document.visibilityState === "visible") {
+        handleWindowFocus();
       }
     };
     const handleTitlebarPointerUp = (event: PointerEvent) => {
@@ -323,18 +336,40 @@ export function TerminalWorkspace({
       logTerminalFocusDiagnostic(`input-after-activation:pointerdown:${describeProbeTarget(event.target)}`);
     };
 
+    let disposed = false;
+    let removeNativeFocusListener: (() => void) | undefined;
+
+    window.addEventListener("blur", handleWindowBlur);
     window.addEventListener("focus", handleWindowFocus);
     document.addEventListener("visibilitychange", handleVisibilityChange);
     document.addEventListener("pointerup", handleTitlebarPointerUp, true);
     document.addEventListener("keydown", handleProbeKeydown, true);
     document.addEventListener("pointerdown", handleProbePointerdown, true);
+    if (isTauriRuntime()) {
+      void listen<boolean>(MAIN_WINDOW_FOCUS_CHANGED_EVENT, (event) => {
+        if (event.payload) {
+          handleWindowFocus();
+        } else {
+          handleWindowBlur();
+        }
+      }).then((unlisten) => {
+        if (disposed) {
+          unlisten();
+        } else {
+          removeNativeFocusListener = unlisten;
+        }
+      });
+    }
 
     return () => {
+      disposed = true;
+      window.removeEventListener("blur", handleWindowBlur);
       window.removeEventListener("focus", handleWindowFocus);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       document.removeEventListener("pointerup", handleTitlebarPointerUp, true);
       document.removeEventListener("keydown", handleProbeKeydown, true);
       document.removeEventListener("pointerdown", handleProbePointerdown, true);
+      removeNativeFocusListener?.();
     };
   }, [focusedPaneId, isActive]);
 
@@ -2957,6 +2992,11 @@ function logTerminalFocusDiagnostic(stage: string) {
     hasFocus: document.hasFocus(),
     activeElement: describe,
   });
+}
+
+function shouldRestoreTerminalFocusAfterWindowBlur() {
+  const activeElement = document.activeElement;
+  return activeElement instanceof HTMLElement && activeElement.closest(".terminal-pane") !== null;
 }
 
 function shouldPreserveTerminalWorkspaceFocus() {


### PR DESCRIPTION
### Motivation
- Alt+Tab returning to the app can leave connected xterm terminals accepting clicks but not keyboard input because WebView2 may not route native keyboard focus to the embedded textarea immediately. 
- The existing restore path focused only the textarea and attempted native focus once, which can be ignored by WebView2 until the webview itself regains OS focus. 
- Avoid stealing focus from dialogs, the assistant, or active input fields while still restoring terminal input when appropriate. 

### Description
- Retry scheduling of the terminal renderer focus (`getPaneRenderer(...).focus()`) immediately and again on the next animation frame so DOM focus is enforced before native focus attempts. 
- After the native focus call, schedule a second focus retry so the textarea receives keyboard input once WebView2 has the OS keyboard focus. 
- Add `window` `focus` and `document.visibilitychange` listeners to call the same restore routine on native window reactivation and visibility return. 
- Preserve the existing guard (`shouldPreserveTerminalWorkspaceFocus`) so the restore does not override user-visible editable or assistant surfaces. 

### Testing
- Ran `npx tsc --noEmit` and it completed successfully. 
- Ran `git diff --check` and it reported no whitespace/merge issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26260f5cf48323926facb4d3408e7c)