### PR TITLE
fix(window): stop TAURI_DRAG_RESIZE_WINDOW from stealing terminal keyboard focus

### DIFF
--- a/src-tauri/src/window_effects.rs
+++ b/src-tauri/src/window_effects.rs
@@ -8,7 +8,61 @@ pub fn apply_title_bar_mode<R: tauri::Runtime>(window: &tauri::WebviewWindow<R>)
     }
 
     apply_main_window_backdrop(window);
+    neutralize_drag_resize_focus(window);
 }
+
+// An undecorated, resizable window makes tauri-runtime-wry attach a focusable
+// child window (class/title "TAURI_DRAG_RESIZE_WINDOW") that proxies edge-resize
+// hit-testing. It is created without WS_EX_NOACTIVATE, so it can hold the Win32
+// keyboard focus; once it does, it becomes the frame's saved focus target and
+// the OS restores focus to it — not the WebView2 content — every time the app is
+// re-activated (minimize/restore, Alt+Tab). The terminal then keeps DOM focus
+// yet never receives WM_KEYDOWN. A window with a native title bar has no such
+// child, which is why it restores focus correctly. Mark the helper
+// non-activating so it can never become the focus target; resize hit-testing
+// (WM_NCHITTEST / WM_NCLBUTTONDOWN, which it forwards to the parent) is
+// unaffected because that path does not require focus or activation.
+#[cfg(target_os = "windows")]
+fn neutralize_drag_resize_focus<R: tauri::Runtime>(window: &tauri::WebviewWindow<R>) {
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        GWL_EXSTYLE, GW_CHILD, GW_HWNDNEXT, GetWindow, GetWindowLongPtrW, GetWindowTextW,
+        SetWindowLongPtrW, WS_EX_NOACTIVATE,
+    };
+
+    let parent = match window.hwnd() {
+        Ok(handle) => HWND(handle.0 as *mut _),
+        Err(_) => return,
+    };
+
+    unsafe {
+        let mut child = match GetWindow(parent, GW_CHILD) {
+            Ok(hwnd) => hwnd,
+            Err(_) => return,
+        };
+        loop {
+            let mut text = [0u16; 32];
+            let len = GetWindowTextW(child, &mut text);
+            if len > 0
+                && String::from_utf16_lossy(&text[..len as usize]) == "TAURI_DRAG_RESIZE_WINDOW"
+            {
+                let ex_style = GetWindowLongPtrW(child, GWL_EXSTYLE);
+                let next = ex_style | WS_EX_NOACTIVATE.0 as isize;
+                if next != ex_style {
+                    SetWindowLongPtrW(child, GWL_EXSTYLE, next);
+                }
+                break;
+            }
+            match GetWindow(child, GW_HWNDNEXT) {
+                Ok(next) => child = next,
+                Err(_) => break,
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn neutralize_drag_resize_focus<R: tauri::Runtime>(_window: &tauri::WebviewWindow<R>) {}
 
 #[cfg(target_os = "windows")]
 pub fn apply_main_window_backdrop<R: tauri::Runtime>(window: &tauri::WebviewWindow<R>) {


### PR DESCRIPTION
## Root cause (finally pinned, via inspect.exe)

The reporter compared KKTerm against [OxideTerm](https://github.com/AnalyseDeCircuit/oxideterm) (same Rust/Tauri/xterm stack, no focus bug) using `inspect.exe`. The **only** structural difference in the window tree:

- **KKTerm** main window's first child = **`TAURI_DRAG_RESIZE_WINDOW`** (window, focusable)
- **OxideTerm** has no such child — its first child is the web content

`tauri-runtime-wry` attaches that helper child to **undecorated + resizable** windows to proxy edge-resize hit-testing (`undecorated_resizing.rs`). It's created with `WS_CHILD | WS_VISIBLE` and **`WINDOW_EX_STYLE::default()` — no `WS_EX_NOACTIVATE`**, so it *can* hold Win32 keyboard focus.

Once it acquires focus, it becomes the frame's **saved focus target**, and on every re-activation (minimize→restore, Alt+Tab) the OS restores focus to *it* instead of the WebView2 content. The terminal keeps DOM focus but never receives `WM_KEYDOWN` — exactly the reported symptom. A **native** title bar has no such child, which is precisely why the reporter found native decorations restore focus correctly while the custom bar does not.

This also explains why earlier native attempts made things *worse*: `GetWindow(frame, GW_CHILD)` returns this helper as the **first child**, so walking/`SetFocus`-ing from there landed on the wrong window.

## Fix

After applying title-bar mode, locate the `TAURI_DRAG_RESIZE_WINDOW` child and set **`WS_EX_NOACTIVATE`** on it so it can never become the focus target.

- **Resize is unaffected:** the helper only handles `WM_NCHITTEST` / `WM_NCLBUTTONDOWN` (which it forwards to the parent); neither needs focus or activation.
- Lives in `window_effects::apply_title_bar_mode`, so it's (re)applied on startup and whenever decorations are re-asserted (settings import / appearance change). Idempotent.
- Windows-only; no-op stub elsewhere.

Builds on #286 (MoveFocus restore): activation now both routes focus into the web content *and* removes the sibling that was stealing it.

## Test plan

- [ ] Custom title bar: minimize → restore → terminal accepts keystrokes immediately (no click)
- [ ] Custom title bar: Alt+Tab away → back → terminal accepts keystrokes
- [ ] Edge-resize of the borderless window still works (drag all 8 edges/corners)
- [ ] In-app tab/module switching keeps terminal focus
- [ ] Re-confirm with inspect.exe that `TAURI_DRAG_RESIZE_WINDOW` is no longer "focusable"

> Note: couldn't compile on the Linux CI container (Windows-first app, GTK absent). API signatures were matched against existing `screenshot.rs` / `rdp.rs` usage. Worth a quick local `cargo check` on Windows before merge.

https://claude.ai/code/session_01Kww2P9kNeBAD4jCSmARe9F

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kww2P9kNeBAD4jCSmARe9F)_