### PR TITLE
fix(ssh): stop PTY echo from hiding the tmux session label

### DIFF
--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -856,7 +856,12 @@ pub(crate) fn remote_tmux_resume_command(
         .map(|directory| format!("cd -- {} && ", shell_single_quote(directory)))
         .unwrap_or_default();
     format!(
-        "if command -v tmux >/dev/null 2>&1; then {cd_command}exec tmux new-session -A -s {} \\; set-option mouse on \\; set-option set-clipboard on \\; set-option history-limit {}; else {cd_command}printf '\\r\\n[KKTerm: tmux not found, using normal shell]\\r\\n'; exec \"${{SHELL:-sh}}\" -i; fi",
+        // The else-branch builds the "[KKTerm: tmux not found, using normal shell]"
+        // marker from a printf %s argument on purpose: the command is typed into the
+        // remote PTY, which echoes it back, and the frontend hides the tmux label when
+        // it sees that marker in terminal output. Keeping the bracketed marker out of
+        // the literal command source means only a genuine tmux-less run emits it.
+        "if command -v tmux >/dev/null 2>&1; then {cd_command}exec tmux new-session -A -s {} \\; set-option mouse on \\; set-option set-clipboard on \\; set-option history-limit {}; else {cd_command}printf '\\r\\n[%s]\\r\\n' 'KKTerm: tmux not found, using normal shell'; exec \"${{SHELL:-sh}}\" -i; fi",
         shell_single_quote(session_id),
         clamp_tmux_history_limit(history_limit),
     )
@@ -1462,6 +1467,23 @@ mod tests {
 
         assert!(error.contains("test SSH agent"));
         assert!(error.contains("failed to list SSH agent identities"));
+    }
+
+    #[test]
+    fn tmux_resume_command_does_not_embed_frontend_unavailable_marker() {
+        // The startup command is typed into the remote interactive PTY, which
+        // echoes it back through `terminal-output`. The frontend hides the tmux
+        // label when it sees this exact marker in the output. If the marker were
+        // a contiguous substring of the command, the harmless PTY echo would trip
+        // detection and hide the label even though tmux is running. The marker
+        // must only ever appear as runtime `printf` output on a tmux-less host.
+        const FRONTEND_MARKER: &str = "[KKTerm: tmux not found, using normal shell]";
+        let cmd = remote_tmux_resume_command(None, "kkterm-test", 5_000);
+        assert!(
+            !cmd.contains(FRONTEND_MARKER),
+            "resume command must not contain the frontend tmux-unavailable marker contiguously, \
+             or PTY echo hides the tmux label while tmux is running: {cmd}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

For a tmux-enabled SSH Connection, the toolbar tmux session label could disappear (or never appear) even though tmux was actually running on the remote.

## Why

KKTerm sends its tmux startup script into the remote **interactive PTY as typed input** (`channel.data("{command}\r")` in `ssh.rs`), not as an SSH `exec` request. An interactive PTY echoes typed input back through the `terminal-output` event before tmux replaces the shell.

PR #282 ("Hide tmux toolbar when SSH tmux is unavailable") detects a tmux-less host by scraping that output for the literal marker `[KKTerm: tmux not found, using normal shell]`. Because that marker was embedded **contiguously in the command source** (the `else` branch of the resume script), the harmless PTY echo of the command matched the detector, which then called `markOpenTerminalPaneTmuxUnavailable` and cleared `pane.tmuxSessionId`. With the id gone, `TmuxSessionTag` renders `null` and the label vanishes.

This explains both reported symptoms as one race:
- **"flickers then disappears"** — React paints the tag, then the echo arrives and clears the id.
- **"never shows"** — the echo arrives at/before first paint.
- It **recurs after the silent reattach**, which re-sends the same command.

## Fix

Build the bracketed marker from a `printf %s` argument:

```
…else …printf '\r\n[%s]\r\n' 'KKTerm: tmux not found, using normal shell'; exec "${SHELL:-sh}" -i; fi
```

The contiguous string `[KKTerm: tmux not found, using normal shell]` now exists only in **runtime printf output**, never in the echoed command source. A genuinely tmux-less host still emits the exact marker, so PR #282 behavior (suppressing tmux controls when the remote lacks tmux) is fully preserved. The frontend constant and detection logic are untouched.

## Tests

- New regression test `tmux_resume_command_does_not_embed_frontend_unavailable_marker` — fails on the old command (marker embedded), passes after the fix.
- The 5 existing `tmux_resume_command_*` tests (mouse mode, OSC 52 clipboard, history limit) still pass — those command segments are unchanged.

Rust-only change; the frontend was not modified, so verification was scoped to `cargo test` for the ssh module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
