### PR TITLE
Fix duplicated local terminal buffer after tab switch

### DIFF
--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -1363,6 +1363,7 @@ function TerminalPaneView({
   const resizeFrameRef = useRef<number | null>(null);
   const resizeTimeoutRefs = useRef<number[]>([]);
   const fitAndResizeRef = useRef<() => void>(() => undefined);
+  const isActiveRef = useRef(isActive);
   const startedRef = useRef(false);
   const tmuxWheelFlushTimerRef = useRef<number | null>(null);
   const tmuxWheelPendingLinesRef = useRef(0);
@@ -1372,6 +1373,9 @@ function TerminalPaneView({
   useEffect(() => {
     onFocusRef.current = onFocus;
   }, [onFocus]);
+  useEffect(() => {
+    isActiveRef.current = isActive;
+  }, [isActive]);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
   const [searchResult, setSearchResult] = useState<{
@@ -1580,6 +1584,7 @@ function TerminalPaneView({
             allowOsc52Clipboard: sshSettings.allowOsc52Clipboard,
           }
         : terminalSettings;
+    const terminalHost = element;
     const terminal = createTerminalRenderer(rendererSettings, terminalOpacity);
     terminalRendererRef.current = terminal;
     const cwdDisposable = terminal.onCwdChange((cwd) => updatePaneCwd(tabId, pane.id, cwd));
@@ -1703,6 +1708,14 @@ function TerminalPaneView({
     });
 
     function fitAndResizeTerminal() {
+      // Inactive workspace Tabs are display:none. Fitting xterm while hidden can
+      // resize Windows ConPTY through a zero/unstable viewport; ConPTY then
+      // replays the visible screen on the next real resize, which appends a
+      // duplicate-looking terminal buffer after switching back to the Tab.
+      if (!isActiveRef.current || terminalHost.clientWidth <= 0 || terminalHost.clientHeight <= 0) {
+        return;
+      }
+
       const dimensions = terminal.fit();
       const lastDimensions = lastResizeDimensionsRef.current;
       if (lastDimensions && terminalDimensionsEqual(lastDimensions, dimensions)) {


### PR DESCRIPTION
### Motivation
- Users reported duplicated terminal output after switching away from and back to a terminal Tab when a local startup command (e.g. `dir`) ran at session start.  The duplication appears to come from fitting/resizing the xterm host while the pane is hidden, causing Windows ConPTY to replay screen contents.

### Description
- Add an `isActiveRef` to `TerminalPaneView` so long-lived resize/fitting callbacks consult current active/visibility state instead of mount-time props (`src/modules/workspace/connections/terminal/TerminalWorkspace.tsx`).
- Capture the terminal host element and skip `xterm.fit()` and backend `resize_terminal` calls when the pane is inactive or its host has no measurable size, preventing ConPTY from replaying the visible screen and producing duplicate buffer text. (Guard added inside `fitAndResizeTerminal` and `started` logic.)
- Change is intentionally minimal and localized to terminal pane lifecycle and resize logic to preserve the lifecycle invariant that switching Tabs must not tear down live Sessions.

### Testing
- Ran the frontend checks with `npm run check`, which completed successfully (test suite passed). 
- Ran `git diff --check` as a code hygiene check with no issues.
- Note: full Windows Tauri runtime manual smoke tests were not run in CI here; please verify a local Windows Tauri run with a local Connection that uses a `localStartupScript` such as `dir` to confirm the duplication is resolved in the real runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a268e76fa008323985b206628abbc70)