### PR TITLE
fix(webview): retry URL overlay show until HWND realizes; anchor overlay to client origin

### DIFF
--- a/src-tauri/src/webview.rs
+++ b/src-tauri/src/webview.rs
@@ -758,17 +758,50 @@ fn overlay_rect(
     let scale_factor = host_window
         .scale_factor()
         .map_err(|error| format!("failed to read host window scale factor: {error}"))?;
-    let host_origin = host_window
-        .inner_position()
-        .map_err(|error| format!("failed to read host window content position: {error}"))?;
+    let host_origin = host_content_origin(host_window)?;
     let left = host_origin.x + (x.max(0.0) * scale_factor).round() as i32;
     let top = host_origin.y + (y.max(0.0) * scale_factor).round() as i32;
-    let width = (width.max(1.0) * scale_factor).round().max(1.0) as u32;
-    let height = (height.max(1.0) * scale_factor).round().max(1.0) as u32;
+    let physical_width = (width.max(1.0) * scale_factor).round().max(1.0) as u32;
+    let physical_height = (height.max(1.0) * scale_factor).round().max(1.0) as u32;
+    webview_debug_log(format!(
+        "overlay_rect scale={scale_factor} host_origin=({host_x},{host_y}) dom=(x={x},y={y},w={width},h={height}) -> pos=({left},{top}) size=({physical_width},{physical_height})",
+        host_x = host_origin.x,
+        host_y = host_origin.y,
+    ));
     Ok((
         PhysicalPosition::new(left, top),
-        PhysicalSize::new(width, height),
+        PhysicalSize::new(physical_width, physical_height),
     ))
+}
+
+/// Screen-space origin of the host WebView's client area — where DOM `(0, 0)`
+/// physically renders. On Windows the host is a borderless, resizable window
+/// whose frame insets can make `inner_position` drift a few pixels from the
+/// actual content origin, leaving a gap beside the overlay; `ClientToScreen`
+/// reports the true client origin instead.
+#[cfg(target_os = "windows")]
+fn host_content_origin(host_window: &WebviewWindow) -> Result<PhysicalPosition<i32>, String> {
+    use windows::Win32::Foundation::{HWND, POINT};
+    use windows::Win32::Graphics::Gdi::ClientToScreen;
+
+    let hwnd = host_window
+        .hwnd()
+        .map_err(|error| format!("failed to read host window HWND: {error}"))?;
+    let mut origin = POINT { x: 0, y: 0 };
+    let mapped = unsafe { ClientToScreen(HWND(hwnd.0), &mut origin) };
+    if mapped.as_bool() {
+        return Ok(PhysicalPosition::new(origin.x, origin.y));
+    }
+    host_window
+        .inner_position()
+        .map_err(|error| format!("failed to read host window content position: {error}"))
+}
+
+#[cfg(not(target_os = "windows"))]
+fn host_content_origin(host_window: &WebviewWindow) -> Result<PhysicalPosition<i32>, String> {
+    host_window
+        .inner_position()
+        .map_err(|error| format!("failed to read host window content position: {error}"))
 }
 
 #[cfg(target_os = "windows")]

--- a/src/modules/workspace/connections/webview/WebViewWorkspace.tsx
+++ b/src/modules/workspace/connections/webview/WebViewWorkspace.tsx
@@ -50,6 +50,11 @@ interface WebviewSessionLease {
 
 const webviewSessionLeases = new Map<string, WebviewSessionLease>();
 const HIDDEN_WEBVIEW_BOUNDS = { x: 0, y: 0, width: 1, height: 1 };
+// The overlay's native window handle is realized asynchronously by the event loop, so the
+// very first show after a session starts can race ahead of it and fail with "the underlying
+// handle is not available". Retrying the show across a few short delays lets the loop catch up.
+const WEBVIEW_HANDLE_NOT_READY_PATTERN = /handle is not available|webview hwnd|failed to realize/i;
+const WEBVIEW_SHOW_RETRY_DELAYS_MS = [80, 160, 320, 640, 1000];
 
 function acquireWebviewSession(sessionId: string, start: () => Promise<WebviewSessionStarted>) {
   const current = webviewSessionLeases.get(sessionId);
@@ -271,6 +276,29 @@ export function WebViewWorkspace({
     });
   };
 
+  const requestWebviewVisibility = (
+    request: { sessionId: string; visible: boolean; x: number; y: number; width: number; height: number },
+    attempt = 0,
+  ): Promise<void | null> =>
+    invokeCommand("set_webview_visibility", { request }).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      const stillWantsVisible = visibilityRef.current.isActive && !visibilityRef.current.suppressed;
+      const shouldRetry =
+        request.visible &&
+        stillWantsVisible &&
+        sessionStartedRef.current &&
+        attempt < WEBVIEW_SHOW_RETRY_DELAYS_MS.length &&
+        WEBVIEW_HANDLE_NOT_READY_PATTERN.test(message);
+      if (!shouldRetry) {
+        throw error instanceof Error ? error : new Error(message);
+      }
+      return new Promise<void | null>((resolve, reject) => {
+        window.setTimeout(() => {
+          requestWebviewVisibility(request, attempt + 1).then(resolve, reject);
+        }, WEBVIEW_SHOW_RETRY_DELAYS_MS[attempt]);
+      });
+    });
+
   const pushWebviewVisibility = () => {
     if (!sessionStartedRef.current) {
       return;
@@ -280,8 +308,10 @@ export function WebViewWorkspace({
     if (!bounds && visible) {
       return;
     }
-    const visibilityUpdate = invokeCommand("set_webview_visibility", {
-      request: { sessionId: sessionIdRef.current, visible, ...(bounds ?? HIDDEN_WEBVIEW_BOUNDS) },
+    const visibilityUpdate = requestWebviewVisibility({
+      sessionId: sessionIdRef.current,
+      visible,
+      ...(bounds ?? HIDDEN_WEBVIEW_BOUNDS),
     });
     void visibilityUpdate.catch((error) => {
       setNavError(error instanceof Error ? error.message : String(error));

--- a/tests/webview-visibility-lifecycle.test.mjs
+++ b/tests/webview-visibility-lifecycle.test.mjs
@@ -85,14 +85,34 @@ test("backend realizes hidden URL overlay windows before HWND-dependent no-activ
 test("backend positions URL overlays from the host WebView client origin", async () => {
   const source = await readFile(new URL("../src-tauri/src/webview.rs", import.meta.url), "utf8");
   const overlayFunction = source.match(/fn overlay_rect\([\s\S]*?\n\}/)?.[0];
+  const hostOriginFunction = source.match(/fn host_content_origin[\s\S]*?ClientToScreen[\s\S]*?\n\}/)?.[0];
 
   assert.ok(overlayFunction, "overlay_rect should exist");
-  assert.match(overlayFunction, /inner_position\(\)/);
+  assert.match(overlayFunction, /host_content_origin\(host_window\)/);
   assert.doesNotMatch(
     overlayFunction,
     /outer_position\(\)/,
     "DOM client coordinates should be offset from the host WebView content origin",
   );
+  assert.ok(hostOriginFunction, "host_content_origin should resolve the client origin via ClientToScreen on Windows");
+  assert.match(hostOriginFunction, /inner_position\(\)/, "host_content_origin should fall back to inner_position");
+});
+
+test("frontend retries the overlay show while the native handle is still realizing", async () => {
+  const source = await readFile(
+    new URL("../src/modules/workspace/connections/webview/WebViewWorkspace.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(source, /const WEBVIEW_HANDLE_NOT_READY_PATTERN = /);
+  assert.match(source, /const WEBVIEW_SHOW_RETRY_DELAYS_MS = \[/);
+  const requestVisibility = source.match(/const requestWebviewVisibility = \([\s\S]*?\n    \}\);/)?.[0];
+  assert.ok(requestVisibility, "requestWebviewVisibility should exist");
+  assert.match(requestVisibility, /request\.visible/);
+  assert.match(requestVisibility, /WEBVIEW_HANDLE_NOT_READY_PATTERN\.test\(message\)/);
+  assert.match(requestVisibility, /attempt < WEBVIEW_SHOW_RETRY_DELAYS_MS\.length/);
+  assert.match(requestVisibility, /requestWebviewVisibility\(request, attempt \+ 1\)/);
+  assert.match(source, /const visibilityUpdate = requestWebviewVisibility\(\{/);
 });
 
 test("frontend repushes URL overlay bounds on native window move", async () => {


### PR DESCRIPTION
## What & why

Two URL-connection WebView bugs on Windows:

### Bug 1 — `failed to get URL webview HWND: the underlying handle is not available` on initial load
The overlay window is built `.visible(false)`, so its native handle is realized **asynchronously** by the event loop. The first `set_webview_visibility` show fires before that, so `window.hwnd()` fails. It only cleared later (e.g. opening the "add connection" dialog forced a re-show after enough time had elapsed). The prior `show()`→retry happened in the same synchronous call, so it never gave the loop a turn.

**Fix:** a bounded retry at the IPC boundary (`requestWebviewVisibility`) that re-invokes the show across `[80, 160, 320, 640, 1000]ms`, gated on the handle-not-ready error signature **and** the pane still wanting to be visible. After exhausting retries it surfaces the error exactly as before. No native thread is blocked (a backend sleep could deadlock the very loop that realizes the handle).

### Bug 2 — gap to the left of the URL pane
The overlay was anchored to the host WebView content origin via tao's `inner_position()`, which can drift a few pixels from the real client origin on a borderless, resizable Windows frame.

**Fix:** resolve the host origin from Win32 `ClientToScreen({0,0})` ground truth (where DOM `(0,0)` actually renders), falling back to `inner_position()` on failure / non-Windows. Added `KKTERM_WEBVIEW_DEBUG=1` logging of the computed overlay rect.

## Reviewer notes
- **Bug 2 needs a live confirm.** I couldn't measure the GUI. If the gap persists, run with `KKTERM_WEBVIEW_DEBUG=1` and check the `overlay_rect ...` log line to pin down host-origin vs overlay-frame vs DPI rounding.
- Two **pre-existing, unrelated** failures in `webview-visibility-lifecycle.test.mjs` (`target=_blank new tab` / `store creates top-level WebView Tabs`) fail on a clean baseline too — not touched here.

## Verification
- `npx tsc --noEmit` — clean
- `cargo check` — clean (new `ClientToScreen`/`as_bool()` compiles)
- `tests/webview-visibility-lifecycle.test.mjs` — updated positioning test + new retry test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)