### PR TITLE
fix(dashboard): remove opaque black backdrop behind AI script widgets

### DIFF
--- a/src/modules/dashboard/script/ScriptWidgetHost.tsx
+++ b/src/modules/dashboard/script/ScriptWidgetHost.tsx
@@ -970,6 +970,11 @@ export function ScriptWidgetHost({
       ref={iframeRef}
       key={reloadKey}
       className="dw-script-frame"
+      // Must match the srcdoc's `:root { color-scheme }`. When an embedded
+      // document's color scheme differs from the iframe element's, browsers
+      // disallow transparency and paint an opaque canvas behind the widget
+      // (black for dark themes) — the "fat black border" around AI widgets.
+      style={{ colorScheme: scriptTheme.colorScheme }}
       title={t("dashboard.scriptWidgetFrameTitle")}
       loading="lazy"
       onLoad={syncVisibility}


### PR DESCRIPTION
## What changed

Set the script-widget iframe element's `color-scheme` style to match the `color-scheme` declared inside its srcdoc (`scriptTheme.colorScheme`) in `ScriptWidgetHost.tsx`.

## Why

Every AI-created widget on a dark-toned backdrop (hero preset, or panel/ambient on a dark surface or dark view background) rendered with an ugly fat black border around its content.

Root cause: the widget srcdoc sets `:root { color-scheme: dark }` for dark-toned widgets, while the host app document never declares a color scheme (defaults to light). Per the CSS Color Adjustment spec — implemented in both WebKit and Chromium — when an embedded document's used color scheme differs from the iframe element's, the browser refuses transparency and paints an opaque canvas behind the iframe (black for dark). So despite `.dw-script-frame { background: transparent }` and a transparent srcdoc body, the engine filled the whole iframe rectangle with black.

Making the iframe element's `color-scheme` agree with the embedded document restores transparency, so widgets sit directly on the dashboard background.

## Notes for reviewers

- Pure render-side fix; applies to all existing widgets immediately, no widget regeneration needed. Both values derive from the same `scriptTheme`, so they cannot drift.
- TypeScript typecheck passes. ESLint could not run in this worktree (`@eslint/js` missing from its `node_modules`); the change is a plain React style prop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)