### PR TITLE
feat(settings): rename General section to Window and tidy card layout

### DIFF
--- a/docs/localization_todo/settings.workspaceAccess.md
+++ b/docs/localization_todo/settings.workspaceAccess.md
@@ -1,0 +1,16 @@
+# settings.workspaceAccess
+
+- **English value**: `Window`
+- **Namespace**: `settings`
+- **File/component**: `src/modules/settings/GeneralSettings.tsx`
+- **UI role**: `heading`
+- **User flow**: Section heading in Settings → General that groups the window-behavior toggles (start with Windows minimized, minimize/close to tray).
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Context/meaning**: Renamed from "Workspace access" to "Window". Refers to the application window and its OS window behaviors (startup, tray), not a browser window or a workspace/Tab. Translate as the desktop application window.
+- **Domain notes**: The i18n key name `workspaceAccess` is retained for stability, but the displayed label is now "Window". Do not translate it as "Workspace" or "Tab".
+
+<!--
+Filename: settings.workspaceAccess.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -277,7 +277,10 @@ pub struct GeneralSettings {
 
 impl GeneralSettings {
     pub(crate) fn allow_clipboard_read(&self) -> bool {
-        self.allow_clipboard_read
+        // Clipboard read is always enabled; the stored flag is retained only for
+        // settings serialization back-compat and no longer gates the permission.
+        let _ = self.allow_clipboard_read;
+        true
     }
 
     pub(crate) fn auto_start_with_windows(&self) -> bool {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -746,7 +746,7 @@
     "navToolbar": "Nav toolbar",
     "toolbarText": "Toolbar text",
     "language": "Language",
-    "workspaceAccess": "Workspace access",
+    "workspaceAccess": "Window",
     "workspaceAccessHint": "Controls quick access and local runtime permissions.",
     "performance": "Performance",
     "performanceHint": "Controls local rendering and screen capture acceleration.",

--- a/src/modules/settings/GeneralSettings.tsx
+++ b/src/modules/settings/GeneralSettings.tsx
@@ -382,18 +382,6 @@ export function GeneralSettings() {
           <p className="field-hint">{t("settings.workspaceAccessHint")}</p>
         </div>
         <div className="settings-toggle-list">
-          <label className="settings-toggle-row">
-            <ToggleSwitch
-              checked={draft.allowClipboardRead}
-              onChange={(checked) =>
-                setDraft((s) => ({ ...s, allowClipboardRead: checked }))
-              }
-            />
-            <span>
-              <strong>{t("settings.allowClipboardRead")}</strong>
-              <small>{t("settings.allowClipboardReadHint")}</small>
-            </span>
-          </label>
           {windowsPlatform ? (
             <label className="settings-toggle-row">
               <ToggleSwitch
@@ -486,7 +474,7 @@ export function GeneralSettings() {
             </span>
           </label>
         </div>
-        <div className="form-grid general-settings-grid">
+        <div className="form-grid general-settings-grid settings-merged-block">
           <label>
             <span>{t("settings.statusBarMonitorInterval")}</span>
             <select
@@ -536,7 +524,7 @@ export function GeneralSettings() {
           </label>
         </div>
         <div
-          className="settings-data-actions"
+          className="settings-data-actions settings-merged-block"
           aria-label={t("settings.settingsDataActions")}
         >
           <button

--- a/src/modules/settings/settings.css
+++ b/src/modules/settings/settings.css
@@ -1368,6 +1368,26 @@
   border-bottom: 0;
 }
 
+/*
+ * Merge a trailing options/actions block into the toggle card directly above it
+ * so they read as one card divided by a rule, instead of two cards separated by
+ * the fieldset gap.
+ */
+.settings-toggle-list:has(+ .settings-merged-block) {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.settings-toggle-list:has(+ .settings-merged-block) .settings-toggle-row:last-child {
+  border-bottom: 1px solid var(--border);
+}
+
+.settings-merged-block {
+  margin-top: -10px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
 .settings-toggle-row span {
   display: grid;
   grid-column: 1;


### PR DESCRIPTION
## What changed

Four Settings → General UI updates:

1. **Renamed the "Workspace access" section to "Window".** Changed the English value of `settings.workspaceAccess` only; the i18n key name is retained for stability and the other 13 locales are tracked in `docs/localization_todo/settings.workspaceAccess.md` for re-translation.
2. **Removed the "Allow clipboard read" toggle** and made clipboard read always enabled globally. All webview consumers go through `GeneralSettings::allow_clipboard_read()`, so that single backend accessor now always returns `true` — this also re-enables it for users who had previously turned it off. The struct field is kept so settings serialization/import stays back-compatible.
3. **Merged the Status Bar "Monitor interval" row** into the toggle card above it, divided by a rule instead of sitting as a separate card below the fieldset gap.
4. **Merged the Settings-data backup/actions row** into the card above it the same way.

## How

- The merge is done by tagging the two trailing blocks with `settings-merged-block`, then CSS pulls them up by the `-10px` fieldset gap, squares the touching corners, and re-enables the last toggle-row's `border-bottom` so a single inset divider line appears (matching existing internal row dividers).

## Reviewer notes

- The now-unused `allowClipboardRead` field/keys were intentionally left in place — fully removing them ripples through the Rust storage struct, webview constructor signature, and `storage/tests.rs`, which is out of scope for a UI tweak and higher-risk per AGENTS.md (clipboard/webview behavior needs real-runtime validation). The forced accessor already delivers always-on behavior.
- **Manual validation needed in the real Tauri runtime:** clipboard paste in a URL/WebView2 tab should now work without the native prompt even on a profile that previously had the toggle disabled.

## Checks

- `npm run i18n:check` ✅ (all locales match en.json)
- `npx tsc --noEmit` ✅
- `cargo check --manifest-path src-tauri/Cargo.toml` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)