### PR TITLE
fix(macos): split DOMAIN\\user for RDP CredSSP + surface real connect error

### DIFF
--- a/src-tauri/src/rdp_client.rs
+++ b/src-tauri/src/rdp_client.rs
@@ -446,6 +446,23 @@ fn extract_server_public_key(
 
 type UpgradedFramed = ironrdp_tokio::TokioFramed<tokio_rustls::client::TlsStream<TcpStream>>;
 
+/// Flatten an error and its `source()` chain into one message, so a generic
+/// top-level label (e.g. "CredSSP") surfaces the underlying reason
+/// (e.g. an NTLM logon failure) instead of being swallowed.
+fn error_chain(error: &dyn std::error::Error) -> String {
+    let mut message = error.to_string();
+    let mut source = error.source();
+    while let Some(inner) = source {
+        let inner_text = inner.to_string();
+        if !message.ends_with(&inner_text) {
+            message.push_str(": ");
+            message.push_str(&inner_text);
+        }
+        source = inner.source();
+    }
+    message
+}
+
 async fn rdp_connect(
     host: String,
     port: u16,
@@ -462,6 +479,16 @@ async fn rdp_connect(
     use ironrdp::pdu::gcc::KeyboardType;
     use ironrdp::pdu::rdp::capability_sets::MajorPlatformType;
     use ironrdp_tokio::{TokioFramed, connect_begin, connect_finalize, mark_as_upgraded};
+
+    // CredSSP/NTLM needs the domain separated from the username. Split a
+    // `DOMAIN\user` login into (domain, user); otherwise keep the requested
+    // domain and the username as-is (UPN `user@domain` is left intact).
+    let (username, domain) = match username.split_once('\\') {
+        Some((d, u)) if !d.trim().is_empty() && !u.trim().is_empty() => {
+            (u.trim().to_string(), Some(d.trim().to_string()))
+        }
+        _ => (username, domain),
+    };
 
     // Step 1: TCP connect + create framed
     let stream = TcpStream::connect((host.as_str(), port))
@@ -508,7 +535,7 @@ async fn rdp_connect(
     let mut connector = ClientConnector::new(config, client_addr);
     let should_upgrade = connect_begin(&mut framed, &mut connector)
         .await
-        .map_err(|e| format!("RDP connect_begin failed: {e}"))?;
+        .map_err(|e| format!("RDP connect_begin failed: {}", error_chain(&e)))?;
 
     // Step 4: Extract inner stream
     let (tcp_stream, leftover) = framed.into_inner();
@@ -536,7 +563,7 @@ async fn rdp_connect(
         None::<KerberosConfig>,
     )
     .await
-    .map_err(|e| format!("RDP connect_finalize failed: {e}"))?;
+    .map_err(|e| format!("RDP connect_finalize failed: {}", error_chain(&e)))?;
 
     Ok((connection_result, upgraded_framed))
 }


### PR DESCRIPTION
## Summary

Follow-up to the IronRDP macOS RDP client (#304) addressing a CredSSP/NLA failure seen in real-runtime testing (`connect_finalize failed: [CredSSP …] CredSSP`).

- **Split `DOMAIN\user` into separate domain + username.** The CredSSP/NTLM path needs the domain and username as distinct fields; the IronRDP client was passing `connection.user` whole with `domain: None`, so a `DOMAIN\user` login failed authentication. Now split like the Windows ActiveX path's `split_windows_user` (UPN `user@domain` is left intact, which NTLM accepts).
- **Surface the real error.** A failed CredSSP step was collapsed to the bare label `"CredSSP"`. The connect error maps now flatten the `source()` chain so the underlying reason (e.g. an NTLM logon-failure status) is shown instead of being swallowed.

The CredSSP failure originates from the sspi step **completing with an error** (not the network client / not TLS), which is an authentication problem — the domain split is the likely fix for domain accounts, and the error-chain change diagnoses the rest.

## Test Plan
- [x] `cargo check` clean; `rdp_client::` tests 4/4
- [ ] **Real macOS → Windows:** connect with a `DOMAIN\user` account → authenticates and the desktop renders
- [ ] Connect with a local account (`user`) and a UPN (`user@domain`) → both still work
- [ ] If it still fails, the error message now shows the specific NTLM reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)