### PR TITLE
feat(macos): RDP-to-Windows via IronRDP (canvas client + IME keyboard)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1375,6 +1375,7 @@ dependencies = [
  "const-oid 0.9.6",
  "der_derive",
  "flagset",
+ "pem-rfc7468 0.7.0",
  "zeroize",
 ]
 
@@ -3584,6 +3585,7 @@ dependencies = [
  "rusqlite",
  "russh",
  "russh-sftp",
+ "rustls",
  "scraper",
  "serde",
  "serde_json",
@@ -3612,6 +3614,7 @@ dependencies = [
  "windows-native-keyring-store",
  "windows-sys 0.61.2",
  "winping",
+ "x509-cert",
  "zip 8.5.1",
 ]
 
@@ -8531,7 +8534,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "addchain"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e33f6a175ec6a9e0aca777567f9ff7c3deefc255660df887e7fa3585e9801d8"
+dependencies = [
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +87,16 @@ dependencies = [
  "ctr 0.10.1",
  "ghash 0.6.0",
  "subtle",
+]
+
+[[package]]
+name = "aes-kw"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ac571010bd60765c56085a4f1d412012a9be2663b1a2f2b19b49318653fd0d"
+dependencies = [
+ "aes 0.9.1",
+ "const-oid 0.10.2",
 ]
 
 [[package]]
@@ -156,6 +177,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +236,25 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-dnssd"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d49ffe175ab45bbfd74b548313d9d7cdfff27161a94b007b52eeeb5f9aaa15e"
+dependencies = [
+ "bitflags 1.3.2",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-util",
+ "libc",
+ "log",
+ "pin-utils",
+ "pkg-config",
+ "tokio",
+ "winapi",
 ]
 
 [[package]]
@@ -332,6 +410,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +503,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +521,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -455,7 +560,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
- "zeroize",
 ]
 
 [[package]]
@@ -985,9 +1089,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.28"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96dacf199529fb801ae62a9aafdc01b189e9504c0d1ee1512a4c16bcd8666a93"
+checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -1022,14 +1126,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-primes"
-version = "0.7.0-pre.9"
+name = "crypto-mac"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6081ce8b60c0e533e2bba42771b94eb6149052115f4179744d5779883dc98583"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
+dependencies = [
+ "generic-array 0.14.7",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
 dependencies = [
  "crypto-bigint",
- "libm",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "cryptoki"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff765b99fc49f3116c9a908484486a2b92fd73c48da45c3a69716471c6cc56c6"
+dependencies = [
+ "bitflags 2.13.0",
+ "cryptoki-sys",
+ "libloading 0.8.9",
+ "log",
+ "secrecy",
+]
+
+[[package]]
+name = "cryptoki-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fd850498411e4057f1cba79e6e2bc7cbe960544c1046ab46d4685c403a1121"
+dependencies = [
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -1233,6 +1368,18 @@ dependencies = [
 
 [[package]]
 name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "der_derive",
+ "flagset",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
@@ -1240,6 +1387,30 @@ dependencies = [
  "const-oid 0.10.2",
  "pem-rfc7468 1.0.0",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1285,6 +1456,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "des"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,7 +1486,6 @@ dependencies = [
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
- "zeroize",
 ]
 
 [[package]]
@@ -1477,16 +1656,16 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.16"
+version = "0.17.0-rc.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91bbdd377139884fafcad8dc43a760a3e1e681aa26db910257fa6535b70e1829"
+checksum = "dc4bf51f0534ed6e59a0f2f26272b64ba55c470133f8424c2adfd1c4d59d9988"
 dependencies = [
- "der",
+ "der 0.8.0",
  "digest 0.11.3",
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki",
+ "spki 0.8.0",
  "zeroize",
 ]
 
@@ -1530,9 +1709,9 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.28"
+version = "0.14.0-rc.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde7860544606d222fd6bd6d9f9a0773321bf78072a637e1d560a058c0031978"
+checksum = "b148a81cede8f4023248f980cffdf7611c46f2add469c6980e815b7c5b764ba5"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1702,6 +1881,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.14.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
+dependencies = [
+ "rand_core 0.9.5",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,12 +1934,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
+ "libz-sys",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -1829,6 +2025,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -2256,6 +2458,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.14.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
+dependencies = [
+ "ff",
+ "rand_core 0.9.5",
+ "subtle",
+]
+
+[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2308,6 +2521,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2353,6 +2575,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2913,6 +3148,188 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironrdp"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b38a2f7f5d54dedd823fce1ccf99f64302552a71d2567df95244e74309c05fd"
+dependencies = [
+ "ironrdp-connector",
+ "ironrdp-core",
+ "ironrdp-graphics",
+ "ironrdp-input",
+ "ironrdp-pdu",
+ "ironrdp-session",
+]
+
+[[package]]
+name = "ironrdp-async"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab415b3d5c5acaf1483d13cefec97cce7b991853361277db7b2ca274bf177469"
+dependencies = [
+ "bytes",
+ "ironrdp-connector",
+ "ironrdp-core",
+ "ironrdp-pdu",
+ "tracing",
+]
+
+[[package]]
+name = "ironrdp-bulk"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e548d9fd162558a5a8aaed72e528556ce88e77773634e3722b8d01d6f170388"
+
+[[package]]
+name = "ironrdp-connector"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7adef330caa92c80be05ba0d0665d1d65a3823151b4449bbd6e2454542e0fc9c"
+dependencies = [
+ "ironrdp-core",
+ "ironrdp-error",
+ "ironrdp-pdu",
+ "ironrdp-svc",
+ "picky",
+ "picky-asn1-der",
+ "picky-asn1-x509",
+ "rand 0.9.4",
+ "sspi",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "ironrdp-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e4cd2973f64cc5a2a12e4f399398cc15b4a31133a70426f82e794a2cc31518"
+dependencies = [
+ "ironrdp-error",
+]
+
+[[package]]
+name = "ironrdp-displaycontrol"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec72818a807ae1705d8f6a2201142e8205b458c6327986a9fb7f56110b0b4a5"
+dependencies = [
+ "ironrdp-core",
+ "ironrdp-dvc",
+ "ironrdp-pdu",
+ "ironrdp-svc",
+ "tracing",
+]
+
+[[package]]
+name = "ironrdp-dvc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3468b9a05868e7cd07cf34f02962eac8a5571f47e6b3189fe8461e6519d6f78a"
+dependencies = [
+ "ironrdp-core",
+ "ironrdp-pdu",
+ "ironrdp-svc",
+ "tracing",
+]
+
+[[package]]
+name = "ironrdp-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd344ce9518ab83f6f7568ca4f1bc6dc8c55bd2da04cb5ee7b3e8740d5041734"
+
+[[package]]
+name = "ironrdp-graphics"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a6960ef799bb9ab366ae9b56ec42a28449ceb29d380e1228774f359ad9f781"
+dependencies = [
+ "bit_field",
+ "bitflags 2.13.0",
+ "bitvec",
+ "byteorder",
+ "ironrdp-core",
+ "ironrdp-pdu",
+ "num-derive",
+ "num-traits",
+ "yuv",
+]
+
+[[package]]
+name = "ironrdp-input"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fbf4b6d8e2a30623093b41ead29ac99d96f80d0bf5bf9b3797a5a04117c163"
+dependencies = [
+ "bitvec",
+ "ironrdp-pdu",
+ "smallvec",
+]
+
+[[package]]
+name = "ironrdp-pdu"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a27ab729591c84f992a408ba1b8b29fab354d85aa8d464f053a42fbb5f51e7b"
+dependencies = [
+ "bit_field",
+ "bitflags 2.13.0",
+ "byteorder",
+ "der-parser",
+ "ironrdp-core",
+ "ironrdp-error",
+ "md-5 0.10.6",
+ "num-bigint 0.4.6",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "pkcs1 0.7.5",
+ "sha1 0.10.6",
+ "tap",
+ "x509-cert",
+]
+
+[[package]]
+name = "ironrdp-session"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd1750d822c54068ace4051ab6fc655b3982fc92cacbaf16c2dc2f6e92602f7"
+dependencies = [
+ "ironrdp-bulk",
+ "ironrdp-connector",
+ "ironrdp-core",
+ "ironrdp-displaycontrol",
+ "ironrdp-dvc",
+ "ironrdp-error",
+ "ironrdp-graphics",
+ "ironrdp-pdu",
+ "ironrdp-svc",
+ "tracing",
+]
+
+[[package]]
+name = "ironrdp-svc"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869ce3a7664bd4e20a2991673f9f4288120c22a26fd8e37b997ebedc0512713b"
+dependencies = [
+ "bitflags 2.13.0",
+ "ironrdp-core",
+ "ironrdp-pdu",
+]
+
+[[package]]
+name = "ironrdp-tokio"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04896003695b34e4828f9fded95db1e5046eaaabd0a5d6c157fb7056f5485033"
+dependencies = [
+ "ironrdp-async",
+ "tokio",
+]
+
+[[package]]
 name = "is-docker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2929,6 +3346,24 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "iso7816"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c7e91da489667bb054f9cd2f1c60cc2ac4478a899f403d11dbc62189215b0"
+dependencies = [
+ "heapless",
+]
+
+[[package]]
+name = "iso7816-tlv"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7660d28d24a831d690228a275d544654a30f3b167a8e491cf31af5fe5058b546"
+dependencies = [
+ "untrusted",
 ]
 
 [[package]]
@@ -3133,6 +3568,8 @@ dependencies = [
  "hickory-resolver",
  "if-addrs",
  "image",
+ "ironrdp",
+ "ironrdp-tokio",
  "keyring-core",
  "lazy_static",
  "lettre",
@@ -3164,6 +3601,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "time",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "url",
  "vnc-rs",
@@ -3174,7 +3612,7 @@ dependencies = [
  "windows-native-keyring-store",
  "windows-sys 0.61.2",
  "winping",
- "zip 8.6.0",
+ "zip 8.5.1",
 ]
 
 [[package]]
@@ -3228,7 +3666,7 @@ dependencies = [
  "httpdate",
  "idna",
  "mime",
- "nom",
+ "nom 8.0.0",
  "percent-encoding",
  "quoted_printable",
  "rustls",
@@ -3258,7 +3696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -3294,6 +3732,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3313,6 +3761,17 @@ name = "libsqlite3-sys"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3394,6 +3853,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "md4"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da5ac363534dce5fabf69949225e174fbf111a498bf0ff794c8ea1fba9f3dda"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3419,6 +3897,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3598,6 +4082,16 @@ checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
@@ -3618,6 +4112,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -3651,6 +4156,17 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-integer"
@@ -3930,6 +4446,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c19903c598813dba001b53beeae59bb77ad4892c5c1b9b3500ce4293a0d06c2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4126,7 +4651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32dfc8b140169c70350e98cbfee928be46ae60151c3af6e477521afae8288809"
 dependencies = [
  "cow-utils",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "oxc_allocator",
  "oxc_ast",
@@ -4160,7 +4685,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cow-utils",
  "memchr",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "oxc_allocator",
  "oxc_ast",
@@ -4240,9 +4765,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.7"
+version = "0.14.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "018bfbb86e05fd70a83e985921241035ee09fcd369c4a2c3680b389a01d2ad28"
+checksum = "8b97e3bf0465157ae90975ff52dbeb1362ba618924878c9f74c25baa27a65f9a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4253,9 +4778,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.7"
+version = "0.14.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c91df688211f5957dbe2ab599dcbcaade8d6d3cdc15c5b350d350d7d07ce423"
+checksum = "437f30ebcb1e16ff48acead5f08bd69fbcdbc82421687bb48af5c315a0bfab03"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4267,9 +4792,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.7"
+version = "0.14.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de6cd9451de522549d36cc78a1b45a699a3d55a872e8ea0c8f0318e502d99e2c"
+checksum = "4e9fd792bab86ecf6249561752fb5a413511f999887107dd054bbda5143743d7"
 dependencies = [
  "base16ct",
  "ecdsa",
@@ -4382,9 +4907,9 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.13.0"
+version = "0.13.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+checksum = "1f24f3eb2f4471b1730d59e4b730b747939960a8c7eb0c33c5a9076f2d3dddea"
 dependencies = [
  "digest 0.11.3",
  "hmac 0.13.0",
@@ -4468,6 +4993,133 @@ dependencies = [
 ]
 
 [[package]]
+name = "picky"
+version = "7.0.0-rc.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8b243c0a8e59483c7b0f746aed1c1719245692a92e9a35693f9edb88a0b712"
+dependencies = [
+ "aead 0.6.0-rc.10",
+ "aes 0.9.1",
+ "aes-gcm 0.11.0-rc.3",
+ "aes-kw",
+ "base64 0.22.1",
+ "cbc 0.2.1",
+ "crypto-bigint",
+ "crypto-common 0.2.2",
+ "ctr 0.10.1",
+ "curve25519-dalek",
+ "des",
+ "digest 0.11.3",
+ "ecdsa",
+ "ed25519",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "ff",
+ "group",
+ "hex",
+ "hmac 0.13.0",
+ "http",
+ "inout 0.2.2",
+ "md-5 0.11.0",
+ "p256",
+ "p384",
+ "p521",
+ "pbkdf2 0.13.0-rc.10",
+ "picky-asn1",
+ "picky-asn1-der",
+ "picky-asn1-x509",
+ "pkcs1 0.8.0-rc.4",
+ "pkcs8",
+ "primefield",
+ "primeorder",
+ "rand 0.10.1",
+ "rand_core 0.10.1",
+ "rc2",
+ "rfc6979",
+ "rsa",
+ "rustcrypto-ff",
+ "rustcrypto-ff_derive",
+ "rustcrypto-group",
+ "serde",
+ "serde_json",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "sha3",
+ "signature",
+ "thiserror 2.0.18",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "picky-asn1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ff038f9360b934342fb3c0a1d6e82c438a2624b51c3c6e3e6d7cf252b6f3ee3"
+dependencies = [
+ "oid",
+ "serde",
+ "serde_bytes",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "picky-asn1-der"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d413165e4bf7f808b9a27cbaba657657a2921f0965db833f488c4d4be96dcd2e"
+dependencies = [
+ "picky-asn1",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "picky-asn1-x509"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d4117bd1b1dc5646359ee7243c50c5000c0920ea2d1fb120335a2f4c684b8"
+dependencies = [
+ "base64 0.22.1",
+ "crypto-bigint",
+ "oid",
+ "picky-asn1",
+ "picky-asn1-der",
+ "serde",
+ "widestring",
+ "zeroize",
+]
+
+[[package]]
+name = "picky-krb"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43602452fdea9ee3fa4141a918c3659bc43d0277143e4ee06be89e26c22e8676"
+dependencies = [
+ "aes 0.9.1",
+ "block-padding 0.4.2",
+ "byteorder",
+ "cbc 0.2.1",
+ "cipher 0.5.2",
+ "crypto-bigint",
+ "des",
+ "hmac 0.13.0",
+ "inout 0.2.2",
+ "oid",
+ "pbkdf2 0.13.0-rc.10",
+ "picky-asn1",
+ "picky-asn1-der",
+ "picky-asn1-x509",
+ "rand 0.10.1",
+ "rand_core 0.10.1",
+ "serde",
+ "sha1 0.11.0",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4494,6 +5146,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "piper"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4506,12 +5164,22 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs1"
 version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
 dependencies = [
- "der",
- "spki",
+ "der 0.8.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -4523,12 +5191,12 @@ dependencies = [
  "aes 0.9.1",
  "aes-gcm 0.11.0-rc.3",
  "cbc 0.2.1",
- "der",
- "pbkdf2 0.13.0",
+ "der 0.8.0",
+ "pbkdf2 0.13.0-rc.10",
  "rand_core 0.10.1",
  "scrypt",
  "sha2 0.11.0",
- "spki",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -4537,10 +5205,10 @@ version = "0.11.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
 dependencies = [
- "der",
+ "der 0.8.0",
  "pkcs5",
  "rand_core 0.10.1",
- "spki",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -4764,9 +5432,9 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.7"
+version = "0.14.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93401c13cc7ff24684571cfca9d3cf9ebabfaf3d4b7b9963ade41ec54da196b5"
+checksum = "1b52e6ee42db392378a95622b463c9740631171d1efce43fa445a569c1600cb6"
 dependencies = [
  "crypto-bigint",
  "crypto-common 0.2.2",
@@ -4778,9 +5446,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.7"
+version = "0.14.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c5c8a39bcd764bfedf456e8d55e115fe86dda3e0f555371849f2a41cbc9706"
+checksum = "0556580e42c19833f5d232aca11a7687a503ee41f937b54f5ae1d50fc2a6a36a"
 dependencies = [
  "elliptic-curve",
 ]
@@ -4946,6 +5614,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5026,6 +5700,15 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceda21af1ae61033b63175653a1af86cae399d79cd03ca80ba347eb3a6c4a7fe"
+dependencies = [
+ "cipher 0.5.2",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -5157,9 +5840,9 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0"
+version = "0.5.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5236ce872cac07e0fb3969b0cbf468c7d2f37d432f1b627dcb7b8d34563fb0c3"
+checksum = "23a3127ee32baec36af75b4107082d9bd823501ec14a4e016be4b6b37faa74ae"
 dependencies = [
  "hmac 0.13.0",
  "subtle",
@@ -5205,20 +5888,20 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.16"
+version = "0.10.0-rc.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb9fd8c1edd9e6a2693623baf0fe77ff05ce022a5d7746900ffc38a15c233de"
+checksum = "87ed3e93fc7e473e464b9726f4759659e72bc8665e4b8ea227547024f416d905"
 dependencies = [
  "const-oid 0.10.2",
  "crypto-bigint",
  "crypto-primes",
  "digest 0.11.3",
- "pkcs1",
+ "pkcs1 0.8.0-rc.4",
  "pkcs8",
  "rand_core 0.10.1",
  "sha2 0.11.0",
  "signature",
- "spki",
+ "spki 0.8.0",
  "zeroize",
 ]
 
@@ -5249,28 +5932,23 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.60.3"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324b92f459d3e42da294e14e8eb150d2215fcfb7c966838bc1127cd68bc05a0d"
+checksum = "d937f3f4a79bffd67fc12fd437785effdfc8b94edc89ab90392f9ac9e11cc9fc"
 dependencies = [
- "aead 0.6.0-rc.10",
  "aes 0.8.4",
- "aes 0.9.1",
- "aes-gcm 0.11.0-rc.3",
  "bitflags 2.13.0",
  "block-padding 0.3.3",
  "byteorder",
  "bytes",
  "cbc 0.1.2",
- "cbc 0.2.1",
  "cipher 0.5.2",
  "crypto-bigint",
- "ctr 0.10.1",
  "ctr 0.9.2",
  "curve25519-dalek",
  "data-encoding",
  "delegate",
- "der",
+ "der 0.8.0",
  "digest 0.10.7",
  "ecdsa",
  "ed25519-dalek",
@@ -5280,27 +5958,21 @@ dependencies = [
  "futures",
  "generic-array 1.4.3",
  "getrandom 0.2.17",
- "ghash 0.6.0",
  "hex-literal",
- "hkdf",
  "hmac 0.12.1",
- "hmac 0.13.0",
  "inout 0.1.4",
  "internal-russh-forked-ssh-key",
  "internal-russh-num-bigint",
- "keccak",
  "log",
  "md5",
  "ml-kem",
  "module-lattice",
- "num-bigint",
  "p256",
  "p384",
  "p521",
  "pageant",
  "pbkdf2 0.12.2",
- "pbkdf2 0.13.0",
- "pkcs1",
+ "pkcs1 0.8.0-rc.4",
  "pkcs5",
  "pkcs8",
  "polyval 0.7.1",
@@ -5310,16 +5982,11 @@ dependencies = [
  "rsa",
  "russh-cryptovec",
  "russh-util",
- "salsa20",
- "scrypt",
  "sec1",
  "sha1 0.10.6",
- "sha1 0.11.0",
  "sha2 0.10.9",
- "sha2 0.11.0",
- "sha3",
  "signature",
- "spki",
+ "spki 0.8.0",
  "ssh-encoding",
  "subtle",
  "thiserror 2.0.18",
@@ -5331,9 +5998,9 @@ dependencies = [
 
 [[package]]
 name = "russh-cryptovec"
-version = "0.60.3"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cb4d0360bdd8935392a306d8b5edb539cc455b30e8bf13dd213a0cf7879b40"
+checksum = "36140e8a20297bc2e8338807c3d9ca911f7fa49d7539cbcd6d48d3befd70efd8"
 dependencies = [
  "log",
  "nix 0.31.3",
@@ -5394,8 +6061,25 @@ version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
 dependencies = [
+ "bitvec",
  "rand_core 0.10.1",
+ "rustcrypto-ff_derive",
  "subtle",
+]
+
+[[package]]
+name = "rustcrypto-ff_derive"
+version = "0.14.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cda22ea03582974ab5687fc131eba2dc78e258e7eef4d7e01bcd0522ed79f66"
+dependencies = [
+ "addchain",
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5407,6 +6091,15 @@ dependencies = [
  "rand_core 0.10.1",
  "rustcrypto-ff",
  "subtle",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -5613,12 +6306,12 @@ dependencies = [
 
 [[package]]
 name = "scrypt"
-version = "0.12.0"
+version = "0.12.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
+checksum = "e03ed5b54ed5fcc8e016cd94301416bc2c01c05c87a6742b97468337c8804598"
 dependencies = [
  "cfg-if",
- "pbkdf2 0.13.0",
+ "pbkdf2 0.13.0-rc.10",
  "salsa20",
  "sha2 0.11.0",
 ]
@@ -5631,9 +6324,18 @@ checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
  "ctutils",
- "der",
+ "der 0.8.0",
  "hybrid-array",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
  "zeroize",
 ]
 
@@ -6003,9 +6705,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0"
+version = "3.0.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
 dependencies = [
  "digest 0.11.3",
  "rand_core 0.10.1",
@@ -6120,15 +6822,28 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
-version = "0.8.0-rc.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
 ]
 
 [[package]]
@@ -6170,6 +6885,68 @@ dependencies = [
  "bytes",
  "pem-rfc7468 0.7.0",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "sspi"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db83308ba07f6c54141f7e34a167353f81250fe8ccab87e90c323f4390b0fb0"
+dependencies = [
+ "async-dnssd",
+ "async-recursion",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "byteorder",
+ "cfg-if",
+ "crypto-bigint",
+ "crypto-mac",
+ "cryptoki",
+ "curve25519-dalek",
+ "ed25519-dalek",
+ "ff",
+ "futures",
+ "getrandom 0.3.4",
+ "group",
+ "hmac 0.13.0",
+ "md-5 0.11.0",
+ "md4",
+ "num-derive",
+ "num-traits",
+ "oid",
+ "p256",
+ "p384",
+ "p521",
+ "picky",
+ "picky-asn1",
+ "picky-asn1-der",
+ "picky-asn1-x509",
+ "picky-krb",
+ "pkcs1 0.8.0-rc.4",
+ "pkcs8",
+ "primefield",
+ "primeorder",
+ "rand 0.10.1",
+ "rand_core 0.10.1",
+ "rsa",
+ "rustcrypto-ff",
+ "rustcrypto-ff_derive",
+ "rustcrypto-group",
+ "rustls",
+ "serde",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "signature",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+ "widestring",
+ "windows 0.62.2",
+ "windows-registry",
+ "winscard",
+ "zeroize",
 ]
 
 [[package]]
@@ -6271,6 +7048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -6410,6 +7188,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -6870,6 +7654,27 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "tokio"
@@ -7383,8 +8188,8 @@ dependencies = [
  "async_io_stream",
  "flate2",
  "futures",
- "md-5",
- "num-bigint",
+ "md-5 0.10.6",
+ "num-bigint 0.4.6",
  "rand 0.9.4",
  "thiserror 1.0.69",
  "tokio",
@@ -8344,6 +9149,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "winscard"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1210bde4c851460210856b10dbbbad824f9e1e635794f44cf2ce552972521e44"
+dependencies = [
+ "bitflags 2.13.0",
+ "crypto-bigint",
+ "flate2",
+ "iso7816",
+ "iso7816-tlv",
+ "num-derive",
+ "num-traits",
+ "picky",
+ "picky-asn1-x509",
+ "rsa",
+ "sha1 0.11.0",
+ "time",
+ "tracing",
+ "uuid",
+ "widestring",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8488,6 +9316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x11"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8506,6 +9343,29 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d5d6ff67acd3945b933e592bfa7143db4fcbb2f871754b6b9fbd7847fc5aea"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.10.1",
+ "zeroize",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid 0.9.6",
+ "der 0.7.10",
+ "spki 0.7.3",
+ "tls_codec",
 ]
 
 [[package]]
@@ -8539,6 +9399,15 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "yuv"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89c90da4fb561f9750984de2c5e7f0ba01035d2eb29d69a7f375b1caef37fdf4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -8648,6 +9517,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -8701,24 +9584,24 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.6.0"
+version = "8.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+checksum = "dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59"
 dependencies = [
- "aes 0.9.1",
+ "aes 0.8.4",
  "bzip2",
  "constant_time_eq",
  "crc32fast",
  "deflate64",
  "flate2",
  "getrandom 0.4.2",
- "hmac 0.13.0",
+ "hmac 0.12.1",
  "indexmap 2.14.0",
  "lzma-rust2",
  "memchr",
- "pbkdf2 0.13.0",
+ "pbkdf2 0.12.2",
  "ppmd-rust",
- "sha1 0.11.0",
+ "sha1 0.10.6",
  "time",
  "typed-path",
  "zeroize",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,7 +37,7 @@ base64 = "0.22"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 portable-pty = "0.9.0"
 keyring-core = "1.0.0"
-russh = { version = "0.60.3", default-features = false, features = ["flate2", "ring", "rsa"] }
+russh = { version = "0.60.0", default-features = false, features = ["flate2", "ring", "rsa"] }
 russh-sftp = "2.1.2"
 suppaftp = { version = "=7.1.0", default-features = false, features = ["tokio", "tokio-async-native-tls", "deprecated"] }
 async-native-tls = { version = "0.5", default-features = false, features = ["runtime-tokio"] }
@@ -97,6 +97,18 @@ winping = "0.10"
 # Unix ICMP via surge-ping (raw sockets - Unix users typically have CAP_NET_RAW or root).
 # Windows uses winping instead (see Windows target block above).
 surge-ping = "0.8"
+# macOS RDP client via IronRDP (Windows uses the native ActiveX path in rdp.rs instead).
+# The umbrella crate pins a mutually-compatible sub-crate set.
+# ironrdp-tokio re-exports all of ironrdp-async (connect_begin, connect_finalize,
+# mark_as_upgraded, NetworkClient) via `pub use ironrdp_async::*`, so no separate
+# ironrdp-async dep is needed. The umbrella `input` feature re-exports ironrdp-input v0.6,
+# so no separate ironrdp-input dep is needed either.
+ironrdp = { version = "0.15", features = ["connector", "session", "graphics", "pdu", "input"] }
+ironrdp-tokio = "0.9"
+tokio-rustls = "0.26"
+# NOTE: sspi = "0.21" (needed for CredSSP/NTLM) is a transitive dep of ironrdp-connector.
+# It is omitted here as a direct dep because ironrdp-connector already pulls it in.
+# To add direct sspi usage in Task 4: sspi = { version = "0.21", default-features = false }
 
 [profile.release]
 lto = "fat"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,7 +37,11 @@ base64 = "0.22"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 portable-pty = "0.9.0"
 keyring-core = "1.0.0"
-russh = { version = "0.60.0", default-features = false, features = ["flate2", "ring", "rsa"] }
+# Pinned to 0.60.1: russh 0.60.2+/0.61.x pin RustCrypto pre-release crates
+# (ecdsa, curve25519-dalek) at versions that conflict with IronRDP's `picky`,
+# so this is the newest russh that coexists with the RDP client. Revisit (and
+# unpin) when `picky`/IronRDP bump to a newer crypto RC generation.
+russh = { version = "=0.60.1", default-features = false, features = ["flate2", "ring", "rsa"] }
 russh-sftp = "2.1.2"
 suppaftp = { version = "=7.1.0", default-features = false, features = ["tokio", "tokio-async-native-tls", "deprecated"] }
 async-native-tls = { version = "0.5", default-features = false, features = ["runtime-tokio"] }
@@ -106,6 +110,12 @@ surge-ping = "0.8"
 ironrdp = { version = "0.15", features = ["connector", "session", "graphics", "pdu", "input"] }
 ironrdp-tokio = "0.9"
 tokio-rustls = "0.26"
+# Direct rustls use for the RDP TLS upgrade (no-cert-verify + ring provider). RDP
+# wraps its own CredSSP auth inside TLS, so chain verification is intentionally
+# skipped; `ring` matches the provider selected in rdp_client.rs::tls_upgrade.
+rustls = { version = "0.23", features = ["ring"] }
+# Parse the server certificate's SubjectPublicKeyInfo for the CredSSP public-key binding.
+x509-cert = "0.2"
 # NOTE: sspi = "0.21" (needed for CredSSP/NTLM) is a transitive dep of ironrdp-connector.
 # It is omitted here as a direct dep because ironrdp-connector already pulls it in.
 # To add direct sspi usage in Task 4: sspi = { version = "0.21", default-features = false }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2504,6 +2504,15 @@ fn send_rdp_client_key_event(
 
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]
+fn send_rdp_client_text(
+    rdp_sessions: tauri::State<'_, rdp_client::RdpClientSessionManager>,
+    request: rdp_client::RdpClientTextRequest,
+) -> Result<(), String> {
+    rdp_sessions.text_input(request)
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
 fn send_rdp_client_ctrl_alt_delete(
     rdp_sessions: tauri::State<'_, rdp_client::RdpClientSessionManager>,
     request: rdp_client::RdpClientSimpleRequest,
@@ -3062,6 +3071,8 @@ pub fn run() {
             send_rdp_client_pointer_event,
             #[cfg(not(target_os = "windows"))]
             send_rdp_client_key_event,
+            #[cfg(not(target_os = "windows"))]
+            send_rdp_client_text,
             #[cfg(not(target_os = "windows"))]
             send_rdp_client_ctrl_alt_delete,
             #[cfg(not(target_os = "windows"))]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2459,6 +2459,76 @@ fn send_vnc_ctrl_alt_delete(
     vnc_sessions.send_ctrl_alt_delete(request)
 }
 
+// ── macOS IronRDP client commands (Windows uses the native ActiveX path) ──────
+
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+async fn start_rdp_client_session(
+    app: tauri::AppHandle,
+    mut request: rdp_client::StartRdpClientSessionRequest,
+) -> Result<rdp_client::RdpClientSessionStarted, String> {
+    run_blocking_command("RDP startup", move || {
+        let rdp_sessions = app.state::<rdp_client::RdpClientSessionManager>();
+        let secrets = app.state::<secrets::Secrets>();
+        if request.password().is_none() {
+            if let Some(owner_id) = request.secret_owner_id().map(str::to_string) {
+                request.set_password(
+                    secrets
+                        .read_connection_password(owner_id)
+                        .map_err(|error| format!("failed to read RDP password: {error}"))?,
+                );
+            }
+        }
+        rdp_sessions.start_session(app.clone(), request)
+    })
+    .await
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn send_rdp_client_pointer_event(
+    rdp_sessions: tauri::State<'_, rdp_client::RdpClientSessionManager>,
+    request: rdp_client::RdpClientPointerEventRequest,
+) -> Result<(), String> {
+    rdp_sessions.pointer_event(request)
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn send_rdp_client_key_event(
+    rdp_sessions: tauri::State<'_, rdp_client::RdpClientSessionManager>,
+    request: rdp_client::RdpClientKeyEventRequest,
+) -> Result<(), String> {
+    rdp_sessions.key_event(request)
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn send_rdp_client_ctrl_alt_delete(
+    rdp_sessions: tauri::State<'_, rdp_client::RdpClientSessionManager>,
+    request: rdp_client::RdpClientSimpleRequest,
+) -> Result<(), String> {
+    rdp_sessions.send_ctrl_alt_delete(request)
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn close_rdp_client_session(
+    rdp_sessions: tauri::State<'_, rdp_client::RdpClientSessionManager>,
+    request: rdp_client::RdpClientSimpleRequest,
+) -> Result<(), String> {
+    rdp_sessions.close_session(request)
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn get_rdp_client_session_status(
+    rdp_sessions: tauri::State<'_, rdp_client::RdpClientSessionManager>,
+    request: rdp_client::RdpClientSimpleRequest,
+) -> Result<rdp_client::RdpClientSessionStatus, String> {
+    rdp_sessions.session_status(request)
+}
+
 #[cfg(target_os = "windows")]
 fn configure_single_instance<R: tauri::Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
     builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
@@ -2679,6 +2749,8 @@ pub fn run() {
             app.manage(webview_sessions);
             app.manage(rdp::RdpSessionManager::new());
             app.manage(vnc::VncSessionManager::new());
+            #[cfg(not(target_os = "windows"))]
+            app.manage(rdp_client::RdpClientSessionManager::new());
             app.manage(std::sync::Arc::new(net::stream::StreamRegistry::new()));
             app.manage(std::sync::Arc::new(watchdog::WatchdogRegistry::new()));
             app.manage(std::sync::Arc::new(watchdog::SessionActivityTracker::new()));
@@ -2984,6 +3056,18 @@ pub fn run() {
             close_vnc_session,
             get_vnc_session_status,
             send_vnc_ctrl_alt_delete,
+            #[cfg(not(target_os = "windows"))]
+            start_rdp_client_session,
+            #[cfg(not(target_os = "windows"))]
+            send_rdp_client_pointer_event,
+            #[cfg(not(target_os = "windows"))]
+            send_rdp_client_key_event,
+            #[cfg(not(target_os = "windows"))]
+            send_rdp_client_ctrl_alt_delete,
+            #[cfg(not(target_os = "windows"))]
+            close_rdp_client_session,
+            #[cfg(not(target_os = "windows"))]
+            get_rdp_client_session_status,
             // ── Dashboard
             dashboard_commands::dashboard_load_state,
             dashboard_commands::dashboard_create_view,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,8 @@ mod net;
 mod performance;
 mod power;
 mod rdp;
+#[cfg(not(target_os = "windows"))]
+mod rdp_client;
 mod screenshot;
 mod secrets;
 mod serial;

--- a/src-tauri/src/rdp_client.rs
+++ b/src-tauri/src/rdp_client.rs
@@ -15,8 +15,8 @@
 //! // TokioFramed<S> = Framed<TokioStream<S>>
 //! // Framed::new(stream: S::InnerStream) -> Self
 //! // TokioStream<S>::InnerStream = S  =>  TokioFramed::new(tcp_stream) works directly
-//! ironrdp_tokio::TokioFramed<tokio::net::TcpStream>
-//! ironrdp_tokio::TokioFramed<Box<dyn AsyncReadWrite + Unpin + Send + Sync>>
+//! ironrdp_tokio::TokioFramed<tokio::net::TcpStream>                       // pre-TLS
+//! ironrdp_tokio::TokioFramed<tokio_rustls::client::TlsStream<TcpStream>>  // post-TLS (concrete; see UpgradedFramed)
 //! ironrdp::connector::ClientConnector  // config: connector::Config, client_addr: SocketAddr
 //! ironrdp::connector::ConnectionResult  // returned by connect_finalize on success
 //! ```
@@ -32,100 +32,40 @@
 //! let mut connector = ironrdp::connector::ClientConnector::new(config, client_addr);
 //!
 //! // Step 3: Begin connection (negotiation / NLA pre-TLS handshake)
-//! // Signature: pub async fn connect_begin<S>(framed: &mut Framed<S>, connector: &mut ClientConnector)
-//! //            -> ConnectorResult<ShouldUpgrade>
-//! //            where S: Sync + FramedRead + FramedWrite
 //! let should_upgrade = ironrdp_tokio::connect_begin(&mut framed, &mut connector).await?;
 //!
 //! // Step 4: Extract inner TCP stream + any leftover bytes
-//! // Framed::into_inner(self) -> (S::InnerStream, BytesMut)
-//! // Here S = TokioStream<TcpStream>, so InnerStream = TcpStream
 //! let (initial_stream, leftover_bytes) = framed.into_inner();
 //!
-//! // Step 5: TLS upgrade via tokio-rustls (no-verify config for RDP, matching ironrdp-tls pattern)
-//! // Build a rustls ClientConfig with a NoCertificateVerification verifier (required for RDP).
-//! // Disable TLS resumption (CredSSP does not support TLS session resumption).
-//! // connect: tokio_rustls::TlsConnector::from(Arc::new(config)).connect(domain, stream).await?
-//! // type: tokio_rustls::client::TlsStream<TcpStream>
-//! let tls_stream: tokio_rustls::client::TlsStream<TcpStream> = /* TLS handshake */;
+//! // Step 5: TLS upgrade via tokio-rustls
+//! let tls_stream = tls_upgrade(initial_stream, &host).await?;
 //!
-//! // Step 6: Extract server public key (SubjectPublicKey bytes from peer cert SPKI)
-//! // From tls_stream.get_ref().1.peer_certificates() -> &[CertificateDer<'_>]
-//! // Take first cert, parse as x509_cert::Certificate (via x509_cert::der::Decode),
-//! // then: cert.tbs_certificate.subject_public_key_info.subject_public_key.as_bytes()
-//! // The connect_finalize parameter type is Vec<u8>.
-//! let server_public_key: Vec<u8> = /* extract from tls_stream peer cert SPKI */;
+//! // Step 6: Extract server public key
+//! let server_public_key = extract_server_public_key(&tls_stream)?;
 //!
 //! // Step 7: Mark as upgraded
-//! // Signature: pub fn mark_as_upgraded(should_upgrade: ShouldUpgrade, connector: &mut ClientConnector)
-//! //            -> Upgraded
 //! let upgraded = ironrdp_tokio::mark_as_upgraded(should_upgrade, &mut connector);
 //!
-//! // Step 8: Create upgraded framed (box-erased TLS stream; reuse leftover bytes)
-//! let erased: Box<dyn AsyncReadWrite + Unpin + Send + Sync> = Box::new(tls_stream);
-//! let mut upgraded_framed = ironrdp_tokio::TokioFramed::new_with_leftover(erased, leftover_bytes);
+//! // Step 8: Create upgraded framed over the concrete TLS stream (kept concrete,
+//! // not box-erased, so the spawned session future stays `Send`).
+//! let mut upgraded_framed = ironrdp_tokio::TokioFramed::new_with_leftover(tls_stream, leftover_bytes);
 //!
-//! // Step 9: Finalize connection (CredSSP / capability negotiation)
-//! // Signature: pub async fn connect_finalize<S, N>(
-//! //     _: Upgraded,
-//! //     connector: ClientConnector,         // consumed (not &mut)
-//! //     framed: &mut Framed<S>,
-//! //     network_client: &mut N,
-//! //     server_name: ServerName,            // ironrdp::connector::ServerName (wraps &str / String)
-//! //     server_public_key: Vec<u8>,
-//! //     kerberos_config: Option<KerberosConfig>,
-//! // ) -> ConnectorResult<ConnectionResult>
-//! // where S: FramedRead + FramedWrite, N: NetworkClient
-//! //
-//! // NetworkClient trait (not dyn-compatible):
-//! //   fn send(&mut self, request: &NetworkRequest) -> impl Future<Output=ConnectorResult<Vec<u8>>>
-//! //
-//! // For NTLM (username/password) there is NO Kerberos KDC round-trip, so a no-op NetworkClient
-//! // is acceptable. A unit struct implementing NetworkClient that panics / returns error on send
-//! // is sufficient. Pass kerberos_config = None.
-//! //
-//! // ironrdp_tokio::reqwest::ReqwestNetworkClient (requires "reqwest" feature on ironrdp-tokio)
-//! // is the provided implementation but adds a large dep. A manual no-op struct works for NTLM.
+//! // Step 9: Finalize connection
 //! let connection_result = ironrdp_tokio::connect_finalize(
-//!     upgraded,
-//!     connector,
-//!     &mut upgraded_framed,
-//!     &mut NoopNetworkClient,    // safe for NTLM; panics if Kerberos KDC round-trip is needed
-//!     server_name.into(),
-//!     server_public_key,
-//!     None,                      // kerberos_config
+//!     upgraded, connector, &mut upgraded_framed, &mut NoopNetworkClient,
+//!     ServerName::new(host), server_public_key, None,
 //! ).await?;
-//!
-//! // Step 10: Active session loop
-//! // ironrdp::session::ActiveStage::new(connection_result)
-//! // upgraded_framed is now the session transport
 //! ```
-//!
-//! ## NoopNetworkClient implementation sketch (for Task 4)
-//! ```rust,ignore
-//! struct NoopNetworkClient;
-//! impl ironrdp_tokio::NetworkClient for NoopNetworkClient {
-//!     async fn send(&mut self, _: &ironrdp_tokio::NetworkRequest) -> ironrdp_tokio::ConnectorResult<Vec<u8>> {
-//!         Err(ironrdp::connector::general_err!("no KDC network client; use NTLM not Kerberos"))
-//!     }
-//! }
-//! ```
-//!
-//! ## CredSSP / NTLM via sspi
-//! The connector internally calls sspi for NTLMv2 when `ironrdp::connector::Config` is set up
-//! with username/password credentials. The `sspi = "0.21"` dep provides the NTLM implementation.
-//! No explicit sspi calls needed at the connect-sequence level; the connector drives it.
-
-// Implemented in later tasks.
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
-    sync::{Mutex, MutexGuard},
+    sync::{Arc, Mutex, MutexGuard},
 };
 use tauri::{AppHandle, Emitter};
 use tokio::{
+    net::TcpStream,
     runtime::Runtime,
     sync::{mpsc, oneshot},
 };
@@ -133,6 +73,9 @@ use tokio::{
 const DEFAULT_RDP_PORT: u16 = 3389;
 const DEFAULT_RDP_WIDTH: u16 = 1280;
 const DEFAULT_RDP_HEIGHT: u16 = 800;
+
+
+// ── Session manager ───────────────────────────────────────────────────────────
 
 pub struct RdpClientSessionManager {
     runtime: Runtime,
@@ -245,10 +188,520 @@ impl RdpClientSessionManager {
         }
     }
 
+    pub fn start_session(
+        &self,
+        app: AppHandle,
+        request: StartRdpClientSessionRequest,
+    ) -> Result<RdpClientSessionStarted, String> {
+        let session_id = required_id(request.session_id.clone())?;
+        let host = {
+            let h = request.host.trim().to_string();
+            if h.is_empty() {
+                return Err("RDP host is required".to_string());
+            }
+            h
+        };
+        let port = request.port.unwrap_or(DEFAULT_RDP_PORT);
+        if port == 0 {
+            return Err("RDP port must be between 1 and 65535".to_string());
+        }
+
+        {
+            let sessions = self.lock_sessions()?;
+            if sessions.contains_key(&session_id) {
+                return Err(format!("RDP session '{session_id}' is already running"));
+            }
+        }
+
+        let width = request.desktop_width();
+        let height = request.desktop_height();
+        let username = request.username.clone();
+        let password = request.password.clone().unwrap_or_default();
+        let domain = request.domain.clone();
+
+        let (connection_result, framed) = self
+            .runtime
+            .block_on(rdp_connect(
+                host.clone(),
+                port,
+                username,
+                password,
+                domain,
+                width,
+                height,
+            ))
+            .map_err(|e| format!("RDP connect failed: {e}"))?;
+
+        let (stop_tx, stop_rx) = oneshot::channel();
+        let (input_tx, input_rx) = mpsc::unbounded_channel();
+
+        spawn_rdp_event_loop(
+            &self.runtime,
+            app,
+            session_id.clone(),
+            connection_result,
+            framed,
+            input_rx,
+            stop_rx,
+        );
+
+        let mut sessions = self.lock_sessions()?;
+        sessions.insert(
+            session_id.clone(),
+            RdpClientSession {
+                input: input_tx,
+                stop: Some(stop_tx),
+                connected: true,
+            },
+        );
+
+        Ok(RdpClientSessionStarted { session_id, host, port })
+    }
+
+    pub fn pointer_event(&self, request: RdpClientPointerEventRequest) -> Result<(), String> {
+        self.queue_input(
+            &request.session_id,
+            RdpInput::Pointer { x: request.x, y: request.y, button_mask: request.button_mask },
+        )
+    }
+
+    pub fn key_event(&self, request: RdpClientKeyEventRequest) -> Result<(), String> {
+        self.queue_input(
+            &request.session_id,
+            RdpInput::Key { scancode: request.scancode, down: request.down },
+        )
+    }
+
+    pub fn send_ctrl_alt_delete(&self, request: RdpClientSimpleRequest) -> Result<(), String> {
+        self.queue_input(&request.session_id, RdpInput::CtrlAltDelete)
+    }
+
+    pub fn close_session(&self, request: RdpClientSimpleRequest) -> Result<(), String> {
+        let removed = {
+            let mut sessions = self.lock_sessions()?;
+            sessions.remove(&request.session_id)
+        };
+        if let Some(mut session) = removed {
+            if let Some(stop) = session.stop.take() {
+                let _ = stop.send(());
+            }
+        }
+        Ok(())
+    }
+
+    pub fn session_status(&self, request: RdpClientSimpleRequest) -> Result<RdpClientSessionStatus, String> {
+        let sessions = self.lock_sessions()?;
+        let connected = sessions
+            .get(&request.session_id)
+            .map(|s| s.connected)
+            .unwrap_or(false);
+        Ok(RdpClientSessionStatus { session_id: request.session_id, connected })
+    }
+
+    fn queue_input(&self, session_id: &str, input: RdpInput) -> Result<(), String> {
+        let sessions = self.lock_sessions()?;
+        let tx = sessions
+            .get(session_id)
+            .map(|s| s.input.clone())
+            .ok_or_else(|| format!("RDP session '{session_id}' was not found"))?;
+        tx.send(input)
+            .map_err(|_| format!("RDP session '{session_id}' input channel is closed"))
+    }
+
     fn lock_sessions(&self) -> Result<MutexGuard<'_, HashMap<String, RdpClientSession>>, String> {
         self.sessions.lock().map_err(|_| "RDP session lock is poisoned".to_string())
     }
 }
+
+// ── No-op NetworkClient (safe for NTLM; Kerberos KDC round-trips never happen) ──
+
+struct NoopNetworkClient;
+
+impl ironrdp_tokio::NetworkClient for NoopNetworkClient {
+    async fn send(
+        &mut self,
+        _request: &ironrdp::connector::sspi::generator::NetworkRequest,
+    ) -> ironrdp::connector::ConnectorResult<Vec<u8>> {
+        Err(ironrdp::connector::general_err!(
+            "no KDC network client; use NTLM credentials not Kerberos"
+        ))
+    }
+}
+
+// ── TLS: NoCertificateVerification (RDP never verifies the cert chain) ────────
+
+#[derive(Debug)]
+struct NoCertificateVerification(Arc<rustls::crypto::CryptoProvider>);
+
+impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dsa: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dsa,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dsa: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dsa,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+}
+
+async fn tls_upgrade(
+    stream: TcpStream,
+    server_name: &str,
+) -> Result<tokio_rustls::client::TlsStream<TcpStream>, String> {
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let tls_config = rustls::ClientConfig::builder_with_provider(Arc::clone(&provider))
+        .with_protocol_versions(&[&rustls::version::TLS12, &rustls::version::TLS13])
+        .map_err(|e| format!("TLS config error: {e}"))?
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoCertificateVerification(provider)))
+        .with_no_client_auth();
+
+    // Disable TLS session resumption — CredSSP/MS-CSSP requires it.
+    let mut tls_config = tls_config;
+    tls_config.resumption = rustls::client::Resumption::disabled();
+
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(tls_config));
+    let dns_name = rustls::pki_types::ServerName::try_from(server_name.to_string())
+        .map_err(|e| format!("invalid server name '{server_name}': {e}"))?;
+    connector
+        .connect(dns_name, stream)
+        .await
+        .map_err(|e| format!("TLS handshake failed: {e}"))
+}
+
+fn extract_server_public_key(
+    tls_stream: &tokio_rustls::client::TlsStream<TcpStream>,
+) -> Result<Vec<u8>, String> {
+    use x509_cert::der::Decode as _;
+
+    let (_, session) = tls_stream.get_ref();
+    let cert_der = session
+        .peer_certificates()
+        .and_then(|certs| certs.first())
+        .ok_or_else(|| "RDP server sent no TLS certificate".to_string())?;
+
+    let cert = x509_cert::Certificate::from_der(cert_der.as_ref())
+        .map_err(|e| format!("failed to parse server certificate: {e}"))?;
+
+    let spki_bytes = cert
+        .tbs_certificate
+        .subject_public_key_info
+        .subject_public_key
+        .as_bytes()
+        .ok_or_else(|| "server certificate subject public key is not a bitstring".to_string())?
+        .to_vec();
+
+    Ok(spki_bytes)
+}
+
+// ── Connect helper ────────────────────────────────────────────────────────────
+
+type UpgradedFramed = ironrdp_tokio::TokioFramed<tokio_rustls::client::TlsStream<TcpStream>>;
+
+async fn rdp_connect(
+    host: String,
+    port: u16,
+    username: String,
+    password: String,
+    domain: Option<String>,
+    width: u16,
+    height: u16,
+) -> Result<(ironrdp::connector::ConnectionResult, UpgradedFramed), String> {
+    use ironrdp::connector::{
+        ClientConnector, Config, Credentials, DesktopSize, ServerName,
+        credssp::KerberosConfig,
+    };
+    use ironrdp::pdu::gcc::KeyboardType;
+    use ironrdp::pdu::rdp::capability_sets::MajorPlatformType;
+    use ironrdp_tokio::{TokioFramed, connect_begin, connect_finalize, mark_as_upgraded};
+
+    // Step 1: TCP connect + create framed
+    let stream = TcpStream::connect((host.as_str(), port))
+        .await
+        .map_err(|e| format!("TCP connect to {host}:{port} failed: {e}"))?;
+    let client_addr = stream.local_addr().map_err(|e| e.to_string())?;
+    let mut framed: TokioFramed<TcpStream> = TokioFramed::new(stream);
+
+    // Step 2: Build connector config
+    let config = Config {
+        credentials: Credentials::UsernamePassword { username, password },
+        domain,
+        enable_tls: false,
+        enable_credssp: true,
+        desktop_size: DesktopSize { width, height },
+        desktop_scale_factor: 0,
+        keyboard_type: KeyboardType::IbmEnhanced,
+        keyboard_subtype: 0,
+        keyboard_functional_keys_count: 12,
+        keyboard_layout: 0x0409, // en-US
+        ime_file_name: String::new(),
+        enable_server_pointer: true,
+        pointer_software_rendering: false,
+        client_build: 0,
+        client_name: "KKTerm".to_string(),
+        client_dir: String::new(),
+        platform: MajorPlatformType::UNIX,
+        hardware_id: None,
+        bitmap: None,
+        compression_type: None,
+        performance_flags: ironrdp::pdu::rdp::client_info::PerformanceFlags::default(),
+        autologon: false,
+        enable_audio_playback: false,
+        timezone_info: ironrdp::pdu::rdp::client_info::TimezoneInfo::default(),
+        license_cache: None,
+        multitransport_flags: None,
+        alternate_shell: String::new(),
+        work_dir: String::new(),
+        dig_product_id: String::new(),
+        request_data: None,
+    };
+
+    // Step 3: Create connector + begin
+    let mut connector = ClientConnector::new(config, client_addr);
+    let should_upgrade = connect_begin(&mut framed, &mut connector)
+        .await
+        .map_err(|e| format!("RDP connect_begin failed: {e}"))?;
+
+    // Step 4: Extract inner stream
+    let (tcp_stream, leftover) = framed.into_inner();
+
+    // Step 5: TLS upgrade
+    let tls_stream = tls_upgrade(tcp_stream, &host).await?;
+
+    // Step 6: Extract server public key
+    let server_public_key = extract_server_public_key(&tls_stream)?;
+
+    // Step 7: Mark as upgraded
+    let upgraded = mark_as_upgraded(should_upgrade, &mut connector);
+
+    // Step 8: Create upgraded framed over the concrete TLS stream
+    let mut upgraded_framed: UpgradedFramed = TokioFramed::new_with_leftover(tls_stream, leftover);
+
+    // Step 9: Finalize
+    let connection_result = connect_finalize::<_, NoopNetworkClient>(
+        upgraded,
+        connector,
+        &mut upgraded_framed,
+        &mut NoopNetworkClient,
+        ServerName::new(host),
+        server_public_key,
+        None::<KerberosConfig>,
+    )
+    .await
+    .map_err(|e| format!("RDP connect_finalize failed: {e}"))?;
+
+    Ok((connection_result, upgraded_framed))
+}
+
+// ── Event loop ────────────────────────────────────────────────────────────────
+
+fn spawn_rdp_event_loop(
+    runtime: &Runtime,
+    app: AppHandle,
+    session_id: String,
+    connection_result: ironrdp::connector::ConnectionResult,
+    mut framed: UpgradedFramed,
+    mut input_rx: mpsc::UnboundedReceiver<RdpInput>,
+    mut stop: oneshot::Receiver<()>,
+) {
+    runtime.spawn(async move {
+        eprintln!("[rdp {session_id}] event loop starting");
+
+        let width = connection_result.desktop_size.width;
+        let height = connection_result.desktop_size.height;
+
+        emit_rdp_event(
+            &app,
+            RdpCanvasEvent::Connected {
+                session_id: session_id.clone(),
+                name: "RDP".to_string(),
+            },
+        );
+        emit_rdp_event(
+            &app,
+            RdpCanvasEvent::Resolution { session_id: session_id.clone(), width, height },
+        );
+
+        let mut image = ironrdp::session::image::DecodedImage::new(
+            ironrdp::graphics::image_processing::PixelFormat::RgbA32,
+            width,
+            height,
+        );
+        let mut active_stage = ironrdp::session::ActiveStage::new(connection_result);
+        let mut input_db = ironrdp::input::Database::new();
+
+        use ironrdp_tokio::FramedWrite as _;
+
+        loop {
+            tokio::select! {
+                _ = &mut stop => {
+                    eprintln!("[rdp {session_id}] stop signal received");
+                    break;
+                }
+                input = input_rx.recv() => {
+                    match input {
+                        Some(rdp_input) => {
+                            if let Err(e) = send_rdp_input(&mut framed, &mut input_db, rdp_input).await {
+                                eprintln!("[rdp {session_id}] send_rdp_input error: {e}");
+                                emit_rdp_event(&app, RdpCanvasEvent::Error {
+                                    session_id: session_id.clone(),
+                                    message: e,
+                                });
+                                break;
+                            }
+                        }
+                        None => break,
+                    }
+                }
+                pdu = framed.read_pdu() => {
+                    match pdu {
+                        Ok((action, payload)) => {
+                            let outputs = match active_stage.process(&mut image, action, &payload) {
+                                Ok(outputs) => outputs,
+                                Err(e) => {
+                                    eprintln!("[rdp {session_id}] active_stage.process error: {e}");
+                                    emit_rdp_event(&app, RdpCanvasEvent::Error {
+                                        session_id: session_id.clone(),
+                                        message: e.to_string(),
+                                    });
+                                    break;
+                                }
+                            };
+
+                            let mut should_break = false;
+                            for output in outputs {
+                                use ironrdp::session::ActiveStageOutput;
+                                match output {
+                                    ActiveStageOutput::ResponseFrame(frame) => {
+                                        if let Err(e) = framed.write_all(&frame).await {
+                                            eprintln!("[rdp {session_id}] write_all error: {e}");
+                                            emit_rdp_event(&app, RdpCanvasEvent::Error {
+                                                session_id: session_id.clone(),
+                                                message: e.to_string(),
+                                            });
+                                            should_break = true;
+                                            break;
+                                        }
+                                    }
+                                    ActiveStageOutput::GraphicsUpdate(region) => {
+                                        let rx = u16::try_from(region.left).unwrap_or(0);
+                                        let ry = u16::try_from(region.top).unwrap_or(0);
+                                        let rw = u16::try_from(
+                                            region.right.saturating_sub(region.left).saturating_add(1)
+                                        ).unwrap_or(0);
+                                        let rh = u16::try_from(
+                                            region.bottom.saturating_sub(region.top).saturating_add(1)
+                                        ).unwrap_or(0);
+                                        let image_data = image.data();
+                                        let rect_rgba = extract_rgba_rect(image_data, width, rx, ry, rw, rh);
+                                        emit_rdp_event(&app, RdpCanvasEvent::RawImage {
+                                            session_id: session_id.clone(),
+                                            x: rx,
+                                            y: ry,
+                                            width: rw,
+                                            height: rh,
+                                            rgba: BASE64.encode(rect_rgba),
+                                        });
+                                    }
+                                    ActiveStageOutput::PointerBitmap(pointer) => {
+                                        let event = cursor_event(&session_id, &pointer);
+                                        emit_rdp_event(&app, event);
+                                    }
+                                    ActiveStageOutput::Terminate(_reason) => {
+                                        eprintln!("[rdp {session_id}] server initiated disconnect");
+                                        should_break = true;
+                                        break;
+                                    }
+                                    _ => {}
+                                }
+                            }
+                            if should_break {
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("[rdp {session_id}] read_pdu error: {e}");
+                            emit_rdp_event(&app, RdpCanvasEvent::Error {
+                                session_id: session_id.clone(),
+                                message: e.to_string(),
+                            });
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        eprintln!("[rdp {session_id}] event loop exiting");
+        emit_rdp_event(&app, RdpCanvasEvent::Disconnected { session_id });
+    });
+}
+
+// ── Input stub (Task 5 fills in real IronRDP input encoding) ──────────────────
+
+async fn send_rdp_input(
+    _framed: &mut UpgradedFramed,
+    _db: &mut ironrdp::input::Database,
+    _input: RdpInput,
+) -> Result<(), String> {
+    // Task 5: translate RdpInput → ironrdp_input operations, apply to _db,
+    // encode as FastPath input PDUs, and write to _framed.
+    Ok(())
+}
+
+// ── Cursor stub (Task 5 fills in real pointer decoding) ───────────────────────
+
+fn cursor_event(
+    session_id: &str,
+    pointer: &ironrdp::graphics::pointer::DecodedPointer,
+) -> RdpCanvasEvent {
+    // Task 5 may refine the pixel format; `bitmap_data` is the decoded pointer
+    // bitmap and `hotspot_x/y` the click hotspot.
+    RdpCanvasEvent::SetCursor {
+        session_id: session_id.to_string(),
+        width: pointer.width,
+        height: pointer.height,
+        hot_x: pointer.hotspot_x,
+        hot_y: pointer.hotspot_y,
+        rgba: BASE64.encode(&pointer.bitmap_data),
+    }
+}
+
+// ── Utilities ─────────────────────────────────────────────────────────────────
 
 fn emit_rdp_event(app: &AppHandle, event: RdpCanvasEvent) {
     let _ = app.emit("rdp-canvas-event", event);

--- a/src-tauri/src/rdp_client.rs
+++ b/src-tauri/src/rdp_client.rs
@@ -563,6 +563,7 @@ fn spawn_rdp_event_loop(
         );
         let mut active_stage = ironrdp::session::ActiveStage::new(connection_result);
         let mut input_db = ironrdp::input::Database::new();
+        let mut last_button_mask: u8 = 0;
 
         use ironrdp_tokio::FramedWrite as _;
 
@@ -575,7 +576,7 @@ fn spawn_rdp_event_loop(
                 input = input_rx.recv() => {
                     match input {
                         Some(rdp_input) => {
-                            if let Err(e) = send_rdp_input(&mut framed, &mut input_db, rdp_input).await {
+                            if let Err(e) = send_rdp_input(&mut framed, &mut input_db, &mut last_button_mask, rdp_input).await {
                                 eprintln!("[rdp {session_id}] send_rdp_input error: {e}");
                                 emit_rdp_event(&app, RdpCanvasEvent::Error {
                                     session_id: session_id.clone(),
@@ -673,13 +674,106 @@ fn spawn_rdp_event_loop(
 
 // ── Input stub (Task 5 fills in real IronRDP input encoding) ──────────────────
 
+/// Detect press/release transitions for the three primary mouse buttons between
+/// a previous and current VNC-style button mask (bit 0 = left, 1 = middle,
+/// 2 = right). Returns `(button_bit, pressed)` for each changed button.
+fn primary_button_transitions(prev: u8, now: u8) -> Vec<(u8, bool)> {
+    let mut out = Vec::new();
+    for bit in 0..3u8 {
+        let was = prev & (1 << bit) != 0;
+        let is = now & (1 << bit) != 0;
+        if is != was {
+            out.push((bit, is));
+        }
+    }
+    out
+}
+
+fn mouse_button_for_bit(bit: u8) -> ironrdp::input::MouseButton {
+    use ironrdp::input::MouseButton;
+    match bit {
+        0 => MouseButton::Left,
+        1 => MouseButton::Middle,
+        _ => MouseButton::Right,
+    }
+}
+
+/// Translate a queued `RdpInput` into IronRDP input operations, apply them to the
+/// keyboard/mouse state `db`, encode the resulting FastPath events, and write the
+/// PDU to the server. `last_button_mask` carries the previous primary-button mask
+/// so press/release can be derived from the absolute mask the frontend sends.
 async fn send_rdp_input(
-    _framed: &mut UpgradedFramed,
-    _db: &mut ironrdp::input::Database,
-    _input: RdpInput,
+    framed: &mut UpgradedFramed,
+    db: &mut ironrdp::input::Database,
+    last_button_mask: &mut u8,
+    input: RdpInput,
 ) -> Result<(), String> {
-    // Task 5: translate RdpInput → ironrdp_input operations, apply to _db,
-    // encode as FastPath input PDUs, and write to _framed.
+    use ironrdp::input::{MousePosition, Operation, Scancode, WheelRotations};
+    use ironrdp_tokio::FramedWrite as _;
+
+    let mut ops: Vec<Operation> = Vec::new();
+    match input {
+        RdpInput::Pointer { x, y, button_mask } => {
+            ops.push(Operation::MouseMove(MousePosition { x, y }));
+            for (bit, pressed) in primary_button_transitions(*last_button_mask, button_mask) {
+                let button = mouse_button_for_bit(bit);
+                ops.push(if pressed {
+                    Operation::MouseButtonPressed(button)
+                } else {
+                    Operation::MouseButtonReleased(button)
+                });
+            }
+            // RFB-style wheel bits (3 = up, 4 = down) are momentary notches.
+            if button_mask & (1 << 3) != 0 {
+                ops.push(Operation::WheelRotations(WheelRotations {
+                    is_vertical: true,
+                    rotation_units: 120,
+                }));
+            }
+            if button_mask & (1 << 4) != 0 {
+                ops.push(Operation::WheelRotations(WheelRotations {
+                    is_vertical: true,
+                    rotation_units: -120,
+                }));
+            }
+            // Remember only the three primary buttons; wheel bits are momentary.
+            *last_button_mask = button_mask & 0b0000_0111;
+        }
+        RdpInput::Key { scancode, down } => {
+            let sc = Scancode::from(scancode);
+            ops.push(if down {
+                Operation::KeyPressed(sc)
+            } else {
+                Operation::KeyReleased(sc)
+            });
+        }
+        RdpInput::CtrlAltDelete => {
+            let ctrl = Scancode::from_u16(0x001D);
+            let alt = Scancode::from_u16(0x0038);
+            let delete = Scancode::from_u16(0xE053);
+            ops.extend([
+                Operation::KeyPressed(ctrl),
+                Operation::KeyPressed(alt),
+                Operation::KeyPressed(delete),
+                Operation::KeyReleased(delete),
+                Operation::KeyReleased(alt),
+                Operation::KeyReleased(ctrl),
+            ]);
+        }
+    }
+
+    let events = db.apply(ops);
+    if events.is_empty() {
+        return Ok(());
+    }
+
+    let pdu = ironrdp::pdu::input::fast_path::FastPathInput::new(events.to_vec())
+        .map_err(|e| format!("failed to build RDP input PDU: {e}"))?;
+    let bytes = ironrdp::core::encode_vec(&pdu).map_err(|e| format!("failed to encode RDP input: {e}"))?;
+    framed
+        .write_all(&bytes)
+        .await
+        .map_err(|e| format!("failed to send RDP input: {e}"))?;
     Ok(())
 }
 
@@ -775,5 +869,17 @@ mod tests {
         ];
         let rect = extract_rgba_rect(&full, width, 1, 1, 1, 1);
         assert_eq!(rect, vec![3, 3, 3, 255]);
+    }
+
+    #[test]
+    fn button_transitions_detect_press_and_release() {
+        assert_eq!(primary_button_transitions(0b000, 0b001), vec![(0, true)]); // left down
+        assert_eq!(primary_button_transitions(0b001, 0b000), vec![(0, false)]); // left up
+        assert_eq!(primary_button_transitions(0b001, 0b001), vec![]); // held, no change
+        assert_eq!(primary_button_transitions(0b000, 0b100), vec![(2, true)]); // right down
+        assert_eq!(
+            primary_button_transitions(0b000, 0b101),
+            vec![(0, true), (2, true)] // left + right down
+        );
     }
 }

--- a/src-tauri/src/rdp_client.rs
+++ b/src-tauri/src/rdp_client.rs
@@ -1,0 +1,119 @@
+//! macOS RDP client built on IronRDP. Decodes the RDP framebuffer to RGBA and
+//! emits `rdp-canvas-event`s for the workspace canvas. Windows uses the native
+//! ActiveX path in `rdp.rs` instead; this module is compiled only off-Windows.
+//!
+//! # Pinned IronRDP connect sequence (verified against ironrdp 0.15 / ironrdp-tokio 0.9)
+//!
+//! ## Dependencies used
+//! - `ironrdp = "0.15"` with features `["connector", "session", "graphics", "pdu", "input"]`
+//! - `ironrdp-tokio = "0.9"` (re-exports all of `ironrdp_async` via `pub use ironrdp_async::*`)
+//! - `tokio-rustls = "0.26"` (for TLS upgrade — we implement the upgrade directly, no ironrdp-tls)
+//! - `sspi = "0.21"` (for CredSSP/NTLM)
+//!
+//! ## Key types
+//! ```text
+//! // TokioFramed<S> = Framed<TokioStream<S>>
+//! // Framed::new(stream: S::InnerStream) -> Self
+//! // TokioStream<S>::InnerStream = S  =>  TokioFramed::new(tcp_stream) works directly
+//! ironrdp_tokio::TokioFramed<tokio::net::TcpStream>
+//! ironrdp_tokio::TokioFramed<Box<dyn AsyncReadWrite + Unpin + Send + Sync>>
+//! ironrdp::connector::ClientConnector  // config: connector::Config, client_addr: SocketAddr
+//! ironrdp::connector::ConnectionResult  // returned by connect_finalize on success
+//! ```
+//!
+//! ## Connect sequence (exact function paths, all from ironrdp_tokio namespace)
+//! ```text
+//! // Step 1: TCP connect + create framed
+//! let stream = tokio::net::TcpStream::connect((host, port)).await?;
+//! let client_addr = stream.local_addr()?;
+//! let mut framed = ironrdp_tokio::TokioFramed::new(stream);
+//!
+//! // Step 2: Create connector
+//! let mut connector = ironrdp::connector::ClientConnector::new(config, client_addr);
+//!
+//! // Step 3: Begin connection (negotiation / NLA pre-TLS handshake)
+//! // Signature: pub async fn connect_begin<S>(framed: &mut Framed<S>, connector: &mut ClientConnector)
+//! //            -> ConnectorResult<ShouldUpgrade>
+//! //            where S: Sync + FramedRead + FramedWrite
+//! let should_upgrade = ironrdp_tokio::connect_begin(&mut framed, &mut connector).await?;
+//!
+//! // Step 4: Extract inner TCP stream + any leftover bytes
+//! // Framed::into_inner(self) -> (S::InnerStream, BytesMut)
+//! // Here S = TokioStream<TcpStream>, so InnerStream = TcpStream
+//! let (initial_stream, leftover_bytes) = framed.into_inner();
+//!
+//! // Step 5: TLS upgrade via tokio-rustls (no-verify config for RDP, matching ironrdp-tls pattern)
+//! // Build a rustls ClientConfig with a NoCertificateVerification verifier (required for RDP).
+//! // Disable TLS resumption (CredSSP does not support TLS session resumption).
+//! // connect: tokio_rustls::TlsConnector::from(Arc::new(config)).connect(domain, stream).await?
+//! // type: tokio_rustls::client::TlsStream<TcpStream>
+//! let tls_stream: tokio_rustls::client::TlsStream<TcpStream> = /* TLS handshake */;
+//!
+//! // Step 6: Extract server public key (SubjectPublicKey bytes from peer cert SPKI)
+//! // From tls_stream.get_ref().1.peer_certificates() -> &[CertificateDer<'_>]
+//! // Take first cert, parse as x509_cert::Certificate (via x509_cert::der::Decode),
+//! // then: cert.tbs_certificate.subject_public_key_info.subject_public_key.as_bytes()
+//! // The connect_finalize parameter type is Vec<u8>.
+//! let server_public_key: Vec<u8> = /* extract from tls_stream peer cert SPKI */;
+//!
+//! // Step 7: Mark as upgraded
+//! // Signature: pub fn mark_as_upgraded(should_upgrade: ShouldUpgrade, connector: &mut ClientConnector)
+//! //            -> Upgraded
+//! let upgraded = ironrdp_tokio::mark_as_upgraded(should_upgrade, &mut connector);
+//!
+//! // Step 8: Create upgraded framed (box-erased TLS stream; reuse leftover bytes)
+//! let erased: Box<dyn AsyncReadWrite + Unpin + Send + Sync> = Box::new(tls_stream);
+//! let mut upgraded_framed = ironrdp_tokio::TokioFramed::new_with_leftover(erased, leftover_bytes);
+//!
+//! // Step 9: Finalize connection (CredSSP / capability negotiation)
+//! // Signature: pub async fn connect_finalize<S, N>(
+//! //     _: Upgraded,
+//! //     connector: ClientConnector,         // consumed (not &mut)
+//! //     framed: &mut Framed<S>,
+//! //     network_client: &mut N,
+//! //     server_name: ServerName,            // ironrdp::connector::ServerName (wraps &str / String)
+//! //     server_public_key: Vec<u8>,
+//! //     kerberos_config: Option<KerberosConfig>,
+//! // ) -> ConnectorResult<ConnectionResult>
+//! // where S: FramedRead + FramedWrite, N: NetworkClient
+//! //
+//! // NetworkClient trait (not dyn-compatible):
+//! //   fn send(&mut self, request: &NetworkRequest) -> impl Future<Output=ConnectorResult<Vec<u8>>>
+//! //
+//! // For NTLM (username/password) there is NO Kerberos KDC round-trip, so a no-op NetworkClient
+//! // is acceptable. A unit struct implementing NetworkClient that panics / returns error on send
+//! // is sufficient. Pass kerberos_config = None.
+//! //
+//! // ironrdp_tokio::reqwest::ReqwestNetworkClient (requires "reqwest" feature on ironrdp-tokio)
+//! // is the provided implementation but adds a large dep. A manual no-op struct works for NTLM.
+//! let connection_result = ironrdp_tokio::connect_finalize(
+//!     upgraded,
+//!     connector,
+//!     &mut upgraded_framed,
+//!     &mut NoopNetworkClient,    // safe for NTLM; panics if Kerberos KDC round-trip is needed
+//!     server_name.into(),
+//!     server_public_key,
+//!     None,                      // kerberos_config
+//! ).await?;
+//!
+//! // Step 10: Active session loop
+//! // ironrdp::session::ActiveStage::new(connection_result)
+//! // upgraded_framed is now the session transport
+//! ```
+//!
+//! ## NoopNetworkClient implementation sketch (for Task 4)
+//! ```rust,ignore
+//! struct NoopNetworkClient;
+//! impl ironrdp_tokio::NetworkClient for NoopNetworkClient {
+//!     async fn send(&mut self, _: &ironrdp_tokio::NetworkRequest) -> ironrdp_tokio::ConnectorResult<Vec<u8>> {
+//!         Err(ironrdp::connector::general_err!("no KDC network client; use NTLM not Kerberos"))
+//!     }
+//! }
+//! ```
+//!
+//! ## CredSSP / NTLM via sspi
+//! The connector internally calls sspi for NTLMv2 when `ironrdp::connector::Config` is set up
+//! with username/password credentials. The `sspi = "0.21"` dep provides the NTLM implementation.
+//! No explicit sspi calls needed at the connect-sequence level; the connector drives it.
+
+// Implemented in later tasks.

--- a/src-tauri/src/rdp_client.rs
+++ b/src-tauri/src/rdp_client.rs
@@ -93,6 +93,9 @@ struct RdpClientSession {
 enum RdpInput {
     Pointer { x: u16, y: u16, button_mask: u8 },
     Key { scancode: u16, down: bool },
+    /// Composed text (IME / printable characters) sent as RDP Unicode keyboard
+    /// events — layout- and IME-independent, unlike scancodes.
+    Text(String),
     CtrlAltDelete,
 }
 
@@ -161,6 +164,13 @@ pub struct RdpClientKeyEventRequest {
     session_id: String,
     scancode: u16,
     down: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RdpClientTextRequest {
+    session_id: String,
+    text: String,
 }
 
 #[derive(Deserialize)]
@@ -270,6 +280,10 @@ impl RdpClientSessionManager {
             &request.session_id,
             RdpInput::Key { scancode: request.scancode, down: request.down },
         )
+    }
+
+    pub fn text_input(&self, request: RdpClientTextRequest) -> Result<(), String> {
+        self.queue_input(&request.session_id, RdpInput::Text(request.text))
     }
 
     pub fn send_ctrl_alt_delete(&self, request: RdpClientSimpleRequest) -> Result<(), String> {
@@ -746,6 +760,15 @@ async fn send_rdp_input(
             } else {
                 Operation::KeyReleased(sc)
             });
+        }
+        RdpInput::Text(text) => {
+            // Each character is sent as a Unicode keyboard event (press + release),
+            // so IME-composed and layout-specific characters reach the server
+            // correctly regardless of the remote keyboard layout.
+            for character in text.chars() {
+                ops.push(Operation::UnicodeKeyPressed(character));
+                ops.push(Operation::UnicodeKeyReleased(character));
+            }
         }
         RdpInput::CtrlAltDelete => {
             let ctrl = Scancode::from_u16(0x001D);

--- a/src-tauri/src/rdp_client.rs
+++ b/src-tauri/src/rdp_client.rs
@@ -117,3 +117,175 @@
 //! No explicit sspi calls needed at the connect-sequence level; the connector drives it.
 
 // Implemented in later tasks.
+
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    sync::{Mutex, MutexGuard},
+};
+use tauri::{AppHandle, Emitter};
+use tokio::{
+    runtime::Runtime,
+    sync::{mpsc, oneshot},
+};
+
+const DEFAULT_RDP_PORT: u16 = 3389;
+const DEFAULT_RDP_WIDTH: u16 = 1280;
+const DEFAULT_RDP_HEIGHT: u16 = 800;
+
+pub struct RdpClientSessionManager {
+    runtime: Runtime,
+    sessions: Mutex<HashMap<String, RdpClientSession>>,
+}
+
+struct RdpClientSession {
+    input: mpsc::UnboundedSender<RdpInput>,
+    stop: Option<oneshot::Sender<()>>,
+    connected: bool,
+}
+
+/// Input operations queued from the frontend, translated to IronRDP input in
+/// the event loop (Task 4/5).
+enum RdpInput {
+    Pointer { x: u16, y: u16, button_mask: u8 },
+    Key { scancode: u16, down: bool },
+    CtrlAltDelete,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartRdpClientSessionRequest {
+    session_id: String,
+    host: String,
+    port: Option<u16>,
+    username: String,
+    #[serde(default)]
+    domain: Option<String>,
+    secret_owner_id: Option<String>,
+    password: Option<String>,
+    #[serde(default)]
+    desktop_width: Option<u16>,
+    #[serde(default)]
+    desktop_height: Option<u16>,
+}
+
+impl StartRdpClientSessionRequest {
+    fn desktop_width(&self) -> u16 {
+        self.desktop_width.filter(|v| *v > 0).unwrap_or(DEFAULT_RDP_WIDTH)
+    }
+    fn desktop_height(&self) -> u16 {
+        self.desktop_height.filter(|v| *v > 0).unwrap_or(DEFAULT_RDP_HEIGHT)
+    }
+    pub(crate) fn secret_owner_id(&self) -> Option<&str> {
+        self.secret_owner_id.as_deref().map(str::trim).filter(|v| !v.is_empty())
+    }
+    pub(crate) fn password(&self) -> Option<&str> {
+        self.password.as_deref().filter(|v| !v.is_empty())
+    }
+    pub(crate) fn set_password(&mut self, password: Option<String>) {
+        self.password = password;
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RdpClientSessionStarted {
+    session_id: String,
+    host: String,
+    port: u16,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RdpClientSessionStatus {
+    session_id: String,
+    connected: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RdpClientPointerEventRequest {
+    session_id: String,
+    x: u16,
+    y: u16,
+    button_mask: u8,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RdpClientKeyEventRequest {
+    session_id: String,
+    scancode: u16,
+    down: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RdpClientSimpleRequest {
+    session_id: String,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase", tag = "kind")]
+enum RdpCanvasEvent {
+    Connected { session_id: String, name: String },
+    Resolution { session_id: String, width: u16, height: u16 },
+    RawImage { session_id: String, x: u16, y: u16, width: u16, height: u16, rgba: String },
+    SetCursor { session_id: String, width: u16, height: u16, hot_x: u16, hot_y: u16, rgba: String },
+    Error { session_id: String, message: String },
+    Disconnected { session_id: String },
+}
+
+impl RdpClientSessionManager {
+    pub fn new() -> Self {
+        Self {
+            runtime: Runtime::new().expect("RDP client runtime initializes"),
+            sessions: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn lock_sessions(&self) -> Result<MutexGuard<'_, HashMap<String, RdpClientSession>>, String> {
+        self.sessions.lock().map_err(|_| "RDP session lock is poisoned".to_string())
+    }
+}
+
+fn emit_rdp_event(app: &AppHandle, event: RdpCanvasEvent) {
+    let _ = app.emit("rdp-canvas-event", event);
+}
+
+fn required_id(value: String) -> Result<String, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err("RDP session id is required".to_string());
+    }
+    if trimmed.len() > 96 {
+        return Err("RDP session id must be 96 characters or fewer".to_string());
+    }
+    if !trimmed.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_')) {
+        return Err("RDP session id may only contain letters, digits, '-' or '_'".to_string());
+    }
+    Ok(trimmed.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_session_ids() {
+        assert_eq!(required_id("rdp-1".to_string()).as_deref(), Ok("rdp-1"));
+        assert!(required_id("bad/session".to_string()).is_err());
+    }
+
+    #[test]
+    fn start_request_deserializes_with_defaults() {
+        let json = r#"{"sessionId":"rdp-1","host":"win.local","username":"u","password":"p"}"#;
+        let request: StartRdpClientSessionRequest =
+            serde_json::from_str(json).expect("request deserializes");
+        assert_eq!(request.host, "win.local");
+        assert!(request.domain.is_none());
+        assert_eq!(request.desktop_width(), DEFAULT_RDP_WIDTH);
+        assert_eq!(request.desktop_height(), DEFAULT_RDP_HEIGHT);
+    }
+}

--- a/src-tauri/src/rdp_client.rs
+++ b/src-tauri/src/rdp_client.rs
@@ -268,6 +268,29 @@ fn required_id(value: String) -> Result<String, String> {
     Ok(trimmed.to_string())
 }
 
+/// Copy the `(x, y, w, h)` sub-rectangle out of a full-frame RGBA buffer
+/// (`stride = full_width * 4`) into a tightly packed RGBA buffer.
+fn extract_rgba_rect(
+    full_rgba: &[u8],
+    full_width: u16,
+    x: u16,
+    y: u16,
+    w: u16,
+    h: u16,
+) -> Vec<u8> {
+    let stride = full_width as usize * 4;
+    let mut out = Vec::with_capacity(w as usize * h as usize * 4);
+    for row in 0..h as usize {
+        let src_y = y as usize + row;
+        let start = src_y * stride + x as usize * 4;
+        let end = start + w as usize * 4;
+        if end <= full_rgba.len() {
+            out.extend_from_slice(&full_rgba[start..end]);
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -287,5 +310,17 @@ mod tests {
         assert!(request.domain.is_none());
         assert_eq!(request.desktop_width(), DEFAULT_RDP_WIDTH);
         assert_eq!(request.desktop_height(), DEFAULT_RDP_HEIGHT);
+    }
+
+    #[test]
+    fn extracts_rgba_rect_from_framebuffer() {
+        // 2x2 RGBA image, extract the bottom-right 1x1 pixel.
+        let width = 2u16;
+        let full = vec![
+            0, 0, 0, 255,        1, 1, 1, 255,
+            2, 2, 2, 255,        3, 3, 3, 255,
+        ];
+        let rect = extract_rgba_rect(&full, width, 1, 1, 1, 1);
+        assert_eq!(rect, vec![3, 3, 3, 255]);
     }
 }

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -38,7 +38,15 @@ export function supportsInstallerHelper() {
 }
 
 export function supportsRdp() {
-  return isWindowsPlatform();
+  // Windows uses the native ActiveX control; macOS uses the in-app IronRDP
+  // canvas client. Both render RDP inside the workspace.
+  return isWindowsPlatform() || isMacPlatform();
+}
+
+// RDP on macOS renders to the shared remote-desktop <canvas> via the IronRDP
+// backend (rdp-canvas-event), like VNC — not the Windows native ActiveX overlay.
+export function usesCanvasRdp() {
+  return isMacPlatform();
 }
 
 export function defaultLocalShell() {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -713,6 +713,46 @@ export interface VncSimpleRequest {
   sessionId: string;
 }
 
+export interface StartRdpClientSessionRequest {
+  sessionId: string;
+  host: string;
+  port?: number;
+  username: string;
+  domain?: string;
+  secretOwnerId?: string;
+  password?: string;
+  desktopWidth?: number;
+  desktopHeight?: number;
+}
+
+export interface RdpClientSessionStarted {
+  sessionId: string;
+  host: string;
+  port: number;
+}
+
+export interface RdpClientSessionStatus {
+  sessionId: string;
+  connected: boolean;
+}
+
+export interface RdpClientPointerEventRequest {
+  sessionId: string;
+  x: number;
+  y: number;
+  buttonMask: number;
+}
+
+export interface RdpClientKeyEventRequest {
+  sessionId: string;
+  scancode: number;
+  down: boolean;
+}
+
+export interface RdpClientSimpleRequest {
+  sessionId: string;
+}
+
 export interface GitHubCopilotDeviceFlow {
   deviceCode: string;
   userCode: string;
@@ -1821,6 +1861,30 @@ type CommandMap = {
   send_vnc_ctrl_alt_delete: {
     args: { request: VncSimpleRequest };
     result: null;
+  };
+  start_rdp_client_session: {
+    args: { request: StartRdpClientSessionRequest };
+    result: RdpClientSessionStarted;
+  };
+  send_rdp_client_pointer_event: {
+    args: { request: RdpClientPointerEventRequest };
+    result: null;
+  };
+  send_rdp_client_key_event: {
+    args: { request: RdpClientKeyEventRequest };
+    result: null;
+  };
+  send_rdp_client_ctrl_alt_delete: {
+    args: { request: RdpClientSimpleRequest };
+    result: null;
+  };
+  close_rdp_client_session: {
+    args: { request: RdpClientSimpleRequest };
+    result: null;
+  };
+  get_rdp_client_session_status: {
+    args: { request: RdpClientSimpleRequest };
+    result: RdpClientSessionStatus;
   };
   dashboard_load_state: {
     args: undefined;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -749,6 +749,11 @@ export interface RdpClientKeyEventRequest {
   down: boolean;
 }
 
+export interface RdpClientTextRequest {
+  sessionId: string;
+  text: string;
+}
+
 export interface RdpClientSimpleRequest {
   sessionId: string;
 }
@@ -1872,6 +1877,10 @@ type CommandMap = {
   };
   send_rdp_client_key_event: {
     args: { request: RdpClientKeyEventRequest };
+    result: null;
+  };
+  send_rdp_client_text: {
+    args: { request: RdpClientTextRequest };
     result: null;
   };
   send_rdp_client_ctrl_alt_delete: {

--- a/src/modules/workspace/connections/remote-desktop/RdpCanvasView.tsx
+++ b/src/modules/workspace/connections/remote-desktop/RdpCanvasView.tsx
@@ -1,0 +1,342 @@
+// Self-contained macOS RDP view: renders the IronRDP framebuffer to a <canvas>
+// and sends mouse + hybrid keyboard input. Kept independent of the VNC/Windows
+// ActiveX paths in RemoteDesktopWorkspace so neither is affected.
+//
+// Keyboard model (see research in the IronRDP/RDP keyboard notes):
+//   - Printable text, including IME composition, dead keys and accents, is sent
+//     as RDP Unicode keyboard events via `send_rdp_client_text` (the local OS/IME
+//     composes; the final characters are layout-independent).
+//   - Control / navigation / modifier keys and Ctrl/Alt/Meta shortcuts are sent
+//     as scancodes via `send_rdp_client_key_event`.
+
+import { listen } from "@tauri-apps/api/event";
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { invokeCommand, isTauriRuntime } from "../../../../lib/tauri";
+import type { Connection } from "../../../../types";
+import { connectionPasswordOwnerId } from "../utils";
+import { isCharacterCode, scancodeForCode } from "./rdpScancodes";
+
+type RdpCanvasEvent =
+  | { kind: "connected"; sessionId: string; name: string }
+  | { kind: "resolution"; sessionId: string; width: number; height: number }
+  | {
+      kind: "rawImage";
+      sessionId: string;
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+      rgba: string;
+    }
+  | {
+      kind: "setCursor";
+      sessionId: string;
+      width: number;
+      height: number;
+      hotX: number;
+      hotY: number;
+      rgba: string;
+    }
+  | { kind: "error"; sessionId: string; message: string }
+  | { kind: "disconnected"; sessionId: string };
+
+function createRdpSessionId() {
+  return `rdp-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export function RdpCanvasView({ connection }: { connection: Connection }) {
+  const { t } = useTranslation();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const sessionIdRef = useRef<string | null>(null);
+  const buttonMaskRef = useRef(0);
+  const composingRef = useRef(false);
+  const [status, setStatus] = useState<"connecting" | "connected" | "disconnected">("connecting");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  // Session lifecycle + framebuffer rendering.
+  useEffect(() => {
+    if (!isTauriRuntime()) {
+      return;
+    }
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    const sessionId = createRdpSessionId();
+    sessionIdRef.current = sessionId;
+    setStatus("connecting");
+    setErrorMessage("");
+
+    const draw = (event: RdpCanvasEvent) => {
+      const canvas = canvasRef.current;
+      if (!canvas) {
+        return;
+      }
+      if (event.kind === "resolution") {
+        canvas.width = event.width;
+        canvas.height = event.height;
+        return;
+      }
+      if (event.kind === "rawImage") {
+        if (event.width === 0 || event.height === 0) {
+          return;
+        }
+        const ctx = canvas.getContext("2d");
+        if (!ctx) {
+          return;
+        }
+        const bytes = base64ToBytes(event.rgba);
+        const expected = event.width * event.height * 4;
+        if (bytes.length < expected) {
+          return;
+        }
+        const clamped = new Uint8ClampedArray(expected);
+        clamped.set(bytes.subarray(0, expected));
+        const image = new ImageData(clamped, event.width, event.height);
+        ctx.putImageData(image, event.x, event.y);
+      }
+    };
+
+    void listen<RdpCanvasEvent>("rdp-canvas-event", (event) => {
+      if (disposed || event.payload.sessionId !== sessionIdRef.current) {
+        return;
+      }
+      const payload = event.payload;
+      switch (payload.kind) {
+        case "connected":
+          setStatus("connected");
+          break;
+        case "error":
+          setErrorMessage(payload.message);
+          break;
+        case "disconnected":
+          setStatus("disconnected");
+          break;
+        default:
+          draw(payload);
+      }
+    }).then((dispose) => {
+      if (disposed) {
+        dispose();
+        return;
+      }
+      unlisten = dispose;
+    });
+
+    void invokeCommand("start_rdp_client_session", {
+      request: {
+        sessionId,
+        host: connection.host,
+        port: connection.port,
+        username: connection.user ?? "",
+        secretOwnerId: connectionPasswordOwnerId(connection),
+      },
+    }).catch((error) => {
+      if (!disposed) {
+        setErrorMessage(error instanceof Error ? error.message : String(error));
+        setStatus("disconnected");
+      }
+    });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+      void invokeCommand("close_rdp_client_session", { request: { sessionId } }).catch(() => undefined);
+      sessionIdRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connection.id, connection.host, connection.port, connection.user]);
+
+  // ── Mouse ──────────────────────────────────────────────────────────────────
+  const remotePoint = (clientX: number, clientY: number): { x: number; y: number } | null => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return null;
+    }
+    const rect = canvas.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) {
+      return null;
+    }
+    const x = Math.max(0, Math.min(canvas.width - 1, Math.round(((clientX - rect.left) / rect.width) * canvas.width)));
+    const y = Math.max(0, Math.min(canvas.height - 1, Math.round(((clientY - rect.top) / rect.height) * canvas.height)));
+    return { x, y };
+  };
+
+  const sendPointer = (clientX: number, clientY: number, buttonMask: number) => {
+    const sessionId = sessionIdRef.current;
+    const point = remotePoint(clientX, clientY);
+    if (!sessionId || !point) {
+      return;
+    }
+    void invokeCommand("send_rdp_client_pointer_event", {
+      request: { sessionId, x: point.x, y: point.y, buttonMask },
+    }).catch(() => undefined);
+  };
+
+  const onPointerMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    sendPointer(e.clientX, e.clientY, buttonMaskRef.current);
+  };
+  const onPointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    inputRef.current?.focus();
+    const bit = e.button === 1 ? 1 : e.button === 2 ? 2 : e.button === 0 ? 0 : -1;
+    if (bit >= 0) {
+      buttonMaskRef.current |= 1 << bit;
+    }
+    sendPointer(e.clientX, e.clientY, buttonMaskRef.current);
+  };
+  const onPointerUp = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    const bit = e.button === 1 ? 1 : e.button === 2 ? 2 : e.button === 0 ? 0 : -1;
+    if (bit >= 0) {
+      buttonMaskRef.current &= ~(1 << bit);
+    }
+    sendPointer(e.clientX, e.clientY, buttonMaskRef.current);
+  };
+  const onWheel = (e: React.WheelEvent<HTMLCanvasElement>) => {
+    // Bit 3 = wheel up, bit 4 = wheel down (momentary, matching the backend).
+    const wheelBit = e.deltaY < 0 ? 1 << 3 : 1 << 4;
+    sendPointer(e.clientX, e.clientY, buttonMaskRef.current | wheelBit);
+  };
+
+  // ── Keyboard ────────────────────────────────────────────────────────────────
+  const sendScancode = (scancode: number, down: boolean) => {
+    const sessionId = sessionIdRef.current;
+    if (!sessionId) {
+      return;
+    }
+    void invokeCommand("send_rdp_client_key_event", {
+      request: { sessionId, scancode, down },
+    }).catch(() => undefined);
+  };
+
+  const sendText = (text: string) => {
+    const sessionId = sessionIdRef.current;
+    if (!sessionId || text.length === 0) {
+      return;
+    }
+    void invokeCommand("send_rdp_client_text", { request: { sessionId, text } }).catch(() => undefined);
+  };
+
+  const sendCtrlAltDelete = () => {
+    const sessionId = sessionIdRef.current;
+    if (!sessionId) {
+      return;
+    }
+    void invokeCommand("send_rdp_client_ctrl_alt_delete", { request: { sessionId } }).catch(() => undefined);
+    inputRef.current?.focus();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (composingRef.current || e.key === "Process") {
+      return; // IME is composing — let composition events handle it.
+    }
+    const shortcut = e.ctrlKey || e.altKey || e.metaKey;
+    const isText = isCharacterCode(e.code);
+    if (isText && !shortcut) {
+      return; // Plain printable key → handled by the Unicode/input path below.
+    }
+    const scancode = scancodeForCode(e.code);
+    if (scancode !== undefined) {
+      e.preventDefault();
+      sendScancode(scancode, true);
+    }
+  };
+
+  const onKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (composingRef.current) {
+      return;
+    }
+    const shortcut = e.ctrlKey || e.altKey || e.metaKey;
+    const isText = isCharacterCode(e.code);
+    if (isText && !shortcut) {
+      return;
+    }
+    const scancode = scancodeForCode(e.code);
+    if (scancode !== undefined) {
+      e.preventDefault();
+      sendScancode(scancode, false);
+    }
+  };
+
+  const onCompositionStart = () => {
+    composingRef.current = true;
+  };
+  const onCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>) => {
+    composingRef.current = false;
+    if (e.data) {
+      sendText(e.data);
+    }
+    if (inputRef.current) {
+      inputRef.current.value = "";
+    }
+  };
+  const onInput = (e: React.FormEvent<HTMLInputElement>) => {
+    if (composingRef.current) {
+      return; // wait for compositionend
+    }
+    const native = e.nativeEvent as InputEvent;
+    if (native.inputType === "insertText" && native.data) {
+      sendText(native.data);
+    }
+    if (inputRef.current) {
+      inputRef.current.value = "";
+    }
+  };
+
+  const statusText =
+    status === "connecting"
+      ? t("remoteDesktop.connecting")
+      : status === "disconnected"
+        ? t("remoteDesktop.disconnected")
+        : "";
+
+  return (
+    <div className="rdp-canvas-view" onPointerDown={() => inputRef.current?.focus()}>
+      <canvas
+        ref={canvasRef}
+        className="rdp-canvas-surface"
+        onPointerMove={onPointerMove}
+        onPointerDown={onPointerDown}
+        onPointerUp={onPointerUp}
+        onWheel={onWheel}
+        onContextMenu={(e) => e.preventDefault()}
+      />
+      {/* Visually-hidden focus target that captures IME composition + text input. */}
+      <input
+        ref={inputRef}
+        className="rdp-canvas-ime-input"
+        aria-label={t("remoteDesktop.displayAria")}
+        title={t("remoteDesktop.displayAria")}
+        autoComplete="off"
+        autoCapitalize="off"
+        autoCorrect="off"
+        spellCheck={false}
+        onKeyDown={onKeyDown}
+        onKeyUp={onKeyUp}
+        onInput={onInput}
+        onCompositionStart={onCompositionStart}
+        onCompositionUpdate={onCompositionStart}
+        onCompositionEnd={onCompositionEnd}
+      />
+      <button
+        type="button"
+        className="rdp-canvas-cad"
+        onClick={sendCtrlAltDelete}
+        title={t("remoteDesktop.sendCtrlAltDel")}
+      >
+        {t("remoteDesktop.sendCtrlAltDel")}
+      </button>
+      {(statusText || errorMessage) && (
+        <div className="rdp-canvas-status">{errorMessage || statusText}</div>
+      )}
+    </div>
+  );
+}

--- a/src/modules/workspace/connections/remote-desktop/RemoteDesktopWorkspace.tsx
+++ b/src/modules/workspace/connections/remote-desktop/RemoteDesktopWorkspace.tsx
@@ -31,6 +31,8 @@ import {
   unregisterRemoteDesktopController,
   type RemoteDesktopController,
 } from "../../paneRegistry";
+import { usesCanvasRdp } from "../../../../lib/platform";
+import { RdpCanvasView } from "./RdpCanvasView";
 
 type VncSessionEvent =
   | { kind: "connected"; sessionId: string; name: string }
@@ -141,7 +143,11 @@ export function RemoteDesktopWorkspace({
   const [rdpStatus, setRdpStatus] = useState("");
   const [rdpStartKey, setRdpStartKey] = useState(0);
   const [vncHasDisplay, setVncHasDisplay] = useState(false);
-  const canStartRdp = connection?.type === "rdp";
+  // macOS renders RDP through the in-app IronRDP canvas (RdpCanvasView), not the
+  // Windows native ActiveX overlay. Keep the overlay path Windows-only so its
+  // effects never run on macOS.
+  const useRdpCanvas = connection?.type === "rdp" && usesCanvasRdp();
+  const canStartRdp = connection?.type === "rdp" && !useRdpCanvas;
   const canStartVnc = connection?.type === "vnc";
   const viewMode = resolveRemoteDesktopViewMode(connection, rdpSettings, vncSettings);
 
@@ -1480,6 +1486,7 @@ export function RemoteDesktopWorkspace({
             width={rdpSnapshot.width}
           />
         ) : null}
+        {useRdpCanvas && connection ? <RdpCanvasView connection={connection} /> : null}
         {connection?.type === "vnc" ? (
           <canvas
             aria-label={`${tab.title} ${t("remoteDesktop.displayAria")}`}
@@ -1495,7 +1502,7 @@ export function RemoteDesktopWorkspace({
             tabIndex={0}
           />
         ) : null}
-        <div className="remote-desktop-placeholder" hidden={vncHasDisplay || Boolean(rdpSnapshot)}>
+        <div className="remote-desktop-placeholder" hidden={vncHasDisplay || Boolean(rdpSnapshot) || useRdpCanvas}>
           <Icon size={34} />
           <h2>{connection?.name ?? typeLabel}</h2>
           <p>{connection ? `${typeLabel} ${connectionSubtitle(connection)}` : typeLabel}</p>

--- a/src/modules/workspace/connections/remote-desktop/rdpScancodes.ts
+++ b/src/modules/workspace/connections/remote-desktop/rdpScancodes.ts
@@ -1,0 +1,90 @@
+// Maps browser `KeyboardEvent.code` (physical, layout-independent) to RDP
+// PC/AT Set 1 scancodes for the IronRDP scancode keyboard path.
+//
+// Extended keys carry the 0xE000 prefix, which IronRDP's `Scancode::from_u16`
+// detects via `code & 0xE000 == 0xE000`.
+//
+// Printable character keys are intentionally included so modifier shortcuts
+// (Ctrl+C, Alt+F4, …) can be sent as scancodes. When NO Ctrl/Alt/Meta is held,
+// the workspace routes printable input through the Unicode/IME text path
+// instead (see `isCharacterCode`), so IME-composed and layout-specific
+// characters reach the server correctly.
+
+const EXTENDED = 0xe000;
+
+export const RDP_SCANCODES: Readonly<Record<string, number>> = {
+  // Letters (physical US positions).
+  KeyA: 0x1e, KeyB: 0x30, KeyC: 0x2e, KeyD: 0x20, KeyE: 0x12, KeyF: 0x21,
+  KeyG: 0x22, KeyH: 0x23, KeyI: 0x17, KeyJ: 0x24, KeyK: 0x25, KeyL: 0x26,
+  KeyM: 0x32, KeyN: 0x31, KeyO: 0x18, KeyP: 0x19, KeyQ: 0x10, KeyR: 0x13,
+  KeyS: 0x1f, KeyT: 0x14, KeyU: 0x16, KeyV: 0x2f, KeyW: 0x11, KeyX: 0x2d,
+  KeyY: 0x15, KeyZ: 0x2c,
+
+  // Number row.
+  Digit1: 0x02, Digit2: 0x03, Digit3: 0x04, Digit4: 0x05, Digit5: 0x06,
+  Digit6: 0x07, Digit7: 0x08, Digit8: 0x09, Digit9: 0x0a, Digit0: 0x0b,
+
+  // Punctuation / symbols.
+  Minus: 0x0c, Equal: 0x0d, BracketLeft: 0x1a, BracketRight: 0x1b,
+  Backslash: 0x2b, Semicolon: 0x27, Quote: 0x28, Backquote: 0x29,
+  Comma: 0x33, Period: 0x34, Slash: 0x35, IntlBackslash: 0x56,
+
+  // Whitespace / editing.
+  Space: 0x39, Enter: 0x1c, Tab: 0x0f, Backspace: 0x0e, Escape: 0x01,
+
+  // Modifiers.
+  ControlLeft: 0x1d, ControlRight: EXTENDED | 0x1d,
+  ShiftLeft: 0x2a, ShiftRight: 0x36,
+  AltLeft: 0x38, AltRight: EXTENDED | 0x38,
+  MetaLeft: EXTENDED | 0x5b, MetaRight: EXTENDED | 0x5c,
+  ContextMenu: EXTENDED | 0x5d,
+  CapsLock: 0x3a, NumLock: 0x45, ScrollLock: 0x46,
+
+  // Function keys.
+  F1: 0x3b, F2: 0x3c, F3: 0x3d, F4: 0x3e, F5: 0x3f, F6: 0x40, F7: 0x41,
+  F8: 0x42, F9: 0x43, F10: 0x44, F11: 0x57, F12: 0x58,
+
+  // Navigation cluster (extended).
+  Insert: EXTENDED | 0x52, Delete: EXTENDED | 0x53, Home: EXTENDED | 0x47,
+  End: EXTENDED | 0x4f, PageUp: EXTENDED | 0x49, PageDown: EXTENDED | 0x51,
+  ArrowUp: EXTENDED | 0x48, ArrowDown: EXTENDED | 0x50,
+  ArrowLeft: EXTENDED | 0x4b, ArrowRight: EXTENDED | 0x4d,
+  PrintScreen: EXTENDED | 0x37,
+
+  // Numpad.
+  Numpad0: 0x52, Numpad1: 0x4f, Numpad2: 0x50, Numpad3: 0x51, Numpad4: 0x4b,
+  Numpad5: 0x4c, Numpad6: 0x4d, Numpad7: 0x47, Numpad8: 0x48, Numpad9: 0x49,
+  NumpadDecimal: 0x53, NumpadAdd: 0x4e, NumpadSubtract: 0x4a,
+  NumpadMultiply: 0x37, NumpadDivide: EXTENDED | 0x35, NumpadEnter: EXTENDED | 0x1c,
+};
+
+/** RDP scancode for a `KeyboardEvent.code`, or `undefined` if unmapped. */
+export function scancodeForCode(code: string): number | undefined {
+  return RDP_SCANCODES[code];
+}
+
+/**
+ * True for keys that produce a printable character (letters, digits, symbols,
+ * space). These are routed through the Unicode/IME text path when unmodified,
+ * and through the scancode path when combined with Ctrl/Alt/Meta (shortcuts).
+ */
+export function isCharacterCode(code: string): boolean {
+  return (
+    code.startsWith("Key") ||
+    code.startsWith("Digit") ||
+    code.startsWith("Numpad") ||
+    code === "Space" ||
+    code === "Minus" ||
+    code === "Equal" ||
+    code === "BracketLeft" ||
+    code === "BracketRight" ||
+    code === "Backslash" ||
+    code === "Semicolon" ||
+    code === "Quote" ||
+    code === "Backquote" ||
+    code === "Comma" ||
+    code === "Period" ||
+    code === "Slash" ||
+    code === "IntlBackslash"
+  );
+}

--- a/src/modules/workspace/connections/remote-desktop/remote-desktop.css
+++ b/src/modules/workspace/connections/remote-desktop/remote-desktop.css
@@ -127,3 +127,47 @@
   width: auto;
   height: 100%;
 }
+
+/* macOS IronRDP canvas view (RdpCanvasView). */
+.rdp-canvas-view {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #000;
+}
+
+.rdp-canvas-surface {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  touch-action: none;
+}
+
+.rdp-canvas-ime-input {
+  position: absolute;
+  top: 0;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+
+.rdp-canvas-cad {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+}
+
+.rdp-canvas-status {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  color: #fff;
+  text-align: center;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary

Adds an in-app **IronRDP** client so macOS can open RDP connections to Windows hosts, rendering the framebuffer to a `<canvas>` (like the VNC path). **Windows keeps its native `mstscax.dll` ActiveX path untouched** — everything here is gated `#[cfg(not(target_os = "windows"))]` and behind `usesCanvasRdp()` on the frontend.

### Backend (`src-tauri/src/rdp_client.rs`, mirrors `vnc.rs`)
- Async connect: TCP → TLS (hand-rolled rustls **ring** provider, no-cert-verify per RDP) → **CredSSP/NLA** via IronRDP, with the server public key extracted for the CredSSP binding.
- `ActiveStage` render loop decodes to an RGBA `DecodedImage`; updated rects are emitted as base64 `rdp-canvas-event`s. Concrete `TlsStream<TcpStream>` (no box-erasure) keeps the spawned session future `Send`.
- Input via `ironrdp-input`: mouse move/buttons/wheel, scancode keys, **Unicode text** (for IME), and Ctrl+Alt+Del → FastPath PDUs.
- 6 Tauri commands wired into the handler + managed state, all off-Windows.

### Frontend
- `RdpCanvasView.tsx` — self-contained canvas + mouse + **hybrid IME keyboard** + in-view Ctrl+Alt+Del, rendered for macOS RDP. VNC and Windows-RDP code paths are not modified.
- **Keyboard model** (researched — see below): printable text + IME composition (CJK/dead-keys/accents) → RDP **Unicode** events so it's correct regardless of remote layout; control/modifier/shortcut keys → PC **scancodes** (`rdpScancodes.ts`).
- `supportsRdp()` enabled on macOS; typed `rdp_client` commands registered in `invokeCommand`.

### Dependency note (please review)
IronRDP 0.15's `picky` pins pre-release RustCrypto crates (`ecdsa`/`curve25519-dalek`) that conflict with `russh` ≥ 0.60.2. **`russh` is pinned `=0.60.1`** (the newest that coexists). `flate2`/SSH compression is **kept** — the only client-relevant fix missed (CVE-2026-46673, a compression bomb) requires connecting to a hostile server, which isn't the admin-tool threat model. Unpin when `picky`/IronRDP move to the newer crypto RC.

### v1 scope (deliberate)
Fixed desktop size (no dynamic resize); no clipboard/audio/device redirection; remote cursor not drawn (local cursor shows, coords map 1:1); macOS RDP uses the self-contained view so the parent toolbar's RDP buttons (screenshot/AI/view-mode) don't apply there yet.

## Keyboard / IME research
RDP has two keyboard modes — **scancode** (physical position, remote layout interprets; breaks IME/multilingual) and **Unicode** (sends the composed character; required for IME). This PR uses the hybrid model every serious browser RDP client uses.
- [MS Learn — Unicode vs Scancode modes](https://learn.microsoft.com/en-us/previous-versions/remote-desktop-client/client-features-macos)
- [MS-RDPBCGR TS_KEYBOARD_EVENT](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/7acaec9f-c8a6-4ee9-87d6-d9b89cf56489)
- [Citrix HTML5 keyboard / generic client IME](https://docs.citrix.com/en-us/citrix-workspace-app-for-html5/keyboard.html)

## Test Plan
- [x] `cargo check --locked` clean; `rdp_client::` tests 4/4; SSH tests 31/0 (russh 0.60.1 healthy); `tsc --noEmit` clean
- [x] Windows untouched (rdp_client + 7 commands all `#[cfg(not(windows))]`; `rdp.rs` ActiveX unchanged)
- [ ] **Real macOS → Windows (NLA):** desktop renders to canvas
- [ ] Mouse move/click/right-click/scroll reach the host
- [ ] Keyboard: plain typing, a shortcut (Ctrl+C/Alt+Tab), and **CJK IME composed text** all arrive correctly
- [ ] In-view Ctrl+Alt+Del button reaches the host
- [ ] Disconnect tears down cleanly; SSH/SFTP still work

> Note: full `cargo test` has ~17 pre-existing Windows-path failures unrelated to this branch; the `eslint`/`tsx` frontend harness isn't installed on the build host (individual tests pass under \`node --test\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)