### PR TITLE
fix(terminal): restore focus via WebView2 MoveFocus instead of raising the frame

### DIFF
--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -14,7 +14,7 @@ import type { FormEvent, KeyboardEvent, MouseEvent as ReactMouseEvent, PointerEv
 import { useTranslation } from "react-i18next";
 import i18next from "../../../../i18n/config";
 import { ariaInvalid, dialogButtonAria, menuButtonAria } from "../../../../lib/aria";
-import { focusCurrentWebview, focusMainWindow, invokeCommand, isTauriRuntime, logUiDebug, saveTextFile, type RemoteLoopbackPort, type TerminalOutput, type TerminalRecordingEntry, type TerminalRecordingInfo, type TmuxSession } from "../../../../lib/tauri";
+import { focusCurrentWebview, invokeCommand, isTauriRuntime, logUiDebug, saveTextFile, type RemoteLoopbackPort, type TerminalOutput, type TerminalRecordingEntry, type TerminalRecordingInfo, type TmuxSession } from "../../../../lib/tauri";
 import { defaultTerminalSettings } from "../../../../app-defaults";
 import { forgetTmuxSessionId, useWorkspaceStore } from "../../../../store";
 import { createTerminalRenderer, type TerminalDimensions, type TerminalRenderer } from "./renderer";
@@ -260,8 +260,15 @@ export function TerminalWorkspace({
     focusRenderer();
     window.requestAnimationFrame(focusRenderer);
     if (isTauriRuntime()) {
-      void focusMainWindow()
-        .then(() => focusCurrentWebview())
+      // Restore keyboard focus through WebView2's own MoveFocus
+      // (focusCurrentWebview), NOT by raising the frame with SetForegroundWindow
+      // (focusMainWindow). With the custom title bar (decorations: false) the OS
+      // no longer auto-restores focus to the WebView2 content child on
+      // activation, and raising the top-level frame first yanked focus back up to
+      // the frame HWND — the regression behind the lost-input bug. MoveFocus is
+      // the documented path a native title bar leverages to route WM_KEYDOWN into
+      // the web content, so we call it alone.
+      void focusCurrentWebview()
         .catch(() => undefined)
         .finally(() => {
           window.requestAnimationFrame(focusRenderer);
@@ -1598,9 +1605,7 @@ function TerminalPaneView({
     // dropped until the user clicks. Route native focus into the webview once
     // when this pane is the active, focused one.
     if (isActive && isFocused && isTauriRuntime()) {
-      void focusMainWindow()
-        .then(() => focusCurrentWebview())
-        .catch(() => undefined);
+      void focusCurrentWebview().catch(() => undefined);
     }
     terminal.attachCustomKeyEventHandler((event) => {
       // xterm.js emits a bare CR for Shift+Enter, indistinguishable from a


### PR DESCRIPTION
## The bug

With the **custom React title bar** (`decorations: false`), the SSH terminal loses keyboard input after minimize/restore (and Alt-Tab). The textarea keeps DOM focus, but `WM_KEYDOWN` never reaches it until the user clicks.

## Root cause (confirmed by comparison with a working app)

Compared KKTerm against [OxideTerm](https://github.com/AnalyseDeCircuit/oxideterm) — same Rust/Tauri/xterm stack, no focus bug. OxideTerm uses **`decorations: true`** (native title bar) and has **zero** window-focus code. With a native title bar, Windows' `DefWindowProc` auto-restores keyboard focus to the WebView2 content child on activation.

This matches the reporter's own finding: **switching KKTerm to a native title bar makes focus restore correctly; the custom bar does not.**

With `decorations: false`, that automatic restoration is gone, so our compensating code becomes the deciding factor — and it was fighting itself. The restore path did:

```ts
focusMainWindow()            // SetForegroundWindow on the top-level frame HWND
  .then(() => focusCurrentWebview())   // WebView2 MoveFocus into web content
```

Raising the frame first yanked keyboard focus **up to the frame HWND**, so the subsequent `MoveFocus` was racing against a focus that had just been parked on the wrong window. The frame raise is the disease, not the cure.

## The fix

Drop the frame raise from both terminal focus-restore paths and rely solely on **WebView2's own `MoveFocus`** (`focusCurrentWebview`) — the exact documented mechanism a native title bar leverages to route keyboard input into the web content. No `SetForegroundWindow`, no native child-HWND walking.

- `restoreFocusedTerminalPane` (minimize/restore, Alt-Tab, title-bar drag): `focusCurrentWebview()` alone + the existing DOM `renderer.focus()`.
- Fresh-terminal-open path: same.

## Why this is different from prior attempts

Every prior PR (#264–#283) *added* native focus machinery (frame `set_focus`, child-HWND `SetFocus` walks). This is the first that **removes** the frame raise and lets WebView2 do what it already does for the native-bar case. Net diff is one file, −frame-raise.

## Test plan

- [x] `tsc --noEmit` passes
- [ ] Custom title bar: minimize → restore → terminal accepts keystrokes immediately (no click)
- [ ] Custom title bar: Alt-Tab away → back → terminal accepts keystrokes
- [ ] In-app module/tab switching keeps terminal focus (no regression from the earlier native-walk attempt)

https://claude.ai/code/session_01Kww2P9kNeBAD4jCSmARe9F

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kww2P9kNeBAD4jCSmARe9F)_