### PR TITLE
Fix terminal search decorations crash

### DIFF
--- a/src/modules/workspace/connections/terminal/renderer.ts
+++ b/src/modules/workspace/connections/terminal/renderer.ts
@@ -458,6 +458,10 @@ function terminalBackgroundColor(opacity: number) {
 function terminalOptionsFor(settings: TerminalSettings, backgroundOpacity: number): ITerminalOptions {
   return {
     altClickMovesCursor: false,
+    // @xterm/addon-search renders match decorations through xterm's proposed
+    // decoration API. Without this, the first decorated scrollback search can
+    // throw from the renderer path and leave the Tauri WebView unusable.
+    allowProposedApi: true,
     allowTransparency: true,
     convertEol: false,
     customGlyphs: true,


### PR DESCRIPTION
### Motivation
- Prevent KKTerm WebView from hanging when using the terminal search: `@xterm/addon-search` uses xterm's proposed decoration API for match highlighting and can throw from the renderer path if the terminal instance does not enable proposed APIs.

### Description
- Enable `allowProposedApi: true` in `terminalOptionsFor` inside `src/modules/workspace/connections/terminal/renderer.ts` and add an inline comment explaining this is required so the search addon can create decorations safely.

### Testing
- Ran the project checks via `npm run check` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27e729964883238d6eea60354c46fb)