### PR TITLE
fix(ssh): send SSH keepalives so idle sessions stop freezing

### DIFF
--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -23,6 +23,15 @@ const SSH_TMUX_RESUME_TIMEOUT: Duration = Duration::from_secs(10);
 const SSH_TMUX_RESUME_DELAY: Duration = Duration::from_millis(750);
 const SSH_STARTUP_TIMEOUT: Duration = Duration::from_secs(15);
 const SSH_X11_REQUEST_WANT_REPLY: bool = true;
+// Idle SSH sessions must keep sending SSH-level keepalives so NAT/firewall state
+// stays alive and a dead link is detected instead of silently freezing input
+// (russh equivalent of OpenSSH ServerAliveInterval/ServerAliveCountMax). An
+// active session resets this timer on received data, so it adds no traffic.
+const SSH_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30);
+// Tear down a dead link after this many unanswered keepalives. With a 30s
+// interval that is a ~2.5 min detection window — tight enough to recover an
+// idle freeze quickly, loose enough to ride out a brief network blip.
+const SSH_KEEPALIVE_MAX_MISSED: usize = 4;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -1002,6 +1011,8 @@ fn x11_auth_cookie() -> String {
 fn native_ssh_client_config() -> client::Config {
     client::Config {
         inactivity_timeout: None,
+        keepalive_interval: Some(SSH_KEEPALIVE_INTERVAL),
+        keepalive_max: SSH_KEEPALIVE_MAX_MISSED,
         ..Default::default()
     }
 }
@@ -1258,6 +1269,21 @@ mod tests {
         let config = native_ssh_client_config();
 
         assert_eq!(config.inactivity_timeout, None);
+    }
+
+    #[test]
+    fn native_ssh_client_sends_keepalives_to_detect_dead_idle_links() {
+        let config = native_ssh_client_config();
+
+        // Without keepalives an idle session behind a NAT/firewall freezes:
+        // the link dies silently, input is swallowed, yet the session never
+        // observes EOF/Close so it keeps reporting as connected.
+        assert_eq!(config.keepalive_interval, Some(SSH_KEEPALIVE_INTERVAL));
+        assert!(
+            config.keepalive_max > 0,
+            "a dead link must be torn down after a bounded number of missed keepalives"
+        );
+        assert_eq!(config.keepalive_max, SSH_KEEPALIVE_MAX_MISSED);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Reported on 0.1.72 (Windows): after an SSH session sits idle for a while, the connection light stays **green** but the terminal accepts **no input** — the only recovery is closing the tab and reconnecting.

## Root cause

`native_ssh_client_config()` set `inactivity_timeout: None` (intentional — don't kill genuinely idle sessions) but left russh's `keepalive_interval` at its default `None`, so the client **never sent a keepalive probe**.

When an idle session sits behind a NAT/stateful firewall (typical on Windows networks), the firewall silently evicts the connection's state-table entry. The TCP link becomes a half-open zombie — no RST, no FIN. With no keepalive, russh's run loop blocks forever in `channel.wait()`, never observes `Eof`/`Close`, and keeps the session reporting as connected (green light). Keystrokes get written into the dead socket, which the OS buffers/retransmits for minutes without erroring → frozen input. A fresh tab makes a new TCP connection, which is why reconnecting is the only recovery.

## Fix

Enable SSH-level keepalive (russh equivalent of OpenSSH `ServerAliveInterval`/`ServerAliveCountMax`):

- `SSH_KEEPALIVE_INTERVAL = 30s` — strict-firewall-grade idle probing keeps NAT/firewall mappings alive, so the connection no longer dies during idle.
- `SSH_KEEPALIVE_MAX_MISSED = 4` — a genuinely dead link is torn down after ~2.5 min, so the loop returns `Disconnected` instead of lying green forever.

russh resets the keepalive timer on any received data, so an **active** session sends zero extra packets — only idle sessions are probed. `inactivity_timeout` stays `None`, so genuinely idle (but alive) sessions are never killed.

Interval/count chosen against documented norms (30–60s interval, 3–5 count); 30s is the recommended value for the aggressive firewalls that cause this exact freeze.

## Testing

- New unit test `native_ssh_client_sends_keepalives_to_detect_dead_idle_links` asserts the keepalive config.
- Existing `native_ssh_client_does_not_timeout_idle_terminal_sessions` still passes (no hard idle-disconnect reintroduced).
- `cargo test --lib ssh::` → 20 passed, 0 failed.

## Not included (separate concern)

The terminal frontend only listens for `terminal-output`; there's no "session ended" event, so the indicator reflects "tab is open," not live TCP health. This PR removes the *cause* of the freeze; wiring the indicator to reflect real liveness on disconnect is a separate frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
