### PR TITLE
fix(terminal): scope native focus escalation to genuine window re-activation

### DIFF
--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -232,7 +232,10 @@ export function TerminalWorkspace({
   const lastFocusRestoreRef = useRef(0);
   const inputProbeArmedRef = useRef(false);
   const restoreFocusOnWindowFocusRef = useRef(false);
-  function restoreFocusedTerminalPane(reason: string) {
+  // Only a genuine OS window re-activation ("window-focus") escalates to native
+  // WebView2 focus; in-app activations stay DOM-only (see restoreFocusedTerminalPane).
+  type TerminalFocusRestoreReason = "workspace-activated" | "window-focus" | "titlebar";
+  function restoreFocusedTerminalPane(reason: TerminalFocusRestoreReason) {
     logTerminalFocusDiagnostic(`restore:${reason}`);
     if (shouldPreserveTerminalWorkspaceFocus()) {
       return;
@@ -254,12 +257,18 @@ export function TerminalWorkspace({
     const focusRenderer = () => getPaneRenderer(focusedPaneId)?.focus();
     // Cover the case where DOM focus did leave the terminal (e.g. a title-bar
     // drag parked it on <body>): re-focus the pane's textarea. This is a no-op
-    // when it already holds focus. Schedule another pass for app activation,
-    // because WebView2 can ignore textarea focus until the webview receives
-    // native keyboard focus after an Alt+Tab return.
+    // when it already holds focus.
     focusRenderer();
     window.requestAnimationFrame(focusRenderer);
-    if (isTauriRuntime()) {
+    // Native focus escalation (window.set_focus -> WebView2 MoveFocus) re-arms
+    // the WebView2 content window's OS keyboard focus. That is only necessary
+    // when the OS actually moved keyboard focus off our window -- an Alt+Tab /
+    // taskbar return ("window-focus"). On in-app activations ("workspace-
+    // activated", "titlebar") the WebView2 content still owns native keyboard
+    // focus, so escalating there forces focus onto the terminal and steals it
+    // from whatever pane/control the UI legitimately routed focus to during the
+    // module switch (the #269/#270 regression). Keep in-app paths DOM-only.
+    if (reason === "window-focus" && isTauriRuntime()) {
       void focusMainWindow()
         .then(() => focusCurrentWebview())
         .catch(() => undefined)
@@ -267,6 +276,8 @@ export function TerminalWorkspace({
           window.requestAnimationFrame(focusRenderer);
           logTerminalFocusDiagnostic(`restored:${reason}`);
         });
+    } else {
+      logTerminalFocusDiagnostic(`restored:${reason}`);
     }
   }
 


### PR DESCRIPTION
## Problem

SSH terminal panes lose keyboard input focus in two scenarios on Windows (Tauri v2 / WebView2):

- **Alt-Tab return** (original bug): returning to the app, keystrokes go nowhere until you click the pane.
- **In-app module switch** (the #269/#270 regression): switching between modules inside the app now drops text focus.

## Root cause

`restoreFocusedTerminalPane` escalated to **native** WebView2 focus (`focusMainWindow()` → `window.set_focus()`, then `focusCurrentWebview()` → wry `MoveFocus`) on **every** invocation reason. One of those reasons, `"workspace-activated"`, fires on every in-app activation/pane change. Forcing WebView2 content focus during an in-app transition is a blunt hammer: the WebView2 content already owns OS keyboard focus in that case, so the native call only serves to yank focus onto the terminal and steal it from whatever pane/control the UI legitimately routed it to.

The native escalation is genuinely needed for the Alt-Tab case (the frameless `decorations: false` window doesn't get OS focus-restoration for free), but it is wrong for in-app activations.

## Fix

Scope the native escalation to `reason === "window-focus"` — a genuine OS Alt-Tab / taskbar return. In-app reasons (`"workspace-activated"`, `"titlebar"`) now re-focus the xterm textarea **DOM-only** (`focusRenderer()`), which is all that's required when native keyboard focus never left the window.

This mirrors the reference architecture compared during investigation (oxideterm): it makes **no** native focus call for in-app activation and relies on DOM focus alone (its `soft`/`strong` focus split). KKTerm needs the native path only because it is frameless; restricting it to true window re-activation keeps the Alt-Tab fix while removing the in-app regression.

Also tightens the `reason` parameter from `string` to a union type (`"workspace-activated" | "window-focus" | "titlebar"`) so the scope is compiler-enforced against future callers.

## Changes

- `src/modules/workspace/connections/terminal/TerminalWorkspace.tsx`: gate native focus escalation on `"window-focus"`; add `TerminalFocusRestoreReason` union type.

## Testing

- ✅ `tsc --noEmit` clean.
- ⚠️ **Not behaviorally verified** — WebView2 native focus routing can't be reproduced in jsdom/vitest and isn't covered by `npm run check`. Needs manual verification on the running Windows app:
  1. **Regression gone:** switch between modules (Dashboard ↔ terminal, terminal ↔ settings); terminal keystrokes land immediately, and focus is not yanked into the terminal when switching to a module that wants an input.
  2. **Alt-Tab fix intact:** Alt-Tab away and back; terminal accepts keystrokes without a click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)