### PR TITLE
docs: rewrite READMEs to focus on user-facing features

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -5,19 +5,19 @@
 <h1 align="center">KKTerm</h1>
 
 <p align="center">
-  <strong>Der native Windows-Admin-Workspace, den das KI-Tools-Zeitalter zu bauen vergessen hat — Terminals, SSH, SFTP, RDP/VNC, Dashboards und eine KI, die deine eigenen Tool-Widgets baut.</strong>
+  <strong>Ein einziges natives Windows-Fenster für Terminals, SSH, SFTP, RDP/VNC und ein Dashboard — plus eine KI, die dir auf Zuruf deine eigenen kleinen Tools baut.</strong>
 </p>
 
 <p align="center">
-  <em>Weil deine Taskleiste nicht wie ein Spielautomat aussehen sollte.</em>
+  <em>Weil deine Taskleiste nicht wie ein Spielautomat in Las Vegas aussehen sollte.</em>
 </p>
 
 <p align="center">
-  <sub>Benannt nach <strong>乖乖 (Kuāi Kuāi)</strong>, dem grünen Kokos-Snack, den taiwanische Sysadmins auf ihre Server stellen, damit die sich ordentlich benehmen. Wir hoffen, dass diese App ihren Platz im Rack verdient.</sub>
+  <sub>Benannt nach <strong>乖乖 (Kuāi Kuāi)</strong>, dem grünen Kokos-Snack, den taiwanische Sysadmins auf Server legen, damit sie sich benehmen. Wir hoffen, diese App verdient sich ihren Platz im Rack.</sub>
 </p>
 
 <p align="center">
-  <strong><a href="https://github.com/ryantsai/KKTerm/releases/latest">Aktuellen Windows-Installer (.exe) herunterladen</a></strong>
+  <strong><a href="https://github.com/ryantsai/KKTerm/releases/latest">Neuesten Windows-Installer (.exe) herunterladen</a></strong>
 </p>
 
 <p align="center">
@@ -38,9 +38,6 @@
   </a>
   <br />
   <img src="https://img.shields.io/badge/Windows%E2%80%91first-by%20design-0078D6?style=flat-square&logo=windows" alt="Windows-first by design" />
-  <img src="https://img.shields.io/badge/built%20with-Tauri%20v2-FFC131?style=flat-square&logo=tauri" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/Rust-russh-orange?style=flat-square&logo=rust" alt="Rust" />
-  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react" alt="React 19" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
   <br />
   <sub>
@@ -63,56 +60,58 @@
 
 ---
 
-## Das Versprechen (45 Sekunden)
+## Der Pitch in 45 Sekunden
 
 Du bist Sysadmin / DevOps / Homelab-Bastler / Vibe-Coder. Gerade hast du:
 
 - Einen Terminal-Emulator
-- Einen separaten SSH-Client (mit einer Profilliste, die dich ein Wochenende gekostet hat)
-- Einen SFTP-Client von 2007, der irgendwie immer noch ausgeliefert wird
-- Remote Desktop in einem Fenster, das du ständig auf dem falschen Monitor verlierst
+- Einen separaten SSH-Client (mit einer Profilliste, an der du ein Wochenende gebaut hast)
+- Einen SFTP-Client von 2007, den es irgendwie noch gibt
+- Remotedesktop in einem Fenster, das du ständig auf dem falschen Monitor verlierst
 - Einen VNC-Viewer für diese eine Linux-Kiste
-- Einen Browser-Tab für die Router-Admin-UI
-- Eine `claude`- / `codex`-Session auf einer Remote-Dev-Box, die abbricht, sobald dein WLAN auch nur niesen muss
-- Einen Zettel mit Passwörtern *(keine Sorge, wir sagen nichts)*
+- Einen Browser-Tab für die Admin-Oberfläche des Routers
+- Eine `claude` / `codex`-Session auf einer entfernten Maschine, die abbricht, sobald dein WLAN niest
+- Einen Klebezettel mit Passwörtern *(keine Sorge, wir sagen nichts)*
 
-**KKTerm ist ein einziges Fenster für all das.** Nativ unter Windows — *mit Absicht, während der Rest der Dev-Tools-Welt alles zuerst für Mac ausliefert und dein Betriebssystem wie eine Fußnote behandelt* — geschrieben in Rust + Tauri v2, kommt als einzelnes Installer-Paket und telefoniert nicht nach Hause.
+**KKTerm ist ein Fenster für all das.** Nativ unter Windows — *mit Absicht, während der Rest der Dev-Tool-Welt mac-first ausliefert und dein OS als Fußnote behandelt* — in einem einzigen Installer, der sich weigert, nach Hause zu telefonieren.
 
-Dazu ein paar Dinge, von denen du nicht wusstest, dass du sie willst:
+Dazu ein paar Dinge, von denen du nicht wusstest, dass du sie wolltest:
 
-- Ein **Dashboard**, auf dem du einer KI sagst *„Bau mir ein Widget, das meinen Router alle 30 Sekunden anpingt"* — und es erscheint, sandboxed, in deinem Grid.
-- **SSH-Panes, die sich automatisch an benannte tmux-Sessions anhängen**, damit deine Remote-`claude`- / `codex`-Session jeden WLAN-Aussetzer deines Laptops übersteht.
-- Ein **AI-Coding-Nutzungs-Widget**, das deine Claude-Code- und Codex-Quoten zeigt — 5-Stunden-Fenster, Wochenfenster, aktueller Plan, Account-E-Mail — auf dem **Dashboard** und in der Statusleiste, damit du nicht mehr um 3 Uhr morgens überrascht gegen die Rate-Limit-Wand läufst.
-- Ein **Installer Helper**-Modul, das einen kuratierten Windows-Entwicklertool-Katalog erkennt, installiert, aktualisiert, deinstalliert und startet — Node, Python, Docker, WSL, KI-Coding-CLIs und die kleinen Utilities, die du sonst in Browser-Tabs zusammensuchst.
-- Ein **eingebauter MCP-Server** (`kkterm-cli`), der externe Coding-Agenten (Claude Code, Codex, Copilot, Antigravity, OpenCode) deinen Workspace und dein Dashboard steuern lässt — Connections auflisten, Terminal-Buffer lesen, Widgets platzieren — über eine kuratierte, sicherheits-gegate Tool-Oberfläche. KI-zu-KI, auf deiner Maschine, ohne Cloud-Relay.
-- Einundzwanzig **animierte Canvas-Hintergründe** (ja, inklusive `matrix`) für das Dashboard, weil wir uns für nichts zu schade sind.
+- Ein **Dashboard**, in dem du einer KI sagst *„bau mir ein Widget, das meinen Router alle 30 Sekunden anpingt"*, und es erscheint, in seiner eigenen Sandbox, auf deinem Raster.
+- **SSH-Panes, die sich nach jedem WLAN-Anfall wieder an deine entfernte `claude` / `codex`-Session anhängen**, damit ein Sechs-Stunden-Job eine Verbindungsunterbrechung überlebt.
+- Eine **KI-Nutzungsanzeige**, damit du nicht um 3 Uhr morgens überraschend gegen die Rate-Limit-Wand fährst.
+- Ein **Installer Helper**, der die Windows-Dev-Tools, die du sonst durch zehn Browser-Tabs jagst, findet, installiert, aktualisiert und startet.
+- **Fünfundzwanzig animierte Hintergründe** fürs Dashboard (ja, inklusive `matrix`), weil wir nicht zu erhaben dafür sind.
 
-Und die KI-Assistentin kann aus einem Satz ein kleines Dashboard-Tool machen, das du tatsächlich weiterbenutzt.
+Und das Beste: Der KI-Assistent kann aus einem einzigen Satz ein winziges Dashboard-Tool machen, das du tatsächlich behältst.
 
-> ⭐ **Wenn das nach der App klingt, die du seit sechs Jahren bauen wolltest — vergib dem Repo einen Stern, damit wir wissen, dass jemand zuschaut. Das hilft wirklich.**
+> ⭐ **Wenn das nach der App klingt, die du seit sechs Jahren bauen wolltest — gib dem Repo einen Stern, damit wir wissen, dass jemand zuschaut. Das hilft wirklich.**
 
----
-
-## Warum "KKTerm"?
-
-Geh in ein taiwanisches Rechenzentrum und schau auf die Oberseite der Racks. Hinter TSMC-Fabs, Taipeis Metro-Leitständen, Cathay-Bank-Serverräumen, Chunghwa-Telecom-Vermittlungstechnik — du wirst immer eine kleine grüne Tüte 乖乖 (Kuāi Kuāi) entdecken, einen kokosnussgewürzten Corn-Snack aus den 1960ern.
-
-Der Name bedeutet wörtlich **„sei brav"**, **„benimm dich"**. Die IT-Tradition ist klar und vollkommen ernst gemeint:
-
-- **Muss grüne Sorte sein (Kokos).** Gelb (Curry) bedeutet *krank zur Arbeit kommen*; Rot (scharf) macht den Server zornig. Nur Grün.
-- **Darf nicht abgelaufen sein.** Ein alter Kuai Kuai wirkt gegen dich. Engineers wechseln ihn gewissenhaft aus.
-- **Muss sichtbar sein.** Der Server muss wissen, dass er da ist.
-- **Nicht essen.** Diese Tüte ist im Dienst.
-
-Einige der größten, langweiligsten, obsessiv-uptime-besessenen Systeme Asiens laufen mit einer Tüte Puffmais am Gehäuse. Es funktioniert, weil die Menschen, die sie warten, daran glauben — eine erstaunlich ehrliche Beschreibung der meisten IT-Kultur.
-
-**KKTerm** ist **Kuai Kuai Term** — ein Admin-Workspace, der denselben Job anstrebt wie der Snack: still neben deinen wichtigen Maschinen sitzen und ihnen helfen, sich ordentlich zu benehmen. Local-first. Kein Telemetrie. KI hinter einer Freigabeschranke. Die langweilige, verlässliche Art von Software.
-
-Wir haben es noch nicht geschafft, eine echte Tüte Kuai Kuai mit dem Installer zu liefern. Das steht auf der v2-Liste.
+Eine Meinung, was als Nächstes kommen sollte? Mach im öffentlichen Feedback-Thread mit:
+**[Was sollte KKTerm für Windows-first-Admin-Workflows priorisieren?](https://github.com/ryantsai/KKTerm/discussions/141)**
 
 ---
 
-## In Aktion sehen
+## Warum „KKTerm"?
+
+Geh in irgendein taiwanisches Rechenzentrum und schau oben auf die Racks. Vorbei an TSMC-Fabs, Leitständen der Taipei-Metro, Serverhallen der Cathay-Bank, Vermittlungstechnik von Chunghwa Telecom — du wirst ein kleines grünes Tütchen 乖乖 (Kuāi Kuāi) entdecken, einen Mais-Snack mit Kokosgeschmack aus den 1960ern.
+
+Der Name bedeutet wörtlich **„sei brav"**, **„benimm dich"**. Die IT-Tradition ist schlicht und absolut ernst gemeint:
+
+- **Muss grün sein (Kokos).** Gelb (Curry) heißt *bleib heute zu Hause*; Rot (scharf) macht den Server wütend. Nur Grün.
+- **Darf nicht abgelaufen sein.** Ein altes Kuai Kuai arbeitet gegen dich. Ingenieure tauschen sie gewissenhaft aus.
+- **Muss sichtbar sein.** Der Server muss wissen, dass es da ist.
+- **Iss es nicht.** Das Tütchen ist im Dienst.
+
+Einige der größten, langweiligsten, am stärksten auf Uptime versessenen Systeme Asiens laufen mit einem Tütchen Maisflips am Gehäuse. Es funktioniert, weil die Leute, die sie warten, glauben, dass es funktioniert — was eine bemerkenswert ehrliche Beschreibung der meisten IT-Kultur ist.
+
+**KKTerm** ist **Kuai Kuai Term** — ein Admin-Workspace, der dasselbe anstrebt wie der Snack: still neben deinen wichtigen Maschinen zu sitzen und ihnen zu helfen, sich zu benehmen. Local-first. Keine Telemetrie. KI mit Freigabe. Die langweilige, verlässliche Sorte Software.
+
+Ein echtes Tütchen Kuai Kuai mit dem Installer auszuliefern, haben wir noch nicht geschafft. Das ist ein Punkt für v2.
+
+---
+
+## In Bewegung sehen
 
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
@@ -124,339 +123,177 @@ Wir haben es noch nicht geschafft, eine echte Tüte Kuai Kuai mit dem Installer 
   </a>
 </p>
 
-<p align="center"><sub><em>(Demo-GIF kommt hier hin. Ein Bild sagt mehr als tausend Bullet-Points, und uns sind die Bullet-Points ausgegangen.)</em></sub></p>
+<p align="center"><sub><em>(Hier kommt das Demo-GIF hin. Ein Bild sagt mehr als tausend Aufzählungspunkte, und uns gehen die Aufzählungspunkte aus.)</em></sub></p>
+
+---
+
+## Ein Fenster, jede Verbindung
+
+| Du wolltest… | KKTerm macht's |
+| --- | --- |
+| Eine lokale PowerShell / cmd / WSL-Shell öffnen | Lokale Terminals, nebeneinander |
+| Per SSH auf einen Server | SSH mit Schlüsseln, Agent, Passwörtern, Jump-Hosts und Port-Forwarding |
+| Dateien auf diesem Server durchsehen | SFTP aus der SSH-Verbindung — Zweispalten-Ansicht, zum Übertragen ziehen |
+| FTP zu einem NAS von 2012 | FTP / FTPS im selben Datei-Browser |
+| Telnet zu uralter Technik | Ja, Telnet ist auch drin |
+| Mit einem seriellen Port reden | Serielle Verbindungen — COM-Port und Baudrate wählen |
+| Per Remote auf eine Windows-Kiste | Das echte Microsoft-Remotedesktop, gleich eingebaut |
+| VNC auf einen Pi | VNC, direkt in den Workspace gerendert |
+| Die Weboberfläche des Routers öffnen | Ein eingebetteter Browser-Tab mit gespeicherten Logins |
+| Die CPU des Hosts beobachten | Eine Live-Statusleiste und ein Dashboard, das du selbst baust |
+
+Dieselbe App. Dasselbe Fenster. Dieselben Hotkeys. Dasselbe, hoffentlich nicht augenfeindliche, Theme.
 
 ---
 
 ## Warum Leute es den ganzen Tag offen lassen
 
-### Windows-first — mit Absicht
+### Windows-first, mit Absicht
 
-Schau dich in der Dev-Tooling-Landschaft von 2026 um. Claude Code: zuerst für Mac/Linux, Windows heißt „nimm WSL." Codex CLI: genauso. `gemini-cli`, die Hälfte von Homebrew, jede glänzende neue TUI: Mac/Linux zuerst, Windows-Nutzer bekommen einen `# Windows: contributions welcome`-Kommentar im README und ein Fish-Completion-Skript, das nicht läuft.
+Schau dich in der Dev-Tool-Landschaft um. Claude Code: mac/linux zuerst, Windows ist „nimm WSL". Codex CLI: dasselbe. Die Hälfte der schicken neuen Tools liefert mac-first und lässt Windows-Nutzern einen `# contributions welcome`-Kommentar und ein Autovervollständigungs-Skript, das nicht läuft.
 
-Dabei sitzen die Menschen, die Unternehmen wirklich am Laufen halten — Corporate IT, MSPs, alle, die Hyper-V, AD, SCCM, IIS oder einen Domain Controller betreiben, der älter ist als manche Praktikanten — vor Windows-Maschinen und fragen sich, warum jedes neue Tool ihr Betriebssystem wie eine Zumutung behandelt.
+Währenddessen sitzen die Leute, die Unternehmen wirklich online halten — Unternehmens-IT, MSPs, alle, die einen Domänencontroller betreiben, der älter ist als manche Praktikanten — an Windows-Kisten und fragen sich, warum jedes neue Tool ihr OS wie eine Unannehmlichkeit behandelt.
 
-**KKTerm macht das Gegenteil.** Wir bauen zuerst nativ für Windows, macOS- und Linux-Ports folgen. Das bedeutet, wir können die Windows-APIs nutzen, die wirklich wichtig sind, anstatt sie mit einer Portabilitätsschicht zu überkleistern:
+**KKTerm macht den umgekehrten Deal.** Wir bauen nativ Windows zuerst, also funktioniert, was Windows-Leuten wichtig ist, einfach: das *echte* Microsoft-Remotedesktop (dasselbe wie `mstsc.exe`, kein Klon), echte PowerShell / cmd / WSL-Shells, Geheimnisse im Windows-Anmeldeinformationsmanager, ein richtiges Tray-Icon, native Menüs und Dialoge. macOS- und Linux-Builds stehen auf der Roadmap und bekommen dieselbe Sorgfalt. Aber wenn du darauf gewartet hast, dass jemand das *gute* Windows-Admin-Tool zuerst statt zuletzt baut — das ist der Deal.
 
-- **ConPTY** für lokale Shells — die echte Windows-Pseudokonsole, kein Übersetzungs-Shim. PowerShell, `cmd.exe`, WSL-Distros, alle als echte PTYs mit Focus, Resize und VT-Sequence-Handling, das dem Plattformverhalten entspricht.
-- **WebView2** für die gesamte UI und eingebettete URL-**Connections** — In-Process-Chromium mit der System-Runtime, was unter anderem der Grund ist, warum der Installer klein ist und schnell startet.
-- **Microsoft RDP ActiveX (`mstscax.dll`)** für RDP — *der echte, von Microsoft ausgelieferte*. Dasselbe Steuerelement wie Remote Desktop Connection (`mstsc.exe`). Keine Drittanbieter-Reimplementierung, kein FreeRDP in einer Wrapper-Schicht. RDP-Profis merken den Unterschied in fünf Sekunden.
-- **Windows Credential Manager** für alle Geheimnisse. SSH-Passwörter, FTP-Passwörter, API-Keys, URL-Connection-Credentials — sie leben im OS keychain, und `credwiz.exe` kann sie auditieren.
-- **NSIS-Installer für aktuelle Nutzer** mit passendem SHA-256, nativem Tray-Menü, Don't-Sleep-Stromsperre, Host-CPU/RAM/Netzwerk-Sampling, nativen Tauri-Kontextmenüs mit echten PNG-Icons, nativen Öffnen/Speichern-Dialogen. Keines davon ist gemockt.
-- **WSL ist eine erstklassige Shell, kein Workaround.** Starte Ubuntu neben einem PowerShell-Pane neben einer SSH-Session neben einem RDP-**Tab** — alles im selben Fenster.
+### Local-first heißt wirklich lokal
 
-Die macOS- und Linux-Builds stehen auf der Roadmap und werden dieselbe Sorgfalt bekommen. Aber wenn du darauf gewartet hast, dass jemand das *gute* Windows-Admin-Tool zuerst statt zuletzt baut — das ist das Angebot.
+Deine gespeicherten Verbindungen liegen in einer Datei auf deiner Maschine. Passwörter liegen im Windows-Anmeldeinformationsmanager, nicht in einer Textdatei neben der App. KKTerm sendet keine Analytics, telefoniert beim Start nicht nach Hause und braucht kein Cloud-Konto zum Starten. Es gibt kein „zum Synchronisieren anmelden", weil es keine Synchronisierung gibt.
 
-### Local-first bedeutet wirklich lokal
+Wenn dein Netzwerkkabel Feuer fängt, öffnet sich KKTerm trotzdem.
 
-Deine gespeicherten **Connections** leben in einer SQLite-Datei auf deiner Maschine. Passwörter leben im **Windows Credential Manager**, nicht in einem JSON neben der Binary. Die App liefert keine Analytics, ruft beim Start nicht nach Hause und braucht keinen Cloud-Account zum Starten. Es gibt kein „Anmelden zum Synchronisieren", weil es keine Synchronisierung gibt.
+### Terminals, die nicht durchdrehen
 
-Wenn dein Netzwerkkabel Feuer fängt, öffnet KKTerm trotzdem.
-
-### Ein Workspace, jede Verbindungsart
-
-| Du wolltest… | KKTerm hat |
-| --- | --- |
-| Eine lokale PowerShell / cmd / WSL-Shell öffnen | ConPTY-gestützte lokale Terminal-**Sessions** |
-| Per SSH auf einen Server | Natives `russh` mit Agent- / Key- / Passwort-Auth, Host-Key-Trust-Flow, ProxyJump, Port-Forwarding |
-| Dateien auf diesem Server durchsuchen | SFTP gestartet aus der SSH-**Connection**, Doppelscheibe, rekursive Transfers, chmod/chown |
-| FTP zu einem NAS von 2012 | FTP / FTPS-**Connections** im selben SFTP-artigen Browser |
-| Telnet zu alter Hardware | Ja, gut, Telnet ist auch drin |
-| Mit einem seriellen Port reden | Serial-**Connection**-Art, COM-Port + Baud, kein Zusatz-Tooling |
-| Remote auf eine Windows-Maschine | Natives RDP via Microsoft-ActiveX-Steuerelement (das echte, kein Klon) |
-| VNC zu einem Pi | Rust `vnc-rs` framebuffer direkt in den Workspace gerendert |
-| Die Router-Web-UI öffnen | Eingebettete WebView2-**URL Connection** mit Credential-Fill |
-| CPU des Hosts beobachten | Live-Statusleiste + ein **Dashboard**-Modul mit Drag/Resize-Widgets |
-
-Alles dieselbe App. Dasselbe Fenster. Dieselben Hotkeys. Dasselbe hoffentlich-nicht-augenblutende Theme.
-
-### Terminals, die nicht den Verstand verlieren
-
-- Geteilte Panes innerhalb eines **Tabs**.
-- WebGL-beschleunigtes xterm.js-Rendering, mit graceful Fallback wenn nötig.
-- Scrollback-Suche.
-- tmux-gestützte SSH-Panes, die sich an stabile per-Pane-Sessions anhängen können — Wiederverbinden bedeutet wirklich *Wiederverbinden*, nicht „von vorne anfangen und so tun, als wäre die letzte Stunde nie gewesen."
-- **Tabs** wechseln **tötet die Session nicht**. Den **Tab** schließen schon. Diese Unterscheidung war intern ein Glaubenskrieg; wir haben gewonnen.
+- Geteilte Panes innerhalb eines Tabs.
+- Schnelles, flüssiges Rendering mit durchsuchbarem Scrollback.
+- Neu verbinden heißt wirklich *neu verbinden* — deine entfernte Session macht da weiter, wo sie war, nicht „von vorne anfangen und so tun, als hätte die letzte Stunde nicht stattgefunden".
+- Den Tab zu wechseln tötet die Session **nicht**. Den Tab zu schließen schon. Diese Unterscheidung war intern ein Religionskrieg; wir haben gewonnen.
 
 ### Ein KI-Assistent, der deine Tools baut
 
-Die meisten „KI in deinem Terminal"-Demos bleiben beim Chat stehen. KKTerms Assistent kann auch kleine, dauerhafte Dashboard-Widgets für deine echte Arbeitsweise bauen. Gefährliche Dinge bleiben trotzdem hinter zwei Schaltern:
+Die meisten „KI im Terminal"-Demos hören beim Chat auf. Der Assistent von KKTerm kann auch kleine, dauerhafte Dashboard-Widgets bauen, zugeschnitten auf deine echte Arbeitsweise — und das Gefährliche bleibt hinter einem Schalter:
 
-- **Tool-Familien** (Dashboard / Connections / Live Sessions) — ein- oder ausschalten pro Kategorie.
-- **Berechtigungsmodus** im Composer — `Prompt` (Standard, fragt jedes Mal) oder `Allow All` (du bist erwachsen, du hast den Haftungsausschluss unterschrieben).
+- **Bestimme, was er anfassen darf** — ganze Tool-Familien (Dashboard / Connections / Live Sessions) an- oder ausschalten.
+- **Bestimme, wie er fragt** — `Prompt` (Standard, fragt jedes Mal) oder `Allow All` (du bist erwachsen, du hast den Haftungsausschluss unterschrieben).
 
-Sprich mit OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA oder allem, was OpenAI-kompatibel ist. API-Keys gehen in den OS keychain. Modelle, die `rm -rf` vorschlagen, werden als gefährlich eingestuft und erfordern explizite menschliche Genehmigung. Die KI kann nicht still einen destruktiven Befehl ausführen, weil jemand clever mit einem Prompt-Injection in einer Man-Page war.
+Alles, was nach `rm -rf` aussieht, wird als gefährlich markiert und wartet auf ein ausdrückliches menschliches Ja. Die KI kann keinen zerstörerischen Befehl heimlich ausführen, nur weil jemand eine Prompt-Injection in einer Man-Page schlau platziert hat.
+
+Sie spricht mit OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA oder allem OpenAI-Kompatiblen. Deine API-Schlüssel landen im OS-Schlüsselbund.
 
 ### Ein Dashboard, das nicht so tut, als wäre es Grafana
 
-Das **Dashboard**-Modul ist ein 12-spaltiges Drag/Resize-Grid aus Widget-Instanzen. Es ist nicht für Petabyte-Observability — es ist für „Ich will einen Button, um meine fünf Lieblingsapps zu starten, und ein Panel mit der Uptime meines SSH-Hosts, *neben* meinem Chat."
+Das Dashboard ist ein Raster aus Widgets, die man zieht und in der Größe ändert. Es ist nicht für Petabyte-Observability — es ist für „ich will einen Knopf, der meine fünf Lieblings-Apps startet, und ein Panel, das die Uptime meines SSH-Hosts zeigt, *neben* meinem Chat".
 
-#### KI-erstellte Widgets — beschreibe es, bekomme es
+#### KI-erstellte Widgets — beschreib es, krieg es
 
-Das ist der Teil, über den wir uns wirklich freuen. Du suchst dir nichts aus einem Marktplatz aus und du schreibst kein JavaScript. Du **sagst dem KI-Assistenten, was du willst**, und er baut das Widget direkt auf deinem Dashboard:
+Das ist der Teil, der uns wirklich begeistert. Du wählst nichts aus einem Marktplatz und schreibst kein JavaScript. Du **sagst dem KI-Assistenten, was du willst**, und er baut das Widget direkt auf deinem Dashboard:
 
-> *„Füge ein Widget hinzu, das die letzten 5 Commits meines Haupt-Repos als Liste zeigt."*
-> *„Mach mir ein Haftnotiz-Widget, das mein Bereitschafts-Spickzettel hält."*
-> *„Bau ein Widget, das meinen Heimrouter alle 30 Sekunden anpingt und Grün/Rot zeigt."*
-> *„Ich brauche eine Stoppuhr. Überrasch mich beim Styling."*
+> *„Füg ein Widget hinzu, das die letzten 5 Commits meines Haupt-Repos als Liste zeigt."*
+> *„Bau mir ein Notizzettel-Widget für meinen Bereitschafts-Spickzettel."*
+> *„Bau ein Widget, das meinen Heimrouter alle 30 Sekunden anpingt und grün/rot zeigt."*
+> *„Ich brauche eine Stoppuhr. Überrasch mich beim Stil."*
 
-Zwei Varianten:
+Manche sind schlichte Anzeige-Panels (Markdown, Checklisten, eine große Zahl); andere führen Live-Code in einer isolierten Sandbox aus, die du freigibst. Jedes Widget, das du behältst, gehört dir — es bleibt erhalten, mit eigener Farbe, eigenem Icon und Titel, und du kannst mehrere Kopien in verschiedenen Größen haben. Lösch eins per Rechtsklick, wenn der Zauber vergeht.
 
-- **Content-Widgets** — deklaratives JSON: Markdown, KV-Listen, Checklisten, einzelne große Zahl. Sicher von Haus aus, kein Script. Die meisten „Ich brauche das einfach auf meinem Dashboard"-Anfragen landen hier.
-- **Script-Widgets** — JavaScript, gehostet in einem isolierten `iframe srcdoc`-Sandbox mit explizit deklarierten Berechtigungen (`network`-Allowlist, `pollSeconds`-Budget). Die KI schreibt das Script, du genehmigst die Berechtigungen, das Widget läuft in einer Box, die den Rest der App nicht erreichen kann.
+#### Animierte Dashboard-Hintergründe (weil wir wollten)
 
-Jedes Widget, das du behältst, gehört dir. Es persistiert in SQLite neben deinen **Connections**, mit eigenem visuellem Preset (`panel` / `ambient` / `hero`), Akzentfarbe, Icon und Titel. Mehrere Instanzen desselben Widgets können nebeneinander existieren, mit völlig unterschiedlichen Größen und Stilen. Per Rechtsklick löschen, wenn der Zauber verblasst.
-
-#### Animierte Dashboard-Hintergründe (weil wir es wollten)
-
-Das Dashboard hat einundzwanzig canvas-animierte Hintergründe, die du pro **Dashboard View** auswählen kannst:
+Wähl pro Dashboard-Ansicht eine Stimmung aus **fünfundzwanzig** Canvas-animierten Hintergründen:
 
 | Stimmung | Hintergründe |
 | --- | --- |
-| Ruhig | `aurora`, `clouds`, `ocean`, `raindrops`, `snow`, `sakura`, `fireflies`, `bubbles`, `ricefield`, `lanterns` |
+| Ruhig | `aurora`, `clouds`, `ocean`, `raindrops`, `rainywindow`, `frostedWindow`, `snow`, `sakura`, `fireflies`, `bubbles`, `aquarium`, `ricefield`, `lanterns` |
 | Weltraum | `starfield`, `nebula` |
 | Warm | `embers`, `lava` |
-| Nerd | `matrix`, `topo`, `synthwave` |
-| Chaotisch | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti` |
+| Geeky | `matrix`, `topo`, `synthwave` |
+| Unruhig | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti`, `particleCursor` |
 
-Sie laufen auf einem einzigen gemeinsamen `requestAnimationFrame` und respektieren den Fensterfokus, sodass sie so gut wie nichts kosten, wenn du woanders bist. Kombiniere `matrix` mit deinem KI-Assistenten für eine Atmosphäre, die sagt „Ich bin extrem produktiv und möglicherweise in einem Wachowski-Film." Oder wähle `ocean` und wirke wie ein ernsthafter Mensch. Wir urteilen über keine der beiden Entscheidungen.
+Sie pausieren, wenn du woanders bist, kosten also so gut wie nichts. Kombiniere `matrix` mit deinem KI-Assistenten für eine Stimmung, die sagt „ich bin extrem produktiv und vermutlich in einem Wachowski-Film". Oder nimm `ocean` und wirk wie ein seriöser Mensch. Wir urteilen über keine der beiden Entscheidungen.
 
-### KI-Coding-Agents auf einem Server — richtig gemacht
+### Deine entfernten KI-Agenten am Leben halten
 
-Das ist das zweite Feature, in das sich die Leute verlieben. KKTerms SSH-Terminals können direkt in eine **benannte tmux-Session** auf dem Remote-Host starten — standardmäßig eine automatisch generierte freundliche ID wie `kkterm-cockpit001`, die Reconnects überlebt:
+Das ist die zweite Funktion, in die sich Leute verlieben. KKTerms SSH-Terminals können dich direkt in eine **benannte tmux-Session** auf dem entfernten Host setzen, die ein Wiederverbinden übersteht:
 
-- Öffne eine SSH-**Connection** mit aktiviertem tmux.
-- Starte im Pane `claude`, `codex`, `gemini-cli`, `cursor-agent` oder welchen langlebigen Coding-Agenten du bevorzugst. Sie sind Vollbild-TUI-Apps; tmux ist genau der richtige Ort für sie.
-- Klappe den Laptop zu. Mach ihn wieder auf. Der Pane hängt sich lautlos an dieselbe tmux-Session an. Der Agent läuft noch, hat seinen Scrollback noch, ist noch mitten in dem, was er tat.
-- Kurzer Netzwerkausfall auf dem SSH-Transport? KKTerm versucht eine begrenzte, stille Wiederanbindung an dieselbe tmux-ID, ohne dich zu stören.
-- Willst du, dass der KI-Assistent sieht, was der Agent tut? „Terminal-Buffer zum Kontext hinzufügen" ruft `capture_tmux_pane` über SSH auf und zieht den vollständigen tmux-Scrollback — nicht nur was auf dem Bildschirm ist, die gesamte Session — in das Gespräch. Dein lokaler Assistent kann jetzt über die Arbeit deines Remote-Agenten nachdenken.
+- Öffne eine SSH-Verbindung mit aktiviertem tmux und starte `claude`, `codex`, `gemini-cli`, `cursor-agent` oder welchen Langläufer-Agenten du magst.
+- Klapp das Notebook zu. Klapp es wieder auf. Das Pane hängt sich still wieder an — der Agent läuft noch, hat sein Scrollback, steckt mittendrin in dem, was er gerade tat.
+- Netzwerk-Aussetzer? KKTerm verbindet sich leise wieder mit derselben Session, ohne dich zu stören.
+- Soll der Assistent helfen? „Terminal-Puffer zum Kontext hinzufügen" zieht die ganze entfernte Session in die Konversation, damit deine lokale KI nachvollziehen kann, was dein entfernter Agent tut.
 
-Wenn du jemals eine sechsstündige `claude`- oder `codex`-Session durch ein wackeliges Hotel-WLAN verloren hast, amortisiert dieses einzige Feature die App. Die App ist kostenlos. Das Feature ist trotzdem seinen Preis wert.
+Wer je eine sechsstündige `claude`- oder `codex`-Session an das wacklige Hotel-WLAN verloren hat, für den rechtfertigt diese eine Funktion die App. (Die App ist gratis. Die Funktion ist sie trotzdem wert.)
 
-### Wissen, wie viel KI dir noch bleibt
+### Wissen, wie viel KI dir bleibt
 
-Coding-Agenten rechnen pro Plan-Fenster ab, nicht pro Monat. Claude Code hat ein 5-Stunden-Fenster und ein Wochenfenster. Codex macht seine eigene Version. Beide können dein Kontingent fröhlich im Hintergrund auffressen, während du im Meeting bist.
+Coding-Agenten rechnen nach Plan-Fenster ab, nicht pro Monat, und sie fressen dein Kontingent gern auf, während du in einem Meeting sitzt. Die **KI-Nutzungsanzeige** hält das sichtbar:
 
-Das **AI-Coding-Nutzungs**-Widget hält das sichtbar:
+- Ein Dashboard-Widget, das **Claude Code** und **Codex** nebeneinander zeigt: verbundenes Konto, Plan, Verbrauch im aktuellen Fenster und diese Woche, nächste Reset-Zeit.
+- Eine kompakte **Statusleisten-Anzeige**, die dieselben Zahlen spiegelt, damit du auch bei geschlossenem Dashboard auf einen Blick siehst, ob noch Luft bis zum nächsten großen Refactoring ist.
+- Sie sagt dir vorab, ob du dich neu anmelden musst — *vor* einer langen Aufgabe, nicht mittendrin.
 
-- Ein Dashboard-Widget, das **Claude Code** und **Codex** nebeneinander zeigt: verbundener Account, Plan-Stufe, im aktuellen 5-Stunden-Fenster genutzte Prozente, diese Woche genutzte Prozente, nächster Reset-Zeitpunkt.
-- Eine kompakte **Statusleisten-Anzeige**, die dieselben Zahlen spiegelt — auch bei geschlossenem Dashboard siehst du auf einen Blick, ob du noch Luft hast, bevor du das nächste große Refactor startest.
-- Der Auth-Status ist direkt sichtbar (`connected` / `expired` / `error`), damit du *vor* einer langen Aufgabe merkst, dass du dich neu einloggen musst — nicht mittendrin.
-- Die Refresh-Policy respektiert Rate-Limits; das Widget pollt in seinem eigenen Takt, statt die Upstream-APIs zu hämmern, wann immer du hinguckst.
+### Andere KIs KKTerm steuern lassen
 
-### Ein eingebauter MCP-Server — lass andere KIs KKTerm bedienen
+KKTerm bringt seinen eigenen MCP-Server mit, damit externe Coding-Agenten (Claude Code, Codex, Copilot, Antigravity, OpenCode) deinen Workspace so nutzen, wie du es tust — Verbindungen auflisten, eine öffnen, einen Terminal-Puffer lesen, Widgets aufs Dashboard setzen. KI zu KI, auf deiner Maschine, ohne Cloud-Relay. Die verändernden, riskanteren Aktionen bleiben hinter einem einzigen Sicherheitsschalter, der standardmäßig **aus** ist.
 
-Dein Terminal ist auch der Ort, an dem Claude Code, Codex, Copilots Agent-Modus, Antigravity und der Rest der MCP-sprechenden Welt arbeiten wollen. Also liefert KKTerm seinen eigenen **stdio-MCP-Server**, [`kkterm-cli`](docs/MCP.md), aus, der einen kuratierten Ausschnitt der App freigibt:
-
-- **Workspace-Modul** (`kkterm.workspace.*`): gespeicherte **Connections** auflisten, eine Connection per id öffnen, lebende **Sessions** auflisten, Input an ein Terminal-Pane senden, einen Buffer-Snapshot lesen.
-- **Dashboard-Modul** (`kkterm.dashboard.*`): Dashboard-State laden, Source eines KI-erstellten Widgets lesen, Views anlegen / ändern / löschen, Widget-Instanzen platzieren / verschieben / entfernen, Bulk-Layouts anwenden.
-- **Gefährliche Sub-Namespaces** (`kkterm.<module>.dangerous.*`): das Mutieren der ausführbaren Oberfläche — Script-Widgets erstellen, in Remote-Desktops klicken, Dashboard wipen — sitzt hinter einer einzelnen Einstellung (`built_in_mcp_allow_all_dangerous`), standardmäßig **aus**.
-
-`kkterm-cli` ist ein dünner Forwarder. Er spricht stdio-JSON-RPC mit deinem MCP-Client und kommuniziert mit dem laufenden KKTerm-Fenster über eine pro Start authentifizierte Windows-Named-Pipe. Bei geschlossener KKTerm.exe funktioniert `tools/list` weiter (Clients können die Oberfläche introspizieren), aber `tools/call` liefert einen strukturierten `app_not_running`-Fehler, statt etwas zu tun.
-
-In deinen Lieblings-Client einhängen, und deine KI benutzt KKTerm jetzt so wie du:
-
-```json
-{
-  "mcpServers": {
-    "kkterm": { "command": "<pfad-zu-kkterm-cli>", "args": [] }
-  }
-}
-```
-
-Settings → AI Assistant → **Built-in MCP Server** hat einen Ein-Klick-„Show config"-Dialog mit JSON- und TOML-Snippets, in denen der aufgelöste Binärpfad bereits eingetragen ist, plus kopierbare `claude mcp add` / `codex mcp add`-Befehle.
-
----
-
-## Wie es zusammenpasst
-
-```mermaid
-flowchart LR
-    User([You]) --> Shell[KKTerm Window<br/>Tauri v2 + React 19]
-    Shell --> Rail[Activity Rail]
-    Rail --> WS[Workspace Module]
-    Rail --> Dash[Dashboard Module]
-    Rail --> Inst[Installer Helper Module]
-    Rail -.-> FE[File Explorer<br/>planned]
-    Rail --> Set[Settings]
-
-    WS --> Tabs[Tabs &amp; Panes]
-    Tabs --> Term[Terminal<br/>ConPTY / russh]
-    Tabs --> SFTP[SFTP / FTP]
-    Tabs --> Web[WebView2 URL]
-    Tabs --> RD[RDP / VNC]
-
-    Shell -.calls.-> Rust[Rust Backend]
-    Rust --> SQLite[(SQLite<br/>Connections)]
-    Rust --> Keychain[(OS Keychain<br/>Secrets)]
-    Rust --> AI[AI Providers<br/>OpenAI-compat]
-
-    AI -. approval gate .-> Tabs
-
-    classDef local fill:#1f6feb,stroke:#1f6feb,color:#fff
-    classDef ai fill:#8a63d2,stroke:#8a63d2,color:#fff
-    class SQLite,Keychain local
-    class AI ai
-```
-
-Die wichtige Form: persistente gespeicherte Daten (**Connection**) sind getrennt von dem Live-Laufzeitzustand (**Session**), der wiederum getrennt vom UI-Container (**Tab**) ist. Einen **Tab** schließen beendet die **Session**. **Tabs** wechseln nicht. Das ist die Regel, die die App bei Verstand hält.
-
----
-
-## Aktuelle Feature-Übersicht
-
-| Bereich | Heute implementiert |
-| --- | --- |
-| **Connections** | SQLite-gestützter Baum, Ordner/Unterordner, Suche, Drag/Drop-Reihenfolge, Umbenennen, Duplizieren, Löschen, **Quick Connect**, benutzerdefinierte Icons, angeheftete/aktive Rail-Shortcuts |
-| **Terminal** | Lokale Shells, SSH, Telnet, Serial, geteilte Panes, xterm.js + opportunistisches WebGL, Scrollback-Suche, lokales Startverzeichnis/-skript |
-| **SSH** | Natives `russh`, Agent-/Key-/Passwort-Auth, Host-Key-Trust-Flow, optionaler System-SSH-Fallback, ProxyJump, Port-Forwarding, **automatisch benannte tmux-Sessions (`kkterm-<scifi-name><n>`) mit stillem Wiederanhängen bei Transport-Unterbrechung** — perfekt für langlebige Remote-Coding-Agents (Claude Code, Codex, gemini-cli usw.) |
-| **SFTP / FTP** | SSH-gestartetes SFTP plus FTP/FTPS-**Connections**, Doppelscheiben-Browser, rekursive Transfers, Warteschlange/Abbruch/Verlauf löschen, Konflikte, Eigenschaften, chmod/chown wo unterstützt |
-| **URL WebView** | Eingebettete WebView2-URL-**Sessions**, Navigations-Toolbar, Favicon-Erfassung, gespeicherte Website-Credential-Metadaten/-Fill, Datenpartitions-Metadaten |
-| **Remote Desktop** | RDP über Windows ActiveX mit geometriebegrenztem Overlay-Parking; VNC über `vnc-rs`-Framebuffer im Workspace-Canvas gerendert |
-| **Dashboard** | Dauerhafte Views, Widget-Instanzen, Bearbeitungsmodus, Drag/Resize, App Launcher, **KI-authored Content-/Script-Widgets** (deklaratives JSON oder sandboxed iframe JS mit Berechtigungen), per-Widget-Presets / Akzent / Icon / Titel, **23 animierte Canvas-Hintergründe** (aurora, clouds, ocean, raindrops, rainywindow, snow, sakura, fireflies, bubbles, ricefield, lanterns, starfield, nebula, embers, lava, matrix, topo, synthwave, cyberpunk, taipei101, thunderstorm, confetti, particleCursor) |
-| **AI Assistant** | Streaming-Chat, OpenAI-kompatibler Runtime, Provider-Registry, Sicherheitsklassifikation für Befehlsvorschläge, Screenshot-/Kontext-Anhänge, **Dashboard-Widget-Authoring (Content + sandboxed Script)**, **tmux-Pane-Capture** als Gesprächskontext für Remote-Sessions, **Connection**-Management-Tools und Live-**Session**-Tools für Terminal, RDP/VNC und SFTP/FTP |
-| **AI Coding Nutzung** | **Dashboard-Widget + Statusleisten-Anzeige**, die die Quoten-Nutzung von **Claude Code** und **Codex** verfolgen: verbundener Account, Plan-Stufe, Prozentwerte für 5-Stunden- und Wochen-Fenster, nächster Reset-Zeitpunkt, Auth-Status (`connected` / `expired` / `error`), Rate-Limit-bewusste Refresh-Policy |
-| **Eingebauter MCP-Server** | stdio-MCP-Server (`kkterm-cli`), der kuratierte Workspace- und Dashboard-Tools für externe Coding-Agenten (Claude Code, Codex, Copilot, Antigravity, OpenCode) freigibt; authentifizierte Named-Pipe-Brücke; per-Modul-`dangerous.*`-Namespaces hinter einem einzelnen Safety-Toggle; Einstellungs-Dialog mit Ein-Klick-JSON-/-TOML-Snippets und `claude mcp add` / `codex mcp add`-Befehlen |
-| **Installer Helper** | Activity-Rail-Modul für einen gebündelten Windows-Entwicklertool-Katalog: installierte Tools erkennen, neueste Versionen vergleichen, installieren/aktualisieren/deinstallieren, Tools aus Update all herauspinnen, Befehlslogs streamen und unterstützte verwaltete Apps starten |
-| **Settings** | Allgemein, Darstellung, Credentials, KI, SSH, Terminal, Terminal-Hintergründe, URL, RDP, VNC, Dashboard, Installer Helper, Über; benutzerdefinierte UI-Schriften; Minimieren in Tray; Don't Sleep; Backup/Import |
-| **Localization** | i18next-UI mit englischer Quelle und dynamischen Locale-Bundles: zh-TW, zh-CN, ja, ko, fr, de, es, es-MX, it, pt-BR, th, id, vi |
-
-### KI-Provider
-
-OpenAI · Anthropic · OpenRouter · DeepSeek · Grok · Azure OpenAI · LiteLLM · GitHub Copilot · Ollama · NVIDIA · jeder OpenAI-kompatible Endpunkt.
-
-Provider-Metadaten liegen in [`src/ai/providerRegistry/`](src/ai/providerRegistry/); Rust-Adapter in [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/). API-Keys gehen durch den OS keychain, niemals SQLite.
-
----
-
-## Schnellstart
-
-Du brauchst:
-
-- **Windows** (primär unterstützte Plattform)
-- **Node.js + npm**
-- **Rust toolchain**
-- **Tauri v2-Voraussetzungen für Windows** inklusive **WebView2**
-
-```bash
-npm install
-npm run tauri dev
-```
-
-Das sollte ein echtes natives Fenster erzeugen. Wenn es stattdessen einen Stack Trace produziert, melde bitte ein Issue — wir lieben eine gute Repro.
-
-### Häufige Checks
-
-```bash
-npm run check                                              # TypeScript
-npm run build                                              # Vite build
-cargo check --manifest-path src-tauri/Cargo.toml           # Rust
-cargo test  --manifest-path src-tauri/Cargo.toml           # Rust tests
-```
-
-### Den Windows-Installer bauen
-
-```bash
-npm run package:installer
-```
-
-Das Installer-Skript schreibt `artifacts/kkterm-<version>-windows-x64-setup.exe` und eine passende `.sha256`-Datei. Der Installer ist derzeit **unsigniert** — Release-Signierung steht auf der Roadmap, bis dahin wird dein Antivirusprogramm dich möglicherweise streng anschauen. Das ist normal.
+Einstellungen → AI Assistant → **Built-in MCP Server** hat einen Ein-Klick-Dialog „Konfiguration anzeigen", schon ausgefüllt, plus kopierbare Befehle `claude mcp add` / `codex mcp add`.
 
 ---
 
 ## Was KKTerm nicht ist
 
-Eine kurze Liste, weil Ehrlichkeit Vertrauen schafft:
+Eine kurze Liste, denn Ehrlichkeit verdient Vertrauen:
 
-- **Kein Cloud-Produkt.** Kein Sync, keine Team-Accounts, keine SaaS-Stufe. Wenn du jemals einen „Bei KKTerm anmelden"-Dialog siehst, ist etwas katastrophal schiefgelaufen.
-- **Gibt nicht vor, plattformübergreifend zu sein.** Wir sind bewusst Windows-first; macOS- und Linux-Ports stehen auf der Roadmap und werden dieselbe Tauri-v2-Shell nutzen. Wenn du heute ein Mac-first-Tool brauchst, hast du Hunderte von Optionen. Wir bauen das Tool, auf das Windows-Admins still gewartet haben.
+- **Kein Cloud-Produkt.** Keine Synchronisierung, keine Team-Konten, keine SaaS-Stufe. Wenn du je einen Dialog „Bei KKTerm anmelden" siehst, ist etwas katastrophal schiefgelaufen.
+- **Tut nicht so, als wäre es plattformübergreifend.** Wir sind mit Absicht Windows-first; macOS und Linux stehen auf der Roadmap. Wenn du heute ein mac-first-Tool brauchst, hast du hunderte Optionen. Wir bauen das eine, auf das Windows-Admins still gewartet haben.
 - **Kein autonomer KI-Agent.** Der Assistent schlägt vor; der Mensch entscheidet. `Allow All` ist eine Wahl, die du triffst, kein Standard.
-- **Kein Grafana- / Datadog-Ersatz.** Das Dashboard ist für persönliche Steueroberflächen, nicht für 10.000-Host-Observability.
-- **Keine Kubernetes-IDE.** Es ist ein terminal-first-Admin-Workspace. Bitte frag ihn nicht, ein Helm-Chart zu rendern.
+- **Kein Grafana-/Datadog-Ersatz.** Das Dashboard ist für persönliche Kontroll-Oberflächen, nicht für Observability über 10.000 Hosts.
+- **Keine Kubernetes-IDE.** Es ist ein Terminal-zentrierter Admin-Workspace. Bitte verlang nicht, dass es ein Helm-Chart rendert.
 
-Wenn eines davon ein Dealbreaker war — fair genug, wir sehen uns in v2.
-
----
-
-## Natives Debugging
-
-Verwende die echte Tauri-Runtime zur Validierung:
-
-```bash
-npm run tauri dev
-```
-
-Eine Vite-Browser-Vorschau ist für einige Frontend-Inspektionen nützlich, hostet aber **keine** echte WebView2-, ConPTY-, RDP-ActiveX-, VNC-Framebuffer-, Keychain- oder native Menüoberfläche. Wenn ein Feature eines davon berührt, validiere es in der echten Desktop-Runtime.
-
-VS-Code-Nutzer: Die `Run KKTerm exe`-Launch-Config startet `src-tauri/target/debug/kkterm.exe` mit `RUST_BACKTRACE=1`. Die dazu passende `Attach KKTerm WebView2`-Config gibt dir DevTools innerhalb des echten WebView2-Hosts.
+Falls einer dieser Punkte *früher* ein K.-o.-Kriterium war — fair genug, dann sehen wir uns in v2.
 
 ---
 
-## Bekannte Grenzen (ja, wir wissen es)
+## KKTerm holen
 
-- Der Installer ist derzeit unsigniert. Update-Checks sind deaktiviert, bis die Release-Signierung konfiguriert ist.
-- SFTP über ProxyJump wird im nativen SFTP-Pfad noch nicht unterstützt.
-- Transfer-Wiederaufnahme, Ordner-Sync/-Diff, Archiv-/Extrahieren und Remote-Bearbeitung sind zurückgestellt.
-- SSH-Config-Import ist implementiert, aber der benutzerseitige Eintrag in Settings ist noch nicht verfügbar.
-- RDP und VNC werden ausgeliefert; reichhaltigere Clipboard-/Geräte-Sync- und Qualitätssteuerungen entwickeln sich noch.
-- macOS- und Linux-Builds stehen auf der Roadmap. Sie kommen, und sie werden ordentlich gemacht — nicht als „wir laufen irgendwie auch da drüben"-Port herausgestürzt.
-- Der KI-Assistent schlägt vor und kann aktivierte Tools innerhalb der konfigurierten Berechtigungsgrenze bedienen — bitte behandle ihn nicht als unbeaufsichtigten Roboter. Er weiß tatsächlich nicht, was dein CEO will.
+**[Lad den neuesten Windows-Installer (.exe) herunter](https://github.com/ryantsai/KKTerm/releases/latest)** und führ ihn aus. Der Installer ist derzeit **unsigniert** — Release-Signierung steht auf der Roadmap, also kann dich dein Virenscanner bis dahin streng anschauen. Das ist normal.
+
+Aus dem Quellcode bauen oder mitmachen? Alles, was du brauchst, steht in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ---
 
-## Roadmap (die Kurzfassung)
+## Roadmap (Kurzfassung)
 
-- macOS + Linux-Builds
+- macOS- + Linux-Builds
 - Signierter Installer + Auto-Update
-- SFTP über ProxyJump im nativen Pfad
-- Transfer-Wiederaufnahme, Ordner-Sync, Archiv/Extrahieren
-- Reichhaltigere RDP-Clipboard-/Geräteumlenkung
-- Mehr eingebaute **Dashboard**-Widgets (und ein öffentliches Schema für KI-authored ones)
+- Mehr Dateiübertragungs-Power (Fortsetzen, Ordner-Sync, Archivieren/Entpacken)
+- Reichere Zwischenablage- und Geräte-Freigabe fürs Remotedesktop
+- Mehr eingebaute Dashboard-Widgets
 
-Vollständige und häufig aktualisierte Version: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+Vollständige, häufig aktualisierte Version: [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
 ---
 
 ## Mitwirken
 
-Wir würden uns freuen über jede Hilfe. Wirklich. Auch kleine Dinge zählen:
+Über eine helfende Hand würden wir uns sehr freuen. Ehrlich. Auch Kleinigkeiten zählen:
 
-- **Probiere den Dev-Build aus** und melde ein Issue, wenn etwas sich falsch anfühlt. „Es fühlte sich falsch an" ist ein legitimer Bug-Report; wir graben gemeinsam.
-- **Übersetze eine Locale.** Englisch ist die Source of Truth in [`src/i18n/locales/en.json`](src/i18n/locales/en.json); 12 weitere Locales liegen daneben und laden on demand. Ausstehende Strings werden per Key unter [`docs/localization_todo/`](docs/localization_todo/) verfolgt — nimm einen, übersetze ihn, lösch die Datei.
-- **Füge ein Dashboard-Widget hinzu.** Eingebaute Widgets liegen in [`src/modules/dashboard/widgets/builtin/`](src/modules/dashboard/widgets/builtin/). Nimm eine kleine Idee, liefere sie aus, lern das Muster.
-- **Verschlanke die KI-Tool-Oberfläche.** Provider-Adapter liegen in [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/); die Frontend-Registry ist in [`src/ai/providerRegistry/`](src/ai/providerRegistry/).
-- **Verbessere das Handbuch.** Endbenutzer-Docs liegen in [`docs/manual/`](docs/manual/). Ein Kapitel pro UI-Modul. Wenn du ein Feature benutzt hast und die Docs nicht halfen, ist ein PR, der das behebt, Gold wert.
+- **Probier den Dev-Build** und mach eine Issue auf, wenn sich etwas falsch anfühlt. „Fühlte sich falsch an" ist ein legitimer Bug-Report; wir graben mit dir.
+- **Übersetz eine Sprache.** Englisch ist die Quelle der Wahrheit; dreizehn weitere Sprachen wohnen daneben.
+- **Füg ein Dashboard-Widget hinzu.** Nimm eine kleine Idee, liefere sie, lern das Muster.
+- **Verbessere das Handbuch.** Wenn du eine Funktion genutzt hast und die Doku nicht half, ist eine PR, die das behebt, Gold wert.
 
-Vollständiges Setup, Projektlayout, PR-Checkliste und die Liste der „bitte das nicht kaputt machen"-Regeln liegen in [`CONTRIBUTING.md`](CONTRIBUTING.md). Die 30-Sekunden-Highlights:
-
-- **Lies [`CONTEXT.md`](CONTEXT.md) bevor du benutzerseitige Begriffe umbenennst.** **Connection**, **Session**, **Tab** und **Quick Connect** bedeuten spezifische Dinge; bitte nicht verwässern.
-- **Jeder benutzersichtbare String geht durch `t()`.** Kein nackter englischer Text in JSX.
-- **Keine Frontend-Close-Hooks.** Tauri v2s Titelleisten-Schließen wurde durch `onCloseRequested`-Muster ein halbes Dutzend Mal kaputt gemacht. Wir haben endlich eine funktionierende Form; bitte nicht wieder einführen.
-- **Führe die Checks aus** (`npm run check && npm run build && cargo check && cargo test`) bevor du einen PR öffnest.
-
-Suchst du einen Einstiegspunkt? Filtere offene Issues nach [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) oder [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22). Wenn noch keine getaggt sind, öffne ein Issue, das beschreibt, woran du arbeiten möchtest, und wir helfen beim Scopen.
+Komplettes Setup, Projektstruktur und PR-Checkliste stehen in [`CONTRIBUTING.md`](CONTRIBUTING.md). Auf der Suche nach einem Einstieg? Filtere offene Issues nach [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) oder [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
 
 ---
 
-## Projektdokumentation
+## Projektdokumente
 
-- [Produktkontext](CONTEXT.md) — die Domänensprache, die du treffen solltest
-- [Architektur](docs/ARCHITECTURE.md) — Modul-Map, wo neuer Code hingehört
+- [Produktkontext](CONTEXT.md) — die Fachsprache, an die du dich halten solltest
+- [Architektur](docs/ARCHITECTURE.md) — Modul-Karte, wohin mit neuem Code
 - [Roadmap](docs/ROADMAP.md)
 - [Dashboard-Architektur](docs/DASHBOARD.md)
 - [KI-Provider-Leitfaden](docs/AI_PROVIDERS.md)
-- [Performance-Notizen](docs/PERFORMANCE.md)
-- [Release-Notes und -Gates](docs/RELEASE.md)
 
 ---
 
-## Stack
-
-Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand · xterm.js · SQLite · WebView2 · `russh` · `russh-sftp` · `vnc-rs` · `suppaftp` · OS keychain storage.
-
----
-
-## Star-Verlauf
+## Stern-Verlauf
 
 <a href="https://www.star-history.com/#ryantsai/KKTerm&Date">
   <picture>
@@ -466,12 +303,12 @@ Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand ·
   </picture>
 </a>
 
-Wenn du bis hier gelesen hast und noch keinen Stern vergeben hast — worauf wartest du noch, eine persönliche Einladung? Das hier ist die persönliche Einladung.
+Wenn du es bis hierher geschafft und noch keinen Stern vergeben hast — worauf wartest du, eine persönliche Einladung? Betrachte dies als die persönliche Einladung.
 
-⭐ **[KKTerm auf GitHub einen Stern geben](https://github.com/ryantsai/KKTerm)** — kostet einen Klick und macht dem Maintainer die ganze Woche. Stell es dir vor als digitales 乖乖 auf dem Rack.
+⭐ **[Gib KKTerm auf GitHub einen Stern](https://github.com/ryantsai/KKTerm)** — kostet einen Klick und macht dem Maintainer die ganze Woche schön. Sieh es als ein digitales 乖乖 im Rack.
 
 ---
 
 ## Lizenz
 
-MIT. Siehe [LICENSE](LICENSE). Nutze es, forke es, shippe es, bau es in ein Homelab, das sonst niemand findet — das ist der Deal.
+MIT. Siehe [LICENSE](LICENSE). Nutz es, fork es, liefer es aus, pack es in ein Homelab, das sonst niemand findet — das ist der Deal.

--- a/README.es-MX.md
+++ b/README.es-MX.md
@@ -5,19 +5,19 @@
 <h1 align="center">KKTerm</h1>
 
 <p align="center">
-  <strong>El workspace de administración nativo para Windows que la era de las herramientas de IA se olvidó de construir — terminales, SSH, SFTP, RDP/VNC, dashboards, y una IA que crea tus propios widgets de herramientas.</strong>
+  <strong>Una sola ventana nativa de Windows para terminales, SSH, SFTP, RDP/VNC y un panel — más una IA que te arma tus propias herramientas cuando se lo pides.</strong>
 </p>
 
 <p align="center">
-  <em>Porque tu barra de tareas no debería parecer una máquina tragamonedas.</em>
+  <em>Porque tu barra de tareas no debería verse como una máquina tragamonedas de Las Vegas.</em>
 </p>
 
 <p align="center">
-  <sub>Su nombre viene de <strong>乖乖 (Kuāi Kuāi)</strong>, el snack de coco verde que los sysadmins taiwaneses ponen encima de sus servidores para que se porten bien. Esperamos que esta app se gane su lugar en el rack.</sub>
+  <sub>Se llama así por <strong>乖乖 (Kuāi Kuāi)</strong>, la botana verde de coco que los administradores de sistemas taiwaneses ponen sobre los servidores para que se porten bien. Ojalá esta app se gane su lugar en el rack.</sub>
 </p>
 
 <p align="center">
-  <strong><a href="https://github.com/ryantsai/KKTerm/releases/latest">Descargar el instalador más reciente para Windows (.exe)</a></strong>
+  <strong><a href="https://github.com/ryantsai/KKTerm/releases/latest">Descargar el instalador más reciente de Windows (.exe)</a></strong>
 </p>
 
 <p align="center">
@@ -38,15 +38,8 @@
   </a>
   <br />
   <img src="https://img.shields.io/badge/Windows%E2%80%91first-by%20design-0078D6?style=flat-square&logo=windows" alt="Windows-first by design" />
-  <img src="https://img.shields.io/badge/built%20with-Tauri%20v2-FFC131?style=flat-square&logo=tauri" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/Rust-russh-orange?style=flat-square&logo=rust" alt="Rust" />
-  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react" alt="React 19" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
   <br />
-  <sub><a href="README.zh-TW.md">繁體中文</a></sub>
-</p>
-
-<p align="center">
   <sub>
     <a href="README.md">English</a> ·
     <a href="README.zh-TW.md">繁體中文</a> ·
@@ -67,66 +60,58 @@
 
 ---
 
-## El Argumento (45 segundos)
+## El argumento en 45 segundos
 
-Eres sysadmin / DevOps / homelab / vibe-coder. Ahorita mismo tienes abierto:
+Eres administrador de sistemas / DevOps / fan del homelab / vibe-coder. Ahorita tienes:
 
 - Un emulador de terminal
-- Un cliente SSH aparte (con una lista de perfiles que te costó un fin de semana armar)
-- Un cliente SFTP del 2007 que de alguna forma todavía existe
-- El Escritorio Remoto en una ventana que siempre pierdes en el monitor equivocado
-- Un visor VNC para ese único servidor Linux
-- Una pestaña del navegador para la interfaz del router
-- Una sesión de `claude` / `codex` corriendo en un servidor remoto que se cae cada vez que tu Wi-Fi estornuda
-- Un papelito con contraseñas *(no te preocupes, aquí no decimos nada)*
+- Un cliente SSH aparte (con una lista de perfiles que te llevó un fin de semana armar)
+- Un cliente SFTP de 2007 que, quién sabe cómo, sigue existiendo
+- El Escritorio remoto en una ventana que siempre pierdes en el monitor equivocado
+- Un visor VNC nada más por esa única máquina Linux
+- Una pestaña del navegador para la interfaz de administración del router
+- Una sesión `claude` / `codex` en una máquina remota que se cae cada que el wifi estornuda
+- Un papelito con contraseñas *(tranqui, no decimos nada)*
 
-**KKTerm es una sola ventana para todo eso.** Nativa en Windows — *a propósito, mientras el resto del mundo de herramientas para devs lanza primero en Mac y trata tu sistema operativo como nota al pie* — escrita en Rust + Tauri v2, se instala con un solo archivo y nunca llama a casa.
+**KKTerm es una sola ventana para todo eso.** Nativo en Windows — *a propósito, mientras el resto del mundo de las herramientas para devs saca primero la versión de mac y trata tu SO como una nota al pie* — en un solo instalador que se niega a llamar a casa.
 
-Y de pilón, unas cosas que no sabías que querías:
+Y unas cuantas cosas que no sabías que querías:
 
-- Un **Dashboard** donde le dices a una IA *"hazme un widget que haga ping a mi router cada 30 segundos"* y aparece, en sandbox, en tu cuadrícula.
-- **Paneles SSH que se re-conectan automáticamente a sesiones tmux con nombre fijo** para que tu sesión remota de `claude` / `codex` sobreviva cada berrinche de Wi-Fi que aventé tu laptop.
-- Un **widget de uso de IA para codear** que muestra tus cuotas de Claude Code y Codex — ventana de 5 horas, ventana semanal, plan actual, email de la cuenta — en el **Dashboard** y en la barra de estado, para que dejes de chocar con la pared del rate-limit a las 3 de la mañana.
-- Un módulo **Installer Helper** que detecta, instala, actualiza, desinstala y lanza un catálogo curado de herramientas de desarrollo para Windows — Node, Python, Docker, WSL, CLIs de coding con IA y esas utilerías pequeñas que normalmente acabas cazando entre pestañas del navegador.
-- Un **servidor MCP integrado** (`kkterm-cli`) que deja que agentes de coding externos (Claude Code, Codex, Copilot, Antigravity, OpenCode) manejen tu Workspace y Dashboard — listar Connections, leer buffers de terminal, colocar widgets — sobre una superficie de herramientas curada y con aprobación. IA-a-IA, en tu máquina, sin relay en la nube.
-- Veintiuno **fondos animados con canvas** (sí, incluyendo `matrix`) para el dashboard, porque no somos tan serios como aparentamos.
+- Un **Dashboard** donde le dices a una IA *«créame un widget que le haga ping a mi router cada 30 segundos»* y aparece, en su propio espacio aislado, sobre tu cuadrícula.
+- **Paneles SSH que se vuelven a conectar a tu sesión remota `claude` / `codex`** después de cada berrinche del wifi, para que un trabajo de seis horas sobreviva a una caída.
+- Un **medidor de uso de IA** para que dejes de estrellarte por sorpresa contra el muro del límite de uso a las 3 de la mañana.
+- Un **Installer Helper** que encuentra, instala, actualiza y abre las herramientas para devs de Windows que normalmente andas persiguiendo por diez pestañas del navegador.
+- **Veinticinco fondos animados** para el panel (sí, incluido `matrix`), porque no nos da pena.
 
-Ah, y el asistente de IA puede convertir una frase en una pequeña herramienta de dashboard que de verdad sigues usando.
+Y lo mejor: el asistente de IA puede convertir una sola frase en una pequeña herramienta de panel que de verdad terminas usando.
 
-> ⭐ **Si esto suena como la app que llevas seis años pensando en construir — ponle estrella al repo para que sepamos que alguien está mirando. De verdad ayuda.**
+> ⭐ **Si esto suena a la app que llevas seis años queriendo construir — dale una estrella al repo para que sepamos que alguien está al pendiente. De verdad ayuda.**
 
----
-
-## ¿Por qué "KKTerm"?
-
-Entra a cualquier centro de datos en Taiwán y mira la parte de arriba de los racks. Desde las fábricas de TSMC, las salas de control del Metro de Taipei, los servidores del Banco Cathay, el equipo de telecomunicaciones de Chunghwa — vas a ver una bolsita verde de 乖乖 (Kuāi Kuāi), un snack de maíz con sabor a coco de los años 60.
-
-El nombre literalmente significa **"pórtate bien"**, **"obedece"**. La tradición de IT es directa y absolutamente seria:
-
-- **Tiene que ser de sabor verde (coco).** El amarillo (curry) significa *quédate en casa*; el rojo (picante) enoja al servidor. Solo verde.
-- **Tiene que estar vigente.** Un Kuai Kuai vencido trabaja en tu contra. Los ingenieros los cambian diligentemente.
-- **Tiene que ser visible.** El servidor necesita saber que está ahí.
-- **No te lo comas.** Esa bolsa está de guardia.
-
-Algunos de los sistemas más grandes, más aburridos y más obsesionados con el uptime en Asia corren con una bolsa de palomitas de maíz pegada al chasis. Funciona porque la gente que los mantiene cree que funciona, lo cual es una descripción sorprendentemente honesta de la mayoría de la cultura de IT.
-
-**KKTerm** es **Kuai Kuai Term** — un workspace de administración que aspira al mismo trabajo que el snack: sentarse tranquilamente junto a tus máquinas importantes y ayudarlas a portarse bien. Local-first. Sin telemetría. IA con aprobación requerida. El tipo de software aburrido y confiable.
-
-Todavía no hemos podido incluir una bolsa real de Kuai Kuai con el instalador. Eso es un ítem para la v2.
+¿Tienes una opinión sobre lo que debería venir después? Métete al hilo público de comentarios:
+**[¿Qué debería priorizar KKTerm para los flujos de administración Windows-first?](https://github.com/ryantsai/KKTerm/discussions/141)**
 
 ---
 
-## Míralo en Acción
+## ¿Por qué «KKTerm»?
 
-<!--
-  TODO: Reemplazar este placeholder con un GIF de demostración real.
-  Recomendado:
-    - 5-10 segundos, en loop
-    - Mostrar: abrir una Connection -> dividir un pane -> subir por SFTP -> la IA propone un comando
-    - Apunta a ~5 MB para que GitHub lo muestre en línea sin lazy-loading
-  Ruta sugerida: docs/assets/demo.gif
-  Luego cambia el <img src=...> de abajo a: src="docs/assets/demo.gif"
--->
+Métete a cualquier centro de datos taiwanés y mira la parte de arriba de los racks. Más allá de las fábricas de TSMC, las salas de control del metro de Taipéi, las salas de servidores del banco Cathay, los equipos de conmutación de Chunghwa Telecom — vas a ver una bolsita verde de 乖乖 (Kuāi Kuāi), una botana de maíz con sabor a coco de los años 60.
+
+El nombre significa literalmente **«pórtate bien»**, **«compórtate»**. La tradición en TI es sencilla y completamente en serio:
+
+- **Debe ser verde (coco).** El amarillo (curry) significa *hoy quédate en casa*; el rojo (picante) hace enojar al servidor. Nada más verde.
+- **No debe estar caducado.** Un Kuai Kuai pasado juega en tu contra. Los ingenieros los cambian con diligencia.
+- **Debe estar a la vista.** El servidor tiene que saber que está ahí.
+- **No te lo comas.** Esa bolsita está de servicio.
+
+Algunos de los sistemas más grandes, más aburridos y más obsesionados con el uptime de Asia funcionan con una bolsita de frituras de maíz pegada al chasis. Funciona porque la gente que los mantiene cree que funciona, lo cual es una descripción notablemente honesta de casi toda la cultura de TI.
+
+**KKTerm** es **Kuai Kuai Term** — un espacio de administración que aspira al mismo trabajo que la botana: sentarse en silencio junto a tus máquinas importantes y ayudarlas a portarse bien. Local primero. Sin telemetría. IA con aprobación. Ese tipo de software aburrido y confiable.
+
+Todavía no hemos podido incluir una bolsa de verdad de Kuai Kuai con el instalador. Eso queda para la v2.
+
+---
+
+## Verlo en movimiento
 
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
@@ -138,339 +123,177 @@ Todavía no hemos podido incluir una bolsa real de Kuai Kuai con el instalador. 
   </a>
 </p>
 
-<p align="center"><sub><em>(Aquí va el GIF de demo. Una imagen vale más que mil bullets, y ya nos quedamos sin bullets.)</em></sub></p>
+<p align="center"><sub><em>(Aquí va el GIF de demostración. Una imagen vale más que mil viñetas, y ya se nos acabaron las viñetas.)</em></sub></p>
 
 ---
 
-## Por Qué la Gente lo Tiene Abierto Todo el Día
+## Una ventana, cada conexión
+
+| Querías… | KKTerm lo hace |
+| --- | --- |
+| Abrir un shell local PowerShell / cmd / WSL | Terminales locales, lado a lado |
+| SSH a un servidor | SSH con llaves, agente, contraseñas, hosts de salto y reenvío de puertos |
+| Explorar los archivos de ese servidor | SFTP desde la conexión SSH — doble panel, arrastra para transferir |
+| FTP a un NAS de 2012 | FTP / FTPS en el mismo explorador de archivos |
+| Telnet a equipos prehistóricos | Sí, Telnet también está ahí |
+| Hablar con un puerto serial | Conexiones seriales — elige un puerto COM y un baudaje |
+| Entrar por remoto a una máquina Windows | El auténtico Escritorio remoto de Microsoft, integrado |
+| VNC a una Pi | VNC, renderizado directo en el espacio de trabajo |
+| Abrir la interfaz web del router | Una pestaña de navegador integrada con inicios de sesión guardados |
+| Vigilar la CPU del host | Una barra de estado en vivo y un panel que armas tú mismo |
+
+La misma app. La misma ventana. Los mismos atajos. El mismo tema, que ojalá no te haga sangrar los ojos.
+
+---
+
+## Por qué la gente lo deja abierto todo el día
 
 ### Windows primero, a propósito
 
-Voltea a ver el panorama de herramientas para devs en 2026. Claude Code: lanza primero en Mac/Linux, Windows es "usa WSL." Codex CLI: igual. `gemini-cli`, la mitad de Homebrew, cada TUI reluciente nueva: Mac/Linux primero, y los usuarios de Windows reciben un comentario de `# Windows: se aceptan contribuciones` en el README y un script de fish-completion que no corre.
+Mira el panorama de las herramientas para devs. Claude Code: mac/linux primero, Windows es «usa WSL». Codex CLI: lo mismo. La mitad de las herramientas nuevas y llamativas salen primero para mac y le dejan a los usuarios de Windows un comentario `# contributions welcome` y un script de autocompletado que ni jala.
 
-Mientras tanto, la gente que de verdad mantiene a las empresas en línea — IT corporativa, MSPs, cualquiera que corra Hyper-V o AD o SCCM o IIS o un domain controller más viejo que algunos practicantes — está frente a máquinas Windows preguntándose por qué cada nueva herramienta trata su sistema operativo como un estorbo.
+Mientras tanto, la gente que de verdad mantiene a las empresas en línea — la TI corporativa, los MSP, cualquiera que administre un controlador de dominio más viejo que algunos becarios — está sentada frente a máquinas Windows preguntándose por qué cada herramienta nueva trata su SO como una molestia.
 
-**KKTerm es la apuesta contraria.** Construimos nativamente para Windows primero, y los ports de macOS / Linux vienen después. Eso significa que podemos usar las APIs de Windows que de verdad importan, en vez de tapar hoyos con capas de portabilidad:
+**KKTerm hace el trato contrario.** Construimos nativo para Windows primero, así que lo que le importa a la gente de Windows simplemente jala: el *auténtico* Escritorio remoto de Microsoft (el mismo que `mstsc.exe`, no un clon), shells reales de PowerShell / cmd / WSL, secretos guardados en el Administrador de credenciales de Windows, un ícono de bandeja como debe ser, menús y diálogos nativos. Las versiones de macOS y Linux están en la hoja de ruta y van a recibir el mismo cuidado. Pero si estabas esperando a que alguien construyera la *buena* herramienta de administración de Windows primero en vez de al último — ese es el trato.
 
-- **ConPTY** para shells locales — la verdadera pseudo-consola de Windows, no un shim de traducción. PowerShell, `cmd.exe`, distros de WSL, todas alojadas como PTYs de verdad con foco, redimensionado y manejo de secuencias VT que coinciden con el comportamiento de la plataforma.
-- **WebView2** para toda la interfaz y las **Connections** de URL embebidas — Chromium en proceso usando el runtime del sistema, que es una de las razones por las que el instalador es pequeño y arranca rápido.
-- **Microsoft RDP ActiveX (`mstscax.dll`)** para RDP — *el de verdad, el que Microsoft incluye*. El mismo control que Remote Desktop Connection (`mstsc.exe`). No es una reimplementación de terceros, no es FreeRDP envuelto en algo. Los que usan RDP van a notar la diferencia en cinco segundos.
-- **Windows Credential Manager** para todos los secretos. Contraseñas SSH, contraseñas FTP, API keys, credenciales de URL Connection — viven en el OS keychain y `credwiz.exe` las puede auditar.
-- **Instalador NSIS para usuario actual** con su SHA-256 correspondiente, menú de bandeja nativo, aserción de encendido Don't-Sleep, muestreo de CPU/RAM/red del host, menús contextuales nativos de Tauri con íconos PNG reales, diálogos nativos de Abrir/Guardar. Ninguno de estos está simulado.
-- **WSL es un shell de primera clase, no un parche.** Levanta Ubuntu junto a un pane de PowerShell junto a una sesión SSH junto a un **Tab** de RDP, todo en la misma ventana.
+### Local primero significa de verdad local
 
-Los builds para macOS y Linux están en el roadmap y recibirán el mismo cuidado. Pero si llevas tiempo esperando que alguien construyera *la buena* herramienta de administración para Windows, en vez de construirla de última — ese es el trato.
+Tus conexiones guardadas viven en un archivo en tu máquina. Las contraseñas viven en el Administrador de credenciales de Windows, no en un archivo de texto junto a la app. KKTerm no manda analíticas, no llama a casa al arrancar y no necesita una cuenta en la nube para abrirse. No hay «inicia sesión para sincronizar» porque no hay sincronización.
 
-### Local-first significa realmente local
+Si tu cable de red se prende en llamas, KKTerm se abre de todos modos.
 
-Tus **Connections** guardadas viven en un archivo SQLite en tu máquina. Las contraseñas viven en el **Windows Credential Manager**, no en un JSON junto al binario. La app no incluye analíticas, no llama a casa al arrancar, y no necesita una cuenta en la nube para abrir. No hay "inicia sesión para sincronizar" porque no hay sincronización.
+### Terminales que no pierden la cabeza
 
-Si se incendia el cable de red, KKTerm sigue abriendo.
+- Paneles divididos dentro de una Tab.
+- Renderizado rápido y fluido, con scrollback que se puede buscar.
+- Reconectar significa de verdad *reconectar* — tu sesión remota retoma donde estaba, no «empezar de cero y hacer como que la última hora no pasó».
+- Cambiar de Tab **no** mata la Session. Cerrar la Tab sí. Esta distinción fue una guerra de religión interna; ganamos.
 
-### Un workspace, todos los tipos de conexión
+### Un asistente de IA que construye tus herramientas
 
-| Querías… | KKTerm tiene |
+La mayoría de los demos de «IA en tu terminal» se quedan en el chat. El asistente de KKTerm también puede construir pequeños widgets de panel duraderos, a la medida de cómo trabajas de verdad — y mantiene lo peligroso detrás de un interruptor:
+
+- **Decide qué puede tocar** — prende o apaga familias enteras de herramientas (Dashboard / Connections / Live Sessions).
+- **Decide cómo pregunta** — `Prompt` (por defecto, pregunta cada vez) o `Allow All` (eres adulto, firmaste el deslinde).
+
+Cualquier cosa que se parezca a un `rm -rf` se marca como peligrosa y espera un sí humano explícito. La IA no puede ejecutar a escondidas un comando destructivo nada más porque alguien se pasó de listo con una inyección de prompt en una página de man.
+
+Habla con OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA o cualquier endpoint compatible con OpenAI. Tus llaves de API van al llavero del SO.
+
+### Un panel que no finge ser Grafana
+
+El Dashboard es una cuadrícula de widgets que arrastras y redimensionas. No es para observabilidad a escala de petabytes — es para «quiero un botón que abra mis cinco apps favoritas y un panel que muestre el uptime de mi host SSH, *al lado* de mi chat».
+
+#### Widgets creados por la IA — descríbelo, lo tienes
+
+Esta es la parte que de verdad nos emociona. No eliges de un marketplace ni escribes JavaScript. Le **dices al asistente de IA lo que quieres**, y construye el widget ahí mismo, en tu panel:
+
+> *«Agrega un widget que muestre los últimos 5 commits de mi repo principal en una lista.»*
+> *«Hazme un widget de nota adhesiva para mi acordeón de guardia.»*
+> *«Construye un widget que le haga ping a mi router de casa cada 30 segundos y muestre verde/rojo.»*
+> *«Necesito un cronómetro. Sorpréndeme con el estilo.»*
+
+Algunos son simples paneles de visualización (markdown, listas de pendientes, una cifra grande); otros corren código en vivo en un espacio aislado que tú apruebas. Cada widget que conservas es tuyo — se queda con su propio color, ícono y título, y puedes tener varias copias de distintos tamaños. Borra uno con clic derecho cuando se acabe la magia.
+
+#### Fondos animados del panel (porque se nos antojó)
+
+Elige un ambiente por vista del panel entre **veinticinco** fondos animados sobre canvas:
+
+| Ambiente | Fondos |
 | --- | --- |
-| Abrir un shell local de PowerShell / cmd / WSL | **Sessions** de terminal local respaldadas por ConPTY |
-| Conectarte por SSH a un servidor | `russh` nativo con auth por agente / llave / contraseña, flujo de confianza de host-key, ProxyJump, port forwarding |
-| Explorar archivos en ese servidor | SFTP lanzado desde la **Connection** SSH, doble panel, transferencias recursivas, chmod/chown |
-| FTP a un NAS del 2012 | **Connections** de FTP / FTPS en el mismo explorador estilo SFTP |
-| Telnet a equipo antiguo | Sí, bueno, Telnet también está |
-| Hablar con un puerto serial | Tipo **Connection** Serial, COM port + baud, sin herramientas extra |
-| Conectarte remotamente a una máquina Windows | RDP nativo vía el control ActiveX de Microsoft (el de verdad, no un clon) |
-| VNC a una Raspberry Pi | Framebuffer de `vnc-rs` en Rust renderizado directo en el workspace |
-| Abrir la interfaz web del router | **URL Connection** embebida con WebView2 y llenado de credenciales |
-| Ver la CPU del host | Barra de estado en vivo + un módulo **Dashboard** con widgets de drag/resize |
-
-Todo es la misma app. La misma ventana. Los mismos atajos de teclado. El mismo tema que esperamos no lastime los ojos.
-
-### Terminales que no se vuelven locas
-
-- Paneles divididos dentro de un **Tab**.
-- Rendering de xterm.js acelerado por WebGL, con fallback elegante cuando no puede.
-- Búsqueda en el scrollback.
-- Paneles SSH respaldados por tmux que pueden re-conectarse a sesiones estables por pane, para que reconectar de verdad signifique *reconectar*, y no "empezar de cero y fingir que la última hora no existió."
-- Cambiar de **Tab** **no** mata la **Session**. Cerrar el **Tab** sí. Esta distinción fue una guerra religiosa internamente; ganamos.
-
-### Un asistente de IA que crea tus herramientas
-
-La mayoría de las demos de "IA en tu terminal" se quedan en chat. El asistente de KKTerm también puede crear pequeños widgets de dashboard, duraderos, para tu forma real de trabajar. Aun así, mantiene lo peligroso detrás de dos controles:
-
-- **Familias de herramientas** (Dashboard / Connections / Live Sessions) — actívalas o desactívalas por categoría.
-- **Modo de permiso** en el compositor — `Prompt` (por defecto, pregunta cada vez) o `Allow All` (eres adulto, firmaste el waiver).
-
-Habla con OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA, o cualquier cosa compatible con OpenAI. Las API keys van al OS keychain. Los modelos que proponen `rm -rf` se clasifican como peligrosos y requieren aprobación humana explícita. La IA no puede ejecutar silenciosamente un comando destructivo porque alguien se puso listo con un prompt injection en una página de manual.
-
-### Un Dashboard que no pretende ser Grafana
-
-El módulo **Dashboard** es una cuadrícula de 12 columnas con drag/resize de instancias de widgets. No es para observabilidad de petabytes — es para "quiero un botón que lance mis cinco apps favoritas y un panel mostrando el uptime de mi servidor SSH, *junto a* mi chat."
-
-#### Widgets Creados por IA — descríbelo, aparece
-
-Esta es la parte que de verdad nos emociona. No escoges de un marketplace y no escribes JavaScript. **Le dices al asistente de IA lo que quieres**, y construye el widget ahí mismo en tu dashboard:
-
-> *"Agrega un widget que muestre los últimos 5 commits de mi repo principal como lista."*
-> *"Hazme un widget de post-it que guarde mis notas de guardia."*
-> *"Crea un widget que haga ping a mi router de casa cada 30 segundos y muestre verde/rojo."*
-> *"Necesito un cronómetro. Sorpréndeme con el estilo."*
-
-Dos sabores:
-
-- **Content widgets** — JSON declarativo: markdown, listas clave-valor, checklists, un solo stat grande. Seguro de construcción, sin script. La mayoría de las solicitudes de "solo necesito esto en mi dashboard" caen aquí.
-- **Script widgets** — JavaScript alojado dentro de un sandbox aislado de `iframe srcdoc` con permisos explícitos y declarados (allowlist de `network`, presupuesto de `pollSeconds`). La IA escribe el script, tú apruebas los permisos, el widget corre en una caja que no puede alcanzar el resto de la app.
-
-Cada widget que conservas es tuyo. Persisten en SQLite junto a tus **Connections**, con su propio preset visual (`panel` / `ambient` / `hero`), color de acento, ícono y título. Pueden coexistir múltiples instancias del mismo widget con tamaños y estilos completamente distintos. Bórralos con clic derecho cuando la magia se acabe.
-
-#### Fondos animados para el dashboard (porque quisimos)
-
-El dashboard tiene veintiuno fondos animados con canvas que puedes elegir por **Dashboard View**:
-
-| Mood | Fondos |
-| --- | --- |
-| Tranquilo | `aurora`, `clouds`, `ocean`, `raindrops`, `snow`, `sakura`, `fireflies`, `bubbles`, `ricefield`, `lanterns` |
+| Calma | `aurora`, `clouds`, `ocean`, `raindrops`, `rainywindow`, `frostedWindow`, `snow`, `sakura`, `fireflies`, `bubbles`, `aquarium`, `ricefield`, `lanterns` |
 | Espacial | `starfield`, `nebula` |
 | Cálido | `embers`, `lava` |
-| Geek | `matrix`, `topo`, `synthwave` |
-| Caótico | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti` |
+| Friki | `matrix`, `topo`, `synthwave` |
+| Inquieto | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti`, `particleCursor` |
 
-Corren en un solo `requestAnimationFrame` compartido y respetan el foco de la ventana, así que no cuestan casi nada cuando estás haciendo otra cosa. Combina `matrix` con tu asistente de IA para un vibe que dice "soy extremadamente productivo y posiblemente estoy en una película de los Wachowski." O elige `ocean` y parece una persona seria. No juzgamos ninguna opción.
+Se pausan cuando estás en otra parte, así que casi no cuestan nada. Combina `matrix` con tu asistente de IA para un ambiente que dice «soy extremadamente productivo y posiblemente estoy en una película de las Wachowski». O elige `ocean` y aparenta ser una persona seria. No juzgamos ninguna de las dos opciones.
 
-### Correr agentes de IA en un servidor, como debe ser
+### Mantén vivos a tus agentes de IA remotos
 
-Esta es la segunda funcionalidad de la que la gente se enamora. Las terminales SSH de KKTerm pueden lanzarse directamente a una **sesión tmux con nombre fijo** en el host remoto — por defecto, un id amigable autogenerado como `kkterm-cockpit001` que sobrevive las reconexiones:
+Esta es la segunda función de la que la gente se enamora. Los terminales SSH de KKTerm pueden dejarte directo en una **sesión tmux con nombre** en el host remoto que sobrevive a la reconexión:
 
-- Abre una **Connection** SSH con tmux habilitado.
-- Dentro del pane, arranca `claude`, `codex`, `gemini-cli`, `cursor-agent`, o el agente de coding de larga duración que prefieras. Son apps TUI de pantalla completa; tmux es exactamente donde quieren vivir.
-- Cierra la laptop. Ábrela de nuevo. El pane se re-conecta silenciosamente a la misma sesión tmux. El agente sigue corriendo, sigue teniendo su scrollback, sigue a la mitad de lo que estaba haciendo.
-- ¿Tirones en la red del transporte SSH? KKTerm hace un intento silencioso y acotado de re-conexión al mismo tmux id sin molestarte.
-- ¿Quieres que el asistente de IA vea qué está haciendo el agente? "Agregar buffer del terminal al contexto" llama a `capture_tmux_pane` por SSH y jala el scrollback completo de tmux — no solo lo que está en pantalla, toda la sesión — a la conversación. Tu asistente local ahora puede razonar sobre el trabajo de tu agente remoto.
+- Abre una conexión SSH con tmux activado y arranca `claude`, `codex`, `gemini-cli`, `cursor-agent` o el agente de larga duración que prefieras.
+- Cierra la laptop. Vuélvela a abrir. El panel se reconecta en silencio — el agente sigue corriendo, conserva su scrollback, a media tarea de lo que estuviera haciendo.
+- ¿Un parpadeo de la red? KKTerm se reconecta discreto a la misma sesión sin molestarte.
+- ¿Quieres que ayude el asistente? «Agregar el búfer del terminal al contexto» mete toda la sesión remota en la conversación, para que tu IA local pueda razonar sobre lo que hace tu agente remoto.
 
-Si alguna vez perdiste una sesión de seis horas de `claude` o `codex` por el Wi-Fi pacheco de un hotel, esta sola función justifica la app. La app es gratis. La función sigue valiendo la pena.
+Si alguna vez perdiste una sesión `claude` o `codex` de seis horas por el wifi inestable de un hotel, esta sola función ya pagó la app. (La app es gratis. La función vale la pena de todos modos.)
 
 ### Saber cuánta IA te queda
 
-Los agentes de coding cobran por ventana de plan, no por mes. Claude Code tiene una ventana de 5 horas y una semanal. Codex hace su propia versión. Los dos se pueden comer tu cuota muy a gusto en segundo plano mientras estás en una junta.
+Los agentes de programación cobran por ventana de plan, no por mes, y se comen felices tu cuota mientras estás en una junta. El **medidor de uso de IA** lo mantiene a la vista:
 
-El widget de **Uso de IA para codear** mantiene eso a la vista:
+- Un widget de panel que muestra **Claude Code** y **Codex** lado a lado: cuenta conectada, plan, consumo de la ventana actual y de esta semana, hora del próximo reinicio.
+- Un **indicador compacto en la barra de estado** que refleja las mismas cifras, para que incluso con el panel cerrado veas de un vistazo si te queda margen antes del próximo gran refactor.
+- Te avisa con anticipación si necesitas volver a iniciar sesión — *antes* de una tarea larga, no a media tarea.
 
-- Un widget de Dashboard que muestra **Claude Code** y **Codex** lado a lado: cuenta conectada, plan, porcentaje usado en la ventana de 5 horas actual, porcentaje usado esta semana, próxima hora de reset.
-- Un **indicador compacto en la barra de estado** que refleja los mismos números, para que aunque tengas el Dashboard cerrado puedas saber de un vistazo si todavía te alcanza para arrancar el siguiente refactor grande.
-- El estado de auth se muestra directo (`connected` / `expired` / `error`) para que te enteres *antes* de una tarea larga de que necesitas re-loguearte, y no a la mitad.
-- La política de refresh respeta los rate limits; el widget hace polling a su propio ritmo en lugar de aporrear las APIs cada que lo miras.
+### Deja que otras IA manejen KKTerm
 
-### Un servidor MCP integrado — deja que otras IAs manejen KKTerm
+KKTerm trae su propio servidor MCP, para que agentes de programación externos (Claude Code, Codex, Copilot, Antigravity, OpenCode) usen tu espacio de trabajo como lo haces tú — listar conexiones, abrir una, leer un búfer de terminal, colocar widgets en el panel. De IA a IA, en tu máquina, sin relevo en la nube. Las acciones que modifican, las más riesgosas, se quedan detrás de un único interruptor de seguridad que está **apagado** por defecto.
 
-Tu terminal también es donde Claude Code, Codex, el modo agente de Copilot, Antigravity y el resto del mundo MCP quieren trabajar. Por eso KKTerm trae su propio **servidor MCP por stdio**, [`kkterm-cli`](docs/MCP.md), que expone una rebanada curada de la app:
-
-- **Módulo Workspace** (`kkterm.workspace.*`): listar **Connections** guardadas, abrir una Connection por id, listar **Sessions** vivas, mandar input a un pane de terminal, leer un snapshot del buffer.
-- **Módulo Dashboard** (`kkterm.dashboard.*`): cargar el estado del Dashboard, leer la fuente de un widget creado por IA, crear / actualizar / borrar vistas, colocar / mover / quitar instancias de widget, aplicar layouts en bulto.
-- **Sub-namespaces peligrosos** (`kkterm.<module>.dangerous.*`): mutar la superficie ejecutable — crear widgets de script, hacer clic en escritorios remotos, vaciar el Dashboard — está protegido detrás de un solo setting (`built_in_mcp_allow_all_dangerous`), apagado por default.
-
-`kkterm-cli` es un forwarder ligerito. Habla stdio JSON-RPC con tu cliente MCP y se comunica con la ventana de KKTerm corriendo por un named pipe de Windows autenticado por lanzamiento. Con KKTerm cerrado, `tools/list` sigue funcionando (los clientes pueden hacer introspección de la superficie), pero `tools/call` regresa un error estructurado de `app_not_running` en lugar de hacer algo.
-
-Conéctalo con tu cliente favorito y tu IA ahora usa KKTerm igual que tú:
-
-```json
-{
-  "mcpServers": {
-    "kkterm": { "command": "<ruta-a-kkterm-cli>", "args": [] }
-  }
-}
-```
-
-Settings → AI Assistant → **Servidor MCP integrado** tiene un diálogo "Mostrar config" de un clic con snippets JSON y TOML ya rellenados con la ruta del binario resuelta, más comandos `claude mcp add` / `codex mcp add` copiables.
+Configuración → AI Assistant → **Built-in MCP Server** tiene un diálogo «Mostrar configuración» de un clic, ya rellenado, además de comandos `claude mcp add` / `codex mcp add` para copiar.
 
 ---
 
-## Cómo Encaja Todo
+## Lo que KKTerm no es
 
-```mermaid
-flowchart LR
-    User([You]) --> Shell[KKTerm Window<br/>Tauri v2 + React 19]
-    Shell --> Rail[Activity Rail]
-    Rail --> WS[Workspace Module]
-    Rail --> Dash[Dashboard Module]
-    Rail --> Inst[Installer Helper Module]
-    Rail -.-> FE[File Explorer<br/>planned]
-    Rail --> Set[Settings]
+Una lista corta, porque la honestidad se gana la confianza:
 
-    WS --> Tabs[Tabs &amp; Panes]
-    Tabs --> Term[Terminal<br/>ConPTY / russh]
-    Tabs --> SFTP[SFTP / FTP]
-    Tabs --> Web[WebView2 URL]
-    Tabs --> RD[RDP / VNC]
+- **No es un producto en la nube.** Sin sincronización, sin cuentas de equipo, sin plan SaaS. Si alguna vez ves un diálogo «Inicia sesión en KKTerm», algo salió catastróficamente mal.
+- **No finge ser multiplataforma.** Somos Windows-first a propósito; macOS y Linux están en la hoja de ruta. Si hoy necesitas una herramienta mac-first, tienes cientos de opciones. Estamos construyendo esa que los administradores de Windows llevan esperando en silencio.
+- **No es un agente de IA autónomo.** El asistente propone; el humano dispone. `Allow All` es una decisión que tomas tú, no un valor por defecto.
+- **No es un sustituto de Grafana / Datadog.** El Dashboard es para superficies de control personales, no para observabilidad de 10,000 hosts.
+- **No es un IDE de Kubernetes.** Es un espacio de administración centrado en el terminal. Por favor, no le pidas que renderice un chart de Helm.
 
-    Shell -.calls.-> Rust[Rust Backend]
-    Rust --> SQLite[(SQLite<br/>Connections)]
-    Rust --> Keychain[(OS Keychain<br/>Secrets)]
-    Rust --> AI[AI Providers<br/>OpenAI-compat]
-
-    AI -. approval gate .-> Tabs
-
-    classDef local fill:#1f6feb,stroke:#1f6feb,color:#fff
-    classDef ai fill:#8a63d2,stroke:#8a63d2,color:#fff
-    class SQLite,Keychain local
-    class AI ai
-```
-
-La forma que importa: los datos guardados duraderos (**Connection**) son independientes del estado de ejecución en vivo (**Session**), que es independiente del contenedor de la interfaz (**Tab**). Cerrar un **Tab** termina la **Session**. Cambiar de **Tab** no. Esta es la regla que mantiene la app en sus cabales.
+Si alguno de esos puntos *era* un factor decisivo — está bien, nos vemos en la v2.
 
 ---
 
-## Mapa de Funcionalidades Actuales
+## Consigue KKTerm
 
-| Área | Implementado hoy |
-| --- | --- |
-| **Connections** | Árbol respaldado por SQLite, carpetas/subcarpetas, búsqueda, orden por drag/drop, renombrar, duplicar, eliminar, **Quick Connect**, íconos personalizados, atajos fijados/activos en el rail |
-| **Terminal** | Shells locales, SSH, Telnet, Serial, paneles divididos, xterm.js + WebGL oportunista, búsqueda en scrollback, directorio/script de inicio local |
-| **SSH** | `russh` nativo, auth por agente/llave/contraseña, flujo de confianza de host-key, fallback opcional al SSH del sistema, ProxyJump, port forwarding, **sesiones tmux con nombre automático (`kkterm-<nombre-scifi><n>`) con re-conexión silenciosa en caída del transporte** — perfecto para agentes de coding de larga duración (Claude Code, Codex, gemini-cli, etc.) |
-| **SFTP / FTP** | SFTP lanzado desde SSH más **Connections** de FTP/FTPS, explorador de doble panel, transferencias recursivas, cola/cancelar/historial, conflictos, propiedades, chmod/chown donde esté soportado |
-| **URL WebView** | **Sessions** de URL embebidas con WebView2, barra de navegación, captura de favicon, metadatos/llenado de credenciales de sitios web guardados, metadatos de partición de datos |
-| **Remote Desktop** | RDP a través de Windows ActiveX con parking de overlay con scope de geometría; VNC a través del framebuffer de `vnc-rs` renderizado en el canvas del workspace |
-| **Dashboard** | Vistas duraderas, instancias de widgets, modo edición, drag/resize, App Launcher, **widgets de contenido/script creados por IA** (JSON declarativo o JS en iframe en sandbox con permisos), presets por widget / acento / ícono / título, **23 fondos animados con canvas** (aurora, clouds, ocean, raindrops, rainywindow, snow, sakura, fireflies, bubbles, ricefield, lanterns, starfield, nebula, embers, lava, matrix, topo, synthwave, cyberpunk, taipei101, thunderstorm, confetti, particleCursor) |
-| **AI Assistant** | Chat en streaming, runtime compatible con OpenAI, registro de proveedores, clasificación de seguridad de propuestas de comandos, adjuntos de captura de pantalla/contexto, **creación de widgets para Dashboard (contenido + script en sandbox)**, **captura de pane tmux** como contexto de conversación para sesiones remotas, herramientas de gestión de **Connection**, y herramientas de **Session** en vivo para terminal, RDP/VNC, y SFTP/FTP |
-| **Uso de IA para codear** | **Widget de Dashboard + indicador en barra de estado** que rastrea el uso de cuotas de **Claude Code** y **Codex**: cuenta conectada, plan, porcentajes de ventanas de 5 horas y semanal, próxima hora de reset, estado de auth (`connected` / `expired` / `error`), política de refresh consciente del rate-limit |
-| **Servidor MCP integrado** | Servidor MCP por stdio (`kkterm-cli`) que expone herramientas curadas de Workspace y Dashboard a agentes externos de coding (Claude Code, Codex, Copilot, Antigravity, OpenCode); bridge de named pipe autenticado; sub-namespaces `dangerous.*` por Módulo protegidos detrás de un solo toggle de seguridad; diálogo en Settings con snippets JSON / TOML de un clic y comandos `claude mcp add` / `codex mcp add` |
-| **Installer Helper** | Módulo del Activity Rail para un catálogo incluido de herramientas de desarrollo de Windows: detectar herramientas instaladas, comparar últimas versiones, instalar/actualizar/desinstalar, excluir herramientas de Update all, transmitir logs de comandos y lanzar apps administradas compatibles |
-| **Settings** | General, Apariencia, Credenciales, IA, SSH, Terminal, fondos de terminal, URL, RDP, VNC, Dashboard, Installer Helper, Acerca de; fuentes de interfaz personalizadas; minimizar a bandeja; Don't Sleep; respaldo/importar |
-| **Localización** | Interfaz con i18next, inglés como fuente de verdad y bundles de idioma dinámicos: zh-TW, zh-CN, ja, ko, fr, de, es, es-MX, it, pt-BR, th, id, vi |
+**[Descarga el instalador más reciente de Windows (.exe)](https://github.com/ryantsai/KKTerm/releases/latest)** y córrelo. El instalador por ahora está **sin firmar** — la firma de versiones está en la hoja de ruta, así que hasta entonces tu antivirus puede mirarte feo. Es normal.
 
-### Proveedores de IA
-
-OpenAI · Anthropic · OpenRouter · DeepSeek · Grok · Azure OpenAI · LiteLLM · GitHub Copilot · Ollama · NVIDIA · cualquier endpoint compatible con OpenAI.
-
-Los metadatos de proveedores viven en [`src/ai/providerRegistry/`](src/ai/providerRegistry/); los adaptadores de Rust en [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/). Las API keys pasan por el OS keychain, nunca por SQLite.
+¿Quieres compilar desde el código fuente o contribuir? Todo lo que necesitas está en [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ---
 
-## Quick Start
+## Hoja de ruta (versión corta)
 
-Necesitas:
+- Versiones macOS + Linux
+- Instalador firmado + actualización automática
+- Más potencia en transferencia de archivos (reanudar, sincronización de carpetas, archivar/extraer)
+- Portapapeles y compartición de dispositivos más rica en el Escritorio remoto
+- Más widgets de panel integrados
 
-- **Windows** (plataforma principal soportada)
-- **Node.js + npm**
-- **Toolchain de Rust**
-- **Prerrequisitos de Tauri v2 para Windows**, incluyendo **WebView2**
-
-```bash
-npm install
-npm run tauri dev
-```
-
-Eso debería producir una ventana nativa de verdad. Si en cambio produce un stack trace, por favor abre un issue — nos encanta un buen repro.
-
-### Verificaciones comunes
-
-```bash
-npm run check                                              # TypeScript
-npm run build                                              # Vite build
-cargo check --manifest-path src-tauri/Cargo.toml           # Rust
-cargo test  --manifest-path src-tauri/Cargo.toml           # Rust tests
-```
-
-### Construir el instalador de Windows
-
-```bash
-npm run package:installer
-```
-
-El script del instalador escribe `artifacts/kkterm-<version>-windows-x64-setup.exe` y un archivo `.sha256` correspondiente. Actualmente está **sin firmar** — la firma para release está en el roadmap, pero hasta entonces tu antivirus puede ponerte cara de fuchi. Es normal.
-
----
-
-## Lo Que KKTerm No Es
-
-Una lista corta, porque la honestidad genera confianza:
-
-- **No es un producto cloud.** Sin sincronización, sin cuentas de equipo, sin tier SaaS. Si alguna vez ves un diálogo de "Inicia sesión en KKTerm", algo salió catastróficamente mal.
-- **No pretende ser multiplataforma.** Somos Windows-first a propósito; macOS y Linux están en el roadmap y usarán el mismo shell de Tauri v2. Si hoy necesitas una herramienta que priorice Mac, tienes cientos de opciones. Nosotros estamos construyendo la que los admins de Windows han estado esperando calladamente.
-- **No es un agente de IA autónomo.** El asistente propone; el humano decide. `Allow All` es una elección que tú haces, no el default.
-- **No reemplaza a Grafana / Datadog.** El Dashboard es para superficies de control personales, no para observabilidad de 10k hosts.
-- **No es un IDE para Kubernetes.** Es un workspace de administración centrado en la terminal. Por favor no le pidas que renderice un Helm chart.
-
-Si alguno de esos *era* un dealbreaker — cuídate, nos vemos en la v2.
-
----
-
-## Debugging Nativo
-
-Usa el runtime real de Tauri para validación:
-
-```bash
-npm run tauri dev
-```
-
-Una vista previa de Vite en el navegador es útil para cierta inspección de frontend, pero **no** aloja un WebView2 real, ConPTY, RDP ActiveX, framebuffer VNC, keychain, ni superficie de menú nativa. Si una funcionalidad toca cualquiera de esos, valídala en el runtime de escritorio real.
-
-Usuarios de VS Code: la configuración de lanzamiento `Run KKTerm exe` arranca `src-tauri/target/debug/kkterm.exe` con `RUST_BACKTRACE=1`. La configuración pareada `Attach KKTerm WebView2` te da DevTools dentro del host WebView2 real.
-
----
-
-## Limitaciones Actuales (sí, ya sabemos)
-
-- El instalador actualmente no está firmado. Las actualizaciones automáticas están deshabilitadas hasta que se configure la firma para release.
-- SFTP sobre ProxyJump todavía no está soportado en el path nativo de SFTP.
-- La reanudación de transferencias de archivos, sincronización/diff de carpetas, compresión/extracción, y edición remota están aplazadas.
-- La importación de configuración SSH está implementada pero la entrada en Settings todavía no está expuesta al usuario.
-- RDP y VNC están disponibles; controles más ricos de clipboard/dispositivo y controles de calidad todavía están evolucionando.
-- Los builds para macOS y Linux están en el roadmap. Vienen, y se harán bien — no apresurados como un port de "también más o menos corremos ahí".
-- El asistente de IA propone y puede operar las herramientas habilitadas dentro del límite de permisos configurado — por favor no lo trates como un robot desatendido. De hecho, no sabe lo que quiere tu CEO.
-
----
-
-## Roadmap (la versión corta)
-
-- Builds para macOS + Linux
-- Instalador firmado + auto-actualización
-- SFTP sobre ProxyJump en el path nativo
-- Reanudación de transferencias, sincronización de carpetas, compresión/extracción
-- Redirección más rica de clipboard/dispositivos en RDP
-- Más widgets integrados para el **Dashboard** (y un esquema público para los creados por IA)
-
-Versión completa y actualizada frecuentemente: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+Versión completa y actualizada seguido: [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
 ---
 
 ## Contribuir
 
-Nos encantaría una mano. En serio. Hasta las cosas pequeñas importan:
+Nos encantaría una mano. De verdad. Hasta las cosas chiquitas cuentan:
 
-- **Prueba el build de desarrollo** y abre un issue cuando algo se sienta raro. "Se sintió raro" es un reporte de bug legítimo; lo investigamos contigo.
-- **Traduce un idioma.** El inglés es la fuente de verdad en [`src/i18n/locales/en.json`](src/i18n/locales/en.json); otros 12 idiomas viven a su lado y cargan bajo demanda. Los strings pendientes se rastrean por clave en [`docs/localization_todo/`](docs/localization_todo/) — escoge uno, tradúcelo, borra el archivo.
-- **Agrega un widget al Dashboard.** Los widgets integrados viven en [`src/modules/dashboard/widgets/builtin/`](src/modules/dashboard/widgets/builtin/). Elige una idea pequeña, mándala, aprende el patrón.
-- **Refina la superficie de herramientas de IA.** Los adaptadores de proveedores viven en [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/); el registro del frontend está en [`src/ai/providerRegistry/`](src/ai/providerRegistry/).
-- **Mejora el manual.** La documentación para usuarios finales vive en [`docs/manual/`](docs/manual/). Un capítulo por módulo de interfaz. Si usaste una funcionalidad y la documentación no te ayudó, un PR que lo arregle vale oro.
+- **Prueba la build de desarrollo** y abre una issue cuando algo te haga ruido. «Me dio mala espina» es un reporte de error legítimo; lo investigamos contigo.
+- **Traduce un idioma.** El inglés es la fuente de la verdad; otros trece idiomas viven al lado.
+- **Agrega un widget de panel.** Agarra una idea pequeña, publícala, aprende el patrón.
+- **Mejora el manual.** Si usaste una función y la documentación no ayudó, una PR que lo arregle vale oro.
 
-La configuración completa, la estructura del proyecto, el checklist de PRs, y la lista de reglas "por favor no rompas esto" viven en [`CONTRIBUTING.md`](CONTRIBUTING.md). Los puntos clave en 30 segundos:
-
-- **Lee [`CONTEXT.md`](CONTEXT.md) antes de renombrar términos visibles al usuario.** **Connection**, **Session**, **Tab** y **Quick Connect** significan cosas específicas; por favor no los modifiques.
-- **Todos los strings visibles al usuario van a través de `t()`.** Sin texto en inglés directamente en JSX.
-- **Sin hooks de cierre en el frontend.** El cierre de la barra de título de Tauri v2 ha sido roto por los patrones `onCloseRequested` mil y un veces. Finalmente tenemos una forma que funciona; por favor no los reintroduzcas.
-- **Corre las verificaciones** (`npm run check && npm run build && cargo check && cargo test`) antes de abrir un PR.
-
-¿Buscas un punto de entrada? Filtra los issues abiertos por [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) o [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22). Si todavía no hay ninguno etiquetado, abre un issue describiendo en qué quieres trabajar y te ayudamos a delimitarlo.
+La configuración completa, la estructura del proyecto y la lista de verificación de PR están en [`CONTRIBUTING.md`](CONTRIBUTING.md). ¿Buscas un punto de entrada? Filtra las issues abiertas por [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) o [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
 
 ---
 
-## Documentación del Proyecto
+## Documentos del proyecto
 
-- [Contexto del producto](CONTEXT.md) — el lenguaje del dominio que debes usar
-- [Arquitectura](docs/ARCHITECTURE.md) — mapa de módulos, dónde poner código nuevo
-- [Roadmap](docs/ROADMAP.md)
+- [Contexto de producto](CONTEXT.md) — el lenguaje de dominio que debes respetar
+- [Arquitectura](docs/ARCHITECTURE.md) — mapa de módulos, dónde poner el código nuevo
+- [Hoja de ruta](docs/ROADMAP.md)
 - [Arquitectura del Dashboard](docs/DASHBOARD.md)
 - [Guía de proveedores de IA](docs/AI_PROVIDERS.md)
-- [Notas de rendimiento](docs/PERFORMANCE.md)
-- [Notas de release y gates](docs/RELEASE.md)
 
 ---
 
-## Stack
-
-Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand · xterm.js · SQLite · WebView2 · `russh` · `russh-sftp` · `vnc-rs` · `suppaftp` · OS keychain storage.
-
----
-
-## Historial de Estrellas
+## Historial de estrellas
 
 <a href="https://www.star-history.com/#ryantsai/KKTerm&Date">
   <picture>
@@ -480,12 +303,12 @@ Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand ·
   </picture>
 </a>
 
-Si llegaste hasta aquí y todavía no le has dado estrella — ¿qué estás esperando, una invitación personal? Considera esto la invitación personal.
+Si llegaste hasta aquí y todavía no le das una estrella — ¿qué esperas, una invitación personal? Considera esto la invitación personal.
 
-⭐ **[Ponle estrella a KKTerm en GitHub](https://github.com/ryantsai/KKTerm)** — cuesta un clic y le alegra la semana al mantenedor. Piénsalo como un 乖乖 digital en el rack.
+⭐ **[Dale una estrella a KKTerm en GitHub](https://github.com/ryantsai/KKTerm)** — cuesta un clic y le alegra la semana entera al mantenedor. Piénsalo como un 乖乖 digital en el rack.
 
 ---
 
 ## Licencia
 
-MIT. Ve [LICENSE](LICENSE). Úsalo, forkéalo, despliégalo, ponlo en un homelab que nadie más puede encontrar — ese es el trato.
+MIT. Ver [LICENSE](LICENSE). Úsalo, fórkalo, publícalo, mételo en un homelab que nadie más encuentre — ese es el trato.

--- a/README.es.md
+++ b/README.es.md
@@ -5,7 +5,7 @@
 <h1 align="center">KKTerm</h1>
 
 <p align="center">
-  <strong>El espacio de trabajo nativo para administradores Windows que la era de la IA se olvidó de construir — terminales, SSH, SFTP, RDP/VNC, dashboards, y una IA que crea tus propios widgets de herramientas.</strong>
+  <strong>Una sola ventana nativa de Windows para terminales, SSH, SFTP, RDP/VNC y un panel — además de una IA que te construye tus propias herramientas a petición.</strong>
 </p>
 
 <p align="center">
@@ -13,11 +13,11 @@
 </p>
 
 <p align="center">
-  <sub>Nombrado en honor a <strong>乖乖 (Kuāi Kuāi)</strong>, el aperitivo de coco verde que los administradores de sistemas taiwaneses colocan sobre los servidores para que se porten bien. Esperamos que esta app se gane su sitio en el rack.</sub>
+  <sub>Llamado así por <strong>乖乖 (Kuāi Kuāi)</strong>, el aperitivo verde de coco que los administradores de sistemas taiwaneses colocan sobre los servidores para que se porten bien. Esperamos que esta app se gane su sitio en el rack.</sub>
 </p>
 
 <p align="center">
-  <strong><a href="https://github.com/ryantsai/KKTerm/releases/latest">Descargar el instalador de Windows más reciente (.exe)</a></strong>
+  <strong><a href="https://github.com/ryantsai/KKTerm/releases/latest">Descargar el último instalador de Windows (.exe)</a></strong>
 </p>
 
 <p align="center">
@@ -38,9 +38,6 @@
   </a>
   <br />
   <img src="https://img.shields.io/badge/Windows%E2%80%91first-by%20design-0078D6?style=flat-square&logo=windows" alt="Windows-first by design" />
-  <img src="https://img.shields.io/badge/built%20with-Tauri%20v2-FFC131?style=flat-square&logo=tauri" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/Rust-russh-orange?style=flat-square&logo=rust" alt="Rust" />
-  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react" alt="React 19" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
   <br />
   <sub>
@@ -63,56 +60,58 @@
 
 ---
 
-## El argumento de venta (45 segundos)
+## El argumento en 45 segundos
 
-Eres administrador de sistemas / DevOps / homelab / vibe-coder. Ahora mismo tienes:
+Eres administrador de sistemas / DevOps / aficionado al homelab / vibe-coder. Ahora mismo tienes:
 
 - Un emulador de terminal
-- Un cliente SSH aparte (con una lista de perfiles que te costó un fin de semana construir)
-- Un cliente SFTP de 2007 que, de algún modo, sigue distribuyéndose
-- Remote Desktop en una ventana que no encuentras nunca en el monitor correcto
-- Un visor VNC para ese único servidor Linux
-- Una pestaña del navegador para la interfaz web del router
-- Una sesión de `claude` / `codex` corriendo en un servidor remoto que se cae cada vez que tu Wi-Fi estornuda
-- Un post-it con contraseñas *(no te preocupes, no diremos nada)*
+- Un cliente SSH aparte (con una lista de perfiles que te llevó un fin de semana montar)
+- Un cliente SFTP de 2007 que, no se sabe cómo, sigue existiendo
+- El Escritorio remoto en una ventana que siempre pierdes en el monitor equivocado
+- Un visor VNC para esa única máquina Linux
+- Una pestaña del navegador para la interfaz de administración del router
+- Una sesión `claude` / `codex` en una máquina remota que se cae cada vez que el wifi estornuda
+- Un pósit con contraseñas *(tranqui, no diremos nada)*
 
-**KKTerm es una sola ventana para todo eso.** Nativo en Windows — *a propósito, mientras el resto del mundo del desarrollo lanza primero en Mac y trata tu sistema operativo como nota a pie de página* — escrito en Rust + Tauri v2, se instala con un solo ejecutable y se niega a llamar a casa.
+**KKTerm es una sola ventana para todo eso.** Nativo en Windows — *a propósito, mientras el resto del mundo de las herramientas para devs sale primero para mac y trata tu SO como una nota a pie de página* — en un único instalador que se niega a llamar a casa.
 
-Además, algunas cosas que no sabías que necesitabas:
+Y unas cuantas cosas que no sabías que querías:
 
-- Un **Dashboard** donde le dices a la IA *"construye un widget que haga ping a mi router cada 30 segundos"* y aparece, en su sandbox, en tu cuadrícula.
-- **Paneles SSH que se reconectan automáticamente a sesiones tmux con nombre**, para que tu sesión remota de `claude` / `codex` sobreviva a cada berrinche Wi-Fi que le dé a tu portátil.
-- Un **Widget de uso de IA para programar** que muestra tus cuotas de Claude Code y Codex — ventana de 5 horas, ventana semanal, plan actual, email de la cuenta — en el **Dashboard** y en la barra de estado, para que dejes de chocar con el muro del rate-limit a las 3 de la madrugada.
-- Un módulo **Installer Helper** que detecta, instala, actualiza, desinstala y lanza un catálogo curado de herramientas de desarrollo para Windows — Node, Python, Docker, WSL, CLIs de programación con IA y esas utilidades pequeñas que normalmente acabas persiguiendo entre pestañas del navegador.
-- Un **servidor MCP integrado** (`kkterm-cli`) que permite a agentes de programación externos (Claude Code, Codex, Copilot, Antigravity, OpenCode) manejar tu Workspace y Dashboard — listar Connections, leer buffers del terminal, colocar Widgets — sobre una superficie de herramientas curada y con aprobación. IA-a-IA, en tu máquina, sin relay en la nube.
-- Veintiuno **fondos animados de canvas** (sí, incluido `matrix`) para el dashboard, porque no somos de los que se reprimen.
+- Un **Dashboard** donde le dices a una IA *«créame un widget que haga ping a mi router cada 30 segundos»* y aparece, en su propio espacio aislado, sobre tu cuadrícula.
+- **Paneles SSH que se vuelven a enganchar a tu sesión remota `claude` / `codex`** tras cada rabieta del wifi, para que un trabajo de seis horas sobreviva a una caída.
+- Un **medidor de uso de IA** para que dejes de chocar por sorpresa contra el muro del límite de uso a las 3 de la mañana.
+- Un **Installer Helper** que encuentra, instala, actualiza y lanza las herramientas para devs de Windows que normalmente persigues por diez pestañas del navegador.
+- **Veinticinco fondos animados** para el panel (sí, incluido `matrix`), porque no estamos por encima de eso.
 
-Y el asistente de IA puede convertir una frase en una pequeña herramienta de dashboard que de verdad sigues usando.
+Y lo mejor: el asistente de IA puede convertir una sola frase en una pequeña herramienta de panel que de verdad acabas usando.
 
-> ⭐ **Si esto suena a la app que llevas seis años pensando en construir — dale una estrella al repositorio para que sepamos que alguien está mirando. Ayuda de verdad.**
+> ⭐ **Si esto suena a la app que llevas seis años queriendo construir — dale una estrella al repo para que sepamos que alguien está mirando. Ayuda de verdad.**
 
----
-
-## ¿Por qué "KKTerm"?
-
-Entra en cualquier centro de datos taiwanés y mira la parte superior de los racks. En fábricas de TSMC, salas de control del Metro de Taipéi, salas de servidores de Cathay Bank, equipos de conmutación de Chunghwa Telecom — encontrarás una pequeña bolsa verde de 乖乖 (Kuāi Kuāi), un aperitivo de maíz con sabor a coco de los años sesenta.
-
-El nombre significa literalmente **"sé bueno"**, **"compórtate"**. La tradición del sector es sencilla y absolutamente seria:
-
-- **Tiene que ser el sabor verde (coco).** El amarillo (curry) significa *quédate en casa*; el rojo (picante) pone al servidor de mal humor. Verde obligatorio.
-- **Tiene que estar sin caducar.** Un Kuai Kuai caducado juega en tu contra. Los ingenieros los cambian con diligencia.
-- **Tiene que estar a la vista.** El servidor tiene que saber que está ahí.
-- **No lo comas.** Esa bolsa está de guardia.
-
-Algunos de los sistemas más grandes, más aburridos y más obsesionados con el uptime de Asia funcionan con una bolsa de palomitas de maíz pegada al chasis. Funciona porque quienes los mantienen creen que funciona, lo cual es una descripción notablemente honesta de gran parte de la cultura IT.
-
-**KKTerm** es **Kuai Kuai Term** — un espacio de trabajo para administradores que aspira al mismo papel que el aperitivo: sentarse en silencio junto a tus máquinas importantes y ayudarlas a portarse bien. Local-first. Sin telemetría. IA con aprobación humana obligatoria. El tipo de software aburrido y fiable.
-
-Todavía no hemos podido incluir una bolsa real de Kuai Kuai en el instalador. Eso es para la v2.
+¿Tienes una opinión sobre lo que debería venir después? Únete al hilo público de feedback:
+**[¿Qué debería priorizar KKTerm para los flujos de administración Windows-first?](https://github.com/ryantsai/KKTerm/discussions/141)**
 
 ---
 
-## Véelo en acción
+## ¿Por qué «KKTerm»?
+
+Entra en cualquier centro de datos taiwanés y mira la parte de arriba de los racks. Más allá de las fábricas de TSMC, las salas de control del metro de Taipéi, las salas de servidores del banco Cathay, los equipos de conmutación de Chunghwa Telecom — verás una pequeña bolsita verde de 乖乖 (Kuāi Kuāi), un aperitivo de maíz con sabor a coco de los años 60.
+
+El nombre significa literalmente **«pórtate bien»**, **«compórtate»**. La tradición en TI es sencilla y absolutamente seria:
+
+- **Debe ser verde (coco).** El amarillo (curry) significa *quédate hoy en casa*; el rojo (picante) cabrea al servidor. Solo verde.
+- **No debe estar caducado.** Un Kuai Kuai pasado juega en tu contra. Los ingenieros los cambian con diligencia.
+- **Debe estar visible.** El servidor tiene que saber que está ahí.
+- **No te lo comas.** Esa bolsita está de servicio.
+
+Algunos de los sistemas más grandes, más aburridos y más obsesionados con el uptime de Asia funcionan con una bolsita de ganchitos de maíz pegada al chasis. Funciona porque la gente que los mantiene cree que funciona, lo cual es una descripción notablemente honesta de la mayor parte de la cultura TI.
+
+**KKTerm** es **Kuai Kuai Term** — un espacio de administración que aspira al mismo trabajo que el aperitivo: sentarse en silencio junto a tus máquinas importantes y ayudarlas a portarse bien. Local primero. Sin telemetría. IA con aprobación. Ese tipo de software aburrido y fiable.
+
+Aún no hemos podido incluir una bolsa real de Kuai Kuai con el instalador. Eso es cosa de la v2.
+
+---
+
+## Verlo en movimiento
 
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
@@ -124,335 +123,173 @@ Todavía no hemos podido incluir una bolsa real de Kuai Kuai en el instalador. E
   </a>
 </p>
 
-<p align="center"><sub><em>(Aquí va el GIF de demo. Una imagen vale más que mil puntos de lista, y nos hemos quedado sin puntos de lista.)</em></sub></p>
+<p align="center"><sub><em>(Aquí va el GIF de demostración. Una imagen vale más que mil viñetas, y se nos han acabado las viñetas.)</em></sub></p>
 
 ---
 
-## Por qué la gente lo tiene abierto todo el día
+## Una ventana, cada conexión
 
-### Windows-first, a propósito
-
-Echa un vistazo al panorama de herramientas de desarrollo en 2026. Claude Code: lanza primero en Mac/Linux, Windows es "usa WSL". Codex CLI: igual. `gemini-cli`, la mitad de Homebrew, cada TUI reluciente y nuevo: Mac/Linux primero, los usuarios de Windows reciben un comentario `# Windows: se agradecen contribuciones` en el README y un script de autocompletado para fish que no funciona.
-
-Mientras tanto, las personas que realmente mantienen las empresas en línea — IT corporativo, MSPs, quien gestione Hyper-V, AD, SCCM, IIS o un controlador de dominio más antiguo que algunos becarios — están sentadas frente a máquinas Windows preguntándose por qué cada herramienta nueva trata su sistema operativo como un incordio.
-
-**KKTerm es justo lo contrario.** Construimos nativamente para Windows primero, y los puertos de macOS / Linux van después. Eso nos permite usar las API de Windows que realmente importan, en lugar de cubrirlas con una capa de portabilidad:
-
-- **ConPTY** para los shells locales — la pseudoconsola real de Windows, no un adaptador de traducción. PowerShell, `cmd.exe`, distribuciones WSL, todos alojados como PTYs auténticos con foco, redimensionado y manejo de secuencias VT que se ajustan al comportamiento de la plataforma.
-- **WebView2** para toda la interfaz y las **Connections** de URL embebidas — Chromium en proceso usando el runtime del sistema, que es una de las razones por las que el instalador es pequeño y arranca rápido.
-- **Microsoft RDP ActiveX (`mstscax.dll`)** para RDP — *el auténtico que distribuye Microsoft*. El mismo control que Remote Desktop Connection (`mstsc.exe`). No es una reimplementación de terceros, no es FreeRDP envuelto. Los que usen RDP notarán la diferencia en cinco segundos.
-- **Windows Credential Manager** para todos los secretos. Contraseñas SSH, contraseñas FTP, claves API, credenciales de URL Connection — viven en el OS keychain y `credwiz.exe` puede auditarlos.
-- **Instalador NSIS para el usuario actual** con su SHA-256 correspondiente, menú de bandeja nativo, aserción de energía Don't-Sleep, muestreo de CPU/RAM/red del host, menús contextuales nativos de Tauri con iconos PNG reales, diálogos nativos de Abrir/Guardar. Ninguno de estos está simulado.
-- **WSL es un shell de primera clase, no un parche.** Lanza Ubuntu junto a un panel PowerShell junto a una sesión SSH junto a un **Tab** RDP en la misma ventana.
-
-Las versiones de macOS y Linux están en la hoja de ruta y recibirán el mismo cuidado. Pero si llevas tiempo esperando que alguien construya la *buena* herramienta de administración para Windows primero en lugar de la última — este es el trato.
-
-### Local-first significa realmente local
-
-Tus **Connections** guardadas viven en un archivo SQLite en tu máquina. Las contraseñas viven en el **Windows Credential Manager**, no en un JSON junto al binario. La app no incluye analíticas, no llama a casa al arrancar y no necesita una cuenta en la nube para iniciarse. No hay "inicia sesión para sincronizar" porque no hay sincronización.
-
-Si se te incendia el cable de red, KKTerm sigue abriendo.
-
-### Un espacio de trabajo, cada tipo de conexión
-
-| Querías… | KKTerm tiene |
+| Querías… | KKTerm lo hace |
 | --- | --- |
-| Abrir un shell local PowerShell / cmd / WSL | **Sessions** de terminal local respaldadas por ConPTY |
-| Conectarte por SSH a un servidor | `russh` nativo con auth por agente / clave / contraseña, flujo de confianza de host-key, ProxyJump, reenvío de puertos |
-| Explorar archivos en ese servidor | SFTP lanzado desde la **Connection** SSH, doble panel, transferencias recursivas, chmod/chown |
-| FTP a un NAS de 2012 | **Connections** FTP / FTPS con el mismo explorador estilo SFTP |
-| Telnet a equipos antiguos | Sí, Telnet también está |
-| Hablar con un puerto serie | Tipo de **Connection** serial, puerto COM + baudios, sin herramientas extra |
-| Conectarte remotamente a un equipo Windows | RDP nativo mediante el control ActiveX de Microsoft (el auténtico, no un clon) |
-| VNC a una Raspberry Pi | Framebuffer `vnc-rs` en Rust renderizado directamente en el espacio de trabajo |
-| Abrir la interfaz web del router | **URL Connection** embebida con WebView2 y relleno de credenciales |
-| Ver la CPU del host | Barra de estado en vivo + un módulo **Dashboard** con widgets de arrastrar y redimensionar |
+| Abrir un shell local PowerShell / cmd / WSL | Terminales locales, lado a lado |
+| SSH a un servidor | SSH con claves, agente, contraseñas, hosts de salto y reenvío de puertos |
+| Explorar los archivos de ese servidor | SFTP desde la conexión SSH — doble panel, arrastra para transferir |
+| FTP a un NAS de 2012 | FTP / FTPS en el mismo explorador de archivos |
+| Telnet a equipos prehistóricos | Sí, Telnet también está ahí |
+| Hablar con un puerto serie | Conexiones serie — elige un puerto COM y un baudaje |
+| Entrar por remoto a una máquina Windows | El auténtico Escritorio remoto de Microsoft, integrado |
+| VNC a una Pi | VNC, renderizado directamente en el espacio de trabajo |
+| Abrir la interfaz web del router | Una pestaña de navegador integrada con inicios de sesión guardados |
+| Vigilar la CPU del host | Una barra de estado en vivo y un panel que montas tú mismo |
 
-Todo en la misma app. La misma ventana. Los mismos atajos de teclado. El mismo tema que esperamos no lastime la vista.
+La misma app. La misma ventana. Los mismos atajos. El mismo tema, que ojalá no te sangren los ojos.
 
-### Terminales que no pierden el norte
+---
 
-- Paneles divididos dentro de un **Tab**.
-- Renderizado xterm.js acelerado por WebGL, con degradación elegante cuando no puede.
-- Búsqueda en el historial de desplazamiento.
-- Paneles SSH respaldados por tmux que pueden conectarse a sesiones estables por panel, para que reconectarse signifique realmente *reconectarse*, y no "empezar de cero y fingir que la última hora no existió."
-- Cambiar de **Tab** **no** termina la **Session**. Cerrar el **Tab** sí. Esta distinción fue una guerra religiosa interna; nosotros ganamos.
+## Por qué la gente lo deja abierto todo el día
 
-### Un asistente de IA que crea tus herramientas
+### Windows primero, a propósito
 
-La mayoría de las demos de "IA en tu terminal" se quedan en el chat. El asistente de KKTerm también puede crear pequeños widgets de dashboard, duraderos, para tu forma real de trabajar. Aun así, mantiene lo peligroso detrás de dos interruptores:
+Mira el panorama de las herramientas para devs. Claude Code: mac/linux primero, Windows es «usa WSL». Codex CLI: lo mismo. La mitad de las herramientas nuevas y relucientes salen primero para mac y le dejan a los usuarios de Windows un comentario `# contributions welcome` y un script de autocompletado que no funciona.
 
-- **Familias de herramientas** (Dashboard / Connections / Live Sessions) — actívalas o desactívalas por categoría.
-- **Modo de permiso** en el compositor — `Prompt` (por defecto, pregunta cada vez) o `Allow All` (eres adulto/a, ya firmaste el descargo).
+Mientras tanto, la gente que de verdad mantiene a las empresas en línea — la TI corporativa, los MSP, cualquiera que administre un controlador de dominio más viejo que algunos becarios — está sentada ante máquinas Windows preguntándose por qué cada nueva herramienta trata su SO como una molestia.
 
-Habla con OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA o cualquier cosa compatible con OpenAI. Las claves API van al OS keychain. Los modelos que proponen `rm -rf` se clasifican como peligrosos y requieren aprobación humana explícita. La IA no puede ejecutar silenciosamente un comando destructivo porque alguien se puso listo con una inyección de prompt en una página man.
+**KKTerm hace el trato contrario.** Construimos nativo para Windows primero, así que lo que le importa a la gente de Windows simplemente funciona: el *auténtico* Escritorio remoto de Microsoft (el mismo que `mstsc.exe`, no un clon), shells reales de PowerShell / cmd / WSL, secretos guardados en el Administrador de credenciales de Windows, un icono de bandeja como Dios manda, menús y diálogos nativos. Las versiones de macOS y Linux están en la hoja de ruta y recibirán el mismo cuidado. Pero si estabas esperando a que alguien construyera la *buena* herramienta de administración de Windows primero en vez de la última — ese es el trato.
 
-### Un Dashboard que no pretende ser Grafana
+### Local primero significa de verdad local
 
-El módulo **Dashboard** es una cuadrícula de 12 columnas de instancias de widgets, con arrastrar y redimensionar. No es para observabilidad de petabytes — es para "quiero un botón que lance mis cinco apps favoritas y un panel con el uptime de mi host SSH, *junto a* mi chat."
+Tus conexiones guardadas viven en un archivo en tu máquina. Las contraseñas viven en el Administrador de credenciales de Windows, no en un archivo de texto junto a la app. KKTerm no envía analíticas, no llama a casa al arrancar y no necesita una cuenta en la nube para lanzarse. No hay «inicia sesión para sincronizar» porque no hay sincronización.
 
-#### Widgets creados por IA — descríbelo y aparece
+Si tu cable de red se prende fuego, KKTerm se abre igual.
 
-Esta es la parte que nos entusiasma de verdad. No eliges de un marketplace y no escribes JavaScript. Le **dices al asistente de IA lo que quieres** y construye el widget ahí mismo en tu dashboard:
+### Terminales que no pierden la cabeza
 
-> *"Añade un widget con los últimos 5 commits de mi repo principal en forma de lista."*
-> *"Hazme un widget de nota adhesiva que guarde mi chuleta de guardia."*
-> *"Construye un widget que haga ping a mi router de casa cada 30 segundos y muestre verde/rojo."*
-> *"Necesito un cronómetro. Sorpréndeme con el estilo."*
+- Paneles divididos dentro de una Tab.
+- Renderizado rápido y fluido, con scrollback que se puede buscar.
+- Reconectar significa de verdad *reconectar* — tu sesión remota retoma donde estaba, no «empezar de cero y fingir que la última hora no pasó».
+- Cambiar de Tab **no** mata la Session. Cerrar la Tab sí. Esta distinción fue una guerra de religión interna; ganamos.
 
-Dos tipos:
+### Un asistente de IA que construye tus herramientas
 
-- **Content widgets** — JSON declarativo: markdown, listas clave-valor, checklists, una estadística grande. Seguros por construcción, sin scripts. La mayoría de las peticiones del tipo "solo necesito esto en mi dashboard" aterrizan aquí.
-- **Script widgets** — JavaScript alojado dentro de un sandbox aislado de `iframe srcdoc` con permisos explícitos y declarados (lista de permitidos de `network`, presupuesto de `pollSeconds`). La IA escribe el script, tú apruebas los permisos, el widget corre en una caja que no puede alcanzar el resto de la app.
+La mayoría de las demos de «IA en tu terminal» se quedan en el chat. El asistente de KKTerm también puede construir pequeños widgets de panel duraderos, a la medida de cómo trabajas de verdad — y mantiene lo peligroso detrás de un interruptor:
 
-Cada widget que conservas es tuyo. Persisten en SQLite junto a tus **Connections**, con su propio preset visual (`panel` / `ambient` / `hero`), color de acento, icono y título. Pueden coexistir múltiples instancias del mismo widget con tamaños y estilos totalmente distintos. Elimínalos con un clic derecho cuando la magia se desvanezca.
+- **Decide qué puede tocar** — activa o desactiva familias enteras de herramientas (Dashboard / Connections / Live Sessions).
+- **Decide cómo pregunta** — `Prompt` (por defecto, pregunta cada vez) o `Allow All` (eres adulto, firmaste el descargo).
 
-#### Fondos animados del dashboard (porque nos apetecía)
+Cualquier cosa que parezca un `rm -rf` se marca como peligrosa y espera un sí humano explícito. La IA no puede ejecutar a escondidas un comando destructivo porque alguien se haya pasado de listo con una inyección de prompt en una página de man.
 
-El dashboard tiene veintiuno fondos animados de canvas que puedes elegir por cada **Dashboard View**:
+Habla con OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA o cualquier endpoint compatible con OpenAI. Tus claves de API van al llavero del SO.
+
+### Un panel que no finge ser Grafana
+
+El Dashboard es una cuadrícula de widgets que arrastras y redimensionas. No es para observabilidad a escala de petabytes — es para «quiero un botón que lance mis cinco apps favoritas y un panel que muestre el uptime de mi host SSH, *al lado* de mi chat».
+
+#### Widgets creados por la IA — descríbelo, lo tienes
+
+Esta es la parte que de verdad nos emociona. No eliges de un marketplace ni escribes JavaScript. Le **dices al asistente de IA lo que quieres**, y construye el widget ahí mismo, en tu panel:
+
+> *«Añade un widget que muestre los últimos 5 commits de mi repo principal en una lista.»*
+> *«Hazme un widget de nota adhesiva para mi chuleta de guardia.»*
+> *«Construye un widget que haga ping a mi router de casa cada 30 segundos y muestre verde/rojo.»*
+> *«Necesito un cronómetro. Sorpréndeme con el estilo.»*
+
+Algunos son simples paneles de visualización (markdown, listas de tareas, una cifra grande); otros ejecutan código en vivo en un espacio aislado que tú apruebas. Cada widget que conservas es tuyo — persiste con su propio color, icono y título, y puedes tener varias copias de distintos tamaños. Borra uno con clic derecho cuando se pase la magia.
+
+#### Fondos animados del panel (porque nos apetecía)
+
+Elige un ambiente por vista del panel entre **veinticinco** fondos animados sobre canvas:
 
 | Ambiente | Fondos |
 | --- | --- |
-| Calma | `aurora`, `clouds`, `ocean`, `raindrops`, `snow`, `sakura`, `fireflies`, `bubbles`, `ricefield`, `lanterns` |
+| Calma | `aurora`, `clouds`, `ocean`, `raindrops`, `rainywindow`, `frostedWindow`, `snow`, `sakura`, `fireflies`, `bubbles`, `aquarium`, `ricefield`, `lanterns` |
 | Espacial | `starfield`, `nebula` |
 | Cálido | `embers`, `lava` |
 | Friki | `matrix`, `topo`, `synthwave` |
-| Caótico | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti` |
+| Inquieto | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti`, `particleCursor` |
 
-Corren sobre un único `requestAnimationFrame` compartido y respetan el foco de la ventana, así que consumen prácticamente nada cuando estás en otra parte. Combina `matrix` con tu asistente de IA para conseguir esa vibración de "soy extremadamente productivo/a y puede que también esté en una película de los Wachowski." O elige `ocean` y aparenta ser una persona seria. No juzgamos ninguna de las dos opciones.
+Se pausan cuando estás en otra parte, así que casi no cuestan nada. Combina `matrix` con tu asistente de IA para un ambiente que dice «soy extremadamente productivo y posiblemente estoy en una película de las Wachowski». O elige `ocean` y aparenta ser una persona seria. No juzgamos ninguna de las dos opciones.
 
-### Agentes de codificación IA en un servidor, como es debido
+### Mantén vivos a tus agentes de IA remotos
 
-Esta es la segunda función de la que la gente se enamora. Los terminales SSH de KKTerm pueden lanzarse directamente en una **sesión tmux con nombre** en el host remoto — por defecto, un identificador amigable autogenerado como `kkterm-cockpit001` que sobrevive a las reconexiones:
+Esta es la segunda función de la que la gente se enamora. Los terminales SSH de KKTerm pueden dejarte directamente en una **sesión tmux con nombre** en el host remoto que sobrevive a la reconexión:
 
-- Abre una **Connection** SSH con tmux activado.
-- Dentro del panel, inicia `claude`, `codex`, `gemini-cli`, `cursor-agent` o cualquier agente de codificación de larga ejecución que prefieras. Son apps TUI a pantalla completa; tmux es exactamente donde quieren vivir.
-- Cierra el portátil. Ábrelo de nuevo. El panel se vuelve a conectar silenciosamente a la misma sesión tmux. El agente sigue corriendo, sigue teniendo su historial, sigue en medio de lo que fuera que estaba haciendo.
-- ¿Un corte en el transporte SSH? KKTerm intenta reconectarse silenciosamente al mismo tmux id sin molestarte.
-- ¿Quieres que el asistente de IA vea lo que hace el agente? "Add terminal buffer to context" ejecuta `capture_tmux_pane` por SSH y trae el historial completo de tmux — no solo lo que hay en pantalla, toda la sesión — a la conversación. Tu asistente local ahora puede razonar sobre el trabajo de tu agente remoto.
+- Abre una conexión SSH con tmux activado y arranca `claude`, `codex`, `gemini-cli`, `cursor-agent` o el agente de larga duración que prefieras.
+- Cierra el portátil. Vuélvelo a abrir. El panel se reengancha en silencio — el agente sigue corriendo, conserva su scrollback, en mitad de lo que estuviera haciendo.
+- ¿Un parpadeo de la red? KKTerm se reconecta discretamente a la misma sesión sin molestarte.
+- ¿Quieres que ayude el asistente? «Añadir el búfer del terminal al contexto» mete toda la sesión remota en la conversación, para que tu IA local pueda razonar sobre lo que hace tu agente remoto.
 
-Si alguna vez has perdido seis horas de sesión de `claude` o `codex` por culpa del Wi-Fi de un hotel, esta sola función amortiza la app. La app es gratuita. La función sigue valiendo la pena.
+Si alguna vez perdiste una sesión `claude` o `codex` de seis horas por el inestable wifi de un hotel, esta sola función amortiza la app. (La app es gratis. La función vale la pena igualmente.)
 
 ### Saber cuánta IA te queda
 
-Los agentes de codificación cobran por ventana de plan, no por mes. Claude Code tiene una ventana de 5 horas y una ventana semanal. Codex hace su propia versión. Ambos pueden comerse tu cuota tranquilamente en segundo plano mientras estás en una reunión.
+Los agentes de programación cobran por ventana de plan, no por mes, y se comen encantados tu cuota mientras estás en una reunión. El **medidor de uso de IA** lo mantiene a la vista:
 
-El Widget **Uso de IA para programar** mantiene eso visible:
+- Un widget de panel que muestra **Claude Code** y **Codex** lado a lado: cuenta conectada, plan, consumo de la ventana actual y de esta semana, hora del próximo reinicio.
+- Un **indicador compacto en la barra de estado** que refleja las mismas cifras, para que incluso con el panel cerrado veas de un vistazo si te queda margen antes del próximo gran refactor.
+- Te avisa por adelantado si necesitas volver a iniciar sesión — *antes* de una tarea larga, no a mitad de ella.
 
-- Un Widget de Dashboard que muestra **Claude Code** y **Codex** lado a lado: cuenta conectada, nivel de plan, porcentaje usado en la ventana de 5 horas actual, porcentaje usado esta semana, hora del próximo reset.
-- Un **indicador compacto en la barra de estado** que refleja los mismos números, para que incluso con el Dashboard cerrado puedas ver de un vistazo si todavía tienes margen antes de lanzar el próximo gran refactor.
-- El estado de autenticación se muestra directamente (`connected` / `expired` / `error`) para que descubras *antes* de una tarea larga que necesitas volver a iniciar sesión, no en medio.
-- La política de refresco respeta los rate limits; el Widget hace polling a su propio ritmo en lugar de aporrear las APIs cada vez que lo miras.
+### Deja que otras IA pilotee KKTerm
 
-### Un servidor MCP integrado — deja que otras IAs manejen KKTerm
+KKTerm trae su propio servidor MCP, para que agentes de programación externos (Claude Code, Codex, Copilot, Antigravity, OpenCode) usen tu espacio de trabajo como lo haces tú — listar conexiones, abrir una, leer un búfer de terminal, colocar widgets en el panel. De IA a IA, en tu máquina, sin relé en la nube. Las acciones que modifican, las más arriesgadas, se quedan detrás de un único interruptor de seguridad que está **apagado** por defecto.
 
-Tu terminal también es donde Claude Code, Codex, el modo agente de Copilot, Antigravity y el resto del mundo MCP quieren trabajar. Por eso KKTerm trae su propio **servidor MCP por stdio**, [`kkterm-cli`](docs/MCP.md), que expone una porción curada de la app:
-
-- **Módulo Workspace** (`kkterm.workspace.*`): listar **Connections** guardadas, abrir una Connection por id, listar **Sessions** activas, enviar entrada a un panel de terminal, leer un snapshot del buffer.
-- **Módulo Dashboard** (`kkterm.dashboard.*`): cargar el estado del Dashboard, leer la fuente de un Widget creado por IA, crear / actualizar / eliminar vistas, colocar / mover / eliminar instancias de Widget, aplicar layouts en bloque.
-- **Sub-namespaces peligrosos** (`kkterm.<module>.dangerous.*`): mutar la superficie ejecutable — crear Widgets de script, hacer clic en escritorios remotos, borrar el Dashboard — está protegido tras un único ajuste (`built_in_mcp_allow_all_dangerous`), desactivado por defecto.
-
-`kkterm-cli` es un forwarder ligero. Habla stdio JSON-RPC con tu cliente MCP y se comunica con la ventana de KKTerm en ejecución por un named pipe de Windows autenticado por lanzamiento. Con KKTerm cerrado, `tools/list` sigue funcionando (los clientes pueden introspeccionar la superficie), pero `tools/call` devuelve un error estructurado `app_not_running` en vez de hacer nada.
-
-Conéctalo a tu cliente favorito y tu IA usa KKTerm igual que tú:
-
-```json
-{
-  "mcpServers": {
-    "kkterm": { "command": "<ruta-a-kkterm-cli>", "args": [] }
-  }
-}
-```
-
-Settings → AI Assistant → **Servidor MCP integrado** tiene un diálogo "Mostrar config" de un clic con snippets JSON y TOML pre-rellenados con la ruta del binario resuelta, además de comandos `claude mcp add` / `codex mcp add` copiables.
-
----
-
-## Cómo encaja todo
-
-```mermaid
-flowchart LR
-    User([You]) --> Shell[KKTerm Window<br/>Tauri v2 + React 19]
-    Shell --> Rail[Activity Rail]
-    Rail --> WS[Workspace Module]
-    Rail --> Dash[Dashboard Module]
-    Rail --> Inst[Installer Helper Module]
-    Rail -.-> FE[File Explorer<br/>planned]
-    Rail --> Set[Settings]
-
-    WS --> Tabs[Tabs &amp; Panes]
-    Tabs --> Term[Terminal<br/>ConPTY / russh]
-    Tabs --> SFTP[SFTP / FTP]
-    Tabs --> Web[WebView2 URL]
-    Tabs --> RD[RDP / VNC]
-
-    Shell -.calls.-> Rust[Rust Backend]
-    Rust --> SQLite[(SQLite<br/>Connections)]
-    Rust --> Keychain[(OS Keychain<br/>Secrets)]
-    Rust --> AI[AI Providers<br/>OpenAI-compat]
-
-    AI -. approval gate .-> Tabs
-
-    classDef local fill:#1f6feb,stroke:#1f6feb,color:#fff
-    classDef ai fill:#8a63d2,stroke:#8a63d2,color:#fff
-    class SQLite,Keychain local
-    class AI ai
-```
-
-La forma que importa: los datos duraderos guardados (**Connection**) son distintos del estado en tiempo de ejecución (**Session**), que es distinto del contenedor de interfaz (**Tab**). Cerrar un **Tab** termina la **Session**. Cambiar de **Tab** no. Esta es la regla que mantiene la app en su sano juicio.
-
----
-
-## Mapa de funcionalidades actual
-
-| Área | Implementado hoy |
-| --- | --- |
-| **Connections** | Árbol respaldado por SQLite, carpetas/subcarpetas, búsqueda, orden por arrastrar y soltar, renombrar, duplicar, eliminar, **Quick Connect**, iconos personalizados, accesos directos en el rail como fijados/activos |
-| **Terminal** | Shells locales, SSH, Telnet, Serial, paneles divididos, xterm.js + WebGL oportunista, búsqueda en historial, directorio/script de inicio local |
-| **SSH** | `russh` nativo, auth por agente/clave/contraseña, flujo de confianza de host-key, alternativa opcional al SSH del sistema, ProxyJump, reenvío de puertos, **sesiones tmux con nombre automático (`kkterm-<nombre-scifi><n>`) con reconexión silenciosa ante corte de transporte** — perfecto para agentes de codificación remotos de larga ejecución (Claude Code, Codex, gemini-cli, etc.) |
-| **SFTP / FTP** | SFTP lanzado desde SSH más **Connections** FTP/FTPS, explorador de doble panel, transferencias recursivas, cola/cancelar/limpiar historial, conflictos, propiedades, chmod/chown donde se admita |
-| **URL WebView** | **Sessions** de URL embebidas con WebView2, barra de navegación, captura de favicon, metadatos/relleno de credenciales de sitios web almacenados, metadatos de partición de datos |
-| **Remote Desktop** | RDP mediante ActiveX de Windows con aparcamiento de superposición por geometría; VNC mediante framebuffer `vnc-rs` renderizado en el canvas del espacio de trabajo |
-| **Dashboard** | Vistas duraderas, instancias de widgets, modo de edición, arrastrar/redimensionar, App Launcher, **widgets de contenido/script creados por IA** (JSON declarativo o JS en iframe con permisos), presets / acento / icono / título por widget, **23 fondos animados de canvas** (aurora, clouds, ocean, raindrops, rainywindow, snow, sakura, fireflies, bubbles, ricefield, lanterns, starfield, nebula, embers, lava, matrix, topo, synthwave, cyberpunk, taipei101, thunderstorm, confetti, particleCursor) |
-| **AI Assistant** | Chat en streaming, runtime compatible con OpenAI, registro de proveedores, clasificación de seguridad de propuestas de comandos, capturas de pantalla/contexto adjuntos, **creación de widgets del Dashboard (contenido + script en sandbox)**, **captura de panel tmux** como contexto de conversación para sesiones remotas, herramientas de gestión de **Connection** y herramientas de **Session** en vivo para terminal, RDP/VNC y SFTP/FTP |
-| **Uso de IA para programar** | **Widget del Dashboard + indicador en la barra de estado** que rastrean el uso de cuotas de **Claude Code** y **Codex**: cuenta conectada, nivel de plan, porcentajes de las ventanas de 5 horas y semanal, hora del próximo reset, estado de autenticación (`connected` / `expired` / `error`), política de refresco consciente del rate-limit |
-| **Servidor MCP integrado** | Servidor MCP por stdio (`kkterm-cli`) que expone herramientas curadas de Workspace y Dashboard a agentes de programación externos (Claude Code, Codex, Copilot, Antigravity, OpenCode); bridge de named pipe autenticado; sub-namespaces `dangerous.*` por Módulo protegidos tras un único toggle de seguridad; diálogo de Settings con snippets JSON / TOML de un clic y comandos `claude mcp add` / `codex mcp add` |
-| **Installer Helper** | Módulo del Activity Rail para un catálogo incluido de herramientas de desarrollo de Windows: detectar herramientas instaladas, comparar últimas versiones, instalar/actualizar/desinstalar, excluir herramientas de Update all, transmitir logs de comandos y lanzar apps administradas compatibles |
-| **Settings** | General, Apariencia, Credenciales, IA, SSH, Terminal, fondos de terminal, URL, RDP, VNC, Dashboard, Installer Helper, Acerca de; fuentes de interfaz personalizadas; minimizar a la bandeja; Don't Sleep; copia de seguridad/importar |
-| **Localización** | Interfaz i18next con inglés como fuente y paquetes de idioma dinámicos: zh-TW, zh-CN, ja, ko, fr, de, es, es-MX, it, pt-BR, th, id, vi |
-
-### Proveedores de IA
-
-OpenAI · Anthropic · OpenRouter · DeepSeek · Grok · Azure OpenAI · LiteLLM · GitHub Copilot · Ollama · NVIDIA · cualquier endpoint compatible con OpenAI.
-
-Los metadatos de proveedores viven en [`src/ai/providerRegistry/`](src/ai/providerRegistry/); los adaptadores Rust en [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/). Las claves API pasan por el OS keychain, nunca por SQLite.
-
----
-
-## Inicio rápido
-
-Necesitas:
-
-- **Windows** (plataforma principal admitida)
-- **Node.js + npm**
-- **Cadena de herramientas de Rust**
-- **Prerrequisitos de Tauri v2 para Windows**, incluyendo **WebView2**
-
-```bash
-npm install
-npm run tauri dev
-```
-
-Eso debería producir una ventana nativa real. Si produce un stack trace en su lugar, abre un issue — nos encantan las reproducciones bien documentadas.
-
-### Comprobaciones habituales
-
-```bash
-npm run check                                              # TypeScript
-npm run build                                              # Vite build
-cargo check --manifest-path src-tauri/Cargo.toml           # Rust
-cargo test  --manifest-path src-tauri/Cargo.toml           # Rust tests
-```
-
-### Construir el instalador de Windows
-
-```bash
-npm run package:installer
-```
-
-El script del instalador genera `artifacts/kkterm-<version>-windows-x64-setup.exe` y un archivo `.sha256` correspondiente. Actualmente **no está firmado** — la firma para las versiones está en la hoja de ruta, pero hasta entonces tu antivirus puede mirarte con severidad. Es normal.
+Ajustes → AI Assistant → **Built-in MCP Server** tiene un diálogo «Mostrar configuración» de un clic, ya rellenado, además de comandos `claude mcp add` / `codex mcp add` para copiar.
 
 ---
 
 ## Lo que KKTerm no es
 
-Una lista breve, porque la honestidad genera confianza:
+Una lista corta, porque la honestidad se gana la confianza:
 
-- **No es un producto en la nube.** Sin sincronización, sin cuentas de equipo, sin nivel SaaS. Si alguna vez ves un diálogo de "Inicia sesión en KKTerm", algo ha ido catastróficamente mal.
-- **No pretende ser multiplataforma.** Somos Windows-first a propósito; macOS y Linux están en la hoja de ruta y usarán el mismo shell de Tauri v2. Si necesitas una herramienta Mac-first hoy, tienes cientos de opciones. Nosotros construimos la que los administradores Windows llevan tiempo esperando en silencio.
-- **No es un agente de IA autónomo.** El asistente propone; el humano dispone. `Allow All` es una elección que tú tomas, no un valor predeterminado.
-- **No reemplaza a Grafana / Datadog.** El Dashboard es para superficies de control personales, no para observabilidad de 10.000 hosts.
-- **No es un IDE para Kubernetes.** Es un espacio de trabajo de administración centrado en el terminal. Por favor, no le pidas que renderice un chart de Helm.
+- **No es un producto en la nube.** Sin sincronización, sin cuentas de equipo, sin plan SaaS. Si alguna vez ves un diálogo «Inicia sesión en KKTerm», algo ha salido catastróficamente mal.
+- **No finge ser multiplataforma.** Somos Windows-first a propósito; macOS y Linux están en la hoja de ruta. Si hoy necesitas una herramienta mac-first, tienes cientos de opciones. Estamos construyendo esa que los administradores de Windows llevan esperando en silencio.
+- **No es un agente de IA autónomo.** El asistente propone; el humano dispone. `Allow All` es una elección que haces tú, no un valor por defecto.
+- **No es un sustituto de Grafana / Datadog.** El Dashboard es para superficies de control personales, no para observabilidad de 10.000 hosts.
+- **No es un IDE de Kubernetes.** Es un espacio de administración centrado en el terminal. Por favor, no le pidas que renderice un chart de Helm.
 
-Si alguno de esos puntos era un factor decisivo — sin problema, nos vemos en la v2.
-
----
-
-## Depuración nativa
-
-Usa el runtime real de Tauri para la validación:
-
-```bash
-npm run tauri dev
-```
-
-Una vista previa de Vite en el navegador es útil para algunas inspecciones de frontend, pero **no** aloja un WebView2 real, ConPTY, RDP ActiveX, framebuffer VNC, keychain ni menú nativo. Si una función toca cualquiera de esos, valídala en el runtime de escritorio real.
-
-Usuarios de VS Code: la configuración de lanzamiento `Run KKTerm exe` inicia `src-tauri/target/debug/kkterm.exe` con `RUST_BACKTRACE=1`. La configuración emparejada `Attach KKTerm WebView2` te da DevTools dentro del host WebView2 real.
+Si alguno de esos puntos *era* un factor decisivo — justo, nos vemos en la v2.
 
 ---
 
-## Limitaciones actuales (sí, lo sabemos)
+## Consigue KKTerm
 
-- El instalador actualmente no está firmado. Las comprobaciones de actualización están desactivadas hasta que se configure la firma de versiones.
-- SFTP sobre ProxyJump todavía no está disponible en la ruta SFTP nativa.
-- La reanudación de transferencias de archivos, sincronización/diff de carpetas, compresión/extracción y edición remota están diferidas.
-- La importación de configuración SSH está implementada pero la entrada en Settings para el usuario aún no está expuesta.
-- RDP y VNC están disponibles; la sincronización de portapapeles/dispositivos y los controles de calidad más avanzados siguen evolucionando.
-- Las versiones de macOS y Linux están en la hoja de ruta. Están en camino, y se harán bien — no como un puerto apresurado de "también funcionamos más o menos allí".
-- El asistente de IA propone y puede operar las herramientas habilitadas dentro del límite de permisos configurado — por favor, no lo trates como un robot desatendido. En realidad, no sabe qué quiere tu CEO.
+**[Descarga el último instalador de Windows (.exe)](https://github.com/ryantsai/KKTerm/releases/latest)** y ejecútalo. El instalador está por ahora **sin firmar** — la firma de versiones está en la hoja de ruta, así que hasta entonces tu antivirus puede mirarte con cara seria. Es normal.
+
+¿Quieres compilar desde el código fuente o contribuir? Todo lo que necesitas está en [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ---
 
 ## Hoja de ruta (versión corta)
 
-- Versiones para macOS + Linux
+- Versiones macOS + Linux
 - Instalador firmado + actualización automática
-- SFTP sobre ProxyJump en la ruta nativa
-- Reanudación de transferencias, sincronización de carpetas, compresión/extracción
-- Redirección de portapapeles/dispositivos RDP más completa
-- Más widgets integrados en el **Dashboard** (y un esquema público para los creados por IA)
+- Más potencia en transferencia de archivos (reanudar, sincronización de carpetas, archivar/extraer)
+- Portapapeles y compartición de dispositivos más rica en el Escritorio remoto
+- Más widgets de panel integrados
 
-Versión completa y actualizada frecuentemente: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+Versión completa y actualizada con frecuencia: [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
 ---
 
 ## Contribuir
 
-Agradeceríamos una mano. De verdad. Incluso las cosas pequeñas importan:
+Nos encantaría una mano. De verdad. Hasta las cosas pequeñas importan:
 
-- **Prueba la versión de desarrollo** y abre un issue cuando algo se note raro. "Se notaba raro" es un informe de error legítimo; investigaremos contigo.
-- **Traduce una variante de idioma.** El inglés es la fuente de verdad en [`src/i18n/locales/en.json`](src/i18n/locales/en.json); otros 12 idiomas viven junto a él y se cargan bajo demanda. Las cadenas pendientes se rastrean por clave en [`docs/localization_todo/`](docs/localization_todo/) — elige uno, tradúcelo, borra el archivo.
-- **Añade un widget al Dashboard.** Los widgets integrados viven en [`src/modules/dashboard/widgets/builtin/`](src/modules/dashboard/widgets/builtin/). Elige una idea pequeña, impleméntala, aprende el patrón.
-- **Ajusta la superficie de herramientas de IA.** Los adaptadores de proveedores viven en [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/); el registro del frontend está en [`src/ai/providerRegistry/`](src/ai/providerRegistry/).
-- **Mejora el manual.** La documentación para usuarios finales vive en [`docs/manual/`](docs/manual/). Un capítulo por módulo de interfaz. Si usaste una función y la documentación no te ayudó, un PR que lo corrija vale su peso en oro.
+- **Prueba la build de desarrollo** y abre una issue cuando algo te chirríe. «Me dio mala espina» es un informe de error legítimo; lo investigamos contigo.
+- **Traduce un idioma.** El inglés es la fuente de la verdad; otros trece idiomas viven al lado.
+- **Añade un widget de panel.** Coge una idea pequeña, publícala, aprende el patrón.
+- **Mejora el manual.** Si usaste una función y la documentación no ayudó, una PR que lo arregle vale oro.
 
-La configuración completa, el diseño del proyecto, la lista de verificación de PRs y las reglas de "por favor no rompas esto" viven en [`CONTRIBUTING.md`](CONTRIBUTING.md). Los puntos clave en 30 segundos:
-
-- **Lee [`CONTEXT.md`](CONTEXT.md) antes de renombrar términos visibles para el usuario.** **Connection**, **Session**, **Tab** y **Quick Connect** significan cosas específicas; por favor, no cambies su significado.
-- **Cada cadena visible para el usuario pasa por `t()`.** Nada de texto en inglés expuesto directamente en JSX.
-- **Sin hooks de cierre en el frontend.** Los patrones `onCloseRequested` han roto el cierre de la barra de título de Tauri v2 media docena de veces. Finalmente tenemos una forma que funciona; por favor, no los reintroduzcas.
-- **Ejecuta las comprobaciones** (`npm run check && npm run build && cargo check && cargo test`) antes de abrir un PR.
-
-¿Buscas un punto de entrada? Filtra los issues abiertos por [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) o [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22). Si aún no hay ninguno etiquetado, abre un issue describiendo en qué quieres trabajar y te ayudaremos a definir el alcance.
+La configuración completa, la estructura del proyecto y la lista de comprobación de PR están en [`CONTRIBUTING.md`](CONTRIBUTING.md). ¿Buscas un punto de entrada? Filtra las issues abiertas por [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) o [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
 
 ---
 
-## Documentación del proyecto
+## Documentos del proyecto
 
-- [Contexto del producto](CONTEXT.md) — el vocabulario del dominio que debes respetar
-- [Arquitectura](docs/ARCHITECTURE.md) — mapa de módulos, dónde colocar código nuevo
+- [Contexto de producto](CONTEXT.md) — el lenguaje de dominio que debes respetar
+- [Arquitectura](docs/ARCHITECTURE.md) — mapa de módulos, dónde poner el código nuevo
 - [Hoja de ruta](docs/ROADMAP.md)
 - [Arquitectura del Dashboard](docs/DASHBOARD.md)
 - [Guía de proveedores de IA](docs/AI_PROVIDERS.md)
-- [Notas de rendimiento](docs/PERFORMANCE.md)
-- [Notas de versión y criterios de publicación](docs/RELEASE.md)
-
----
-
-## Stack tecnológico
-
-Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand · xterm.js · SQLite · WebView2 · `russh` · `russh-sftp` · `vnc-rs` · `suppaftp` · OS keychain storage.
 
 ---
 
@@ -466,12 +303,12 @@ Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand ·
   </picture>
 </a>
 
-Si has llegado hasta aquí y todavía no lo has marcado con una estrella — ¿a qué estás esperando, una invitación personal? Considera esto la invitación personal.
+Si has llegado hasta aquí y aún no le has dado una estrella — ¿a qué esperas, a una invitación personal? Considera esto la invitación personal.
 
-⭐ **[Dale una estrella a KKTerm en GitHub](https://github.com/ryantsai/KKTerm)** — cuesta un clic y le alegra la semana al mantenedor. Considéralo un 乖乖 digital sobre el rack.
+⭐ **[Dale una estrella a KKTerm en GitHub](https://github.com/ryantsai/KKTerm)** — cuesta un clic y le alegra la semana entera al mantenedor. Piénsalo como un 乖乖 digital en el rack.
 
 ---
 
 ## Licencia
 
-MIT. Véase [LICENSE](LICENSE). Úsalo, fórcalo, distribúyelo, ponlo en un homelab que nadie más pueda encontrar — ese es el trato.
+MIT. Ver [LICENSE](LICENSE). Úsalo, fórkalo, publícalo, mételo en un homelab que nadie más encuentre — ese es el trato.

--- a/README.fr.md
+++ b/README.fr.md
@@ -5,15 +5,15 @@
 <h1 align="center">KKTerm</h1>
 
 <p align="center">
-  <strong>L'espace de travail d'administration Windows natif que l'ère des outils IA a oublié de construire — terminaux, SSH, SFTP, RDP/VNC, dashboards, et une IA qui construit tes propres Widgets d'outils.</strong>
+  <strong>Une seule fenêtre native Windows pour les terminaux, le SSH, le SFTP, le RDP/VNC et un tableau de bord — plus une IA qui fabrique vos petits outils sur demande.</strong>
 </p>
 
 <p align="center">
-  <em>Parce que ta barre des tâches ne devrait pas ressembler à une machine à sous de Las Vegas.</em>
+  <em>Parce que votre barre des tâches ne devrait pas ressembler à une machine à sous de Las Vegas.</em>
 </p>
 
 <p align="center">
-  <sub>Nommé d'après <strong>乖乖 (Kuāi Kuāi)</strong>, le snack à la noix de coco que les sysadmins taïwanais posent sur leurs serveurs pour qu'ils se tiennent tranquilles. On espère que cette appli mérite sa place dans le rack.</sub>
+  <sub>Nommé d'après <strong>乖乖 (Kuāi Kuāi)</strong>, l'en-cas vert à la noix de coco que les administrateurs taïwanais posent sur leurs serveurs pour qu'ils se tiennent bien. On espère que cette appli gagnera sa place sur le rack.</sub>
 </p>
 
 <p align="center">
@@ -38,9 +38,6 @@
   </a>
   <br />
   <img src="https://img.shields.io/badge/Windows%E2%80%91first-by%20design-0078D6?style=flat-square&logo=windows" alt="Windows-first by design" />
-  <img src="https://img.shields.io/badge/built%20with-Tauri%20v2-FFC131?style=flat-square&logo=tauri" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/Rust-russh-orange?style=flat-square&logo=rust" alt="Rust" />
-  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react" alt="React 19" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
   <br />
   <sub>
@@ -63,56 +60,58 @@
 
 ---
 
-## Le pitch (45 secondes)
+## L'argumentaire en 45 secondes
 
-Tu es sysadmin / DevOps / homelab / vibe-coder. En ce moment, tu as ouvert :
+Vous êtes sysadmin / DevOps / bricoleur de homelab / vibe-codeur. En ce moment, vous avez :
 
 - Un émulateur de terminal
-- Un client SSH séparé (avec une liste de profils qui t'a coûté un week-end entier)
-- Un client SFTP de 2007 qui tourne encore miraculeusement
-- Remote Desktop dans une fenêtre que tu perds constamment sur le mauvais écran
-- Un viewer VNC pour cette unique machine Linux
-- Un onglet de navigateur pour l'interface d'admin du routeur
-- Une session `claude` / `codex` sur un serveur distant qui coupe à chaque fois que ton Wi-Fi éternue
-- Un post-it avec des mots de passe *(t'inquiète, on ne dira rien)*
+- Un client SSH à part (avec une liste de profils qu'il vous a fallu un week-end pour bâtir)
+- Un client SFTP de 2007 qui, on ne sait comment, existe encore
+- Le Bureau à distance dans une fenêtre que vous perdez toujours sur le mauvais écran
+- Une visionneuse VNC pour cette seule machine Linux
+- Un onglet de navigateur pour l'interface admin du routeur
+- Une session `claude` / `codex` sur une machine distante qui tombe dès que votre Wi-Fi éternue
+- Un post-it avec des mots de passe *(t'inquiète, on dira rien)*
 
-**KKTerm, c'est une seule fenêtre pour tout ça.** Natif sur Windows — *volontairement, pendant que tout le reste du monde des outils de dev livre mac-first et traite ton OS comme une note de bas de page* — écrit en Rust + Tauri v2, livré en un seul installateur, et qui refuse de téléphoner à la maison.
+**KKTerm, c'est une seule fenêtre pour tout ça.** Native sous Windows — *volontairement, alors que le reste du monde des outils dev sort d'abord pour mac et traite votre OS comme une note de bas de page* — dans un seul installateur qui refuse de téléphoner à la maison.
 
-Et quelques trucs dont tu ne savais pas encore avoir besoin :
+Plus quelques trucs que vous ne saviez pas vouloir :
 
-- Un **Dashboard** où tu dis à une IA *"crée-moi un Widget qui pingue mon routeur toutes les 30 secondes"* et ça apparaît, sandboxé, sur ta grille.
-- **Des panes SSH qui s'attachent automatiquement à des Sessions tmux nommées** pour que ta session `claude` / `codex` distante survive à chaque caprice Wi-Fi de ton laptop.
-- Un **Widget de consommation d'IA de codage** qui affiche tes quotas Claude Code et Codex — fenêtre 5 heures, fenêtre hebdomadaire, plan en cours, e-mail du compte — sur le **Dashboard** et dans la barre d'état, pour ne plus te prendre le mur du rate-limit à 3 h du mat.
-- Un module **Installer Helper** qui détecte, installe, met à jour, désinstalle et lance un catalogue curaté d'outils de développement Windows — Node, Python, Docker, WSL, CLI de codage IA et les petits utilitaires qu'on finit d'habitude par traquer dans des onglets de navigateur.
-- Un **serveur MCP intégré** (`kkterm-cli`) qui permet aux agents de code externes (Claude Code, Codex, Copilot, Antigravity, OpenCode) de piloter ton Workspace et ton Dashboard — lister les Connections, lire des buffers de terminal, placer des Widgets — via une surface d'outils curatée et soumise à approbation. IA-vers-IA, sur ta machine, sans relais cloud.
-- Vingt et un **fonds animés** (oui, dont `matrix`) pour le Dashboard, parce qu'on n'est pas au-dessus de ça.
+- Un **Dashboard** où vous dites à une IA *« construis-moi un widget qui ping mon routeur toutes les 30 secondes »* et il apparaît, dans son propre bac à sable, sur votre grille.
+- **Des panneaux SSH qui se rattachent à votre session distante `claude` / `codex`** après chaque caprice du Wi-Fi, pour qu'un travail de six heures survive à une coupure.
+- Une **jauge d'utilisation IA** pour ne plus heurter le mur des quotas par surprise à 3 h du matin.
+- Un **Installer Helper** qui trouve, installe, met à jour et lance les outils dev Windows que vous traquez d'habitude à travers dix onglets de navigateur.
+- **Vingt-cinq fonds animés** pour le tableau de bord (oui, dont `matrix`), parce qu'on n'est pas au-dessus de ça.
 
-Oh, et l'assistant IA peut transformer une phrase en petit outil de Dashboard que tu continues vraiment à utiliser.
+Et le meilleur : l'assistant IA peut transformer une seule phrase en un petit outil de tableau de bord que vous gardez vraiment.
 
-> ⭐ **Si ça ressemble à l'appli que tu avais l'intention de construire depuis six ans — étoile le repo pour qu'on sache que quelqu'un regarde. Ça aide vraiment.**
+> ⭐ **Si ça ressemble à l'appli que vous comptiez construire depuis six ans — mettez une étoile au dépôt pour qu'on sache que quelqu'un regarde. Ça aide vraiment.**
+
+Un avis sur la suite ? Rejoignez le fil de retours public :
+**[Que devrait prioriser KKTerm pour les workflows admin Windows-first ?](https://github.com/ryantsai/KKTerm/discussions/141)**
 
 ---
 
 ## Pourquoi « KKTerm » ?
 
-Entre dans n'importe quel data center taïwanais et regarde le haut des racks. Chez TSMC, dans les salles de contrôle du métro de Taipei, dans les salles serveurs de la Cathay Bank, dans les équipements de commutation de Chunghwa Telecom — tu verras un petit sachet vert de 乖乖 (Kuāi Kuāi), un snack au maïs aromatisé à la noix de coco des années 1960.
+Entrez dans n'importe quel data center taïwanais et regardez le haut des racks. Au-delà des fabs de TSMC, des salles de contrôle du métro de Taipei, des salles serveurs de la banque Cathay, des équipements de commutation de Chunghwa Telecom — vous repérerez un petit sachet vert de 乖乖 (Kuāi Kuāi), un en-cas au maïs parfumé à la noix de coco des années 1960.
 
-Le nom signifie littéralement **« sois sage »**, **« tiens-toi bien »**. La tradition IT est simple et absolument sérieuse :
+Le nom signifie littéralement **« sois sage »**, **« tiens-toi bien »**. La tradition informatique est simple et tout à fait sérieuse :
 
-- **Doit être la saveur verte (noix de coco).** Le jaune (curry) ça veut dire *reste chez toi* ; le rouge (pimenté) énerve le serveur. Vert uniquement.
-- **Doit être non périmé.** Un Kuai Kuai périmé se retourne contre toi. Les ingénieurs les changent scrupuleusement.
-- **Doit être visible.** Le serveur doit savoir qu'il est là.
-- **Ne pas le manger.** Ce sachet est en service.
+- **Il doit être vert (noix de coco).** Le jaune (curry) veut dire *reste chez toi aujourd'hui* ; le rouge (épicé) met le serveur en colère. Vert seulement.
+- **Il ne doit pas être périmé.** Un Kuai Kuai éventé joue contre vous. Les ingénieurs les remplacent avec diligence.
+- **Il doit être visible.** Le serveur doit savoir qu'il est là.
+- **Ne le mangez pas.** Ce sachet est en service.
 
-Certains des systèmes les plus grands, les plus ennuyeux, les plus obsédés par l'uptime en Asie tournent avec un sachet de soufflés au maïs collé au châssis. Ça marche parce que ceux qui les maintiennent croient que ça marche, ce qui est une description remarquablement honnête de la culture IT en général.
+Certains des systèmes les plus grands, les plus ennuyeux et les plus obsédés par la disponibilité en Asie tournent avec un sachet de soufflés de maïs scotché au châssis. Ça marche parce que les gens qui les maintiennent croient que ça marche, ce qui est une description remarquablement honnête de la plupart de la culture IT.
 
-**KKTerm** est **Kuai Kuai Term** — un espace de travail d'administration qui aspire au même rôle que le snack : rester tranquillement à côté de tes machines importantes et les aider à bien se comporter. Local-first. Zéro télémétrie. IA soumise à approbation. Le genre de logiciel fiable et sans surprise.
+**KKTerm**, c'est **Kuai Kuai Term** — un espace d'administration qui vise le même rôle que l'en-cas : s'asseoir tranquillement à côté de vos machines importantes et les aider à bien se tenir. Local d'abord. Pas de télémétrie. IA sous validation. Le genre de logiciel ennuyeux et fiable.
 
-On n'a pas encore réussi à livrer un vrai sachet de Kuai Kuai avec l'installateur. C'est prévu pour la v2.
+On n'a pas encore réussi à livrer un vrai sachet de Kuai Kuai avec l'installateur. C'est un point pour la v2.
 
 ---
 
-## Voir ça en action
+## Voir ça bouger
 
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
@@ -124,283 +123,138 @@ On n'a pas encore réussi à livrer un vrai sachet de Kuai Kuai avec l'installat
   </a>
 </p>
 
-<p align="center"><sub><em>(Le GIF de démo vient ici. Une image vaut mille bullet points, et on a épuisé les bullet points.)</em></sub></p>
+<p align="center"><sub><em>(Le GIF de démo va ici. Une image vaut mille puces, et on est à court de puces.)</em></sub></p>
 
 ---
 
-## Pourquoi les gens le gardent ouvert toute la journée
+## Une fenêtre, chaque connexion
 
-### Windows-first, volontairement
-
-Regarde le paysage des outils de dev en 2026. Claude Code : livré mac/linux d'abord, Windows c'est « utilise WSL ». Codex CLI : pareil. `gemini-cli`, la moitié de Homebrew, chaque nouveau TUI qui brille : mac/linux d'abord, les utilisateurs Windows ont droit à un commentaire `# Windows: contributions welcome` dans le README et un script de complétion fish qui ne tourne pas.
-
-Pendant ce temps, les gens qui font vraiment tourner les entreprises — l'IT corporate, les MSPs, ceux qui gèrent Hyper-V ou AD ou SCCM ou IIS ou un contrôleur de domaine plus vieux que certains stagiaires — sont assis devant des machines Windows en se demandant pourquoi chaque nouvel outil traite leur OS comme une nuisance.
-
-**KKTerm prend le parti inverse.** On construit natif Windows en premier, et les portages macOS / Linux suivent. Ça nous permet d'utiliser les API Windows qui comptent vraiment, au lieu de les masquer derrière une couche de portabilité :
-
-- **ConPTY** pour les shells locaux — la vraie pseudo-console Windows, pas un shim de traduction. PowerShell, `cmd.exe`, les distros WSL, tous hébergés comme de vrais PTYs avec focus, redimensionnement et gestion des séquences VT qui correspondent au comportement de la plateforme.
-- **WebView2** pour toute l'UI et les **Connections** URL embarquées — Chromium en cours de processus utilisant le runtime système, ce qui explique en partie pourquoi l'installateur est petit et démarre vite.
-- **Microsoft RDP ActiveX (`mstscax.dll`)** pour RDP — *le vrai, celui que Microsoft livre*. Même contrôle que Remote Desktop Connection (`mstsc.exe`). Pas une réimplémentation tierce, pas FreeRDP dans un wrapper. Les gens qui utilisent RDP verront la différence en cinq secondes.
-- **Windows Credential Manager** pour tous les secrets. Mots de passe SSH, mots de passe FTP, clés API, identifiants de Connection URL — ils vivent dans l'OS keychain et `credwiz.exe` peut les auditer.
-- **Installateur NSIS utilisateur courant** avec un SHA-256 correspondant, menu système natif, assertion d'alimentation Don't-Sleep, échantillonnage CPU/RAM/réseau hôte, menus contextuels Tauri natifs avec de vraies icônes PNG, dialogues Ouvrir/Enregistrer natifs. Aucun de ces éléments n'est simulé.
-- **WSL est un shell de première classe, pas un palliatif.** Lance Ubuntu à côté d'un pane PowerShell à côté d'une session SSH à côté d'un **Tab** RDP dans la même fenêtre.
-
-Les builds macOS et Linux sont sur la feuille de route et recevront le même soin. Mais si tu attendais que quelqu'un construise le *bon* outil d'admin Windows en premier plutôt qu'en dernier — c'est le deal.
-
-### Local-first signifie vraiment local
-
-Tes **Connections** enregistrées vivent dans un fichier SQLite sur ta machine. Les mots de passe vivent dans le **Windows Credential Manager**, pas dans un JSON à côté du binaire. L'appli ne livre pas d'analytics, ne téléphone pas à la maison au démarrage, et n'a pas besoin d'un compte cloud pour se lancer. Il n'y a pas de « se connecter pour synchroniser » parce qu'il n'y a pas de synchronisation.
-
-Si ton câble réseau prend feu, KKTerm s'ouvre quand même.
-
-### Un Workspace, chaque type de connexion
-
-| Tu voulais… | KKTerm a |
+| Ce que vous vouliez… | Ce que fait KKTerm |
 | --- | --- |
-| Ouvrir un shell PowerShell / cmd / WSL local | **Sessions** terminal local sur ConPTY |
-| SSH sur un serveur | `russh` natif avec auth agent / clé / mot de passe, flux de confiance clé hôte, ProxyJump, redirection de port |
-| Parcourir les fichiers de ce serveur | SFTP lancé depuis la **Connection** SSH, double-volet, transferts récursifs, chmod/chown |
-| FTP vers un NAS de 2012 | **Connections** FTP / FTPS dans le même navigateur style SFTP |
-| Telnet vers du matériel ancien | Oui, bon, Telnet est là aussi |
-| Parler à un port série | Type de **Connection** Serial, port COM + baud, pas d'outillage supplémentaire |
-| Contrôle à distance d'une machine Windows | RDP natif via le contrôle ActiveX Microsoft (le vrai, pas un clone) |
-| VNC sur un Pi | Framebuffer Rust `vnc-rs` rendu directement dans le Workspace |
-| Ouvrir l'interface web du routeur | **Connection** URL WebView2 embarquée avec remplissage d'identifiants |
-| Surveiller le CPU de l'hôte | Barre de statut en direct + un module **Dashboard** avec Widgets drag/resize |
+| Ouvrir un shell local PowerShell / cmd / WSL | Des terminaux locaux, côte à côte |
+| SSH vers un serveur | SSH avec clés, agent, mots de passe, hôtes de rebond et redirection de ports |
+| Parcourir les fichiers de ce serveur | SFTP depuis la connexion SSH — double volet, glissez pour transférer |
+| FTP vers un NAS de 2012 | FTP / FTPS dans le même explorateur de fichiers |
+| Telnet vers du matériel antique | Oui, Telnet est là aussi |
+| Parler à un port série | Connexions série — choisissez un port COM et un débit |
+| Prendre la main sur une machine Windows | Le vrai Bureau à distance Microsoft, intégré |
+| VNC vers un Pi | VNC, rendu directement dans l'espace de travail |
+| Ouvrir l'interface web du routeur | Un onglet de navigateur intégré avec identifiants enregistrés |
+| Surveiller le CPU de l'hôte | Une barre d'état en direct et un tableau de bord à bâtir vous-même |
 
-Tout ça, c'est la même appli. Même fenêtre. Mêmes raccourcis clavier. Même thème qui espère ne pas faire saigner les yeux.
+La même appli. La même fenêtre. Les mêmes raccourcis. Le même thème, qu'on espère non agressif pour les yeux.
+
+---
+
+## Pourquoi les gens le laissent ouvert toute la journée
+
+### Windows d'abord, volontairement
+
+Regardez le paysage des outils dev. Claude Code : mac/linux d'abord, Windows c'est « utilise WSL ». Codex CLI : pareil. La moitié des nouveaux outils brillants sortent d'abord pour mac et laissent aux utilisateurs Windows un commentaire `# contributions welcome` et un script d'autocomplétion qui ne tourne pas.
+
+Pendant ce temps, les gens qui gardent vraiment les entreprises en ligne — l'IT d'entreprise, les MSP, ceux qui administrent un contrôleur de domaine plus vieux que certains stagiaires — sont devant des machines Windows à se demander pourquoi chaque nouvel outil traite leur OS comme un désagrément.
+
+**KKTerm fait le pari inverse.** On construit natif Windows d'abord, donc ce qui compte pour les gens de Windows fonctionne, point : le *vrai* Bureau à distance Microsoft (le même que `mstsc.exe`, pas un clone), de vrais shells PowerShell / cmd / WSL, des secrets gardés dans le Gestionnaire d'identification Windows, une vraie icône dans la barre d'état, des menus et boîtes de dialogue natifs. Les builds macOS et Linux sont sur la feuille de route et recevront le même soin. Mais si vous attendiez que quelqu'un construise le *bon* outil d'admin Windows en premier au lieu d'en dernier — c'est le marché.
+
+### Local d'abord, c'est vraiment local
+
+Vos connexions enregistrées vivent dans un fichier sur votre machine. Les mots de passe vivent dans le Gestionnaire d'identification Windows, pas dans un fichier texte à côté de l'appli. KKTerm n'envoie aucune analytique, ne téléphone pas à la maison au démarrage et n'a besoin d'aucun compte cloud pour se lancer. Il n'y a pas de « connectez-vous pour synchroniser » parce qu'il n'y a pas de synchro.
+
+Si votre câble réseau prend feu, KKTerm s'ouvre quand même.
 
 ### Des terminaux qui ne perdent pas la tête
 
-- Panes découpés dans un **Tab**.
-- Rendu xterm.js accéléré WebGL, avec repli gracieux quand ce n'est pas possible.
-- Recherche dans le scrollback.
-- Panes SSH adossés à tmux qui peuvent s'attacher à des Sessions stables par pane, pour que se reconnecter signifie vraiment *se reconnecter*, pas « repartir de zéro et faire semblant que la dernière heure n'a pas existé ».
-- Changer de **Tab** ne tue **pas** la **Session**. Fermer le **Tab** oui. Cette distinction a été une guerre de religion en interne ; on a gagné.
+- Volets divisés dans un Tab.
+- Un rendu rapide et fluide, avec scrollback consultable.
+- Se reconnecter veut vraiment dire *se reconnecter* — votre session distante reprend là où elle en était, pas « on recommence à zéro et on fait comme si la dernière heure n'avait pas eu lieu ».
+- Changer de Tab ne tue **pas** la Session. Fermer le Tab, oui. Cette distinction a été une guerre de religion en interne ; on a gagné.
 
-### Un assistant IA qui construit tes outils
+### Un assistant IA qui fabrique vos outils
 
-La plupart des démos « IA dans ton terminal » s'arrêtent au chat. L'assistant de KKTerm peut aussi construire de petits Widgets de Dashboard durables, adaptés à ta vraie façon de travailler. Il garde quand même les actions dangereuses derrière deux interrupteurs :
+La plupart des démos d'« IA dans le terminal » s'arrêtent au chat. L'assistant de KKTerm peut aussi fabriquer de petits widgets de tableau de bord durables, taillés pour votre façon de travailler — et il garde le dangereux derrière un interrupteur :
 
-- **Familles d'outils** (Dashboard / Connections / Sessions en direct) — à activer ou désactiver par catégorie.
-- **Mode de permission** dans le compositeur — `Prompt` (par défaut, demande à chaque fois) ou `Allow All` (tu es adulte, tu as signé la décharge).
+- **Choisissez ce qu'il peut toucher** — activez/désactivez des familles d'outils entières (Dashboard / Connections / Live Sessions).
+- **Choisissez comment il demande** — `Prompt` (par défaut, demande à chaque fois) ou `Allow All` (vous êtes adulte, vous avez signé la décharge).
 
-Parle à OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA, ou n'importe quoi de compatible OpenAI. Les clés API vont dans l'OS keychain. Les modèles qui proposent `rm -rf` sont classifiés comme dangereux et nécessitent une approbation humaine explicite. L'IA ne peut pas exécuter discrètement une commande destructrice parce que quelqu'un a été malin avec une injection de prompt dans une page de man.
+Tout ce qui ressemble à `rm -rf` est marqué comme dangereux et attend un oui humain explicite. L'IA ne peut pas exécuter discrètement une commande destructrice parce que quelqu'un a glissé une injection de prompt dans une page de man.
 
-### Un Dashboard qui ne prétend pas être Grafana
+Il parle à OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA, ou n'importe quel endpoint compatible OpenAI. Vos clés API vont dans le trousseau de l'OS.
 
-Le module **Dashboard** est une grille drag/resize de 12 colonnes d'instances de Widgets. Ce n'est pas pour l'observabilité à l'échelle du pétaoctet — c'est pour « je veux un bouton pour lancer mes cinq applis préférées et un panneau montrant l'uptime de mon hôte SSH, *à côté* de mon chat ».
+### Un tableau de bord qui ne se prend pas pour Grafana
 
-#### Widgets créés par l'IA — décris-le, obtiens-le
+Le Dashboard est une grille de widgets que l'on glisse et redimensionne. Ce n'est pas pour l'observabilité à l'échelle du pétaoctet — c'est pour « je veux un bouton pour lancer mes cinq applis préférées et un panneau montrant la disponibilité de mon hôte SSH, *à côté* de mon chat ».
 
-C'est la partie qui nous enthousiasme vraiment. Tu ne choisis pas dans un marketplace et tu n'écris pas de JavaScript. Tu **dis à l'assistant IA ce que tu veux**, et il construit le Widget directement sur ton Dashboard :
+#### Widgets créés par l'IA — décrivez-le, obtenez-le
 
-> *« Ajoute un Widget montrant les 5 derniers commits de mon repo principal sous forme de liste. »*
-> *« Fais-moi un Widget post-it pour garder ma fiche de permanence. »*
-> *« Construis un Widget qui pingue mon routeur toutes les 30 secondes et affiche vert/rouge. »*
-> *« J'ai besoin d'un chronomètre. Surprends-moi pour le style. »*
+C'est la partie qui nous emballe vraiment. Vous ne choisissez pas dans un marketplace et vous n'écrivez pas de JavaScript. Vous **dites à l'assistant IA ce que vous voulez**, et il construit le widget là, sur votre tableau de bord :
 
-Deux saveurs :
+> *« Ajoute un widget qui montre les 5 derniers commits de mon repo principal en liste. »*
+> *« Fais-moi un widget pense-bête pour ma fiche d'astreinte. »*
+> *« Construis un widget qui ping mon routeur domestique toutes les 30 secondes et affiche vert/rouge. »*
+> *« Il me faut un chronomètre. Surprends-moi sur le style. »*
 
-- **Content widgets** — JSON déclaratif : markdown, listes kv, checklists, une grande stat. Sûr par construction, pas de script. La plupart des demandes « j'ai juste besoin de ça sur mon Dashboard » atterrissent ici.
-- **Script widgets** — JavaScript hébergé dans un sandbox `iframe srcdoc` isolé avec des permissions explicites et déclarées (liste blanche `network`, budget `pollSeconds`). L'IA écrit le script, tu approuves les permissions, le Widget tourne dans une boîte qui ne peut pas atteindre le reste de l'appli.
+Certains sont de simples panneaux d'affichage (markdown, listes à cocher, un gros chiffre) ; d'autres exécutent du code en direct dans un bac à sable isolé que vous approuvez. Chaque widget que vous gardez est à vous — il persiste avec sa couleur, son icône et son titre, et vous pouvez en avoir plusieurs copies de tailles différentes. Supprimez-en un d'un clic droit quand la magie s'estompe.
 
-Chaque Widget que tu gardes t'appartient. Ils persistent dans SQLite à côté de tes **Connections**, avec leur propre préréglage visuel (`panel` / `ambient` / `hero`), couleur d'accent, icône et titre. Plusieurs instances du même Widget peuvent coexister avec des tailles et des styles totalement différents. Supprime-les d'un clic droit quand la magie se dissipe.
+#### Fonds animés du tableau de bord (parce qu'on en avait envie)
 
-#### Fonds animés pour le Dashboard (parce qu'on en avait envie)
-
-Le Dashboard propose vingt et un fonds animés sur canvas que tu peux choisir par **Dashboard View** :
+Choisissez une ambiance par vue de tableau de bord parmi **vingt-cinq** fonds animés sur canvas :
 
 | Ambiance | Fonds |
 | --- | --- |
-| Calme | `aurora`, `clouds`, `ocean`, `raindrops`, `snow`, `sakura`, `fireflies`, `bubbles`, `ricefield`, `lanterns` |
+| Calme | `aurora`, `clouds`, `ocean`, `raindrops`, `rainywindow`, `frostedWindow`, `snow`, `sakura`, `fireflies`, `bubbles`, `aquarium`, `ricefield`, `lanterns` |
 | Spatial | `starfield`, `nebula` |
-| Chaleureux | `embers`, `lava` |
+| Chaud | `embers`, `lava` |
 | Geek | `matrix`, `topo`, `synthwave` |
-| Erratique | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti` |
+| Agité | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti`, `particleCursor` |
 
-Ils tournent sur un seul `requestAnimationFrame` partagé et respectent le focus de la fenêtre, donc ils ne coûtent pratiquement rien quand tu es ailleurs. Associe `matrix` à ton assistant IA pour une ambiance qui dit « je suis extrêmement productif et peut-être aussi dans un film des Wachowski. » Ou choisis `aurora` et donne l'impression d'être quelqu'un de sérieux. On ne juge ni l'un ni l'autre.
+Ils se mettent en pause quand vous êtes ailleurs, donc ils ne coûtent quasi rien. Associez `matrix` à votre assistant IA pour une ambiance qui dit « je suis extrêmement productif et probablement dans un film des Wachowski ». Ou choisissez `ocean` pour avoir l'air d'une personne sérieuse. On ne juge ni l'un ni l'autre.
 
-### Faire tourner des agents de code IA sur un serveur, comme il faut
+### Garder vos agents IA distants en vie
 
-C'est la deuxième fonctionnalité dont les gens tombent amoureux. Les terminaux SSH de KKTerm peuvent se lancer directement dans une **Session tmux nommée** sur l'hôte distant — par défaut, un identifiant amical auto-généré comme `kkterm-cockpit001` qui survit à la reconnexion :
+C'est la deuxième fonction dont les gens tombent amoureux. Les terminaux SSH de KKTerm peuvent vous déposer directement dans une **session tmux nommée** sur l'hôte distant, qui survit à la reconnexion :
 
-- Ouvre une **Connection** SSH avec tmux activé.
-- Dans le pane, lance `claude`, `codex`, `gemini-cli`, `cursor-agent`, ou n'importe quel agent de code longue durée que tu préfères. Ce sont des applis TUI plein écran ; tmux est exactement là où elles veulent vivre.
-- Ferme le laptop. Rouvre-le. Le pane se réattache silencieusement à la même Session tmux. L'agent tourne encore, a toujours son scrollback, est toujours en train de faire ce qu'il faisait.
-- Une coupure réseau sur le transport SSH ? KKTerm tente une réattache silencieuse bornée au même tmux id sans t'embêter.
-- Tu veux que l'assistant IA voie ce que fait l'agent ? « Ajouter le buffer terminal au contexte » appelle `capture_tmux_pane` via SSH et tire le scrollback tmux complet — pas juste ce qui est à l'écran, toute la Session — dans la conversation. Ton assistant local peut maintenant raisonner sur le travail de ton agent distant.
+- Ouvrez une connexion SSH avec tmux activé et lancez `claude`, `codex`, `gemini-cli`, `cursor-agent`, ou tout agent au long cours que vous préférez.
+- Fermez le portable. Rouvrez-le. Le panneau se rattache en silence — l'agent tourne encore, garde son scrollback, en plein milieu de ce qu'il faisait.
+- Une coupure réseau ? KKTerm se reconnecte discrètement à la même session sans vous embêter.
+- Besoin de l'aide de l'assistant ? « Ajouter le tampon du terminal au contexte » aspire toute la session distante dans la conversation, pour que votre IA locale raisonne sur ce que fait votre agent distant.
 
-Si tu as déjà perdu une session `claude` ou `codex` de six heures à cause d'un Wi-Fi d'hôtel défaillant, cette seule fonctionnalité justifie l'appli. L'appli est gratuite. La fonctionnalité en vaut quand même la peine.
+Si vous avez déjà perdu une session `claude` ou `codex` de six heures à cause du Wi-Fi capricieux d'un hôtel, cette seule fonction rentabilise l'appli. (L'appli est gratuite. La fonction en vaut quand même la peine.)
 
-### Savoir combien d'IA il te reste
+### Savoir combien d'IA il vous reste
 
-Les agents de code facturent par fenêtre de plan, pas par mois. Claude Code a une fenêtre de 5 heures et une fenêtre hebdomadaire. Codex fait sa propre version. Tous deux peuvent dévorer ton quota en arrière-plan pendant que tu es en réunion.
+Les agents de code facturent à la fenêtre de forfait, pas au mois, et ils dévorent volontiers votre quota pendant que vous êtes en réunion. La **jauge d'utilisation IA** garde ça visible :
 
-Le Widget **Consommation d'IA de codage** garde ça visible :
+- Un widget de tableau de bord montrant **Claude Code** et **Codex** côte à côte : compte connecté, forfait, consommation de la fenêtre actuelle et de la semaine, heure de la prochaine réinitialisation.
+- Un **indicateur compact dans la barre d'état** qui reflète les mêmes chiffres, pour que même tableau de bord fermé, vous voyiez d'un coup d'œil s'il vous reste de la marge avant le prochain gros refactoring.
+- Il vous prévient en amont s'il faut vous reconnecter — *avant* une longue tâche, pas en plein milieu.
 
-- Un Widget de Dashboard montrant **Claude Code** et **Codex** côte-à-côte : compte connecté, niveau du plan, pourcentage utilisé dans la fenêtre 5 heures en cours, pourcentage utilisé cette semaine, prochaine heure de reset.
-- Un **indicateur compact dans la barre d'état** qui reprend les mêmes chiffres, pour que même Dashboard fermé tu voies d'un coup d'œil s'il reste de la marge avant le prochain gros refactor.
-- L'état d'authentification est affiché directement (`connected` / `expired` / `error`) pour que tu apprennes *avant* une tâche longue qu'il faut te reconnecter, pas en plein milieu.
-- La politique de rafraîchissement respecte les rate limits ; le Widget poll à son rythme au lieu de marteler les APIs en amont chaque fois que tu le regardes.
+### Laisser d'autres IA piloter KKTerm
 
-### Un serveur MCP intégré — laisse d'autres IA piloter KKTerm
+KKTerm embarque son propre serveur MCP, pour que des agents de code externes (Claude Code, Codex, Copilot, Antigravity, OpenCode) utilisent votre espace de travail comme vous le faites — lister les connexions, en ouvrir une, lire un tampon de terminal, placer des widgets sur le tableau de bord. D'IA à IA, sur votre machine, sans relais cloud. Les actions qui modifient, plus risquées, restent derrière un unique interrupteur de sécurité **désactivé** par défaut.
 
-Ton terminal est aussi l'endroit où Claude Code, Codex, le mode agent de Copilot, Antigravity et le reste du monde MCP veulent travailler. Alors KKTerm livre son propre **serveur MCP stdio**, [`kkterm-cli`](docs/MCP.md), qui expose une tranche curatée de l'appli :
-
-- **Module Workspace** (`kkterm.workspace.*`) : lister les **Connections** sauvegardées, ouvrir une Connection par id, lister les **Sessions** en cours, envoyer du texte à un pane de terminal, lire un snapshot du buffer.
-- **Module Dashboard** (`kkterm.dashboard.*`) : charger l'état du Dashboard, lire la source d'un Widget créé par IA, créer / modifier / supprimer des vues, placer / déplacer / supprimer des instances de Widget, appliquer des layouts en bloc.
-- **Sous-espaces dangereux** (`kkterm.<module>.dangerous.*`) : muter la surface exécutable — créer des Widgets scriptés, cliquer dans des bureaux distants, vider le Dashboard — est verrouillé derrière un unique réglage (`built_in_mcp_allow_all_dangerous`), désactivé par défaut.
-
-`kkterm-cli` est un mince transitaire. Il parle stdio JSON-RPC à ton client MCP et communique avec la fenêtre KKTerm en cours via un named pipe Windows authentifié par lancement. Quand KKTerm est fermé, `tools/list` fonctionne toujours (les clients peuvent introspecter la surface), mais `tools/call` renvoie une erreur structurée `app_not_running` au lieu d'agir.
-
-Branche-le à ton client préféré et ton IA utilise KKTerm comme toi :
-
-```json
-{
-  "mcpServers": {
-    "kkterm": { "command": "<chemin-vers-kkterm-cli>", "args": [] }
-  }
-}
-```
-
-Settings → AI Assistant → **Built-in MCP Server** propose un dialogue « Show config » d'un clic avec des snippets JSON et TOML pré-remplis avec le chemin du binaire résolu, plus des commandes `claude mcp add` / `codex mcp add` copiables.
-
----
-
-## Comment tout s'articule
-
-```mermaid
-flowchart LR
-    User([You]) --> Shell[KKTerm Window<br/>Tauri v2 + React 19]
-    Shell --> Rail[Activity Rail]
-    Rail --> WS[Workspace Module]
-    Rail --> Dash[Dashboard Module]
-    Rail --> Inst[Installer Helper Module]
-    Rail -.-> FE[File Explorer<br/>planned]
-    Rail --> Set[Settings]
-
-    WS --> Tabs[Tabs &amp; Panes]
-    Tabs --> Term[Terminal<br/>ConPTY / russh]
-    Tabs --> SFTP[SFTP / FTP]
-    Tabs --> Web[WebView2 URL]
-    Tabs --> RD[RDP / VNC]
-
-    Shell -.calls.-> Rust[Rust Backend]
-    Rust --> SQLite[(SQLite<br/>Connections)]
-    Rust --> Keychain[(OS Keychain<br/>Secrets)]
-    Rust --> AI[AI Providers<br/>OpenAI-compat]
-
-    AI -. approval gate .-> Tabs
-
-    classDef local fill:#1f6feb,stroke:#1f6feb,color:#fff
-    classDef ai fill:#8a63d2,stroke:#8a63d2,color:#fff
-    class SQLite,Keychain local
-    class AI ai
-```
-
-La forme qui compte : les données sauvegardées durables (**Connection**) sont séparées de l'état d'exécution en direct (**Session**), qui est séparé du conteneur UI (**Tab**). Fermer un **Tab** termine la **Session**. Changer de **Tab** non. C'est la règle qui garde l'appli saine d'esprit.
-
----
-
-## Carte des fonctionnalités actuelles
-
-| Domaine | Implémenté aujourd'hui |
-| --- | --- |
-| **Connections** | Arbre sur SQLite, dossiers/sous-dossiers, recherche, ordre drag/drop, renommer, dupliquer, supprimer, **Quick Connect**, icônes personnalisées, raccourcis rail épinglés/actifs |
-| **Terminal** | Shells locaux, SSH, Telnet, Serial, panes découpés, xterm.js + WebGL opportuniste, recherche scrollback, répertoire/script de démarrage local |
-| **SSH** | `russh` natif, auth agent/clé/mot de passe, flux de confiance clé hôte, fallback SSH système optionnel, ProxyJump, redirection de port, **Sessions tmux auto-nommées (`kkterm-<scifi-name><n>`) avec réattache silencieuse sur coupure transport** — parfait pour les agents de code distants longue durée (Claude Code, Codex, gemini-cli, etc.) |
-| **SFTP / FTP** | SFTP lancé via SSH plus **Connections** FTP/FTPS, navigateur double-volet, transferts récursifs, file d'attente/annulation/historique effaçable, conflits, propriétés, chmod/chown où supporté |
-| **URL WebView** | **Sessions** URL WebView2 embarquées, barre de navigation, capture favicon, métadonnées/remplissage d'identifiants de sites web stockés, métadonnées de partition de données |
-| **Remote Desktop** | RDP via Windows ActiveX avec parking d'overlay délimité géométriquement ; VNC via framebuffer `vnc-rs` rendu sur le canvas du Workspace |
-| **Dashboard** | Vues durables, instances de Widgets, mode édition, drag/resize, App Launcher, **Widgets contenu/script créés par IA** (JSON déclaratif ou iframe JS sandboxé avec permissions), préréglages / accent / icône / titre par Widget, **23 fonds animés sur canvas** (aurora, clouds, ocean, raindrops, rainywindow, snow, sakura, fireflies, bubbles, ricefield, lanterns, starfield, nebula, embers, lava, matrix, topo, synthwave, cyberpunk, taipei101, thunderstorm, confetti, particleCursor) |
-| **AI Assistant** | Chat en streaming, runtime compatible OpenAI, registre de fournisseurs, classification de sécurité des propositions de commandes, captures d'écran/pièces jointes contextuelles, **création de Widgets Dashboard (contenu + script sandboxé)**, **capture de pane tmux** comme contexte de conversation pour les Sessions distantes, outils de gestion des **Connections**, et outils de **Session** en direct pour terminal, RDP/VNC, et SFTP/FTP |
-| **Consommation d'IA de codage** | **Widget Dashboard + indicateur dans la barre d'état** suivant la consommation des quotas **Claude Code** et **Codex** : compte connecté, niveau du plan, pourcentages des fenêtres 5 heures et hebdomadaire, prochaine heure de reset, état d'auth (`connected` / `expired` / `error`), politique de rafraîchissement respectueuse des rate limits |
-| **Serveur MCP intégré** | Serveur MCP stdio (`kkterm-cli`) exposant des outils Workspace et Dashboard curatés aux agents de code externes (Claude Code, Codex, Copilot, Antigravity, OpenCode) ; bridge named pipe authentifié ; sous-espaces `dangerous.*` par Module verrouillés derrière un unique toggle de sécurité ; dialogue Settings avec snippets JSON / TOML en un clic et commandes `claude mcp add` / `codex mcp add` |
-| **Installer Helper** | Module Activity Rail pour un catalogue d'outils de développement Windows embarqué : détecter les outils installés, comparer les dernières versions, installer/mettre à jour/désinstaller, exclure des outils de Update all, diffuser les logs de commande et lancer les applis gérées prises en charge |
-| **Settings** | Général, Apparence, Identifiants, IA, SSH, Terminal, fonds de terminal, URL, RDP, VNC, Dashboard, Installer Helper, À propos ; polices UI personnalisées ; minimiser dans la barre système ; Don't Sleep ; sauvegarde/import |
-| **Localisation** | UI i18next avec source anglaise et bundles de locale dynamiques : zh-TW, zh-CN, ja, ko, fr, de, es, es-MX, it, pt-BR, th, id, vi |
-
-### Fournisseurs IA
-
-OpenAI · Anthropic · OpenRouter · DeepSeek · Grok · Azure OpenAI · LiteLLM · GitHub Copilot · Ollama · NVIDIA · n'importe quel endpoint compatible OpenAI.
-
-Les métadonnées des fournisseurs vivent dans [`src/ai/providerRegistry/`](src/ai/providerRegistry/) ; les adaptateurs Rust dans [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/). Les clés API passent par l'OS keychain, jamais SQLite.
-
----
-
-## Démarrage rapide
-
-Tu as besoin de :
-
-- **Windows** (plateforme principale supportée)
-- **Node.js + npm**
-- **Chaîne d'outils Rust**
-- **Prérequis Tauri v2 pour Windows** dont **WebView2**
-
-```bash
-npm install
-npm run tauri dev
-```
-
-Ça devrait produire une vraie fenêtre native. Si ça produit une stack trace à la place, ouvre un ticket — on adore un bon repro.
-
-### Vérifications courantes
-
-```bash
-npm run check                                              # TypeScript
-npm run build                                              # Vite build
-cargo check --manifest-path src-tauri/Cargo.toml           # Rust
-cargo test  --manifest-path src-tauri/Cargo.toml           # Rust tests
-```
-
-### Construire l'installateur Windows
-
-```bash
-npm run package:installer
-```
-
-Le script d'installation écrit `artifacts/kkterm-<version>-windows-x64-setup.exe` et un fichier `.sha256` correspondant. Il est actuellement **non signé** — la signature de version est sur la feuille de route, mais d'ici là ton antivirus risque de te regarder sévèrement. C'est normal.
+Réglages → AI Assistant → **Built-in MCP Server** propose une boîte « Afficher la config » en un clic, déjà remplie, plus des commandes `claude mcp add` / `codex mcp add` à copier.
 
 ---
 
 ## Ce que KKTerm n'est pas
 
-Une courte liste, parce que l'honnêteté mérite la confiance :
+Une courte liste, parce que l'honnêteté inspire confiance :
 
-- **Pas un produit cloud.** Pas de sync, pas de comptes d'équipe, pas de tier SaaS. Si tu vois un jour un dialogue « Se connecter à KKTerm », quelque chose a catastrophiquement mal tourné.
-- **Pas en train de prétendre être multiplateforme.** On est Windows-first volontairement ; macOS et Linux sont sur la feuille de route et utiliseront le même shell Tauri v2. Si tu as besoin d'un outil mac-first aujourd'hui, tu as des centaines d'options. On construit celui que les admins Windows attendaient silencieusement.
-- **Pas un agent IA autonome.** L'assistant propose ; l'humain dispose. `Allow All` est un choix que tu fais, pas une valeur par défaut.
-- **Pas un remplaçant Grafana / Datadog.** Le Dashboard est pour les surfaces de contrôle personnelles, pas pour l'observabilité à 10 000 hôtes.
-- **Pas un IDE Kubernetes.** C'est un espace de travail d'admin terminal-first. Ne lui demande pas de rendre un chart Helm.
+- **Pas un produit cloud.** Pas de synchro, pas de comptes d'équipe, pas d'offre SaaS. Si vous voyez un jour une boîte « Se connecter à KKTerm », c'est qu'un truc a catastrophiquement mal tourné.
+- **Pas un faux multiplateforme.** On est Windows-first volontairement ; macOS et Linux sont sur la feuille de route. S'il vous faut un outil mac-first aujourd'hui, vous avez des centaines d'options. On construit celui que les admins Windows attendaient en silence.
+- **Pas un agent IA autonome.** L'assistant propose ; l'humain dispose. `Allow All` est un choix que vous faites, pas un défaut.
+- **Pas un remplaçant de Grafana / Datadog.** Le Dashboard est pour des surfaces de contrôle personnelles, pas pour l'observabilité de 10 000 hôtes.
+- **Pas un IDE Kubernetes.** C'est un espace d'administration centré terminal. Ne lui demandez pas de rendre un chart Helm.
 
-Si l'un de ces points était rédhibitoire — c'est honnête, on se revoit en v2.
-
----
-
-## Débogage natif
-
-Utilise le vrai runtime Tauri pour la validation :
-
-```bash
-npm run tauri dev
-```
-
-Un aperçu navigateur Vite est utile pour certaines inspections frontend, mais il n'héberge **pas** un vrai WebView2, ConPTY, RDP ActiveX, framebuffer VNC, keychain, ou surface de menu natif. Si une fonctionnalité touche à l'un de ceux-là, valide-la dans le vrai runtime desktop.
-
-Utilisateurs VS Code : la configuration de lancement `Run KKTerm exe` démarre `src-tauri/target/debug/kkterm.exe` avec `RUST_BACKTRACE=1`. La configuration `Attach KKTerm WebView2` associée te donne les DevTools dans le vrai hôte WebView2.
+Si l'un de ces points *était* rédhibitoire — très bien, on se voit en v2.
 
 ---
 
-## Limites actuelles (oui, on sait)
+## Obtenir KKTerm
 
-- L'installateur est actuellement non signé. Les vérifications de mise à jour sont désactivées jusqu'à la configuration de la signature de version.
-- SFTP via ProxyJump n'est pas encore supporté dans le chemin SFTP natif.
-- La reprise de transfert de fichiers, la synchronisation/diff de dossiers, l'archive/extraction, et l'édition distante sont reportées.
-- L'import de config SSH est implémenté mais l'entrée côté utilisateur dans les Settings n'est pas encore exposée.
-- RDP et VNC sont livrés ; la synchronisation plus riche du presse-papiers/périphériques et les contrôles de qualité évoluent encore.
-- Les builds macOS et Linux sont sur la feuille de route. Ils arrivent, et ce sera fait correctement — pas expédié comme un portage « on tourne vaguement là-bas aussi ».
-- L'assistant IA propose et peut utiliser les outils activés dans la limite de permission configurée — ne le traite pas comme un robot sans surveillance. Il ne sait pas, en fait, ce que ton PDG veut.
+**[Téléchargez le dernier installateur Windows (.exe)](https://github.com/ryantsai/KKTerm/releases/latest)** et lancez-le. L'installateur est pour l'instant **non signé** — la signature de version est sur la feuille de route, donc d'ici là votre antivirus pourrait vous jeter un regard sévère. C'est normal.
+
+Envie de compiler depuis les sources ou de contribuer ? Tout ce qu'il vous faut est dans [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ---
 
@@ -408,10 +262,9 @@ Utilisateurs VS Code : la configuration de lancement `Run KKTerm exe` démarre `
 
 - Builds macOS + Linux
 - Installateur signé + mise à jour automatique
-- SFTP via ProxyJump dans le chemin natif
-- Reprise de transfert de fichiers, synchronisation de dossiers, archive/extraction
-- Redirection plus riche du presse-papiers/périphériques RDP
-- Plus de Widgets **Dashboard** intégrés (et un schéma public pour ceux créés par IA)
+- Transferts de fichiers plus puissants (reprise, synchro de dossiers, archive/extraction)
+- Partage presse-papiers et périphériques plus riche pour le Bureau à distance
+- Plus de widgets de tableau de bord intégrés
 
 Version complète et fréquemment mise à jour : [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
@@ -419,40 +272,24 @@ Version complète et fréquemment mise à jour : [`docs/ROADMAP.md`](docs/ROADMA
 
 ## Contribuer
 
-On aimerait bien un coup de main. Vraiment. Même les petites choses comptent :
+On adorerait un coup de main. Vraiment. Même les petites choses comptent :
 
-- **Essaie le build de dev** et ouvre un ticket quand quelque chose paraît bizarre. « Ça paraissait bizarre » est un rapport de bug légitime ; on creusera avec toi.
-- **Traduis une locale.** L'anglais est la source de vérité dans [`src/i18n/locales/en.json`](src/i18n/locales/en.json) ; 12 autres locales vivent à côté et se chargent à la demande. Les chaînes en attente sont suivies par clé dans [`docs/localization_todo/`](docs/localization_todo/) — prends-en une, traduis-la, supprime le fichier.
-- **Ajoute un Widget Dashboard.** Les Widgets intégrés vivent dans [`src/modules/dashboard/widgets/builtin/`](src/modules/dashboard/widgets/builtin/). Prends une petite idée, livre-la, apprends le pattern.
-- **Resserre la surface des outils IA.** Les adaptateurs de fournisseurs vivent dans [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/) ; le registre frontend est dans [`src/ai/providerRegistry/`](src/ai/providerRegistry/).
-- **Améliore le manuel.** La doc utilisateur final vit dans [`docs/manual/`](docs/manual/). Un chapitre par module UI. Si tu as utilisé une fonctionnalité et que la doc n'a pas aidé, une PR qui corrige ça, c'est de l'or.
+- **Essayez le build dev** et ouvrez une issue quand quelque chose cloche. « Ça paraissait bizarre » est un rapport de bug légitime ; on creusera avec vous.
+- **Traduisez une langue.** L'anglais est la source de vérité ; treize autres langues vivent à côté.
+- **Ajoutez un widget de tableau de bord.** Prenez une petite idée, livrez-la, apprenez le motif.
+- **Améliorez le manuel.** Si vous avez utilisé une fonction et que la doc n'a pas aidé, une PR qui corrige ça vaut de l'or.
 
-La configuration complète, la structure du projet, la checklist PR, et la liste des règles « ne cassez pas ça svp » vivent dans [`CONTRIBUTING.md`](CONTRIBUTING.md). Les points essentiels en 30 secondes :
-
-- **Lis [`CONTEXT.md`](CONTEXT.md) avant de renommer des termes visibles par l'utilisateur.** **Connection**, **Session**, **Tab**, et **Quick Connect** ont des significations précises ; ne les dévie pas.
-- **Toute chaîne visible par l'utilisateur passe par `t()`.** Pas de texte anglais nu dans JSX.
-- **Pas de hooks de fermeture frontend.** Le bouton de fermeture de la barre de titre Tauri v2 a été cassé par les patterns `onCloseRequested` une bonne demi-douzaine de fois. On a enfin une forme qui marche ; ne les réintroduis pas.
-- **Lance les vérifications** (`npm run check && npm run build && cargo check && cargo test`) avant d'ouvrir une PR.
-
-Tu cherches un point d'entrée ? Filtre les tickets ouverts par [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) ou [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22). S'il n'y en a pas encore de tagués, ouvre un ticket décrivant ce sur quoi tu aimerais travailler et on t'aidera à le délimiter.
+L'installation complète, la structure du projet et la checklist de PR sont dans [`CONTRIBUTING.md`](CONTRIBUTING.md). Vous cherchez un point d'entrée ? Filtrez les issues ouvertes par [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) ou [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
 
 ---
 
-## Documentation du projet
+## Docs du projet
 
-- [Contexte produit](CONTEXT.md) — le langage du domaine que tu dois respecter
+- [Contexte produit](CONTEXT.md) — le langage métier à respecter
 - [Architecture](docs/ARCHITECTURE.md) — carte des modules, où mettre le nouveau code
 - [Feuille de route](docs/ROADMAP.md)
-- [Architecture Dashboard](docs/DASHBOARD.md)
+- [Architecture du Dashboard](docs/DASHBOARD.md)
 - [Guide des fournisseurs IA](docs/AI_PROVIDERS.md)
-- [Notes de performance](docs/PERFORMANCE.md)
-- [Notes de version et critères](docs/RELEASE.md)
-
----
-
-## Stack
-
-Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand · xterm.js · SQLite · WebView2 · `russh` · `russh-sftp` · `vnc-rs` · `suppaftp` · stockage OS keychain.
 
 ---
 
@@ -466,12 +303,12 @@ Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand ·
   </picture>
 </a>
 
-Tu es arrivé jusqu'ici et tu n'as pas encore mis une étoile — qu'est-ce que tu attends, une invitation personnelle ? Considère ça comme l'invitation personnelle.
+Si vous êtes arrivé jusqu'ici sans mettre d'étoile — qu'attendez-vous, une invitation personnelle ? Considérez ceci comme l'invitation personnelle.
 
-⭐ **[Étoile KKTerm sur GitHub](https://github.com/ryantsai/KKTerm)** — ça coûte un clic et ça fait la semaine du mainteneur. Pense-y comme un 乖乖 numérique sur le rack.
+⭐ **[Mettez une étoile à KKTerm sur GitHub](https://github.com/ryantsai/KKTerm)** — ça coûte un clic et ça illumine toute la semaine du mainteneur. Voyez-le comme un 乖乖 numérique sur le rack.
 
 ---
 
 ## Licence
 
-MIT. Voir [LICENSE](LICENSE). Utilise-le, fork-le, livre-le, mets-le dans un homelab que personne d'autre ne peut trouver — c'est le deal.
+MIT. Voir [LICENSE](LICENSE). Utilisez-le, forkez-le, livrez-le, mettez-le dans un homelab que personne d'autre ne trouvera — c'est le marché.

--- a/README.id.md
+++ b/README.id.md
@@ -5,15 +5,15 @@
 <h1 align="center">KKTerm</h1>
 
 <p align="center">
-  <strong>Workspace admin Windows native yang lupa dibangun oleh era AI-tools — terminal, SSH, SFTP, RDP/VNC, dashboard, dan AI yang membangun widget tool milikmu sendiri.</strong>
+  <strong>Satu jendela Windows native untuk terminal, SSH, SFTP, RDP/VNC, dan dashboard — plus AI yang membuatkan alat-alat kecilmu sendiri sesuai permintaan.</strong>
 </p>
 
 <p align="center">
-  <em>Karena taskbar kamu tidak seharusnya terlihat seperti mesin slot Vegas.</em>
+  <em>Karena taskbar-mu tidak seharusnya terlihat seperti mesin slot Las Vegas.</em>
 </p>
 
 <p align="center">
-  <sub>Dinamai dari <strong>乖乖 (Kuāi Kuāi)</strong>, camilan kelapa hijau yang ditaruh sysadmin Taiwan di atas server supaya perangkat mereka tetap nurut. Semoga app ini layak menempati raknya.</sub>
+  <sub>Dinamai dari <strong>乖乖 (Kuāi Kuāi)</strong>, camilan jagung hijau rasa kelapa yang ditaruh para sysadmin Taiwan di atas server agar berperilaku baik. Semoga aplikasi ini juga mendapat tempatnya di rak.</sub>
 </p>
 
 <p align="center">
@@ -38,9 +38,6 @@
   </a>
   <br />
   <img src="https://img.shields.io/badge/Windows%E2%80%91first-by%20design-0078D6?style=flat-square&logo=windows" alt="Windows-first by design" />
-  <img src="https://img.shields.io/badge/built%20with-Tauri%20v2-FFC131?style=flat-square&logo=tauri" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/Rust-russh-orange?style=flat-square&logo=rust" alt="Rust" />
-  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react" alt="React 19" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
   <br />
   <sub>
@@ -63,66 +60,58 @@
 
 ---
 
-## Pitch-nya (45 detik)
+## Pitch dalam 45 detik
 
-Kamu seorang sysadmin / DevOps / homelab / vibe-coder. Sekarang kamu punya:
+Kamu seorang sysadmin / DevOps / penggemar homelab / vibe-coder. Saat ini kamu punya:
 
-- Satu terminal emulator
-- SSH client terpisah (dengan daftar profil yang butuh satu weekend buat dibangun)
-- SFTP client dari tahun 2007 yang entah kenapa masih terus dipakai
-- Remote Desktop di jendela yang selalu nyasar ke monitor yang salah
-- VNC viewer buat satu kotak Linux itu
-- Tab browser untuk admin UI router
-- Sesi `claude` / `codex` yang jalan di dev box remote dan putus setiap kali Wi-Fi bersin
-- Sticky note berisi password *(tenang, kita tidak akan bilang siapa-siapa)*
+- Sebuah emulator terminal
+- Klien SSH terpisah (dengan daftar profil yang butuh satu akhir pekan untuk dirakit)
+- Klien SFTP dari 2007 yang entah bagaimana masih ada
+- Remote Desktop di jendela yang selalu kamu kehilangan di monitor yang salah
+- Sebuah viewer VNC hanya demi satu mesin Linux itu
+- Satu tab browser untuk halaman admin router
+- Sebuah sesi `claude` / `codex` di mesin remote yang putus setiap kali Wi-Fi bersin
+- Secarik sticky note berisi kata sandi *(tenang, kami tak akan bilang)*
 
-**KKTerm adalah satu jendela untuk semua itu.** Native di Windows — *memang sengaja, sementara semua tools developer lain rilis untuk Mac duluan dan memperlakukan OS kamu seperti catatan kaki* — ditulis dengan Rust + Tauri v2, tersedia sebagai satu installer, dan tidak pernah lapor ke mana-mana.
+**KKTerm adalah satu jendela untuk semua itu.** Native di Windows — *sengaja, sementara dunia dev tools lainnya merilis mac dulu dan memperlakukan OS-mu seperti catatan kaki* — dalam satu installer yang menolak menelepon pulang.
 
-Plus beberapa hal yang belum kamu tahu kamu inginkan:
+Ditambah beberapa hal yang kamu tak tahu kamu inginkan:
 
-- Sebuah **Dashboard** tempat kamu bilang ke AI *"buatkan widget yang ping router saya setiap 30 detik"* dan langsung muncul, tersandbox, di gridmu.
-- **SSH pane yang otomatis attach ke sesi tmux bernama** supaya sesi remote `claude` / `codex` kamu bertahan dari setiap tantrum Wi-Fi yang dilempar laptopmu.
-- Sebuah **widget penggunaan AI Coding** yang menampilkan kuota Claude Code dan Codex kamu — jendela 5 jam, jendela mingguan, plan saat ini, email akun — di **Dashboard** dan di status bar, supaya kamu berhenti kaget kena tembok rate-limit jam 3 pagi.
-- Sebuah Module **Installer Helper** yang mendeteksi, memasang, memperbarui, menghapus, dan menjalankan katalog tool developer Windows yang dikurasi — Node, Python, Docker, WSL, CLI coding AI, dan utilitas kecil yang biasanya kamu buru lewat banyak tab browser.
-- Sebuah **server MCP built-in** (`kkterm-cli`) yang memungkinkan coding agent eksternal (Claude Code, Codex, Copilot, Antigravity, OpenCode) mengendalikan Workspace dan Dashboard kamu — list Connections, baca buffer terminal, place widget — lewat surface tool yang dikurasi dan di-gate dengan safety. AI-ke-AI, di mesin kamu, tanpa relay cloud.
-- Dua puluh satu **latar belakang canvas beranimasi** (iya, termasuk `matrix`) untuk dashboard, karena kami memang tidak malu-malu soal itu.
+- Sebuah **Dashboard** tempat kamu menyuruh AI *"buatkan widget yang ping router-ku tiap 30 detik"* lalu ia muncul, dalam sandbox-nya sendiri, di grid-mu.
+- **Panel SSH yang menyambung kembali ke sesi remote `claude` / `codex`-mu** setelah setiap amukan Wi-Fi, agar kerja enam jam selamat dari putusnya koneksi.
+- Sebuah **pengukur penggunaan AI** agar kamu berhenti menabrak tembok rate limit secara mengejutkan pukul 3 pagi.
+- Sebuah **Installer Helper** yang menemukan, memasang, memperbarui, dan menjalankan alat dev Windows yang biasanya kamu kejar lewat sepuluh tab browser.
+- **Dua puluh lima latar animasi** untuk dashboard (ya, termasuk `matrix`), karena kami tak terlalu jaim untuk itu.
 
-Oh, dan asisten AI-nya bisa mengubah satu kalimat menjadi tool dashboard kecil yang benar-benar terus kamu pakai.
+Dan bagian terbaiknya: asisten AI bisa mengubah satu kalimat menjadi alat dashboard kecil yang benar-benar terus kamu pakai.
 
-> ⭐ **Kalau ini kedengarannya seperti app yang sudah kamu rencanakan ingin bangun selama enam tahun terakhir — star repo-nya supaya kami tahu ada yang memperhatikan. Ini benar-benar membantu.**
+> ⭐ **Kalau ini terdengar seperti aplikasi yang sudah enam tahun ingin kamu bangun — beri bintang ke repo-nya agar kami tahu ada yang memperhatikan. Ini sungguh membantu.**
+
+Punya pendapat tentang apa yang sebaiknya datang berikutnya? Gabung ke thread umpan balik publik:
+**[Apa yang sebaiknya diprioritaskan KKTerm untuk alur kerja admin Windows-first?](https://github.com/ryantsai/KKTerm/discussions/141)**
 
 ---
 
 ## Kenapa "KKTerm"?
 
-Masuk ke data center mana saja di Taiwan dan lihat bagian atas rak. Dari pabrik TSMC, ruang kendali Taipei Metro, ruang server Cathay Bank, perangkat switching Chunghwa Telecom — kamu akan menemukan sekantong kecil 乖乖 (Kuāi Kuāi), camilan jagung rasa kelapa dari tahun 1960-an.
+Masuklah ke data center Taiwan mana pun dan lihat bagian atas rak. Melewati pabrik TSMC, ruang kendali Metro Taipei, ruang server bank Cathay, perangkat switching Chunghwa Telecom — kamu akan melihat kantong hijau kecil 乖乖 (Kuāi Kuāi), camilan jagung rasa kelapa dari era 1960-an.
 
-Namanya secara harfiah berarti **"jadilah baik"**, **"berperilaku"**. Tradisi IT-nya sederhana dan sangat serius:
+Namanya secara harfiah berarti **"jadilah baik"**, **"berperilakulah"**. Tradisi IT-nya sederhana dan sungguh-sungguh serius:
 
-- **Harus rasa hijau (kelapa).** Kuning (kari) artinya *bolos kerja*; merah (pedas) bikin server marah. Hijau saja.
-- **Harus belum kedaluwarsa.** Kuai Kuai basi justru merugikanmu. Para engineer rajin menggantinya.
-- **Harus terlihat.** Server harus tahu kalau itu ada.
+- **Harus hijau (kelapa).** Kuning (kari) berarti *hari ini di rumah saja*; merah (pedas) membuat server marah. Hanya hijau.
+- **Tidak boleh kedaluwarsa.** Kuai Kuai basi justru merugikanmu. Para insinyur rajin menggantinya.
+- **Harus terlihat.** Server harus tahu ia ada di sana.
 - **Jangan dimakan.** Kantong itu sedang bertugas.
 
-Beberapa sistem terbesar, paling membosankan, dan paling terobsesi dengan uptime di Asia dijalankan dengan sekantong puff jagung yang ditempel di chassis. Berhasil karena orang-orang yang merawatnya percaya itu berhasil — yang merupakan deskripsi paling jujur dari sebagian besar budaya IT.
+Beberapa sistem terbesar, paling membosankan, dan paling terobsesi pada uptime di Asia berjalan dengan sekantong jagung yang ditempel di sasis. Itu berhasil karena orang-orang yang merawatnya percaya itu berhasil, yang merupakan deskripsi luar biasa jujur tentang sebagian besar budaya IT.
 
-**KKTerm** adalah **Kuai Kuai Term** — workspace admin yang bercita-cita menjalankan tugas yang sama seperti camilan itu: duduk diam di samping mesin-mesin pentingmu dan membantu mereka berperilaku baik. Local-first. Tanpa telemetry. AI dengan approval-gate. Perangkat lunak yang membosankan dan bisa diandalkan.
+**KKTerm** adalah **Kuai Kuai Term** — ruang kerja admin yang mengincar pekerjaan yang sama dengan camilan itu: duduk diam di samping mesin-mesin pentingmu dan membantu mereka berperilaku baik. Local-first. Tanpa telemetri. AI dengan persetujuan. Jenis perangkat lunak yang membosankan tapi bisa diandalkan.
 
-Kami belum berhasil menyertakan kantong Kuai Kuai sungguhan dengan installer. Itu item v2.
+Kami belum berhasil menyertakan sekantong Kuai Kuai sungguhan bersama installer-nya. Itu item untuk v2.
 
 ---
 
-## Lihat Gerakannya
-
-<!--
-  TODO: Ganti placeholder ini dengan GIF demo yang nyata.
-  Rekomendasi:
-    - 5-10 detik, diputar berulang
-    - Tampilkan: buka Connection -> split pane -> upload SFTP -> AI mengusulkan perintah
-    - Target ~5 MB supaya GitHub me-render inline tanpa lazy-loading
-  Jalur yang disarankan: docs/assets/demo.gif
-  Kemudian ganti <img src=...> di bawah menjadi: src="docs/assets/demo.gif"
--->
+## Lihat ia bergerak
 
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
@@ -134,294 +123,148 @@ Kami belum berhasil menyertakan kantong Kuai Kuai sungguhan dengan installer. It
   </a>
 </p>
 
-<p align="center"><sub><em>(GIF demo ada di sini. Satu gambar bernilai seribu bullet point, dan kami kehabisan bullet point.)</em></sub></p>
+<p align="center"><sub><em>(GIF demo ada di sini. Satu gambar bernilai seribu poin, dan poin kami sudah habis.)</em></sub></p>
 
 ---
 
-## Kenapa Orang Membiarkannya Terbuka Sepanjang Hari
+## Satu jendela, setiap koneksi
 
-### Windows-first, memang sengaja
+| Kamu ingin… | KKTerm melakukannya |
+| --- | --- |
+| Buka shell lokal PowerShell / cmd / WSL | Terminal lokal, berdampingan |
+| SSH ke server | SSH dengan kunci, agent, kata sandi, jump host, dan port forwarding |
+| Jelajahi berkas di server itu | SFTP dari koneksi SSH — panel ganda, seret untuk transfer |
+| FTP ke NAS dari 2012 | FTP / FTPS di browser berkas yang sama |
+| Telnet ke perangkat purba | Ya, Telnet juga ada di dalamnya |
+| Bicara dengan port serial | Koneksi serial — pilih port COM dan baud |
+| Remote ke mesin Windows | Remote Desktop Microsoft asli, terintegrasi langsung |
+| VNC ke sebuah Pi | VNC, dirender langsung ke ruang kerja |
+| Buka UI web router | Tab browser tertanam dengan login tersimpan |
+| Pantau CPU host | Bilah status langsung dan dashboard yang kamu rakit sendiri |
 
-Lihat lanskap tooling developer 2026. Claude Code: rilis untuk mac/linux duluan, Windows adalah "pakai WSL." Codex CLI: sama. `gemini-cli`, separuh Homebrew, setiap TUI baru yang kinclong: mac/linux duluan, pengguna Windows mendapat komentar `# Windows: contributions welcome` di README dan skrip fish-completion yang tidak bisa dijalankan.
+Aplikasi yang sama. Jendela yang sama. Pintasan yang sama. Tema yang sama, yang semoga tak bikin matamu berdarah.
 
-Sementara itu, orang-orang yang benar-benar menjaga perusahaan tetap online — corporate IT, MSP, siapa pun yang menjalankan Hyper-V atau AD atau SCCM atau IIS atau domain controller yang lebih tua dari beberapa intern — duduk di depan mesin Windows bertanya-tanya kenapa setiap tools baru bersikap seolah OS mereka adalah gangguan.
+---
 
-**KKTerm adalah kebalikannya.** Kami membangun Windows native duluan, dan port macOS / Linux menyusul. Artinya kami bisa memanfaatkan Windows API yang benar-benar penting, bukan melapisinya dengan portability layer:
+## Kenapa orang membiarkannya terbuka seharian
 
-- **ConPTY** untuk shell lokal — pseudo-console Windows yang asli, bukan shim terjemahan. PowerShell, `cmd.exe`, distro WSL, semua di-hosting sebagai PTY proper dengan focus, resize, dan penanganan VT sequence yang sesuai perilaku platform.
-- **WebView2** untuk seluruh UI dan **Connections** URL yang ditanam — Chromium in-process menggunakan runtime sistem, yang merupakan salah satu alasan installer-nya kecil dan cepat dibuka.
-- **Microsoft RDP ActiveX (`mstscax.dll`)** untuk RDP — *yang asli dari Microsoft*. Control yang sama dengan Remote Desktop Connection (`mstsc.exe`). Bukan reimplementasi pihak ketiga, bukan FreeRDP dalam wrapper. Pengguna RDP akan merasakan bedanya dalam lima detik.
-- **Windows Credential Manager** untuk semua rahasia. Password SSH, password FTP, API key, kredensial URL Connection — semuanya hidup di OS keychain dan `credwiz.exe` bisa mengauditnya.
-- **NSIS current-user installer** dengan SHA-256 yang matching, tray menu native, Don't-Sleep power assertion, sampling CPU/RAM/jaringan host, Tauri context menu native dengan ikon PNG sungguhan, dialog Open/Save native. Tidak ada satu pun yang dipalsukan.
-- **WSL adalah shell kelas satu, bukan solusi darurat.** Jalankan Ubuntu di samping pane PowerShell di samping sesi SSH di samping **Tab** RDP dalam satu jendela yang sama.
+### Windows dulu, dengan sengaja
 
-Build untuk macOS dan Linux ada di roadmap dan akan mendapat perhatian yang sama. Tapi kalau kamu sudah lama menunggu seseorang membangun tools admin Windows yang *bagus* duluan bukan terakhir — ini dia dealnya.
+Lihatlah lanskap dev tools. Claude Code: mac/linux dulu, Windows itu "pakai WSL". Codex CLI: sama. Separuh tool baru yang berkilau dirilis mac dulu dan meninggalkan pengguna Windows sebuah komentar `# contributions welcome` dan skrip autocomplete yang tak jalan.
+
+Sementara itu, orang-orang yang benar-benar menjaga perusahaan tetap online — IT korporat, MSP, siapa pun yang mengelola domain controller yang lebih tua dari sebagian magang — duduk di mesin Windows sambil bertanya-tanya kenapa setiap tool baru memperlakukan OS mereka seperti gangguan.
+
+**KKTerm mengambil pilihan sebaliknya.** Kami membangun native Windows dulu, jadi hal yang dipedulikan orang Windows langsung berfungsi: Remote Desktop Microsoft yang *asli* (yang sama dengan `mstsc.exe`, bukan tiruan), shell PowerShell / cmd / WSL sungguhan, rahasia yang disimpan di Windows Credential Manager, ikon tray yang benar, menu dan dialog native. Build macOS dan Linux ada di roadmap dan akan mendapat perhatian yang sama. Tapi kalau kamu sudah menunggu seseorang membangun tool admin Windows yang *bagus* lebih dulu alih-alih terakhir — itulah kesepakatannya.
 
 ### Local-first artinya benar-benar lokal
 
-**Connections** yang tersimpan hidup dalam file SQLite di mesinmu. Password hidup di **Windows Credential Manager**, bukan di JSON di samping binary. App ini tidak menyertakan analitik, tidak melapor ke mana-mana saat startup, dan tidak butuh akun cloud untuk diluncurkan. Tidak ada "masuk untuk sync" karena tidak ada sync.
+Koneksi tersimpanmu ada di sebuah berkas di mesinmu. Kata sandi ada di Windows Credential Manager, bukan di berkas teks di sebelah aplikasi. KKTerm tidak mengirim analitik, tidak menelepon pulang saat dijalankan, dan tidak butuh akun cloud untuk dibuka. Tidak ada "masuk untuk sinkronisasi" karena tidak ada sinkronisasi.
 
-Kalau kabel jaringanmu kebakaran, KKTerm tetap bisa dibuka.
+Kalau kabel jaringanmu terbakar, KKTerm tetap terbuka.
 
-### Satu workspace, setiap jenis koneksi
+### Terminal yang tidak hilang akal
 
-| Kamu mau… | KKTerm punya |
-| --- | --- |
-| Buka shell PowerShell / cmd / WSL lokal | **Sessions** terminal lokal berbasis ConPTY |
-| SSH ke server | `russh` native dengan auth agent / key / password, alur trust host-key, ProxyJump, port forwarding |
-| Browse file di server itu | SFTP diluncurkan dari **Connection** SSH, dual-pane, transfer rekursif, chmod/chown |
-| FTP ke NAS dari tahun 2012 | **Connections** FTP / FTPS dalam browser bergaya SFTP yang sama |
-| Telnet ke perangkat jadul | Iya, oke, Telnet juga ada |
-| Bicara ke serial port | **Connection** kind Serial, COM port + baud, tanpa tooling tambahan |
-| Remote ke mesin Windows | RDP native via kontrol Microsoft ActiveX (yang asli, bukan tiruannya) |
-| VNC ke Raspberry Pi | Rust `vnc-rs` framebuffer yang dirender langsung ke workspace |
-| Buka web UI router | **URL Connection** WebView2 tertanam dengan pengisian kredensial |
-| Pantau CPU di host | Status bar langsung + modul **Dashboard** dengan widget yang bisa di-drag/resize |
+- Panel terbagi di dalam sebuah Tab.
+- Render cepat dan mulus, dengan scrollback yang bisa dicari.
+- Menyambung kembali benar-benar berarti *menyambung kembali* — sesi remote-mu melanjutkan dari posisinya, bukan "mulai dari nol dan berpura-pura satu jam terakhir tak pernah terjadi".
+- Berpindah Tab **tidak** membunuh Session. Menutup Tab, ya. Perbedaan ini dulu jadi perang agama internal; kami menang.
 
-Semuanya satu app yang sama. Satu jendela yang sama. Hotkey yang sama. Tema yang mudah-mudahan tidak bikin mata perih.
+### Asisten AI yang membangun alatmu
 
-### Terminal yang tidak gila-gilaan
+Kebanyakan demo "AI di terminalmu" berhenti di obrolan. Asisten KKTerm juga bisa membangun widget dashboard kecil yang awet, pas dengan cara kerjamu yang sebenarnya — dan menyimpan yang berbahaya di balik sakelar:
 
-- Split pane di dalam **Tab**.
-- Rendering xterm.js berakselerasi WebGL, dengan fallback yang mulus saat tidak bisa.
-- Pencarian scrollback.
-- SSH pane berbasis tmux yang bisa attach ke sesi per-pane yang stabil, jadi reconnect benar-benar berarti *menyambung kembali*, bukan "mulai dari awal dan pura-pura satu jam terakhir tidak pernah terjadi."
-- Berganti **Tab** **tidak** mematikan **Session**. Menutup **Tab** yang melakukannya. Perbedaan ini sempat jadi perang saudara secara internal; kami yang menang.
+- **Tentukan apa yang boleh ia sentuh** — nyalakan atau matikan seluruh keluarga alat (Dashboard / Connections / Live Sessions).
+- **Tentukan bagaimana ia bertanya** — `Prompt` (default, bertanya setiap kali) atau `Allow All` (kamu sudah dewasa, kamu menandatangani pernyataannya).
 
-### Asisten AI yang membangun tool-mu
+Apa pun yang terlihat seperti `rm -rf` ditandai berbahaya dan menunggu kata "ya" eksplisit dari manusia. AI tidak bisa diam-diam menjalankan perintah merusak hanya karena ada yang berbuat licik dengan prompt injection di sebuah halaman man.
 
-Sebagian besar demo "AI di terminal" berhenti di chat. Asisten KKTerm juga bisa membangun widget dashboard kecil yang tahan lama untuk cara kerjamu yang sebenarnya. Hal-hal berbahaya tetap dijaga di balik dua sakelar:
-
-- **Tool families** (Dashboard / Connections / Live Sessions) — toggle on atau off per kategori.
-- **Permission mode** di composer — `Prompt` (default, selalu tanya) atau `Allow All` (kamu sudah dewasa, kamu yang tanda tangan waivernya).
-
-Bicara ke OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA, atau apapun yang kompatibel dengan OpenAI. API key masuk ke OS keychain. Model yang mengusulkan `rm -rf` diklasifikasikan sebagai berbahaya dan memerlukan persetujuan manusia yang eksplisit. AI tidak bisa diam-diam menjalankan perintah destruktif hanya karena seseorang pintar melakukan prompt injection di halaman man.
+Ia bicara dengan OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA, atau endpoint apa pun yang kompatibel OpenAI. Kunci API-mu masuk ke keychain OS.
 
 ### Dashboard yang tidak berpura-pura jadi Grafana
 
-Modul **Dashboard** adalah grid drag/resize 12 kolom dari instance widget. Ini bukan untuk observabilitas petabyte — ini untuk "aku mau tombol untuk membuka lima app favorit dan panel yang menampilkan uptime SSH host, *di samping* chatku."
+Dashboard adalah grid widget yang bisa kamu seret dan ubah ukurannya. Ini bukan untuk observability skala petabyte — ini untuk "aku mau satu tombol untuk meluncurkan lima aplikasi favoritku dan satu panel yang menampilkan uptime host SSH-ku, *di samping* obrolanku".
 
-#### Widget Buatan AI — deskripsikan, langsung jadi
+#### Widget buatan AI — jelaskan, langsung jadi
 
-Ini bagian yang benar-benar membuat kami excited. Kamu tidak perlu pilih dari marketplace dan tidak perlu nulis JavaScript. Kamu **bilang ke asisten AI apa yang kamu mau**, dan dia membangun widget itu langsung di dashboardmu:
+Ini bagian yang benar-benar membuat kami bersemangat. Kamu tidak memilih dari marketplace dan tidak menulis JavaScript. Kamu **memberi tahu asisten AI apa yang kamu mau**, lalu ia membangun widget-nya langsung di dashboard-mu:
 
-> *"Tambahkan widget yang menampilkan 5 commit terakhir di repo utama saya sebagai daftar."*
-> *"Buatkan saya widget sticky-note yang menyimpan cheat sheet on-call saya."*
-> *"Buat widget yang ping router rumah saya setiap 30 detik dan tampilkan hijau/merah."*
-> *"Saya butuh stopwatch. Bebas ya soal styling-nya."*
+> *"Tambahkan widget yang menampilkan 5 commit terakhir repo utamaku sebagai daftar."*
+> *"Buatkan aku widget sticky-note untuk contekan jaga on-call-ku."*
+> *"Bangun widget yang ping router rumahku tiap 30 detik dan menampilkan hijau/merah."*
+> *"Aku butuh stopwatch. Kejutkan aku soal gayanya."*
 
-Dua jenis:
+Sebagian adalah panel tampilan sederhana (markdown, checklist, satu angka besar); sebagian menjalankan kode langsung di sandbox terisolasi yang kamu setujui. Setiap widget yang kamu simpan jadi milikmu — tersimpan dengan warna, ikon, dan judulnya sendiri, dan kamu bisa punya beberapa salinan dengan ukuran berbeda. Hapus satu dengan klik kanan saat keajaibannya memudar.
 
-- **Content widgets** — JSON deklaratif: markdown, kv list, checklist, satu stat besar. Aman secara konstruksi, tanpa skrip. Sebagian besar permintaan "aku hanya butuh ini di dashboard-ku" berakhir di sini.
-- **Script widgets** — JavaScript yang di-hosting di dalam sandbox `iframe srcdoc` yang terisolasi dengan izin yang eksplisit dan dideklarasikan (allowlist `network`, budget `pollSeconds`). AI yang menulis skrip, kamu yang menyetujui izin, widget berjalan di kotak yang tidak bisa menjangkau sisa app.
+#### Latar animasi dashboard (karena kami mau saja)
 
-Setiap widget yang kamu simpan adalah milikmu. Mereka bertahan di SQLite di samping **Connections**-mu, dengan preset visual mereka sendiri (`panel` / `ambient` / `hero`), warna aksen, ikon, dan judul. Beberapa instance dari widget yang sama bisa hidup berdampingan dengan ukuran dan gaya yang benar-benar berbeda. Hapus dengan klik kanan ketika magicnya sudah habis.
+Pilih satu suasana per tampilan dashboard dari **dua puluh lima** latar animasi canvas:
 
-#### Latar belakang dashboard beranimasi (karena kami memang mau)
-
-Dashboard punya dua puluh satu latar belakang canvas beranimasi yang bisa kamu pilih per **Dashboard View**:
-
-| Suasana | Latar Belakang |
+| Suasana | Latar |
 | --- | --- |
-| Tenang | `aurora`, `clouds`, `ocean`, `raindrops`, `snow`, `sakura`, `fireflies`, `bubbles`, `ricefield`, `lanterns` |
-| Luar Angkasa | `starfield`, `nebula` |
+| Tenang | `aurora`, `clouds`, `ocean`, `raindrops`, `rainywindow`, `frostedWindow`, `snow`, `sakura`, `fireflies`, `bubbles`, `aquarium`, `ricefield`, `lanterns` |
+| Antariksa | `starfield`, `nebula` |
 | Hangat | `embers`, `lava` |
 | Geek | `matrix`, `topo`, `synthwave` |
-| Ugal-ugalan | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti` |
+| Gelisah | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti`, `particleCursor` |
 
-Semuanya berjalan di satu `requestAnimationFrame` bersama dan menghormati focus jendela, jadi biayanya hampir nol saat kamu ada di tempat lain. Pasangkan `matrix` dengan asisten AI untuk vibe yang terkesan "aku sangat produktif dan mungkin juga berada dalam film Wachowski." Atau pilih `ocean` dan terlihat seperti orang serius. Kami tidak menghakimi pilihan apapun.
+Mereka berhenti saat kamu di tempat lain, jadi nyaris tak memakan sumber daya. Padukan `matrix` dengan asisten AI-mu untuk suasana yang berkata "aku sangat produktif dan mungkin sedang berada di film Wachowski". Atau pilih `ocean` dan tampak seperti orang serius. Kami tidak menghakimi kedua pilihan itu.
 
-### Menjalankan agen coding AI di server, dengan benar
+### Jaga agar agen AI remote-mu tetap hidup
 
-Ini fitur kedua yang langsung disukai orang. Terminal SSH KKTerm bisa diluncurkan langsung ke **sesi tmux bernama** di host remote — secara default, friendly id yang auto-generated seperti `kkterm-cockpit001` yang bertahan saat reconnect:
+Ini fitur kedua yang membuat orang jatuh cinta. Terminal SSH KKTerm bisa langsung menjatuhkanmu ke sebuah **sesi tmux bernama** di host remote yang selamat dari penyambungan ulang:
 
-- Buka **Connection** SSH dengan tmux diaktifkan.
-- Di dalam pane, jalankan `claude`, `codex`, `gemini-cli`, `cursor-agent`, atau agen coding long-running apapun yang kamu suka. Mereka adalah app TUI full-screen; tmux persis tempat yang mereka inginkan.
-- Tutup laptop. Buka lagi. Pane diam-diam re-attach ke sesi tmux yang sama. Agen masih berjalan, masih punya scrollback-nya, masih di tengah-tengah apa yang sedang dilakukannya.
-- Gangguan jaringan di transport SSH? KKTerm melakukan bounded silent reattach attempt ke tmux id yang sama tanpa mengganggumu.
-- Mau asisten AI melihat apa yang dilakukan agen itu? "Tambahkan terminal buffer ke context" memanggil `capture_tmux_pane` via SSH dan menarik seluruh scrollback tmux — bukan hanya yang ada di layar, seluruh sesinya — ke dalam percakapan. Asisten lokal kamu kini bisa bernalar tentang pekerjaan agen remote-mu.
+- Buka koneksi SSH dengan tmux aktif lalu jalankan `claude`, `codex`, `gemini-cli`, `cursor-agent`, atau agen jangka panjang apa pun yang kamu suka.
+- Tutup laptop. Buka lagi. Panel menyambung kembali diam-diam — agennya masih berjalan, masih punya scrollback-nya, masih di tengah apa pun yang sedang dikerjakannya.
+- Jaringan tersendat? KKTerm menyambung kembali diam-diam ke sesi yang sama tanpa mengganggumu.
+- Mau bantuan asisten? "Tambahkan terminal buffer ke konteks" menarik seluruh sesi remote ke dalam percakapan, agar AI lokalmu bisa menalar apa yang sedang dikerjakan agen remote-mu.
 
-Kalau kamu pernah kehilangan sesi `claude` atau `codex` enam jam karena Wi-Fi hotel yang tidak stabil, fitur tunggal ini sudah melunasi harga app-nya. App-nya gratis. Fiturnya tetap worth it.
+Kalau kamu pernah kehilangan sesi `claude` atau `codex` enam jam gara-gara Wi-Fi hotel yang labil, fitur satu ini saja sudah menebus harga aplikasinya. (Aplikasinya gratis. Fiturnya tetap layak.)
 
-### Tahu berapa AI kamu yang tersisa
+### Tahu berapa sisa AI-mu
 
-Coding agent menagih per jendela plan, bukan per bulan. Claude Code punya jendela 5 jam dan jendela mingguan. Codex punya versinya sendiri. Keduanya bisa dengan senang hati melahap kuota kamu di background saat kamu lagi meeting.
+Agen coding menagih per jendela paket, bukan per bulan, dan mereka dengan senang hati melahap kuotamu saat kamu sedang rapat. **Pengukur penggunaan AI** menjaga itu tetap terlihat:
 
-Widget **Penggunaan AI Coding** menjaga itu tetap terlihat:
+- Widget dashboard yang menampilkan **Claude Code** dan **Codex** berdampingan: akun terhubung, paket, pemakaian di jendela saat ini dan minggu ini, waktu reset berikutnya.
+- Sebuah **indikator ringkas di bilah status** yang mencerminkan angka yang sama, sehingga bahkan dengan dashboard tertutup kamu bisa melihat sekilas apakah masih ada ruang sebelum refactoring besar berikutnya.
+- Ia memberitahumu lebih awal kalau kamu perlu login ulang — *sebelum* tugas panjang, bukan di tengahnya.
 
-- Widget Dashboard yang menampilkan **Claude Code** dan **Codex** berdampingan: akun yang terhubung, level plan, persen yang dipakai di jendela 5 jam saat ini, persen yang dipakai minggu ini, waktu reset berikutnya.
-- Indikator **status bar yang ringkas** yang memantulkan angka yang sama, jadi meski Dashboard ditutup kamu bisa lihat sekilas apakah masih ada ruang sebelum mulai refactor besar berikutnya.
-- Status auth ditampilkan langsung (`connected` / `expired` / `error`) supaya kamu tahu *sebelum* tugas panjang bahwa kamu perlu re-login, bukan di tengah-tengah.
-- Policy refresh menghormati rate limit; widget polling di tempo sendiri alih-alih menghantam API upstream tiap kali kamu lihat.
+### Biarkan AI lain mengemudikan KKTerm
 
-### Sebuah server MCP built-in — biarkan AI lain mengendalikan KKTerm
+KKTerm membawa server MCP-nya sendiri, agar agen coding eksternal (Claude Code, Codex, Copilot, Antigravity, OpenCode) bisa memakai ruang kerjamu seperti kamu — mendaftar koneksi, membuka satu, membaca buffer terminal, menempatkan widget di dashboard. AI ke AI, di mesinmu, tanpa relay cloud. Aksi yang mengubah dan lebih berisiko tetap di balik satu sakelar keamanan yang **mati** secara default.
 
-Terminal kamu juga tempat Claude Code, Codex, Copilot agent mode, Antigravity, dan sisa dunia yang ngobrol MCP ingin bekerja. Maka KKTerm membawa **server MCP stdio**-nya sendiri, [`kkterm-cli`](docs/MCP.md), yang membuka slice app yang dikurasi:
-
-- **Modul Workspace** (`kkterm.workspace.*`): list **Connections** tersimpan, buka Connection by id, list **Sessions** yang hidup, kirim input ke pane terminal, baca snapshot buffer.
-- **Modul Dashboard** (`kkterm.dashboard.*`): load state Dashboard, baca source AI-Created Widget, buat / update / hapus view, place / pindah / hapus widget instance, apply bulk layout.
-- **Sub-namespace berbahaya** (`kkterm.<module>.dangerous.*`): mengubah surface yang executable — bikin widget script, klik ke remote desktop, wipe Dashboard — di-gate di balik satu setting (`built_in_mcp_allow_all_dangerous`), default **mati**.
-
-`kkterm-cli` adalah forwarder tipis. Dia bicara stdio JSON-RPC ke MCP client kamu dan berkomunikasi dengan window KKTerm yang berjalan via Windows named pipe yang ter-authenticate per-launch. Saat KKTerm tertutup, `tools/list` tetap jalan (client bisa introspeksi surface), tapi `tools/call` mengembalikan error terstruktur `app_not_running` alih-alih melakukan apapun.
-
-Sambungkan ke client favorit kamu dan AI kamu sekarang pakai KKTerm seperti kamu:
-
-```json
-{
-  "mcpServers": {
-    "kkterm": { "command": "<path-ke-kkterm-cli>", "args": [] }
-  }
-}
-```
-
-Settings → AI Assistant → **Built-in MCP Server** punya dialog "Show config" satu klik dengan snippet JSON dan TOML pre-filled dengan path binary yang resolved, plus command `claude mcp add` / `codex mcp add` yang bisa di-copy.
+Pengaturan → AI Assistant → **Built-in MCP Server** punya dialog "Tampilkan konfig" sekali klik, sudah terisi, plus perintah `claude mcp add` / `codex mcp add` yang bisa disalin.
 
 ---
 
-## Cara Kerjanya
+## Apa yang bukan KKTerm
 
-```mermaid
-flowchart LR
-    User([You]) --> Shell[KKTerm Window<br/>Tauri v2 + React 19]
-    Shell --> Rail[Activity Rail]
-    Rail --> WS[Workspace Module]
-    Rail --> Dash[Dashboard Module]
-    Rail --> Inst[Installer Helper Module]
-    Rail -.-> FE[File Explorer<br/>planned]
-    Rail --> Set[Settings]
+Daftar singkat, karena kejujuran menumbuhkan kepercayaan:
 
-    WS --> Tabs[Tabs &amp; Panes]
-    Tabs --> Term[Terminal<br/>ConPTY / russh]
-    Tabs --> SFTP[SFTP / FTP]
-    Tabs --> Web[WebView2 URL]
-    Tabs --> RD[RDP / VNC]
+- **Bukan produk cloud.** Tanpa sinkronisasi, tanpa akun tim, tanpa tingkatan SaaS. Kalau suatu hari kamu melihat dialog "Masuk ke KKTerm", ada yang salah secara katastrofik.
+- **Tidak berpura-pura lintas platform.** Kami Windows-first dengan sengaja; macOS dan Linux ada di roadmap. Kalau kamu butuh tool mac-first hari ini, kamu punya ratusan pilihan. Kami sedang membangun yang sudah lama ditunggu para admin Windows dalam diam.
+- **Bukan agen AI otonom.** Asisten mengusulkan; manusia memutuskan. `Allow All` adalah pilihan yang kamu buat, bukan default.
+- **Bukan pengganti Grafana / Datadog.** Dashboard untuk permukaan kendali pribadi, bukan observability 10.000 host.
+- **Bukan IDE Kubernetes.** Ini ruang kerja admin yang berpusat pada terminal. Tolong jangan minta ia me-render chart Helm.
 
-    Shell -.calls.-> Rust[Rust Backend]
-    Rust --> SQLite[(SQLite<br/>Connections)]
-    Rust --> Keychain[(OS Keychain<br/>Secrets)]
-    Rust --> AI[AI Providers<br/>OpenAI-compat]
-
-    AI -. approval gate .-> Tabs
-
-    classDef local fill:#1f6feb,stroke:#1f6feb,color:#fff
-    classDef ai fill:#8a63d2,stroke:#8a63d2,color:#fff
-    class SQLite,Keychain local
-    class AI ai
-```
-
-Bentuk yang penting: data tersimpan yang tahan lama (**Connection**) terpisah dari state runtime langsung (**Session**), yang terpisah dari container UI (**Tab**). Menutup **Tab** mengakhiri **Session**. Berganti **Tab** tidak. Ini aturan yang menjaga app tetap waras.
+Kalau salah satu poin itu *dulunya* jadi penentu — wajar saja, sampai jumpa di v2.
 
 ---
 
-## Peta Fitur Saat Ini
+## Dapatkan KKTerm
 
-| Area | Sudah diimplementasikan hari ini |
-| --- | --- |
-| **Connections** | Pohon berbasis SQLite, folder/subfolder, pencarian, urutan drag/drop, rename, duplicate, hapus, **Quick Connect**, ikon kustom, pintasan rail yang disematkan/aktif |
-| **Terminal** | Shell lokal, SSH, Telnet, Serial, split pane, xterm.js + WebGL oportunistik, pencarian scrollback, direktori/skrip startup lokal |
-| **SSH** | `russh` native, auth agent/key/password, alur trust host-key, fallback SSH sistem opsional, ProxyJump, port forwarding, **sesi tmux auto-named (`kkterm-<scifi-name><n>`) dengan silent reattach saat transport blip** — sempurna untuk agen coding remote long-running (Claude Code, Codex, gemini-cli, dll.) |
-| **SFTP / FTP** | SFTP yang diluncurkan via SSH plus **Connections** FTP/FTPS, browser dual-pane, transfer rekursif, antrean/batalkan/bersihkan riwayat, konflik, properti, chmod/chown jika didukung |
-| **URL WebView** | **Sessions** URL WebView2 tertanam, toolbar navigasi, pengambilan favicon, metadata/isian kredensial website tersimpan, metadata partisi data |
-| **Remote Desktop** | RDP melalui Windows ActiveX dengan geometry-scoped overlay parking; VNC melalui `vnc-rs` framebuffer yang dirender di canvas workspace |
-| **Dashboard** | View yang tahan lama, instance widget, mode edit, drag/resize, App Launcher, **widget konten/skrip buatan AI** (JSON deklaratif atau iframe JS tersandbox dengan izin), preset / aksen / ikon / judul per-widget, **23 latar belakang canvas beranimasi** (aurora, clouds, ocean, raindrops, rainywindow, snow, sakura, fireflies, bubbles, ricefield, lanterns, starfield, nebula, embers, lava, matrix, topo, synthwave, cyberpunk, taipei101, thunderstorm, confetti, particleCursor) |
-| **AI Assistant** | Chat streaming, runtime kompatibel OpenAI, registri provider, klasifikasi keamanan proposal perintah, lampiran screenshot/context, **pembuatan widget Dashboard (konten + skrip tersandbox)**, **penangkapan pane tmux** sebagai context percakapan untuk sesi remote, tools manajemen **Connection**, dan tools **Session** langsung untuk terminal, RDP/VNC, dan SFTP/FTP |
-| **Penggunaan AI Coding** | **Widget Dashboard + indikator status bar** yang melacak penggunaan kuota **Claude Code** dan **Codex**: akun terhubung, level plan, persen jendela 5 jam dan mingguan, waktu reset berikutnya, status auth (`connected` / `expired` / `error`), policy refresh yang sadar rate-limit |
-| **Server MCP Built-in** | Server MCP stdio (`kkterm-cli`) yang membuka tools Workspace dan Dashboard yang dikurasi ke agen coding eksternal (Claude Code, Codex, Copilot, Antigravity, OpenCode); bridge named pipe ter-authenticate; sub-namespace `dangerous.*` per-Modul di balik satu toggle safety; dialog Settings dengan snippet JSON / TOML satu klik dan command `claude mcp add` / `codex mcp add` |
-| **Installer Helper** | Module Activity Rail untuk katalog tool developer Windows yang dibundel: mendeteksi tool terpasang, membandingkan versi terbaru, install/update/uninstall, mengecualikan tool dari Update all, streaming log command, dan menjalankan managed app yang didukung |
-| **Settings** | Umum, Tampilan, Kredensial, AI, SSH, Terminal, latar terminal, URL, RDP, VNC, Dashboard, Installer Helper, Tentang; font UI kustom; minimize-to-tray; Don't Sleep; backup/import |
-| **Lokalisasi** | UI i18next dengan sumber bahasa Inggris dan bundel lokal dinamis: zh-TW, zh-CN, ja, ko, fr, de, es, es-MX, it, pt-BR, th, id, vi |
+**[Unduh installer Windows terbaru (.exe)](https://github.com/ryantsai/KKTerm/releases/latest)** lalu jalankan. Installer-nya saat ini **belum ditandatangani** — penandatanganan rilis ada di roadmap, jadi sampai saat itu antivirus-mu mungkin menatapmu tajam. Itu normal.
 
-### AI Providers
-
-OpenAI · Anthropic · OpenRouter · DeepSeek · Grok · Azure OpenAI · LiteLLM · GitHub Copilot · Ollama · NVIDIA · endpoint apapun yang kompatibel dengan OpenAI.
-
-Metadata provider ada di [`src/ai/providerRegistry/`](src/ai/providerRegistry/); adapter Rust ada di [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/). API key melewati OS keychain, tidak pernah SQLite.
-
----
-
-## Quick Start
-
-Yang kamu butuhkan:
-
-- **Windows** (platform yang didukung utama)
-- **Node.js + npm**
-- **Rust toolchain**
-- **Prasyarat Tauri v2 untuk Windows** termasuk **WebView2**
-
-```bash
-npm install
-npm run tauri dev
-```
-
-Itu seharusnya menghasilkan jendela native yang sungguhan. Kalau malah menghasilkan stack trace, silakan buat issue — kami suka repro yang bagus.
-
-### Pengecekan umum
-
-```bash
-npm run check                                              # TypeScript
-npm run build                                              # Vite build
-cargo check --manifest-path src-tauri/Cargo.toml           # Rust
-cargo test  --manifest-path src-tauri/Cargo.toml           # Rust tests
-```
-
-### Build installer Windows
-
-```bash
-npm run package:installer
-```
-
-Skrip installer menulis `artifacts/kkterm-<version>-windows-x64-setup.exe` dan file `.sha256` yang matching. Saat ini **belum ditandatangani** — penandatanganan rilis ada di roadmap, tapi sampai saat itu antivirus kamu mungkin akan menatap dengan tatapan serius. Itu normal.
-
----
-
-## Apa yang KKTerm Bukan
-
-Daftar singkat, karena kejujuran membangun kepercayaan:
-
-- **Bukan produk cloud.** Tidak ada sync, tidak ada akun tim, tidak ada tier SaaS. Kalau kamu pernah melihat dialog "Masuk ke KKTerm", ada yang salah secara katastrofis.
-- **Tidak berpura-pura lintas platform.** Kami Windows-first secara sengaja; macOS dan Linux ada di roadmap dan akan menggunakan shell Tauri v2 yang sama. Kalau kamu butuh tools mac-first hari ini, kamu punya ratusan pilihan. Kami sedang membangun yang selama ini diam-diam ditunggu oleh admin Windows.
-- **Bukan agen AI otonom.** Asisten mengusulkan; manusia yang memutuskan. `Allow All` adalah pilihan yang kamu buat, bukan default.
-- **Bukan pengganti Grafana / Datadog.** Dashboard ini untuk control surface personal, bukan observabilitas 10k host.
-- **Bukan Kubernetes IDE.** Ini adalah workspace admin yang mengutamakan terminal. Tolong jangan minta dia me-render Helm chart.
-
-Kalau ada dari itu yang *jadi dealbreaker* — tidak apa-apa, kita ketemu di v2.
-
----
-
-## Debugging Native
-
-Gunakan runtime Tauri yang sesungguhnya untuk validasi:
-
-```bash
-npm run tauri dev
-```
-
-Preview browser Vite berguna untuk beberapa inspeksi frontend, tapi **tidak** meng-hosting WebView2, ConPTY, RDP ActiveX, VNC framebuffer, keychain, atau permukaan menu native yang sesungguhnya. Kalau sebuah fitur menyentuh salah satu dari itu, validasi di runtime desktop yang asli.
-
-Pengguna VS Code: konfigurasi launch `Run KKTerm exe` memulai `src-tauri/target/debug/kkterm.exe` dengan `RUST_BACKTRACE=1`. Konfigurasi berpasangan `Attach KKTerm WebView2` memberikanmu DevTools di dalam host WebView2 yang sesungguhnya.
-
----
-
-## Batasan Saat Ini (iya, kami tahu)
-
-- Installer saat ini belum ditandatangani. Pemeriksaan update dinonaktifkan sampai penandatanganan rilis dikonfigurasi.
-- SFTP melalui ProxyJump belum didukung di jalur SFTP native.
-- Resume transfer file, sync/diff folder, archive/extract, dan pengeditan remote ditunda.
-- Impor SSH config sudah diimplementasikan tapi entri yang menghadap pengguna di Settings belum terekspos.
-- RDP dan VNC sedang dirilis; sinkronisasi clipboard/perangkat yang lebih kaya dan kontrol kualitas masih berkembang.
-- Build macOS dan Linux ada di roadmap. Mereka akan datang, dan akan dikerjakan dengan benar — tidak terburu-buru sebagai port "kami juga agak bisa di sana."
-- Asisten AI mengusulkan dan dapat mengoperasikan tools yang diaktifkan dalam batas izin yang dikonfigurasi — tolong jangan perlakukan dia sebagai robot tanpa pengawasan. Dia sebenarnya tidak tahu apa yang diinginkan CEO kamu.
+Mau build dari sumber atau berkontribusi? Semua yang kamu butuhkan ada di [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ---
 
 ## Roadmap (versi singkat)
 
 - Build macOS + Linux
-- Installer bertanda tangan + auto-update
-- SFTP melalui ProxyJump di jalur native
-- Resume transfer file, sync folder, archive/extract
-- Pengalihan clipboard/perangkat RDP yang lebih kaya
-- Lebih banyak widget **Dashboard** bawaan (dan skema publik untuk yang dibuat AI)
+- Installer bertanda tangan + pembaruan otomatis
+- Transfer berkas lebih bertenaga (lanjutkan, sinkron folder, arsip/ekstrak)
+- Berbagi clipboard dan perangkat Remote Desktop yang lebih kaya
+- Lebih banyak widget dashboard bawaan
 
 Versi lengkap dan sering diperbarui: [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
@@ -429,44 +272,28 @@ Versi lengkap dan sering diperbarui: [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
 ## Berkontribusi
 
-Kami sangat butuh bantuan. Sungguh. Bahkan hal kecil pun berarti:
+Kami akan senang sekali dibantu. Sungguh. Hal kecil pun penting:
 
-- **Coba dev build** dan buat issue ketika ada yang terasa aneh. "Rasanya aneh" adalah laporan bug yang sah; kami akan menggali bersama kamu.
-- **Terjemahkan satu lokal.** Bahasa Inggris adalah sumber kebenaran di [`src/i18n/locales/en.json`](src/i18n/locales/en.json); 12 lokal lainnya ada di sebelahnya dan dimuat sesuai permintaan. String yang tertunda dilacak per-key di bawah [`docs/localization_todo/`](docs/localization_todo/) — pilih satu, terjemahkan, hapus file-nya.
-- **Tambahkan widget Dashboard.** Widget bawaan ada di [`src/modules/dashboard/widgets/builtin/`](src/modules/dashboard/widgets/builtin/). Pilih ide kecil, kirim, pelajari polanya.
-- **Sempurnakan tool surface AI.** Adapter provider ada di [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/); registri frontend ada di [`src/ai/providerRegistry/`](src/ai/providerRegistry/).
-- **Tingkatkan manual.** Dokumen pengguna akhir ada di [`docs/manual/`](docs/manual/). Satu bab per modul UI. Kalau kamu menggunakan sebuah fitur dan dokumennya tidak membantu, PR yang memperbaiki itu sangat berharga.
+- **Coba build dev** dan buka issue saat ada yang terasa janggal. "Rasanya janggal" adalah laporan bug yang sah; kami akan menggali bersamamu.
+- **Terjemahkan satu bahasa.** Bahasa Inggris adalah sumber kebenaran; tiga belas bahasa lain tinggal di sebelahnya.
+- **Tambahkan widget dashboard.** Ambil satu ide kecil, rilis, pelajari polanya.
+- **Perbaiki manual.** Kalau kamu memakai sebuah fitur dan dokumentasinya tak membantu, PR yang memperbaikinya berharga emas.
 
-Setup lengkap, tata letak proyek, checklist PR, dan daftar aturan "tolong jangan rusak ini" ada di [`CONTRIBUTING.md`](CONTRIBUTING.md). Highlights 30 detik:
-
-- **Baca [`CONTEXT.md`](CONTEXT.md) sebelum mengganti nama istilah yang menghadap pengguna.** **Connection**, **Session**, **Tab**, dan **Quick Connect** punya arti spesifik; tolong jangan melenceng.
-- **Setiap string yang terlihat pengguna melewati `t()`.** Tidak ada teks bahasa Inggris polos di JSX.
-- **Tidak ada frontend close hooks.** Close title-bar Tauri v2 sudah beberapa kali rusak oleh pola `onCloseRequested`. Kami akhirnya punya bentuk yang berfungsi; tolong jangan diperkenalkan kembali.
-- **Jalankan pengecekan** (`npm run check && npm run build && cargo check && cargo test`) sebelum membuka PR.
-
-Mencari titik masuk? Filter issue terbuka dengan [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) atau [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22). Kalau belum ada yang ditag, buat issue yang mendeskripsikan apa yang ingin kamu kerjakan dan kami akan membantu menentukan cakupannya.
+Penyiapan lengkap, struktur proyek, dan checklist PR ada di [`CONTRIBUTING.md`](CONTRIBUTING.md). Mencari titik masuk? Saring issue terbuka dengan [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) atau [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
 
 ---
 
-## Dokumentasi Proyek
+## Dokumen proyek
 
-- [Konteks produk](CONTEXT.md) — bahasa domain yang harus kamu cocokkan
+- [Konteks produk](CONTEXT.md) — bahasa domain yang harus kamu ikuti
 - [Arsitektur](docs/ARCHITECTURE.md) — peta modul, di mana menaruh kode baru
 - [Roadmap](docs/ROADMAP.md)
 - [Arsitektur Dashboard](docs/DASHBOARD.md)
-- [Panduan AI provider](docs/AI_PROVIDERS.md)
-- [Catatan performa](docs/PERFORMANCE.md)
-- [Catatan rilis dan gates](docs/RELEASE.md)
+- [Panduan penyedia AI](docs/AI_PROVIDERS.md)
 
 ---
 
-## Stack
-
-Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand · xterm.js · SQLite · WebView2 · `russh` · `russh-sftp` · `vnc-rs` · `suppaftp` · OS keychain storage.
-
----
-
-## Riwayat Star
+## Riwayat bintang
 
 <a href="https://www.star-history.com/#ryantsai/KKTerm&Date">
   <picture>
@@ -476,12 +303,12 @@ Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand ·
   </picture>
 </a>
 
-Kalau kamu sudah sampai sejauh ini dan belum bintangin — apa yang kamu tunggu, undangan pribadi? Anggap ini sebagai undangan pribadinya.
+Kalau kamu sudah sampai sejauh ini dan belum memberi bintang — tunggu apa lagi, undangan pribadi? Anggap ini undangan pribadinya.
 
-⭐ **[Bintangi KKTerm di GitHub](https://github.com/ryantsai/KKTerm)** — butuh satu klik dan membuat minggu maintainer-nya jadi lebih bermakna. Anggap saja sebagai 乖乖 digital di raknya.
+⭐ **[Beri bintang KKTerm di GitHub](https://github.com/ryantsai/KKTerm)** — cukup satu klik dan membuat sepekan penuh sang maintainer cerah. Anggap saja 乖乖 digital di rak.
 
 ---
 
 ## Lisensi
 
-MIT. Lihat [LICENSE](LICENSE). Gunakan, fork, kirim, taruh di homelab yang tidak bisa ditemukan siapapun — begitulah dealnya.
+MIT. Lihat [LICENSE](LICENSE). Pakai, fork, rilis, taruh di homelab yang takkan ditemukan orang lain — itulah kesepakatannya.

--- a/README.it.md
+++ b/README.it.md
@@ -5,7 +5,7 @@
 <h1 align="center">KKTerm</h1>
 
 <p align="center">
-  <strong>Il workspace di amministrazione nativo per Windows che l'era degli AI-tool si è dimenticata di costruire — terminali, SSH, SFTP, RDP/VNC, dashboard, e un'AI che costruisce i tuoi widget-strumento.</strong>
+  <strong>Un'unica finestra nativa Windows per terminali, SSH, SFTP, RDP/VNC e una dashboard — più un'IA che ti costruisce i tuoi piccoli strumenti su richiesta.</strong>
 </p>
 
 <p align="center">
@@ -13,11 +13,11 @@
 </p>
 
 <p align="center">
-  <sub>Prende il nome da <strong>乖乖 (Kuāi Kuāi)</strong>, lo snack al cocco verde che i sysadmin taiwanesi posizionano sui server per tenerli a bada. Speriamo che questa app si guadagni il suo posto nel rack.</sub>
+  <sub>Prende il nome da <strong>乖乖 (Kuāi Kuāi)</strong>, lo snack verde al cocco che i sysadmin taiwanesi posano sui server perché si comportino bene. Speriamo che questa app si guadagni il suo posto sul rack.</sub>
 </p>
 
 <p align="center">
-  <strong><a href="https://github.com/ryantsai/KKTerm/releases/latest">Scarica l'ultimo installer Windows (.exe)</a></strong>
+  <strong><a href="https://github.com/ryantsai/KKTerm/releases/latest">Scarica l'ultimo installer per Windows (.exe)</a></strong>
 </p>
 
 <p align="center">
@@ -38,9 +38,6 @@
   </a>
   <br />
   <img src="https://img.shields.io/badge/Windows%E2%80%91first-by%20design-0078D6?style=flat-square&logo=windows" alt="Windows-first by design" />
-  <img src="https://img.shields.io/badge/built%20with-Tauri%20v2-FFC131?style=flat-square&logo=tauri" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/Rust-russh-orange?style=flat-square&logo=rust" alt="Rust" />
-  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react" alt="React 19" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
   <br />
   <sub>
@@ -63,56 +60,58 @@
 
 ---
 
-## Il Discorso (45 secondi)
+## Il pitch in 45 secondi
 
-Sei un sysadmin / DevOps / homelab / vibe-coder. Adesso hai:
+Sei sysadmin / DevOps / smanettone di homelab / vibe-coder. In questo momento hai:
 
 - Un emulatore di terminale
-- Un client SSH separato (con una lista di profili che hai impiegato un weekend intero a costruire)
-- Un client SFTP del 2007 che per qualche motivo viene ancora distribuito
-- Remote Desktop in una finestra che continui a perdere sul monitor sbagliato
-- Un viewer VNC per quella macchina Linux
-- Una scheda del browser per l'interfaccia admin del router
-- Una sessione `claude` / `codex` su un server di sviluppo remoto che si disconnette ogni volta che il tuo Wi-Fi starnutisce
-- Un post-it con le password *(non ti preoccupare, non lo diciamo a nessuno)*
+- Un client SSH a parte (con una lista di profili che ti è costata un weekend per metterla insieme)
+- Un client SFTP del 2007 che, chissà come, esiste ancora
+- Il Desktop remoto in una finestra che perdi sempre sul monitor sbagliato
+- Un viewer VNC solo per quella macchina Linux
+- Una scheda del browser per l'interfaccia di amministrazione del router
+- Una sessione `claude` / `codex` su una macchina remota che cade ogni volta che il Wi-Fi starnutisce
+- Un post-it con le password *(tranquillo, non lo diciamo)*
 
-**KKTerm è una finestra sola per tutto questo.** Nativo su Windows — *apposta, mentre il resto del mondo degli strumenti per sviluppatori distribuisce prima su Mac e tratta il tuo OS come una nota a piè di pagina* — scritto in Rust + Tauri v2, si installa con un singolo installer, e si rifiuta categoricamente di telefonare a casa.
+**KKTerm è un'unica finestra per tutto questo.** Nativa su Windows — *di proposito, mentre il resto del mondo dei tool per dev esce prima su mac e tratta il tuo OS come una nota a piè di pagina* — in un unico installer che si rifiuta di telefonare a casa.
 
-Più qualche cosa di cui non sapevi di aver bisogno:
+Più un paio di cose che non sapevi di volere:
 
-- Una **Dashboard** dove dici a un'AI *"costruiscimi un widget che fa ping al mio router ogni 30 secondi"* e appare, in sandbox, sulla tua griglia.
-- **Pane SSH che si collegano automaticamente a sessioni tmux con nome** così la tua sessione remota `claude` / `codex` sopravvive a ogni capriccio Wi-Fi che il tuo laptop si inventa.
-- Un **widget di utilizzo AI Coding** che mostra le tue quote di Claude Code e Codex — finestra da 5 ore, finestra settimanale, piano attuale, email account — sulla **Dashboard** e nella status bar, così smetti di sbatterti contro il muro del rate-limit alle 3 del mattino.
-- Un modulo **Installer Helper** che rileva, installa, aggiorna, disinstalla e avvia un catalogo curato di tool di sviluppo Windows — Node, Python, Docker, WSL, CLI di coding AI e le piccole utility che di solito finisci a cercare tra mille tab del browser.
-- Un **server MCP integrato** (`kkterm-cli`) che permette agli agenti di coding esterni (Claude Code, Codex, Copilot, Antigravity, OpenCode) di pilotare il tuo Workspace e la Dashboard — elencare Connections, leggere buffer di terminale, posizionare widget — su una superficie di tool curata e gated da safety. AI-a-AI, sulla tua macchina, senza relay cloud.
-- Ventuno **sfondi canvas animati** (sì, incluso `matrix`) per la dashboard, perché non siamo al di sopra di queste cose.
+- Una **Dashboard** dove dici a un'IA *«costruiscimi un widget che fa il ping al mio router ogni 30 secondi»* e appare, nella sua sandbox, sulla tua griglia.
+- **Pannelli SSH che si riagganciano alla tua sessione remota `claude` / `codex`** dopo ogni capriccio del Wi-Fi, così un lavoro di sei ore sopravvive a una caduta.
+- Un **misuratore d'uso dell'IA** così smetti di sbattere a sorpresa contro il muro del rate limit alle 3 di notte.
+- Un **Installer Helper** che trova, installa, aggiorna e avvia i tool da dev per Windows che di solito insegui per dieci schede del browser.
+- **Venticinque sfondi animati** per la dashboard (sì, incluso `matrix`), perché non siamo troppo seri per farlo.
 
-E l'assistente AI può trasformare una frase in un piccolo strumento da dashboard che continui davvero a usare.
+E la parte migliore: l'assistente IA può trasformare una sola frase in un piccolo strumento da dashboard che davvero continui a usare.
 
-> ⭐ **Se questa sembra l'app che stavi pensando di costruire da sei anni — metti una stella al repo così sappiamo che qualcuno sta guardando. Aiuta davvero.**
+> ⭐ **Se ti suona come l'app che volevi costruire da sei anni — metti una stella al repo così sappiamo che qualcuno sta guardando. Aiuta davvero.**
+
+Hai un'opinione su cosa dovrebbe arrivare dopo? Unisciti al thread pubblico di feedback:
+**[Cosa dovrebbe dare priorità KKTerm per i workflow di amministrazione Windows-first?](https://github.com/ryantsai/KKTerm/discussions/141)**
 
 ---
 
-## Perché "KKTerm"?
+## Perché «KKTerm»?
 
-Entra in qualsiasi data center taiwanese e guarda in cima ai rack. Passando per le fabbriche TSMC, le sale controllo della metropolitana di Taipei, i server hall della Cathay Bank, gli apparati di commutazione di Chunghwa Telecom — vedrai un sacchettino verde di 乖乖 (Kuāi Kuāi), uno snack al mais e cocco degli anni '60.
+Entra in un qualunque data center taiwanese e guarda la cima dei rack. Oltre le fab di TSMC, le sale di controllo della metro di Taipei, le sale server della banca Cathay, gli apparati di commutazione di Chunghwa Telecom — scorgerai un sacchettino verde di 乖乖 (Kuāi Kuāi), uno snack di mais al gusto di cocco degli anni '60.
 
-Il nome significa letteralmente **"stai buono"**, **"comportati bene"**. La tradizione IT è semplice e assolutamente seria:
+Il nome significa letteralmente **«fai il bravo»**, **«comportati bene»**. La tradizione informatica è semplice e del tutto seria:
 
-- **Deve essere il gusto verde (cocco).** Il giallo (curry) significa *resta a casa dal lavoro*; il rosso (piccante) fa arrabbiare il server. Solo verde.
-- **Non deve essere scaduto.** Un Kuai Kuai stantio lavora contro di te. I tecnici li sostituiscono diligentemente.
-- **Deve essere visibile.** Il server deve sapere che c'è.
+- **Dev'essere verde (cocco).** Il giallo (curry) significa *oggi resta a casa*; il rosso (piccante) fa arrabbiare il server. Solo verde.
+- **Non dev'essere scaduto.** Un Kuai Kuai andato a male gioca contro di te. Gli ingegneri li cambiano con diligenza.
+- **Dev'essere visibile.** Il server deve sapere che è lì.
 - **Non mangiarlo.** Quel sacchetto è in servizio.
 
-Alcuni dei sistemi più grandi, più noiosi, più ossessionati dall'uptime in Asia girano con un sacchetto di soffietti al mais attaccato allo chassis. Funziona perché le persone che li gestiscono credono che funzioni, il che è una descrizione sorprendentemente onesta della maggior parte della cultura IT.
+Alcuni dei sistemi più grandi, più noiosi e più ossessionati dall'uptime in Asia funzionano con un sacchetto di soffiati di mais attaccato allo chassis. Funziona perché chi li mantiene crede che funzioni, il che è una descrizione notevolmente onesta di gran parte della cultura IT.
 
-**KKTerm** è **Kuai Kuai Term** — un workspace da amministratore che aspira allo stesso compito dello snack: stare silenziosamente vicino alle tue macchine importanti e aiutarle a comportarsi bene. Local-first. Nessuna telemetria. AI con approvazione obbligatoria. Il tipo di software noioso e affidabile.
+**KKTerm** è **Kuai Kuai Term** — uno spazio di amministrazione che aspira allo stesso lavoro dello snack: sedersi in silenzio accanto alle tue macchine importanti e aiutarle a comportarsi bene. Local-first. Niente telemetria. IA con approvazione. Quel genere di software noioso e affidabile.
 
-Non siamo ancora riusciti a includere un vero sacchetto di Kuai Kuai nell'installer. È un elemento della v2.
+Non siamo ancora riusciti a spedire un vero sacchetto di Kuai Kuai con l'installer. È roba da v2.
 
 ---
 
-## Guardalo in Azione
+## Vederlo in movimento
 
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
@@ -124,339 +123,177 @@ Non siamo ancora riusciti a includere un vero sacchetto di Kuai Kuai nell'instal
   </a>
 </p>
 
-<p align="center"><sub><em>(Qui ci va la GIF dimostrativa. Un'immagine vale mille punti elenco, e noi abbiamo esaurito i punti elenco.)</em></sub></p>
+<p align="center"><sub><em>(Qui va la GIF dimostrativa. Un'immagine vale più di mille punti elenco, e i punti elenco li abbiamo finiti.)</em></sub></p>
 
 ---
 
-## Perché la Gente lo Tiene Aperto Tutto il Giorno
+## Una finestra, ogni connessione
 
-### Windows-first, apposta
-
-Guarda il panorama degli strumenti per sviluppatori nel 2026. Claude Code: distribuisce prima su mac/linux, Windows è "usa WSL." Codex CLI: uguale. `gemini-cli`, metà di Homebrew, ogni nuovo TUI scintillante: prima mac/linux, gli utenti Windows ricevono un commento `# Windows: contributions welcome` nel README e uno script di fish-completion che non gira.
-
-Nel frattempo, le persone che tengono davvero le aziende online — IT aziendale, MSP, chiunque gestisca Hyper-V o AD o SCCM o IIS o un domain controller più vecchio di alcuni stagisti — è seduta davanti a macchine Windows a chiedersi perché ogni nuovo strumento si comporta come se il loro OS fosse un fastidio.
-
-**KKTerm è la scelta opposta.** Costruiamo prima per Windows nativo, e i port per macOS / Linux vengono dopo. Questo significa che possiamo usare le API Windows che contano davvero, invece di coprirle con uno strato di portabilità:
-
-- **ConPTY** per le shell locali — la vera pseudo-console Windows, non uno shim di traduzione. PowerShell, `cmd.exe`, distro WSL, tutti ospitati come PTY autentici con gestione di focus, ridimensionamento e sequenze VT coerenti con il comportamento della piattaforma.
-- **WebView2** per l'intera interfaccia utente e le **Connection** URL incorporate — Chromium in-process che usa il runtime di sistema, il che è uno dei motivi per cui l'installer è piccolo e si avvia velocemente.
-- **Microsoft RDP ActiveX (`mstscax.dll`)** per RDP — *quello vero distribuito da Microsoft*. Lo stesso controllo di Remote Desktop Connection (`mstsc.exe`). Non una reimplementazione di terze parti, non FreeRDP-in-un-wrapper. Chi usa RDP lo noterà in cinque secondi.
-- **Windows Credential Manager** per tutti i segreti. Password SSH, password FTP, chiavi API, credenziali per le Connection URL — vivono nell'OS keychain e `credwiz.exe` può verificarle.
-- **Installer NSIS current-user** con SHA-256 corrispondente, menu nella tray nativo, asserzione di potenza Don't-Sleep, campionamento CPU/RAM/rete dell'host, menu contestuali Tauri nativi con icone PNG reali, dialoghi nativi di apertura/salvataggio. Nemmeno uno di questi è simulato.
-- **WSL è una shell di prima classe, non un workaround.** Avvia Ubuntu accanto a un Pane PowerShell accanto a una sessione SSH accanto a un **Tab** RDP nella stessa finestra.
-
-Le build per macOS e Linux sono nella roadmap e riceveranno la stessa cura. Ma se hai aspettato che qualcuno costruisse il *buon* strumento di amministrazione Windows per primo invece che per ultimo — questo è l'accordo.
-
-### Local-first significa davvero locale
-
-Le tue **Connection** salvate vivono in un file SQLite sulla tua macchina. Le password vivono nel **Windows Credential Manager**, non in un JSON accanto al binario. L'app non distribuisce analytics, non telefona a casa all'avvio, e non ha bisogno di un account cloud per avviarsi. Non c'è "accedi per sincronizzare" perché non c'è sincronizzazione.
-
-Se il tuo cavo di rete prende fuoco, KKTerm si apre lo stesso.
-
-### Un workspace, ogni tipo di Connection
-
-| Volevi… | KKTerm ha |
+| Volevi… | KKTerm lo fa |
 | --- | --- |
-| Aprire una shell PowerShell / cmd / WSL locale | **Session** terminal locali basate su ConPTY |
-| Fare SSH su un server | `russh` nativo con auth agent / chiave / password, flusso di fiducia host-key, ProxyJump, port forwarding |
-| Sfogliare i file su quel server | SFTP avviato dalla **Connection** SSH, doppio pannello, trasferimenti ricorsivi, chmod/chown |
-| FTP su un NAS del 2012 | **Connection** FTP / FTPS nello stesso browser in stile SFTP |
-| Telnet su dispositivi antichi | Sì, va bene, Telnet c'è anche quello |
-| Parlare con una porta seriale | Tipo di **Connection** Serial, porta COM + baud, nessun tooling extra |
-| Connettersi da remoto a una macchina Windows | RDP nativo tramite il controllo Microsoft ActiveX (quello vero, non un clone) |
-| VNC su un Pi | Framebuffer Rust `vnc-rs` renderizzato direttamente nel workspace |
-| Aprire l'interfaccia web del router | **URL Connection** WebView2 incorporato con riempimento delle credenziali |
-| Monitorare la CPU dell'host | Barra di stato live + un modulo **Dashboard** con widget drag/resize |
+| Aprire una shell locale PowerShell / cmd / WSL | Terminali locali, affiancati |
+| SSH verso un server | SSH con chiavi, agent, password, jump host e port forwarding |
+| Sfogliare i file su quel server | SFTP dalla connessione SSH — doppio pannello, trascina per trasferire |
+| FTP verso un NAS del 2012 | FTP / FTPS nello stesso file browser |
+| Telnet verso ferraglia antica | Sì, c'è anche Telnet |
+| Parlare con una porta seriale | Connessioni seriali — scegli porta COM e baud |
+| Entrare in remoto su una macchina Windows | Il vero Desktop remoto Microsoft, integrato |
+| VNC su un Pi | VNC, renderizzato direttamente nello spazio di lavoro |
+| Aprire l'interfaccia web del router | Una scheda di browser integrata con login salvati |
+| Tenere d'occhio la CPU dell'host | Una barra di stato dal vivo e una dashboard che costruisci tu |
 
-È tutta la stessa app. Stessa finestra. Stesse scorciatoie da tastiera. Stesso tema che si spera non faccia sanguinare gli occhi.
+La stessa app. La stessa finestra. Le stesse scorciatoie. Lo stesso tema, si spera non sanguinoso per gli occhi.
 
-### Terminali che non perdono la testa
+---
 
-- Pane divisi all'interno di un **Tab**.
-- Rendering xterm.js accelerato WebGL, con fallback elegante quando non è possibile.
-- Ricerca nello scrollback.
-- Pane SSH con tmux che possono collegarsi a sessioni stabili per pane, così riconnettersi significa davvero *riconnettersi*, non "ricominciare da capo fingendo che l'ultima ora non sia mai esistita."
-- Cambiare **Tab** **non** uccide la **Session**. Chiudere il **Tab** sì. Questa distinzione è stata una guerra di religione internamente; abbiamo vinto noi.
+## Perché la gente lo tiene aperto tutto il giorno
 
-### Un Assistente AI che costruisce i tuoi strumenti
+### Windows prima, di proposito
 
-La maggior parte delle demo "AI nel tuo terminale" si ferma alla chat. L'assistente di KKTerm può anche costruire piccoli widget dashboard persistenti per il tuo modo reale di lavorare. Mantiene comunque le cose pericolose dietro due interruttori:
+Guardati intorno nel panorama dei tool per dev. Claude Code: prima mac/linux, Windows è «usa WSL». Codex CLI: idem. Metà dei nuovi tool scintillanti esce prima su mac e lascia agli utenti Windows un commento `# contributions welcome` e uno script di completamento che non parte.
 
-- **Famiglie di strumenti** (Dashboard / Connections / Session Live) — attivale o disattivale per categoria.
-- **Modalità permesso** nel compositore — `Prompt` (predefinita, chiede ogni volta) o `Allow All` (sei un adulto, hai firmato il modulo di esonero).
+Intanto chi tiene davvero le aziende online — l'IT aziendale, gli MSP, chiunque gestisca un domain controller più vecchio di certi stagisti — è seduto a macchine Windows a chiedersi perché ogni nuovo tool tratti il suo OS come una scocciatura.
 
-Parla con OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA, o qualsiasi cosa compatibile con OpenAI. Le chiavi API vanno nell'OS keychain. I modelli che propongono `rm -rf` vengono classificati come pericolosi e richiedono l'approvazione esplicita di un essere umano. L'AI non può eseguire silenziosamente un comando distruttivo perché qualcuno era furbo con un'iniezione di prompt in una man page.
+**KKTerm fa l'accordo opposto.** Costruiamo nativo Windows prima, così quello che conta per chi sta su Windows semplicemente funziona: il *vero* Desktop remoto Microsoft (lo stesso di `mstsc.exe`, non un clone), shell reali PowerShell / cmd / WSL, segreti custoditi in Gestione credenziali di Windows, una vera icona nella tray, menu e finestre di dialogo nativi. Le build macOS e Linux sono nella roadmap e riceveranno la stessa cura. Ma se aspettavi che qualcuno costruisse il *buon* tool di amministrazione Windows per primo invece che per ultimo — questo è l'accordo.
 
-### Una Dashboard che non finge di essere Grafana
+### Local-first vuol dire davvero locale
 
-Il modulo **Dashboard** è una griglia drag/resize a 12 colonne di istanze di widget. Non è per l'osservabilità a petabyte — è per "voglio un pulsante per avviare le mie cinque app preferite e un pannello che mostra l'uptime del mio host SSH, *accanto* alla mia chat."
+Le tue connessioni salvate vivono in un file sulla tua macchina. Le password vivono in Gestione credenziali di Windows, non in un file di testo accanto all'app. KKTerm non invia analytics, non telefona a casa all'avvio e non ha bisogno di un account cloud per partire. Non c'è alcun «accedi per sincronizzare» perché non c'è sincronizzazione.
 
-#### Widget Creati dall'AI — descrivilo, ottienilo
+Se il tuo cavo di rete prende fuoco, KKTerm si apre comunque.
 
-Questa è la parte di cui siamo genuinamente entusiasti. Non scegli da un marketplace e non scrivi JavaScript. **Dici all'assistente AI cosa vuoi**, e costruisce il widget direttamente sulla tua dashboard:
+### Terminali che non danno di matto
 
-> *"Aggiungi un widget che mostra gli ultimi 5 commit sul mio repo principale come lista."*
-> *"Fammi un widget sticky-note che tiene il mio cheat sheet di on-call."*
-> *"Costruisci un widget che fa ping al mio router di casa ogni 30 secondi e mostra verde/rosso."*
-> *"Ho bisogno di un cronometro. Sorprendimi con lo stile."*
+- Pannelli divisi dentro un Tab.
+- Rendering veloce e fluido, con scrollback ricercabile.
+- Riconnettersi significa davvero *riconnettersi* — la tua sessione remota riprende da dov'era, non «ricominciamo da capo e facciamo finta che l'ultima ora non sia successa».
+- Cambiare Tab **non** uccide la Session. Chiudere il Tab sì. Questa distinzione è stata una guerra di religione interna; abbiamo vinto.
 
-Due varianti:
+### Un assistente IA che costruisce i tuoi strumenti
 
-- **Widget di contenuto** — JSON dichiarativo: markdown, liste kv, checklist, singola statistica grande. Sicuri per costruzione, nessuno script. La maggior parte delle richieste "ho solo bisogno di questo sulla mia dashboard" finisce qui.
-- **Widget script** — JavaScript ospitato all'interno di una sandbox `iframe srcdoc` isolata con permessi espliciti e dichiarati (allowlist `network`, budget `pollSeconds`). L'AI scrive lo script, tu approvi i permessi, il widget gira in una scatola che non può raggiungere il resto dell'app.
+Gran parte delle demo «IA nel terminale» si ferma alla chat. L'assistente di KKTerm può anche costruire piccoli widget da dashboard duraturi, su misura per come lavori davvero — e tiene la roba pericolosa dietro un interruttore:
 
-Ogni widget che mantieni è tuo. Persistono in SQLite accanto alle tue **Connection**, con il loro preset visivo (`panel` / `ambient` / `hero`), colore d'accento, icona e titolo. Più istanze dello stesso widget possono coesistere con dimensioni e stili completamente diversi. Eliminali con un clic destro quando la magia svanisce.
+- **Decidi cosa può toccare** — accendi o spegni intere famiglie di tool (Dashboard / Connections / Live Sessions).
+- **Decidi come chiede** — `Prompt` (predefinito, chiede ogni volta) o `Allow All` (sei adulto, hai firmato la liberatoria).
 
-#### Sfondi animati per la dashboard (perché ne avevamo voglia)
+Tutto ciò che assomiglia a `rm -rf` viene marcato come pericoloso e attende un sì umano esplicito. L'IA non può eseguire di nascosto un comando distruttivo solo perché qualcuno ha fatto il furbo con un prompt injection in una pagina di man.
 
-La dashboard ha ventuno sfondi animati su canvas che puoi scegliere per ogni **Dashboard View**:
+Parla con OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA o qualsiasi endpoint compatibile con OpenAI. Le tue chiavi API vanno nel portachiavi dell'OS.
 
-| Umore | Sfondi |
+### Una dashboard che non finge di essere Grafana
+
+La Dashboard è una griglia di widget che trascini e ridimensioni. Non è per l'osservabilità su scala petabyte — è per «voglio un pulsante che lanci le mie cinque app preferite e un pannello che mostra l'uptime del mio host SSH, *accanto* alla mia chat».
+
+#### Widget creati dall'IA — descrivilo, ce l'hai
+
+Questa è la parte che ci entusiasma davvero. Non scegli da un marketplace e non scrivi JavaScript. **Dici all'assistente IA cosa vuoi**, e costruisce il widget lì, sulla tua dashboard:
+
+> *«Aggiungi un widget che mostra gli ultimi 5 commit del mio repo principale come lista.»*
+> *«Fammi un widget post-it per il mio cheat sheet di reperibilità.»*
+> *«Costruisci un widget che fa il ping al router di casa ogni 30 secondi e mostra verde/rosso.»*
+> *«Mi serve un cronometro. Sorprendimi con lo stile.»*
+
+Alcuni sono semplici pannelli di visualizzazione (markdown, checklist, un numero grande); altri eseguono codice dal vivo in una sandbox isolata che approvi tu. Ogni widget che tieni è tuo — resta con il suo colore, la sua icona e il suo titolo, e puoi averne più copie di dimensioni diverse. Cancellane uno col tasto destro quando la magia svanisce.
+
+#### Sfondi animati della dashboard (perché ne avevamo voglia)
+
+Scegli un'atmosfera per ogni vista della dashboard tra **venticinque** sfondi animati su canvas:
+
+| Atmosfera | Sfondi |
 | --- | --- |
-| Calmo | `aurora`, `clouds`, `ocean`, `raindrops`, `snow`, `sakura`, `fireflies`, `bubbles`, `ricefield`, `lanterns` |
+| Calmo | `aurora`, `clouds`, `ocean`, `raindrops`, `rainywindow`, `frostedWindow`, `snow`, `sakura`, `fireflies`, `bubbles`, `aquarium`, `ricefield`, `lanterns` |
 | Spaziale | `starfield`, `nebula` |
 | Caldo | `embers`, `lava` |
-| Nerd | `matrix`, `topo`, `synthwave` |
-| Caotico | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti` |
+| Geek | `matrix`, `topo`, `synthwave` |
+| Irrequieto | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti`, `particleCursor` |
 
-Girano su un singolo `requestAnimationFrame` condiviso e rispettano il focus della finestra, quindi costano praticamente zero quando sei altrove. Abbina `matrix` al tuo assistente AI per un'atmosfera che dice "sono estremamente produttivo e forse anche in un film dei Wachowski." Oppure scegli `ocean` e sembrare una persona seria. Non giudichiamo nessuna delle due scelte.
+Si mettono in pausa quando sei altrove, quindi non costano praticamente nulla. Abbina `matrix` al tuo assistente IA per un'atmosfera che dice «sono estremamente produttivo e probabilmente dentro un film delle Wachowski». Oppure scegli `ocean` e sembra una persona seria. Non giudichiamo nessuna delle due scelte.
 
-### Eseguire agenti AI di coding su un server, nel modo giusto
+### Tieni vivi i tuoi agenti IA remoti
 
-Questa è la seconda funzionalità di cui le persone si innamorano. I terminali SSH di KKTerm possono avviarsi direttamente in una **sessione tmux con nome** sull'host remoto — per impostazione predefinita, un id amichevole generato automaticamente come `kkterm-cockpit001` che sopravvive alla riconnessione:
+Questa è la seconda funzione di cui la gente s'innamora. I terminali SSH di KKTerm possono catapultarti direttamente in una **sessione tmux con nome** sull'host remoto che sopravvive alla riconnessione:
 
-- Apri una **Connection** SSH con tmux abilitato.
-- All'interno del pane, avvia `claude`, `codex`, `gemini-cli`, `cursor-agent`, o qualsiasi agente di coding a lunga esecuzione che preferisci. Sono app TUI a schermo intero; tmux è esattamente dove vogliono vivere.
-- Chiudi il laptop. Riaprilo. Il pane si ricollegherà silenziosamente alla stessa sessione tmux. L'agente è ancora in esecuzione, ha ancora il suo scrollback, ancora nel mezzo di qualsiasi cosa stava facendo.
-- Interruzione di rete nel trasporto SSH? KKTerm effettua un tentativo di riaggancio silenzioso limitato allo stesso tmux id senza disturbarti.
-- Vuoi che l'assistente AI veda cosa sta facendo l'agente? "Aggiungi il buffer del terminale al contesto" chiama `capture_tmux_pane` tramite SSH e porta l'intero scrollback tmux — non solo quello sullo schermo, l'intera sessione — nella conversazione. Il tuo assistente locale può ora ragionare sul lavoro del tuo agente remoto.
+- Apri una connessione SSH con tmux attivo e avvia `claude`, `codex`, `gemini-cli`, `cursor-agent` o l'agente di lunga durata che preferisci.
+- Chiudi il portatile. Riaprilo. Il pannello si riaggancia in silenzio — l'agente è ancora in esecuzione, ha il suo scrollback, nel mezzo di ciò che stava facendo.
+- Un singhiozzo della rete? KKTerm si riconnette in silenzio alla stessa sessione senza disturbarti.
+- Vuoi l'aiuto dell'assistente? «Aggiungi il buffer del terminale al contesto» risucchia l'intera sessione remota nella conversazione, così la tua IA locale può ragionare su cosa sta facendo il tuo agente remoto.
 
-Se hai mai perso una sessione `claude` o `codex` di sei ore a causa di un Wi-Fi alberghiero instabile, questa singola funzionalità vale l'intero prezzo dell'app. L'app è gratuita. La funzionalità vale comunque.
+Se hai mai perso una sessione `claude` o `codex` di sei ore per il Wi-Fi ballerino di un hotel, questa singola funzione ripaga l'app. (L'app è gratis. La funzione vale comunque.)
 
-### Sapere quanta AI ti resta
+### Sapere quanta IA ti resta
 
-Gli agenti di coding fatturano per finestra di piano, non per mese. Claude Code ha una finestra da 5 ore e una settimanale. Codex fa la sua versione. Entrambi possono divorarti la quota in background mentre sei in una riunione.
+Gli agenti di coding fatturano per finestra di piano, non al mese, e si divorano volentieri la tua quota mentre sei in riunione. Il **misuratore d'uso dell'IA** lo tiene visibile:
 
-Il widget **Utilizzo AI Coding** lo tiene visibile:
+- Un widget da dashboard che mostra **Claude Code** e **Codex** affiancati: account connesso, piano, consumo della finestra attuale e di questa settimana, ora del prossimo reset.
+- Un **indicatore compatto nella barra di stato** che rispecchia gli stessi numeri, così anche a dashboard chiusa capisci a colpo d'occhio se hai margine prima del prossimo grande refactoring.
+- Ti avvisa in anticipo se devi rifare il login — *prima* di un'attività lunga, non a metà.
 
-- Un widget di Dashboard che mostra **Claude Code** e **Codex** affiancati: account connesso, livello del piano, percentuale usata nella finestra 5 ore corrente, percentuale usata questa settimana, prossimo reset.
-- Un **indicatore compatto nella status bar** che riflette gli stessi numeri, così anche con la Dashboard chiusa vedi a colpo d'occhio se hai ancora margine prima di lanciare il prossimo grosso refactor.
-- Lo stato di auth è in chiaro (`connected` / `expired` / `error`), così scopri *prima* di una task lunga che devi rifare login, non a metà.
-- La policy di refresh rispetta i rate limit; il widget fa polling al proprio ritmo invece di martellare le API a monte ogni volta che lo guardi.
+### Lascia che altre IA pilotino KKTerm
 
-### Un server MCP integrato — lascia che altre AI pilotino KKTerm
+KKTerm porta con sé il proprio server MCP, così agenti di coding esterni (Claude Code, Codex, Copilot, Antigravity, OpenCode) possono usare il tuo spazio di lavoro come fai tu — elencare connessioni, aprirne una, leggere un buffer di terminale, piazzare widget sulla dashboard. Da IA a IA, sulla tua macchina, senza relay cloud. Le azioni che modificano, le più rischiose, restano dietro un unico interruttore di sicurezza **disattivato** di default.
 
-Il tuo terminale è anche dove Claude Code, Codex, la modalità agente di Copilot, Antigravity e il resto del mondo MCP-parlante vogliono lavorare. Quindi KKTerm spedisce il proprio **server MCP stdio**, [`kkterm-cli`](docs/MCP.md), che espone una fetta curata dell'app:
-
-- **Modulo Workspace** (`kkterm.workspace.*`): elenca **Connections** salvate, apre una Connection per id, elenca **Sessions** vive, invia input a un pane di terminale, legge uno snapshot del buffer.
-- **Modulo Dashboard** (`kkterm.dashboard.*`): carica lo stato della Dashboard, legge il source di un widget creato da AI, crea / aggiorna / elimina view, posiziona / sposta / rimuove istanze di widget, applica layout in blocco.
-- **Sub-namespace pericolosi** (`kkterm.<module>.dangerous.*`): mutare la superficie eseguibile — creare widget script, cliccare in remote desktop, azzerare la Dashboard — è dietro a un singolo settaggio (`built_in_mcp_allow_all_dangerous`), **off** di default.
-
-`kkterm-cli` è un forwarder sottile. Parla stdio JSON-RPC con il tuo client MCP e comunica con la finestra KKTerm in esecuzione tramite una named pipe di Windows autenticata per lancio. A KKTerm chiusa, `tools/list` continua a funzionare (i client possono fare introspection), ma `tools/call` restituisce un errore strutturato `app_not_running` invece di fare qualcosa.
-
-Cablalo nel tuo client preferito e la tua AI ora usa KKTerm come fai tu:
-
-```json
-{
-  "mcpServers": {
-    "kkterm": { "command": "<percorso-a-kkterm-cli>", "args": [] }
-  }
-}
-```
-
-Settings → AI Assistant → **Server MCP integrato** ha un dialog "Mostra config" a un clic con snippet JSON e TOML pre-compilati con il path del binario risolto, più comandi `claude mcp add` / `codex mcp add` copiabili.
+Impostazioni → AI Assistant → **Built-in MCP Server** ha una finestra «Mostra configurazione» con un clic, già compilata, più i comandi copiabili `claude mcp add` / `codex mcp add`.
 
 ---
 
-## Come si Incastra Tutto
+## Cosa KKTerm non è
 
-```mermaid
-flowchart LR
-    User([You]) --> Shell[KKTerm Window<br/>Tauri v2 + React 19]
-    Shell --> Rail[Activity Rail]
-    Rail --> WS[Workspace Module]
-    Rail --> Dash[Dashboard Module]
-    Rail --> Inst[Installer Helper Module]
-    Rail -.-> FE[File Explorer<br/>planned]
-    Rail --> Set[Settings]
+Una lista breve, perché l'onestà conquista fiducia:
 
-    WS --> Tabs[Tabs &amp; Panes]
-    Tabs --> Term[Terminal<br/>ConPTY / russh]
-    Tabs --> SFTP[SFTP / FTP]
-    Tabs --> Web[WebView2 URL]
-    Tabs --> RD[RDP / VNC]
-
-    Shell -.calls.-> Rust[Rust Backend]
-    Rust --> SQLite[(SQLite<br/>Connections)]
-    Rust --> Keychain[(OS Keychain<br/>Secrets)]
-    Rust --> AI[AI Providers<br/>OpenAI-compat]
-
-    AI -. approval gate .-> Tabs
-
-    classDef local fill:#1f6feb,stroke:#1f6feb,color:#fff
-    classDef ai fill:#8a63d2,stroke:#8a63d2,color:#fff
-    class SQLite,Keychain local
-    class AI ai
-```
-
-La struttura che conta: i dati salvati durevoli (**Connection**) sono separati dallo stato runtime live (**Session**), che è separato dal contenitore UI (**Tab**). Chiudere un **Tab** termina la **Session**. Cambiare **Tab** no. Questa è la regola che mantiene l'app sana.
-
----
-
-## Mappa delle Funzionalità Attuali
-
-| Area | Implementato oggi |
-| --- | --- |
-| **Connections** | Albero basato su SQLite, cartelle/sottocartelle, ricerca, ordine drag/drop, rinomina, duplica, elimina, **Quick Connect**, icone personalizzate, scorciatoie rail pinnate/attive |
-| **Terminal** | Shell locali, SSH, Telnet, Serial, pane divisi, xterm.js + WebGL opportunistico, ricerca scrollback, directory/script di avvio locale |
-| **SSH** | `russh` nativo, auth agent/chiave/password, flusso di fiducia host-key, fallback SSH di sistema opzionale, ProxyJump, port forwarding, **sessioni tmux con nome automatico (`kkterm-<scifi-name><n>`) con riaggancio silenzioso in caso di interruzione del trasporto** — perfetto per agenti di coding remoti a lunga esecuzione (Claude Code, Codex, gemini-cli, ecc.) |
-| **SFTP / FTP** | SFTP avviato da SSH più **Connection** FTP/FTPS, browser a doppio pannello, trasferimenti ricorsivi, coda/annulla/cancella cronologia, conflitti, proprietà, chmod/chown dove supportato |
-| **URL WebView** | **Session** URL WebView2 incorporate, barra di navigazione, acquisizione favicon, metadati/riempimento credenziali sito web memorizzate, metadati partizione dati |
-| **Remote Desktop** | RDP tramite Windows ActiveX con parcheggio overlay con scope geometrico; VNC tramite framebuffer `vnc-rs` renderizzato nel canvas del workspace |
-| **Dashboard** | Viste durevoli, istanze widget, modalità modifica, drag/resize, App Launcher, **widget di contenuto/script creati dall'AI** (JSON dichiarativo o JS iframe sandboxed con permessi), preset / accento / icona / titolo per widget, **23 sfondi canvas animati** (aurora, clouds, ocean, raindrops, rainywindow, snow, sakura, fireflies, bubbles, ricefield, lanterns, starfield, nebula, embers, lava, matrix, topo, synthwave, cyberpunk, taipei101, thunderstorm, confetti, particleCursor) |
-| **AI Assistant** | Chat in streaming, runtime compatibile OpenAI, registro provider, classificazione sicurezza proposte comandi, allegati screenshot/contesto, **creazione widget Dashboard (contenuto + script sandboxed)**, **cattura pane tmux** come contesto di conversazione per sessioni remote, strumenti di gestione **Connection**, e strumenti **Session** live per terminale, RDP/VNC, e SFTP/FTP |
-| **Utilizzo AI Coding** | **Widget Dashboard + indicatore in status bar** che tracciano l'utilizzo delle quote di **Claude Code** e **Codex**: account connesso, livello del piano, percentuali finestra 5 ore e settimanale, prossimo reset, stato di auth (`connected` / `expired` / `error`), policy di refresh rate-limit aware |
-| **Server MCP integrato** | Server MCP stdio (`kkterm-cli`) che espone tool curati di Workspace e Dashboard ad agenti di coding esterni (Claude Code, Codex, Copilot, Antigravity, OpenCode); bridge named pipe autenticato; sub-namespace `dangerous.*` per Modulo dietro un singolo toggle di sicurezza; dialog in Settings con snippet JSON / TOML a un clic e comandi `claude mcp add` / `codex mcp add` |
-| **Installer Helper** | Modulo Activity Rail per un catalogo Windows di tool di sviluppo incluso: rileva tool installati, confronta ultime versioni, installa/aggiorna/disinstalla, esclude tool da Update all, mostra log comando in streaming e avvia app gestite supportate |
-| **Settings** | Generale, Aspetto, Credenziali, AI, SSH, Terminal, sfondi terminale, URL, RDP, VNC, Dashboard, Installer Helper, Info; font UI personalizzati; minimizza nella tray; Don't Sleep; backup/importa |
-| **Localizzazione** | UI i18next con sorgente inglese e bundle locale dinamici: zh-TW, zh-CN, ja, ko, fr, de, es, es-MX, it, pt-BR, th, id, vi |
-
-### Provider AI
-
-OpenAI · Anthropic · OpenRouter · DeepSeek · Grok · Azure OpenAI · LiteLLM · GitHub Copilot · Ollama · NVIDIA · qualsiasi endpoint compatibile OpenAI.
-
-I metadati dei provider si trovano in [`src/ai/providerRegistry/`](src/ai/providerRegistry/); gli adattatori Rust in [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/). Le chiavi API passano attraverso l'OS keychain, mai SQLite.
-
----
-
-## Quick Start
-
-Ti serve:
-
-- **Windows** (piattaforma supportata primaria)
-- **Node.js + npm**
-- **Toolchain Rust**
-- **Prerequisiti Tauri v2 per Windows** incluso **WebView2**
-
-```bash
-npm install
-npm run tauri dev
-```
-
-Questo dovrebbe produrre una vera finestra nativa. Se produce uno stack trace, apri un issue — adoriamo un buon repro.
-
-### Controlli comuni
-
-```bash
-npm run check                                              # TypeScript
-npm run build                                              # Vite build
-cargo check --manifest-path src-tauri/Cargo.toml           # Rust
-cargo test  --manifest-path src-tauri/Cargo.toml           # Rust tests
-```
-
-### Costruire l'installer Windows
-
-```bash
-npm run package:installer
-```
-
-Lo script dell'installer scrive `artifacts/kkterm-<version>-windows-x64-setup.exe` e un file `.sha256` corrispondente. È attualmente **non firmato** — la firma per il rilascio è nella roadmap, ma nel frattempo il tuo antivirus potrebbe guardarti storto. È normale.
-
----
-
-## Cosa KKTerm Non È
-
-Un elenco breve, perché l'onestà guadagna fiducia:
-
-- **Non è un prodotto cloud.** Nessuna sincronizzazione, nessun account team, nessun livello SaaS. Se mai vedi un dialogo "Accedi a KKTerm", qualcosa è andato catastroficamente storto.
-- **Non finge di essere cross-platform.** Siamo Windows-first apposta; macOS e Linux sono nella roadmap e useranno lo stesso shell Tauri v2. Se hai bisogno di uno strumento mac-first oggi, hai centinaia di opzioni. Stiamo costruendo quello che gli admin Windows stavano aspettando in silenzio.
-- **Non è un agente AI autonomo.** L'assistente propone; l'essere umano decide. `Allow All` è una scelta che fai tu, non un'impostazione predefinita.
+- **Non è un prodotto cloud.** Niente sync, niente account di team, niente piano SaaS. Se mai vedi una finestra «Accedi a KKTerm», qualcosa è andato catastroficamente storto.
+- **Non finge di essere multipiattaforma.** Siamo Windows-first di proposito; macOS e Linux sono nella roadmap. Se ti serve oggi un tool mac-first, hai centinaia di opzioni. Stiamo costruendo quello che gli admin Windows aspettavano in silenzio.
+- **Non è un agente IA autonomo.** L'assistente propone; l'umano dispone. `Allow All` è una scelta che fai tu, non un default.
 - **Non è un sostituto di Grafana / Datadog.** La Dashboard è per superfici di controllo personali, non per l'osservabilità di 10.000 host.
-- **Non è un Kubernetes IDE.** È un workspace di amministrazione terminale-first. Per favore non chiedergli di renderizzare un Helm chart.
+- **Non è un IDE per Kubernetes.** È uno spazio di amministrazione incentrato sul terminale. Per favore non chiedergli di renderizzare un chart Helm.
 
-Se qualcuno di questi *era* un motivo per non usarlo — capito, ci vediamo nella v2.
-
----
-
-## Debug Nativo
-
-Usa il vero runtime Tauri per la validazione:
-
-```bash
-npm run tauri dev
-```
-
-Un'anteprima browser Vite è utile per alcune ispezioni frontend, ma **non** ospita un vero WebView2, ConPTY, RDP ActiveX, framebuffer VNC, keychain, o superficie di menu nativa. Se una funzionalità tocca uno di questi, validala nell'effettivo runtime desktop.
-
-Utenti VS Code: la configurazione di lancio `Run KKTerm exe` avvia `src-tauri/target/debug/kkterm.exe` con `RUST_BACKTRACE=1`. La configurazione abbinata `Attach KKTerm WebView2` ti dà DevTools all'interno del vero host WebView2.
+Se uno di questi punti *era* un dealbreaker — giusto così, ci vediamo in v2.
 
 ---
 
-## Limiti Attuali (sì, lo sappiamo)
+## Ottieni KKTerm
 
-- L'installer è attualmente non firmato. I controlli di aggiornamento sono disabilitati fino a quando la firma per il rilascio non sarà configurata.
-- SFTP tramite ProxyJump non è ancora supportato nel percorso SFTP nativo.
-- La ripresa dei trasferimenti file, la sincronizzazione/diff di cartelle, l'archiviazione/estrazione e la modifica remota sono rimandati.
-- L'importazione della configurazione SSH è implementata ma la voce nell'interfaccia utente di Settings non è ancora esposta.
-- RDP e VNC sono in distribuzione; sincronizzazione più ricca degli appunti/dispositivi e controlli di qualità sono ancora in evoluzione.
-- Le build per macOS e Linux sono nella roadmap. Arriveranno, e saranno fatte bene — non distribuite di corsa come un port "funzioniamo anche lì più o meno."
-- L'assistente AI propone e può operare gli strumenti abilitati entro il confine di permesso configurato — per favore non trattarlo come un robot incustodito. Non sa, di fatto, cosa vuole il tuo CEO.
+**[Scarica l'ultimo installer per Windows (.exe)](https://github.com/ryantsai/KKTerm/releases/latest)** ed eseguilo. L'installer al momento è **non firmato** — la firma delle release è nella roadmap, quindi fino ad allora il tuo antivirus potrebbe guardarti storto. È normale.
+
+Vuoi compilare dai sorgenti o contribuire? Tutto ciò che serve è in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ---
 
-## Roadmap (la versione breve)
+## Roadmap (versione breve)
 
-- Build per macOS + Linux
-- Installer firmato + auto-aggiornamento
-- SFTP tramite ProxyJump nel percorso nativo
-- Ripresa trasferimento file, sincronizzazione cartelle, archiviazione/estrazione
-- Reindirizzamento più ricco degli appunti/dispositivi RDP
-- Più widget **Dashboard** integrati (e uno schema pubblico per quelli creati dall'AI)
+- Build macOS + Linux
+- Installer firmato + aggiornamento automatico
+- Trasferimento file più potente (ripresa, sync di cartelle, archivia/estrai)
+- Condivisione di appunti e dispositivi più ricca per il Desktop remoto
+- Più widget da dashboard integrati
 
-Versione completa e aggiornata frequentemente: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+Versione completa e aggiornata di frequente: [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
 ---
 
 ## Contribuire
 
-Ci farebbe piacere un aiuto. Davvero. Anche le piccole cose contano:
+Ci farebbe piacere una mano. Davvero. Anche le piccole cose contano:
 
-- **Prova la build dev** e apri un issue quando qualcosa sembra sbagliato. "Sembrava sbagliato" è un bug report legittimo; scaveremo insieme.
-- **Traduci una locale.** L'inglese è la fonte di verità su [`src/i18n/locales/en.json`](src/i18n/locales/en.json); 12 altre locale si trovano accanto ad essa e si caricano on demand. Le stringhe in sospeso sono tracciate per chiave in [`docs/localization_todo/`](docs/localization_todo/) — scegline una, traducila, elimina il file.
-- **Aggiungi un widget Dashboard.** I widget integrati si trovano in [`src/modules/dashboard/widgets/builtin/`](src/modules/dashboard/widgets/builtin/). Scegli un'idea piccola, distribuiscila, impara il pattern.
-- **Affina la superficie degli strumenti AI.** Gli adattatori provider si trovano in [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/); il registro frontend è in [`src/ai/providerRegistry/`](src/ai/providerRegistry/).
-- **Migliora il manuale.** La documentazione per l'utente finale si trova in [`docs/manual/`](docs/manual/). Un capitolo per modulo UI. Se hai usato una funzionalità e la documentazione non ti ha aiutato, una PR che lo corregge è oro.
+- **Prova la build di sviluppo** e apri una issue quando qualcosa non torna. «Mi sembrava strano» è una segnalazione di bug legittima; scaviamo con te.
+- **Traduci una lingua.** L'inglese è la fonte di verità; altre tredici lingue vivono accanto.
+- **Aggiungi un widget da dashboard.** Prendi una piccola idea, rilasciala, impara il pattern.
+- **Migliora il manuale.** Se hai usato una funzione e la documentazione non ha aiutato, una PR che la sistema vale oro.
 
-Setup completo, struttura del progetto, checklist PR e lista delle regole "per favore non rompere queste" si trovano in [`CONTRIBUTING.md`](CONTRIBUTING.md). I punti salienti in 30 secondi:
-
-- **Leggi [`CONTEXT.md`](CONTEXT.md) prima di rinominare termini rivolti all'utente.** **Connection**, **Session**, **Tab** e **Quick Connect** hanno significati specifici; per favore non deviare.
-- **Ogni stringa visibile all'utente passa attraverso `t()`.** Nessun testo inglese diretto in JSX.
-- **Nessun hook di chiusura frontend.** Il pulsante di chiusura della barra del titolo di Tauri v2 è stato rotto dai pattern `onCloseRequested` mezza dozzina di volte. Finalmente abbiamo una forma funzionante; per favore non reintroducili.
-- **Esegui i controlli** (`npm run check && npm run build && cargo check && cargo test`) prima di aprire una PR.
-
-Cerchi un punto di ingresso? Filtra le issue aperte per [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) o [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22). Se non ce ne sono ancora etichettate, apri un issue descrivendo su cosa vorresti lavorare e ti aiuteremo a definirlo.
+Setup completo, struttura del progetto e checklist per le PR sono in [`CONTRIBUTING.md`](CONTRIBUTING.md). Cerchi un punto d'ingresso? Filtra le issue aperte per [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) o [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
 
 ---
 
-## Documentazione del Progetto
+## Documenti del progetto
 
-- [Contesto del prodotto](CONTEXT.md) — il linguaggio del dominio che dovresti seguire
+- [Contesto di prodotto](CONTEXT.md) — il linguaggio di dominio da rispettare
 - [Architettura](docs/ARCHITECTURE.md) — mappa dei moduli, dove mettere il nuovo codice
 - [Roadmap](docs/ROADMAP.md)
-- [Architettura Dashboard](docs/DASHBOARD.md)
-- [Guida ai provider AI](docs/AI_PROVIDERS.md)
-- [Note sulle prestazioni](docs/PERFORMANCE.md)
-- [Note di rilascio e gate](docs/RELEASE.md)
+- [Architettura della Dashboard](docs/DASHBOARD.md)
+- [Guida ai provider IA](docs/AI_PROVIDERS.md)
 
 ---
 
-## Stack
-
-Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand · xterm.js · SQLite · WebView2 · `russh` · `russh-sftp` · `vnc-rs` · `suppaftp` · archiviazione OS keychain.
-
----
-
-## Cronologia delle Stelle
+## Cronologia delle stelle
 
 <a href="https://www.star-history.com/#ryantsai/KKTerm&Date">
   <picture>
@@ -466,12 +303,12 @@ Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand ·
   </picture>
 </a>
 
-Se sei arrivato fin qui e non hai ancora messo la stella — cosa stai aspettando, un invito personale? Considera questo l'invito personale.
+Se sei arrivato fin qui senza mettere una stella — cosa aspetti, un invito personale? Consideralo l'invito personale.
 
-⭐ **[Metti una stella a KKTerm su GitHub](https://github.com/ryantsai/KKTerm)** — costa un click e fa passare all'amministratore tutta la settimana. Pensala come un 乖乖 digitale sul rack.
+⭐ **[Metti una stella a KKTerm su GitHub](https://github.com/ryantsai/KKTerm)** — costa un clic e rende migliore l'intera settimana del manutentore. Pensalo come un 乖乖 digitale sul rack.
 
 ---
 
 ## Licenza
 
-MIT. Vedi [LICENSE](LICENSE). Usalo, forkalo, distribuiscilo, mettilo in un homelab che nessun altro riesce a trovare — questo è l'accordo.
+MIT. Vedi [LICENSE](LICENSE). Usalo, forkalo, spediscilo, mettilo in un homelab che nessun altro troverà — questo è l'accordo.

--- a/README.ja.md
+++ b/README.ja.md
@@ -5,7 +5,7 @@
 <h1 align="center">KKTerm</h1>
 
 <p align="center">
-  <strong>ターミナル、SSH、SFTP、RDP/VNC、Dashboard、そして自分専用のツールWidgetを作るAI——AIツール時代に誰も作らなかった、Windowsネイティブの管理者向けワークスペース。</strong>
+  <strong>ターミナル、SSH、SFTP、RDP/VNC、Dashboard を1つのWindowsネイティブウィンドウに——おまけに、頼めば自分専用の小さなツールを作ってくれるAI付き。</strong>
 </p>
 
 <p align="center">
@@ -38,9 +38,6 @@
   </a>
   <br />
   <img src="https://img.shields.io/badge/Windows%E2%80%91first-by%20design-0078D6?style=flat-square&logo=windows" alt="Windows-first by design" />
-  <img src="https://img.shields.io/badge/built%20with-Tauri%20v2-FFC131?style=flat-square&logo=tauri" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/Rust-russh-orange?style=flat-square&logo=rust" alt="Rust" />
-  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react" alt="React 19" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
   <br />
   <sub>
@@ -73,46 +70,48 @@
 - どこか別のモニターに消えているリモートデスクトップのウィンドウ
 - 某Linuxマシン専用のVNCビューア
 - ルーター管理UIを開いたブラウザのタブ
-- リモートの開発サーバーで動いている `claude` / `codex` のセッション（Wi-Fiがくしゃみをするたびに切れる）
+- リモートマシンで動いている `claude` / `codex` のセッション（Wi-Fiがくしゃみをするたびに切れる）
 - パスワードを書いた付箋 *（言わない、絶対言わない）*
 
-**KKTerm はそのすべてを1つのウィンドウにまとめる。** Windowsネイティブ——*他のdevツールがmacファーストで出荷しながらWindowsをおまけ扱いにしている中で、意図的に*——Rust + Tauri v2で書かれ、シングルインストーラーで配布、テレメトリーなし。
+**KKTerm はそのすべてを1つのウィンドウにまとめる。** Windowsネイティブ——*他のdevツールがmacファーストで出荷しながらWindowsをおまけ扱いにしている中で、意図的に*——シングルインストーラーで配布、テレメトリーなし。
 
 さらに、あなたがまだ気づいていなかったものも：
 
 - **Dashboard** でAIに *「ルーターを30秒おきにpingするWidget を作って」* と言えば、サンドボックス化されたグリッドの上にそれが現れる。
-- **SSHのPane が名前付きtmux Sessionに自動アタッチ**されるので、ラップトップのWi-Fiがどれだけ癇癪を起こしても、リモートの `claude` / `codex` のセッションは生き続ける。
-- **AIコーディング使用量Widget** が、Claude Code と Codex のクォータ（5時間ウィンドウ・週次ウィンドウ・現在のプラン・アカウントメール）を **Dashboard** とステータスバーに表示。深夜3時にレートリミットの壁に突き当たって驚かなくなる。
-- **Installer Helper Module**。Node、Python、Docker、WSL、AIコーディングCLI、そして普段ならブラウザータブを渡り歩いて探す小さなユーティリティまで、厳選されたWindows開発ツールカタログを検出・インストール・更新・アンインストール・起動できる。
-- **ビルトインMCPサーバー**（`kkterm-cli`）。外部コーディングエージェント（Claude Code、Codex、Copilot、Antigravity、OpenCode）が、キュレートされた安全ゲート付きツール経由で、あなたのWorkspaceとDashboardを操作できる——Connection一覧、ターミナルバッファ読み取り、Widget配置など。AIからAIへ、ローカルマシン上で、クラウドリレーなし。
-- Dashboard用のアニメーションキャンバス背景が23種類（そう、`matrix` もある）。やりすぎかもしれないが、後悔はしていない。
+- **リモートの `claude` / `codex` セッションに自動アタッチし直すSSHのPane**。Wi-Fiがどれだけ癇癪を起こしても、6時間動かしっぱなしのジョブが生き残る。
+- **AI使用量メーター**。深夜3時にレートリミットの壁に突き当たって驚かなくなる。
+- **Installer Helper**。普段ならブラウザータブを10個渡り歩いて探すWindows開発ツールを、見つけて・インストールして・更新して・起動できる。
+- Dashboard用の**25種類のアニメーション背景**（そう、`matrix` もある）。やりすぎかもしれないが、後悔はしていない。
 
-それと、AIアシスタントは一文から、実際に使い続けられる小さなDashboardツールを作れる。
+そして一番いいところ：AIアシスタントは一文から、実際に使い続けられる小さなDashboardツールを作れる。
 
 > ⭐ **「俺が6年間ずっと作ろうと思ってたやつだ」と思ったなら——リポジトリにスターをつけて、誰かが見ていることを教えてほしい。本当に力になる。**
+
+次に何をすべきか意見がある？公開フィードバックスレッドへどうぞ：
+**[KKTerm は Windows-first の管理ワークフローで何を優先すべきか？](https://github.com/ryantsai/KKTerm/discussions/141)**
 
 ---
 
 ## なぜ「KKTerm」なのか
 
-台湾のデータセンターに行って、ラックの上を見てみてほしい。TSMCの工場、台北メトロの制御室、国泰銀行のサーバーホール、中華電信の交換機——どこかに必ず小さな緑色の袋が置いてある。**乖乖 (グァイグァイ / Kuāi Kuāi)**、1960年代から続くコーナッツ味のコーンスナックだ。
+台湾のデータセンターに行って、ラックの上を見てみてほしい。TSMCの工場、台北メトロの制御室、国泰銀行のサーバーホール、中華電信の交換機——どこかに必ず小さな緑色の袋が置いてある。**乖乖 (グァイグァイ / Kuāi Kuāi)**、1960年代から続くココナッツ味のコーンスナックだ。
 
 名前の意味はそのまま**「おりこうにしなさい」**、**「ちゃんと動きなさい」**。IT業界の慣習はシンプルで、かつ至って本気だ：
 
-- **緑（ coconut味）でなければならない。** 黄色（カレー味）は「家で休め」を意味し、赤（辛口）はサーバーを怒らせる。緑だけ。
-- **賞味期限内でなければならない。** 古い乖乖は逆効果。エンジニアはこまめに交換する。
-- **見える場所に置かなければならない。** サーバーがそこにあることを認識できるように。
-- **食べてはいけない。** その袋は今、任務中だ。
+- **緑（ココナッツ味）でなければならない。** 黄色（カレー）は*今日は仕事を休め*の意味；赤（辛味）はサーバーを怒らせる。緑だけ。
+- **賞味期限切れはダメ。** 期限切れの乖乖は逆効果。エンジニアはこまめに入れ替える。
+- **見える場所に。** サーバーがそこにあると認識できなければならない。
+- **食べるな。** その袋は勤務中だ。
 
-アジア最大規模の、退屈なくらい稼働率にこだわるシステムの一部が、シャーシにコーンスナックの袋をテープで貼り付けて動いている。それが機能するのは、管理する人間がそれを信じているからだ——これは、ITカルチャーの大半についての、驚くほど正直な説明でもある。
+アジアで最も大きく、最も退屈で、最も稼働率に取り憑かれたシステムのいくつかが、シャーシに貼り付けられたコーンスナックの袋とともに動いている。効くのは、それを維持する人々が効くと信じているからだ——これはたいていのIT文化に対する、驚くほど正直な説明でもある。
 
-**KKTerm** は **Kuai Kuai Term**——そのスナックと同じ役割を目指す管理者ワークスペース。大事なマシンの隣に静かに座って、それが素直に動くのを助ける。ローカルファースト。テレメトリーなし。承認必須のAI。退屈で、信頼できる種類のソフトウェア。
+**KKTerm** は **Kuai Kuai Term**——あのスナックと同じ志を持つ管理ワークスペースだ：大事なマシンの隣に静かに座って、ちゃんと動くのを助ける。ローカルファースト。テレメトリーなし。AIは承認ゲート付き。退屈で頼れる類のソフトウェア。
 
-インストーラーに実際の乖乖の袋を同梱することはまだできていない。それはv2の課題だ。
+実物の乖乖をインストーラーに同梱することは、まだ実現できていない。それは v2 の課題だ。
 
 ---
 
-## 動いている様子を見る
+## 動いているところを見る
 
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
@@ -124,339 +123,177 @@
   </a>
 </p>
 
-<p align="center"><sub><em>（デモGIFをここに置く予定。百聞は一見に如かず——でも今は百個の箇条書きで勘弁してほしい。）</em></sub></p>
+<p align="center"><sub><em>（デモGIFはここに。一枚の絵は千の箇条書きに勝る。そして箇条書きはもう尽きかけている。）</em></sub></p>
 
 ---
 
-## なぜ一日中開いておくのか
+## 1つのウィンドウ、あらゆる接続
 
-### Windowsファースト、意図的に
+| やりたかったこと | KKTerm ならこうなる |
+| --- | --- |
+| ローカルの PowerShell / cmd / WSL シェルを開く | ローカルターミナルを並べて表示 |
+| サーバーへSSH | 鍵・agent・パスワード・踏み台ホスト・ポートフォワーディング対応のSSH |
+| そのサーバーのファイルを見る | SSH接続からSFTPを起動——デュアルペイン、ドラッグで転送 |
+| 2012年のNASへFTP | FTP / FTPS、同じファイルブラウザの中で |
+| 骨董品の機器へTelnet | はい、Telnetも入っています |
+| シリアルポートと会話 | Serial接続——COMポートとボーレートを選ぶだけ |
+| Windowsマシンへリモート | 本物のMicrosoftリモートデスクトップを内蔵 |
+| Piへ VNC | VNC、ワークスペースに直接描画 |
+| ルーターのWeb UIを開く | ログイン情報を保存できる組み込みブラウザタブ |
+| ホストのCPUを見る | ライブのステータスバーと、自分で組み立てられるDashboard |
 
-2026年のdevツール界隈を見回してほしい。Claude Code：mac/linuxファーストで出荷、Windowsは「WSLを使え」。Codex CLI：同じ。`gemini-cli`、Homebrewの半分、ピカピカの新しいTUIの数々：mac/linuxファースト、WindowsユーザーはREADMEに `# Windows: contributions welcome` のコメントと、動かないfish補完スクリプトをもらう。
+同じアプリ。同じウィンドウ。同じホットキー。同じ、できれば目に優しいテーマ。
 
-一方、実際に会社のネットワークを維持している人々——企業IT、MSP、Hyper-VやADやSCCMやIISや一部のインターンより年上のドメインコントローラーを運用している人々——はWindowsマシンの前に座って、なぜ新しいツールがことごとく自分たちのOSを邪魔者扱いするのか、首をかしげている。
+---
 
-**KKTerm は逆の選択をした。** ネイティブWindowsをまず作り、macOS/Linuxはそれに続く。そのおかげで、移植性レイヤーで誤魔化すことなく、本当に重要なWindows APIを使える：
+## なぜ一日中開きっぱなしになるのか
 
-- **ConPTY** によるローカルシェル——本物のWindowsの疑似コンソール、変換シムではない。PowerShell、`cmd.exe`、WSLディストリビューション、すべてフォーカス・リサイズ・VTシーケンス処理がプラットフォームの動作に合致した正規のPTYとしてホストされる。
-- **WebView2** によるUI全体および埋め込みURL Connection——システムランタイムを使ったインプロセスのChromiumで、インストーラーが小さく起動が速い理由の一つだ。
-- **Microsoft RDP ActiveX (`mstscax.dll`)** によるRDP——*Microsoftが出荷している本物*。Remote Desktop Connection (`mstsc.exe`) と同じコントロール。サードパーティの再実装でも、FreeRDPをラップしたものでもない。RDPを使う人間は5秒で違いに気づく。
-- **Windows Credential Manager** によるすべてのシークレット管理。SSHパスワード、FTPパスワード、APIキー、URL Connection の認証情報——すべてOS keychainに保存され、`credwiz.exe` で監査できる。
-- **NSSIのcurrent-userインストーラー**、SHA-256照合、ネイティブトレイメニュー、Don't-Sleep電源アサーション、ホストCPU/RAM/ネットワークのサンプリング、本物のPNGアイコン付きネイティブTauriコンテキストメニュー、ネイティブOpen/Saveダイアログ。これらのどれもモックではない。
-- **WSLはファーストクラスのシェルであり、回避策ではない。** 同じウィンドウの中で、UbuntuをPowerShell Paneの隣に、SSH Sessionの隣に、RDP Tabの隣に立ち上げられる。
+### 意図的にWindowsファースト
 
-macOSとLinuxのビルドはロードマップにあり、同じ丁寧さで作る。しかし、最後ではなく最初にまともなWindows管理ツールを誰かが作るのをずっと待っていたなら——これがそれだ。
+今のdevツールを見渡してほしい。Claude Code：mac/linuxが先、Windowsは「WSLを使え」。Codex CLI：同じ。新しくて格好いいツールの半分はmacファーストで出荷し、Windowsユーザーには `# contributions welcome` のコメントと、動かない補完スクリプトを残していく。
+
+一方、実際に会社をオンラインに保っている人々——企業IT、MSP、一部のインターンより年上のドメインコントローラーを管理している人々——はWindowsマシンの前に座って、なぜどの新しいツールも自分のOSを厄介者扱いするのか、と首をかしげている。
+
+**KKTerm は逆の選択をする。** まずWindowsネイティブで作るから、Windowsユーザーが気にするものがちゃんと動く：*本物の*Microsoftリモートデスクトップ（`mstsc.exe` と同じもの、クローンではない）、本物の PowerShell / cmd / WSL シェル、Windows資格情報マネージャーに保存されるパスワード、まともなトレイアイコン、ネイティブのメニューとダイアログ。macOSとLinuxのビルドはロードマップにあり、同じだけ丁寧に作る。でも、*いい*Windows管理ツールを最後ではなく最初に作る人を待っていたなら——これがその取引だ。
 
 ### ローカルファーストとは、本当にローカルということ
 
-保存した Connection は自分のマシン上のSQLiteファイルに保存される。パスワードはバイナリの隣のJSONではなく、**Windows Credential Manager** に保存される。アプリは起動時に外部通信せず、アナリティクスを送らず、クラウドアカウントなしで起動できる。「ログインして同期」は存在しない。なぜなら同期機能がないからだ。
+保存した接続はあなたのマシン上のファイルに入る。パスワードはアプリの隣のテキストファイルではなく、Windows資格情報マネージャーに入る。KKTerm は分析データを送らず、起動時に外部へ通信せず、起動にクラウドアカウントを必要としない。「サインインして同期」が存在しないのは、そもそも同期がないからだ。
 
-ネットワークケーブルが燃えても、KKTerm は起動する。
+ネットワークケーブルが燃えても、KKTerm はちゃんと開く。
 
-### 1つのWorkspace、あらゆる接続タイプ
+### 正気を失わないターミナル
 
-| やりたいこと | KKTerm にあるもの |
-| --- | --- |
-| ローカルのPowerShell / cmd / WSLシェルを開く | ConPTYバックのローカルターミナル Session |
-| サーバーにSSH接続する | ネイティブ `russh`、agent/key/passwordによる認証、ホストキー信頼フロー、ProxyJump、ポートフォワーディング |
-| そのサーバーのファイルを参照する | SSH Connection から起動するSFTP、デュアルペイン、再帰転送、chmod/chown |
-| 2012年製NASにFTP接続する | 同じSFTPスタイルブラウザのFTP/FTPS Connection |
-| 古い機器にTelnet接続する | そう、Telnetも入っている |
-| シリアルポートと通信する | Serial Connection、COMポート＋ボーレート、追加ツール不要 |
-| Windowsマシンにリモート接続する | Microsoft ActiveXコントロール経由のネイティブRDP（本物）|
-| RaspberryにVNC接続する | Rust `vnc-rs` フレームバッファをWorkspaceに直接レンダリング |
-| ルーターのWeb UIを開く | 認証情報の自動入力付き埋め込みWebView2 URL Connection |
-| ホストのCPUを監視する | ライブステータスバー＋ドラッグ/リサイズWidget付きの Dashboard モジュール |
+- Tab内でペインを分割。
+- 速く滑らかな描画、スクロールバックは検索可能。
+- 再接続は本当に*再接続*——リモートセッションは続きから始まる。「最初からやり直して、さっきの1時間はなかったことにする」ではない。
+- Tabの切り替えはSessionを殺さ**ない**。Tabを閉じれば殺す。この区別は社内で宗教戦争になった；我々が勝った。
 
-すべて同じアプリ。同じウィンドウ。同じホットキー。できれば目が痛くない同じテーマ。
+### ツールを作ってくれるAIアシスタント
 
-### 理性を失わないターミナル
+たいていの「ターミナルの中のAI」デモはチャットで止まる。KKTerm のアシスタントは、あなたの実際の働き方に合わせて、小さくて長持ちするDashboard Widgetも作れる——そして危険なものはスイッチの裏に置く：
 
-- Tab 内でPaneを分割できる。
-- WebGLアクセラレーションによるxterm.jsレンダリング、できない場合はグレースフルフォールバック。
-- スクロールバック検索。
-- tmuxバックのSSH Paneは安定した1Pane-1Sessionにアタッチできるので、再接続は本当の意味での*再接続*であり、「また最初からやり直して、この1時間は無かったことにする」ではない。
-- Tabを切り替えても Session は**終了しない**。Tabを閉じると終了する。この区別は社内で宗教戦争になった。我々が勝った。
+- **何に触れられるかを決める**——ツールのカテゴリ（Dashboard / Connections / Live Sessions）をまるごとオン/オフ。
+- **どう尋ねるかを決める**——`Prompt`（既定、毎回尋ねる）か `Allow All`（あなたは大人だ、誓約書にサインした）。
 
-### ツールを作るAIアシスタント
+`rm -rf` のように見えるものはすべて危険としてフラグが立ち、人間の明示的なイエスを待つ。man pageに仕込まれたプロンプトインジェクションで誰かが小細工をしても、AIが破壊的なコマンドをこっそり実行することはない。
 
-「ターミナルにAI」系のデモの多くはチャットで止まる。KKTermのアシスタントは、あなたの実際の作業に合わせた小さく永続的なDashboard Widgetも作れる。それでも危険な操作は2つのスイッチの後ろに置かれている：
-
-- **Toolファミリー**（Dashboard / Connections / Live Sessions）——カテゴリごとにオン/オフ切り替え可能。
-- コンポーザーの**パーミッションモード**——`Prompt`（デフォルト、毎回確認）または `Allow All`（大人の選択、免責事項に署名済み）。
-
-OpenAI、Anthropic、OpenRouter、DeepSeek、Grok、Azure OpenAI、LiteLLM、GitHub Copilot、Ollama、NVIDIA、またはOpenAI互換の任意のエンドポイントと通信できる。APIキーはOS keychainに保存される。`rm -rf` を提案するモデルは危険と分類され、明示的な人間の承認が必要になる。manページへのプロンプトインジェクションで誰かが巧みに仕掛けたとしても、AIが静かに破壊的なコマンドを実行することはない。
+OpenAI、Anthropic、OpenRouter、DeepSeek、Grok、Azure OpenAI、LiteLLM、GitHub Copilot、Ollama、NVIDIA、あるいはOpenAI互換のあらゆるエンドポイントと会話する。APIキーはOSのキーチェーンに入る。
 
 ### Grafanaのふりをしないダッシュボード
 
-**Dashboard** モジュールは、Widgetインスタンスの12カラムドラッグ/リサイズグリッドだ。ペタバイト規模のオブザーバビリティツールではない——「お気に入りの5つのアプリを起動するボタンと、SSHホストのアップタイムを表示するパネルが、チャットの*隣に*欲しい」というためのものだ。
+Dashboard はドラッグ＆リサイズできるWidgetのグリッドだ。ペタバイト規模の可観測性のためのものではない——「お気に入りのアプリ5つを起動するボタンと、SSHホストの稼働時間を表示するパネルが、チャットの*隣に*ほしい」のためのものだ。
 
-#### AI作成Widget——説明するだけで手に入る
+#### AIが作るWidget——口で言えば、出てくる
 
-ここが我々が本当に興奮している部分だ。マーケットプレイスから選ぶ必要も、JavaScriptを書く必要もない。**AIアシスタントに何が欲しいかを伝えれば**、ダッシュボードにWidgetを作ってくれる：
+ここは我々が本気でわくわくしている部分だ。マーケットプレイスから選ぶのでもなく、JavaScriptを書くのでもない。**AIアシスタントに欲しいものを伝える**だけで、あなたのDashboardの上にWidgetを作ってくれる：
 
-> *「メインリポジトリの最新5コミットをリスト表示するWidgetを追加して。」*
-> *「オンコールのチートシートを保持する付箋Widgetを作って。」*
-> *「ホームルーターを30秒おきにpingして緑/赤で表示するWidgetを作って。」*
-> *「ストップウォッチが欲しい。スタイリングはおまかせで。」*
+> *「メインのrepoの直近5コミットをリストで表示するWidgetを追加して。」*
+> *「オンコールのカンペを置く付箋Widgetを作って。」*
+> *「自宅ルーターを30秒おきにpingして緑/赤を出すWidgetを作って。」*
+> *「ストップウォッチが欲しい。スタイルは任せる、驚かせて。」*
 
-2種類のフレーバー：
+単純な表示パネル（markdown、チェックリスト、大きな数字ひとつ）もあれば、あなたが承認した隔離サンドボックスの中でライブのコードを動かすものもある。残したWidgetはすべてあなたのもの——独自の色・アイコン・タイトルを持って保存され、サイズ違いを何個でも置ける。飽きたら右クリックで削除。
 
-- **Content Widget** ——宣言的JSON：マークダウン、kvリスト、チェックリスト、大きな単一スタット。スクリプトなしで安全な構造。「ダッシュボードにこれが欲しい」というリクエストの大半はここに収まる。
-- **Script Widget** ——明示的に宣言されたパーミッション（`network` の許可リスト、`pollSeconds` の上限）を持つ、隔離された `iframe srcdoc` サンドボックス内でホストされるJavaScript。AIがスクリプトを書き、あなたがパーミッションを承認し、Widgetはアプリの他の部分に届かないボックスの中で動く。
+#### Dashboardのアニメーション背景（やりたかったから）
 
-保存したWidgetはすべてあなたのものだ。Connectionと同じSQLiteに、自分のビジュアルプリセット（`panel` / `ambient` / `hero`）、アクセントカラー、アイコン、タイトルとともに保存される。同じWidgetの複数インスタンスが、まったく異なるサイズとスタイルで共存できる。飽きたら右クリックで削除すればいい。
-
-#### アニメーションダッシュボード背景（作りたかったから作った）
-
-ダッシュボードには、**Dashboard View** ごとに選べる23種類のキャンバスアニメーション背景がある：
+Dashboardのビューごとに、**25種類**のキャンバスアニメーション背景から気分を選べる：
 
 | 気分 | 背景 |
 | --- | --- |
-| 落ち着き | `aurora`, `clouds`, `ocean`, `raindrops`, `rainywindow`, `snow`, `sakura`, `fireflies`, `bubbles`, `ricefield`, `lanterns` |
-| 宇宙的 | `starfield`, `nebula` |
-| 温かみ | `embers`, `lava` |
-| ギーク | `matrix`, `topo`, `synthwave` |
-| カオス | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti`, `particleCursor` |
+| 穏やか | `aurora`、`clouds`、`ocean`、`raindrops`、`rainywindow`、`frostedWindow`、`snow`、`sakura`、`fireflies`、`bubbles`、`aquarium`、`ricefield`、`lanterns` |
+| 宇宙 | `starfield`、`nebula` |
+| 暖 | `embers`、`lava` |
+| ギーク | `matrix`、`topo`、`synthwave` |
+| 騒がしい | `cyberpunk`、`taipei101`、`thunderstorm`、`confetti`、`particleCursor` |
 
-単一共有の requestAnimationFrame で動作し、ウィンドウのフォーカスを尊重するので、別の作業中はほぼコストゼロ。`matrix` とAIアシスタントを組み合わせれば「めちゃくちゃ生産的でしかもウォシャウスキー兄弟（姉妹）の映画の登場人物みたい」というバイブになる。真面目な人に見せたければ `ocean` を選ぶといい。どちらの選択も我々は支持する。
+別の画面にいる間は一時停止するので、コストはほぼゼロ。`matrix` をAIアシスタントと組み合わせれば「私はきわめて生産的で、しかもたぶんウォシャウスキーの映画の中にいる」という雰囲気になる。あるいは `ocean` を選んでまともな人間に見せる。どちらの選択も我々は評価しない。
 
-### サーバー上でAIコーディングエージェントを動かす、正しい方法
+### リモートのAIエージェントを生かし続ける
 
-これが2番目に人が惚れ込む機能だ。KKTermのSSHターミナルは、リモートホスト上の**名前付きtmux Session**に直接起動できる——デフォルトでは `kkterm-cockpit001` のような、再接続後も生き続ける自動生成のフレンドリーIDが使われる：
+これがみんなが惚れ込む2つ目の機能だ。KKTerm のSSHターミナルは、再接続を生き延びるリモートホスト上の**名前付きtmuxセッション**に、あなたを直接放り込める：
 
-- tmuxを有効にしてSSH Connection を開く。
-- Pane内で `claude`、`codex`、`gemini-cli`、`cursor-agent`、またはお好みの長時間稼働型コーディングエージェントを起動する。これらはフルスクリーンのTUIアプリ——tmuxはまさに彼らが住みたい場所だ。
-- ラップトップを閉じる。また開く。Paneは静かに同じtmux Sessionに再アタッチされる。エージェントはまだ動いていて、スクロールバックも残っていて、やっていた作業の途中にいる。
-- SSH転送でネットワークが瞬断した？KKTermはあなたを煩わせることなく、同じtmux IDへの限定的な再アタッチを試みる。
-- AIアシスタントにエージェントの作業を見せたい？「ターミナルバッファをコンテキストに追加」するとSSH越しに `capture_tmux_pane` を呼び出して、画面に見えている部分だけでなく、セッション全体のtmuxスクロールバックを会話に取り込む。ローカルのアシスタントがリモートエージェントの作業を把握して推論できるようになる。
+- tmuxを有効にしたSSH接続を開いて、`claude`、`codex`、`gemini-cli`、`cursor-agent`、あるいは好きな長時間エージェントを起動する。
+- ラップトップを閉じる。また開く。Paneは静かに再アタッチする——エージェントはまだ動いていて、スクロールバックも残っていて、さっきの続きをやっている。
+- ネットワークが一瞬途切れた？KKTerm はあなたを煩わせずに同じセッションへ静かに繋ぎ直す。
+- アシスタントに手伝ってほしい？「ターミナルバッファをコンテキストに追加」で、リモートセッション全体が会話に取り込まれ、ローカルのAIがリモートエージェントの仕事を推論できる。
 
-不安定なホテルのWi-Fiで6時間の `claude` や `codex` セッションを失ったことがあるなら、この1機能だけでこのアプリを使う価値がある。アプリは無料だ。機能はそれでも価値がある。
+ホテルの不安定なWi-Fiで6時間の `claude` や `codex` セッションを失った経験があるなら、この機能ひとつでアプリの元は取れる。（アプリは無料だ。それでもこの機能には価値がある。）
 
-### 残りAIクォータを把握する
+### AIの残量を把握する
 
-コーディングエージェントは月額ではなく「プランウィンドウ」単位で課金する。Claude Codeには5時間ウィンドウと週次ウィンドウがある。Codexにも独自版がある。どちらも会議中に気付かないうちにクォータを食い尽くしてくれる。
+コーディングエージェントは月単位ではなくプランのウィンドウ単位で課金され、あなたが会議に出ている間にも喜んでクォータを食い尽くす。**AI使用量メーター**がそれを常に見えるようにする：
 
-**AIコーディング使用量** Widgetがそれを見える化する：
+- **Claude Code** と **Codex** を並べて表示するDashboard Widget：接続中のアカウント、プラン、現在のウィンドウと今週の使用量、次のリセット時刻。
+- 同じ数字を映すコンパクトな**ステータスバーインジケーター**。Dashboardを閉じていても、次の大きなリファクタリングの前に余裕があるか一目でわかる。
+- 再ログインが必要かどうかを前もって教えてくれる——長いタスクの*前*に、途中ではなく。
 
-- Claude CodeとCodexを横並びで表示するDashboard Widget：接続済みアカウント、プラン階層、現在の5時間ウィンドウ使用率、今週使用率、次回リセット時刻。
-- 同じ数字を映すコンパクトな**ステータスバーインジケータ**。Dashboardを閉じていても、次の大きなリファクタを始める前に余裕があるか一目で分かる。
-- 認証状態（`connected` / `expired` / `error`）も直接表示。長時間タスクの途中ではなく、開始前に再ログインが必要だと分かる。
-- リフレッシュ方針はレートリミットを尊重し、Widgetを見るたびに上流APIを叩かない独自ペースでポーリング。
+### 他のAIにKKTermを操作させる
 
-### ビルトインMCPサーバー — 他のAIにKKTermを操作させる
+KKTerm は独自のMCPサーバーを内蔵しているので、外部のコーディングエージェント（Claude Code、Codex、Copilot、Antigravity、OpenCode）が、あなたと同じようにワークスペースを使える——接続を一覧し、開き、ターミナルバッファを読み、Dashboardに Widget を置く。AIからAIへ、あなたのマシン上で、クラウドリレーなし。変更を伴う、よりリスクの高い操作は、既定で**オフ**の安全トグルの裏に置かれている。
 
-あなたのターミナルは、Claude Code、Codex、CopilotエージェントモードやAntigravityなど、MCPを話す世界が仕事をしたい場所でもある。だからKKTermは独自の**stdio MCPサーバー**、[`kkterm-cli`](docs/MCP.md) を同梱し、アプリの一部をキュレート公開する：
-
-- **Workspace Module**（`kkterm.workspace.*`）: 保存済み **Connection** 一覧、idでConnectionを開く、ライブ **Session** 一覧、ターミナルPaneへの入力送信、ターミナルバッファのスナップショット読み取り。
-- **Dashboard Module**（`kkterm.dashboard.*`）: Dashboard状態のロード、AI作成Widgetのソース読み取り、Viewの作成 / 更新 / 削除、Widgetインスタンスの配置 / 移動 / 削除、一括レイアウト適用。
-- **危険サブネームスペース**（`kkterm.<module>.dangerous.*`）: 実行可能サーフェスの変更——スクリプトWidget作成、リモートデスクトップへのクリック、Dashboardのワイプ——は単一の設定（`built_in_mcp_allow_all_dangerous`）の背後でゲート、デフォルト **オフ**。
-
-`kkterm-cli` は薄いフォワーダ。MCPクライアントとはstdio JSON-RPCで対話し、起動中のKKTermウィンドウとは起動ごとに認証されるWindows名前付きパイプで通信する。KKTermが閉じている時も `tools/list` は動作（クライアントが内省できる）、しかし `tools/call` は構造化された `app_not_running` エラーを返す。
-
-お気に入りのクライアントに接続すれば、AIはあなたと同じようにKKTermを使える：
-
-```json
-{
-  "mcpServers": {
-    "kkterm": { "command": "<path-to-kkterm-cli>", "args": [] }
-  }
-}
-```
-
-Settings → AI Assistant → **ビルトインMCPサーバー** にはワンクリック「設定を表示」ダイアログがあり、解決済みバイナリパス入りのJSON / TOMLスニペットと、コピー可能な `claude mcp add` / `codex mcp add` コマンドが揃っている。
+設定 → AI Assistant → **Built-in MCP Server** に、すべて記入済みのワンクリック「設定を表示」ダイアログがあり、コピーできる `claude mcp add` / `codex mcp add` コマンドも用意されている。
 
 ---
 
-## どう組み合わさっているか
+## KKTerm でないもの
 
-```mermaid
-flowchart LR
-    User([You]) --> Shell[KKTerm Window<br/>Tauri v2 + React 19]
-    Shell --> Rail[Activity Rail]
-    Rail --> WS[Workspace Module]
-    Rail --> Dash[Dashboard Module]
-    Rail --> Inst[Installer Helper Module]
-    Rail -.-> FE[File Explorer<br/>planned]
-    Rail --> Set[Settings]
+短いリスト。正直さが信頼を生むからだ：
 
-    WS --> Tabs[Tabs &amp; Panes]
-    Tabs --> Term[Terminal<br/>ConPTY / russh]
-    Tabs --> SFTP[SFTP / FTP]
-    Tabs --> Web[WebView2 URL]
-    Tabs --> RD[RDP / VNC]
+- **クラウド製品ではない。** 同期なし、チームアカウントなし、SaaSプランなし。もし「KKTerm にサインイン」ダイアログを見たら、何かが壊滅的に間違っている。
+- **クロスプラットフォームのふりはしない。** 意図的にWindowsファースト；macOSとLinuxはロードマップにある。今日macファーストのツールが必要なら、選択肢は何百もある。我々はWindows管理者が静かに待っていた、その一つを作っている。
+- **自律型AIエージェントではない。** アシスタントは提案し、人間が決める。`Allow All` は既定ではなく、あなたが下す選択だ。
+- **Grafana / Datadog の代替ではない。** Dashboard は個人のコントロール面のためのもので、1万台規模の可観測性のためではない。
+- **Kubernetes IDE ではない。** これはターミナル中心の管理ワークスペースだ。Helmチャートを描けと頼まないでほしい。
 
-    Shell -.calls.-> Rust[Rust Backend]
-    Rust --> SQLite[(SQLite<br/>Connections)]
-    Rust --> Keychain[(OS Keychain<br/>Secrets)]
-    Rust --> AI[AI Providers<br/>OpenAI-compat]
-
-    AI -. approval gate .-> Tabs
-
-    classDef local fill:#1f6feb,stroke:#1f6feb,color:#fff
-    classDef ai fill:#8a63d2,stroke:#8a63d2,color:#fff
-    class SQLite,Keychain local
-    class AI ai
-```
-
-重要な構造：永続保存されるデータ（**Connection**）はライブのランタイム状態（**Session**）と分離されており、さらにUIコンテナ（**Tab**）とも分離されている。**Tab** を閉じると **Session** が終了する。**Tab** を切り替えても終了しない。これがアプリを正気に保つルールだ。
+そのどれかが*もし*決定的な問題だったなら——わかった、v2で会おう。
 
 ---
 
-## 現在の機能マップ
+## KKTerm を入手する
 
-| エリア | 現在の実装内容 |
-| --- | --- |
-| **Connections** | SQLiteバックのツリー、フォルダ/サブフォルダ、検索、ドラッグ/ドロップ並び替え、リネーム、複製、削除、**Quick Connect**、カスタムアイコン、固定/アクティブなRailショートカット |
-| **Terminal** | ローカルシェル、SSH、Telnet、Serial、分割Pane、xterm.js＋機会的WebGL、スクロールバック検索、ローカル起動ディレクトリ/スクリプト |
-| **SSH** | ネイティブ `russh`、agent/key/password認証、ホストキー信頼フロー、オプションのシステムSSHフォールバック、ProxyJump、ポートフォワーディング、**自動命名tmux Session（`kkterm-<scifi-name><n>`）と転送瞬断時のサイレント再アタッチ**——長時間稼働リモートコーディングエージェント（Claude Code、Codex、gemini-cliなど）に最適 |
-| **SFTP / FTP** | SSH起動SFTP＋FTP/FTPS Connection、デュアルペインブラウザ、再帰転送、キュー/キャンセル/クリア履歴、競合処理、プロパティ、サポートされている場合のchmod/chown |
-| **URL WebView** | 埋め込みWebView2 URL Session、ナビゲーションツールバー、ファビキャプチャ、保存されたWebサイト認証情報メタデータ/自動入力、データパーティションメタデータ |
-| **Remote Desktop** | ジオメトリスコープのオーバーレイパーキングを持つWindows ActiveX経由のRDP；`vnc-rs` フレームバッファをWorkspaceキャンバスにレンダリングするVNC |
-| **Dashboard** | 永続View、Widgetインスタンス、編集モード、ドラッグ/リサイズ、App Launcher、**AI作成のcontent/script Widget**（宣言的JSONまたはパーミッション付きサンドボックスiframe JS）、Widget毎のプリセット/アクセント/アイコン/タイトル、**23種類のアニメーションキャンバス背景**（aurora, clouds, ocean, raindrops, rainywindow, snow, sakura, fireflies, bubbles, ricefield, lanterns, starfield, nebula, embers, lava, matrix, topo, synthwave, cyberpunk, taipei101, thunderstorm, confetti, particleCursor）|
-| **AI Assistant** | ストリーミングチャット、OpenAI互換ランタイム、プロバイダーレジストリ、コマンド提案の安全分類、スクリーンショット/コンテキスト添付、**Dashboard Widgetオーサリング（contentおよびサンドボックスscript）**、リモートSession用会話コンテキストとしての **tmux Paneキャプチャ**、**Connection** 管理ツール、ターミナル・RDP/VNC・SFTP/FTP用ライブ **Session** ツール |
-| **AIコーディング使用量** | **Claude Code** と **Codex** のクォータ使用量を追跡する **Dashboard Widget + ステータスバーインジケータ**：接続済みアカウント、プラン階層、5時間および週次ウィンドウの使用率、次回リセット時刻、認証状態（`connected` / `expired` / `error`）、レートリミットを意識したリフレッシュ方針 |
-| **ビルトインMCPサーバー** | 外部コーディングエージェント（Claude Code、Codex、Copilot、Antigravity、OpenCode）にキュレート版のWorkspaceおよびDashboardツールを公開するstdio MCPサーバー（`kkterm-cli`）；認証付き名前付きパイプブリッジ；モジュール毎の `dangerous.*` ネームスペースは単一の安全トグルの背後でゲート；解決済みバイナリパス入りJSON / TOMLスニペットと `claude mcp add` / `codex mcp add` コマンドのSettingsダイアログ |
-| **Installer Helper** | バンドル済みWindows開発ツールカタログ用のActivity Rail Module。インストール済みツールの検出、最新版比較、インストール/更新/アンインストール、Update allからの除外、コマンドログのストリーミング、対応する管理対象アプリの起動を行う |
-| **Settings** | 一般、外観、認証情報、AI、SSH、ターミナル、ターミナル背景、URL、RDP、VNC、Dashboard、Installer Helper、About；カスタムUIフォント；最小化してトレイへ；Don't Sleep；バックアップ/インポート |
-| **ローカライゼーション** | i18next UIと英語ソース、動的ロケールバンドル：zh-TW、zh-CN、ja、ko、fr、de、es、es-MX、it、pt-BR、th、id、vi |
+**[最新の Windows インストーラー (.exe) をダウンロード](https://github.com/ryantsai/KKTerm/releases/latest)** して実行する。インストーラーは現在**未署名**だ——リリース署名はロードマップにあるので、それまではウイルス対策ソフトに厳しい目で見られるかもしれない。正常だ。
 
-### AIプロバイダー
-
-OpenAI · Anthropic · OpenRouter · DeepSeek · Grok · Azure OpenAI · LiteLLM · GitHub Copilot · Ollama · NVIDIA · OpenAI互換の任意エンドポイント。
-
-プロバイダーのメタデータは [`src/ai/providerRegistry/`](src/ai/providerRegistry/) に保存され、Rustアダプターは [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/) にある。APIキーはSQLiteではなくOS keychainを通じて管理される。
-
----
-
-## クイックスタート
-
-必要なもの：
-
-- **Windows**（主要サポートプラットフォーム）
-- **Node.js + npm**
-- **Rustツールチェーン**
-- **WebView2** を含む **Tauri v2のWindows前提条件**
-
-```bash
-npm install
-npm run tauri dev
-```
-
-本物のネイティブウィンドウが表示されるはずだ。スタックトレースが出た場合は、Issueを立ててほしい——良い再現ケースは大歓迎だ。
-
-### よくある確認事項
-
-```bash
-npm run check                                              # TypeScript
-npm run build                                              # Vite build
-cargo check --manifest-path src-tauri/Cargo.toml           # Rust
-cargo test  --manifest-path src-tauri/Cargo.toml           # Rust tests
-```
-
-### Windowsインストーラーのビルド
-
-```bash
-npm run package:installer
-```
-
-インストーラースクリプトは `artifacts/kkterm-<version>-windows-x64-setup.exe` と対応する `.sha256` ファイルを出力する。現時点では**署名なし**——リリース署名はロードマップ上にあるが、それまではウイルス対策ソフトから厳しい目で見られるかもしれない。正常な動作だ。
-
----
-
-## KKTerm ではないもの
-
-正直さは信頼を生む。簡潔に：
-
-- **クラウド製品ではない。** 同期なし、チームアカウントなし、SaaSティアなし。もし「KKTermにサインイン」ダイアログが表示されたら、何か壊滅的なことが起きている。
-- **クロスプラットフォームのふりをしない。** 意図的にWindowsファーストで作っており、macOSとLinuxはロードマップにある。同じTauri v2シェルを使う。今日macファーストのツールが必要なら、選択肢は山ほどある。我々は、Windows管理者が静かに待ち続けていたものを作っている。
-- **自律型AIエージェントではない。** アシスタントが提案し、人間が判断する。`Allow All` はあなたが下す選択であり、デフォルトではない。
-- **Grafana / Datadogの代替ではない。** Dashboardは個人のコントロールサーフェス用であり、1万ホストのオブザーバビリティ用ではない。
-- **KubernetesのIDEではない。** ターミナルファーストの管理者ワークスペースだ。Helmチャートのレンダリングを頼まないでほしい。
-
-それらが本当に必要なら——なるほど、v2で会おう。
-
----
-
-## ネイティブデバッグ
-
-検証には本物のTauriランタイムを使うこと：
-
-```bash
-npm run tauri dev
-```
-
-Viteのブラウザプレビューはフロントエンドの一部の検査に役立つが、本物のWebView2、ConPTY、RDP ActiveX、VNCフレームバッファ、keychain、ネイティブメニューサーフェスは**ホストしない**。これらのいずれかに触れる機能は、実際のデスクトップランタイムで検証すること。
-
-VS Codeユーザー：`Run KKTerm exe` 起動設定は `RUST_BACKTRACE=1` で `src-tauri/target/debug/kkterm.exe` を起動する。対の `Attach KKTerm WebView2` 設定で、本物のWebView2ホスト内でDevToolsが使える。
-
----
-
-## 現在の制限（分かっている）
-
-- インストーラーは現時点で署名なし。リリース署名が設定されるまで更新チェックは無効。
-- ネイティブSFTPパスでのProxyJump経由SFTPはまだ未サポート。
-- ファイル転送の再開、フォルダ同期/差分、アーカイブ/展開、リモート編集は保留中。
-- SSHコンフィグのインポートは実装済みだが、Settings上のユーザー向けエントリはまだ公開されていない。
-- RDPとVNCは提供中；クリップボード/デバイス同期の強化と品質コントロールは引き続き改善中。
-- macOSとLinuxのビルドはロードマップにある。「そこでも一応動きます」的なポートではなく、きちんと作る——急いで出すつもりはない。
-- AIアシスタントは設定されたパーミッション境界内で提案・操作できる——無人ロボットとして扱わないこと。CEOが何を求めているかはAIには分からない。
+ソースからビルドしたい、または貢献したい？必要なものはすべて [`CONTRIBUTING.md`](CONTRIBUTING.md) にある。
 
 ---
 
 ## ロードマップ（短縮版）
 
-- macOS + Linuxビルド
-- 署名済みインストーラー＋自動更新
-- ネイティブパスでのProxyJump経由SFTP
-- ファイル転送再開、フォルダ同期、アーカイブ/展開
-- RDPクリップボード/デバイスリダイレクトの強化
-- より多くの組み込み **Dashboard** Widget（AIが作成したものの公開スキーマも）
+- macOS + Linux ビルド
+- 署名済みインストーラー + 自動更新
+- より強力なファイル転送（再開、フォルダ同期、圧縮/展開）
+- より充実したリモートデスクトップのクリップボード・デバイス共有
+- 組み込みDashboard Widget の追加
 
-完全版・頻繁更新版：[`docs/ROADMAP.md`](docs/ROADMAP.md)。
+完全で頻繁に更新される版：[`docs/ROADMAP.md`](docs/ROADMAP.md)。
 
 ---
 
-## コントリビューション
+## 貢献
 
-本当に助けてほしい。小さなことでも重要だ：
+手を貸してくれたら嬉しい。本気だ。小さなことでも大事だ：
 
-- **devビルドを試して**、何かおかしいと感じたらIssueを立ててほしい。「なんか変だった」は正当なバグレポートだ；一緒に掘り下げる。
-- **ロケールを翻訳する。** [`src/i18n/locales/en.json`](src/i18n/locales/en.json) が英語のソース；12の他のロケールが隣にあってオンデマンドで読み込まれる。未翻訳の文字列は [`docs/localization_todo/`](docs/localization_todo/) にキーごとに記録されている——ひとつ選んで、翻訳して、ファイルを削除する。
-- **Dashboard Widgetを追加する。** 組み込みWidgetは [`src/modules/dashboard/widgets/builtin/`](src/modules/dashboard/widgets/builtin/) にある。小さなアイデアを選んで、出荷して、パターンを学ぶ。
-- **AIのtoolサーフェスを改善する。** プロバイダーアダプターは [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/) に、フロントエンドレジストリは [`src/ai/providerRegistry/`](src/ai/providerRegistry/) にある。
-- **マニュアルを改善する。** エンドユーザー向けのドキュメントは [`docs/manual/`](docs/manual/) にある。UIモジュールごとに1チャプター。機能を使ってドキュメントが役に立たなかったなら、それを修正するPRは金だ。
+- **devビルドを試して**、何かおかしいと感じたらissueを立ててほしい。「なんか変だった」も立派なバグ報告だ；一緒に掘る。
+- **ロケールを翻訳する。** 英語がsource of truth；その隣に他の13言語が住んでいる。
+- **Dashboard Widget を追加する。** 小さなアイデアを選び、出荷し、パターンを学ぶ。
+- **マニュアルを改善する。** ある機能を使ったのにドキュメントが役に立たなかったなら、それを直すPRは金だ。
 
-完全なセットアップ手順、プロジェクト構成、PRチェックリスト、「これは壊さないで」ルールの一覧は [`CONTRIBUTING.md`](CONTRIBUTING.md) にある。30秒のハイライト：
-
-- **ユーザー向けの用語をリネームする前に [`CONTEXT.md`](CONTEXT.md) を読む。** **Connection**、**Session**、**Tab**、**Quick Connect** は特定の意味を持つ；ブレないように。
-- **ユーザーに見えるすべての文字列は `t()` を通す。** JSXにベタ書き英語テキストを書かない。
-- **フロントエンドのcloseフックを追加しない。** Tauri v2のタイトルバークローズは `onCloseRequested` パターンで何度も壊れてきた。ようやく機能する形に落ち着いた；それを再導入しないこと。
-- **PRを開く前にチェックを実行する**（`npm run check && npm run build && cargo check && cargo test`）。
-
-取っかかりを探しているなら、Issueを [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) または [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) でフィルタしてみてほしい。まだタグ付けされていない場合は、取り組みたいことを書いてIssueを立ててくれれば、一緒にスコープを決める。
+セットアップ一式、プロジェクト構成、PRチェックリストは [`CONTRIBUTING.md`](CONTRIBUTING.md) にある。入口を探している？open issueを [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) や [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) で絞り込んでみてほしい。
 
 ---
 
 ## プロジェクトドキュメント
 
 - [プロダクトコンテキスト](CONTEXT.md) — 合わせるべきドメイン言語
-- [アーキテクチャ](docs/ARCHITECTURE.md) — モジュールマップ、新しいコードを置く場所
+- [アーキテクチャ](docs/ARCHITECTURE.md) — モジュールマップ、新しいコードの置き場所
 - [ロードマップ](docs/ROADMAP.md)
-- [Dashboardアーキテクチャ](docs/DASHBOARD.md)
+- [Dashboard アーキテクチャ](docs/DASHBOARD.md)
 - [AIプロバイダーガイド](docs/AI_PROVIDERS.md)
-- [パフォーマンスノート](docs/PERFORMANCE.md)
-- [リリースノートとゲート](docs/RELEASE.md)
 
 ---
 
-## スタック
-
-Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand · xterm.js · SQLite · WebView2 · `russh` · `russh-sftp` · `vnc-rs` · `suppaftp` · OS keychain ストレージ。
-
----
-
-## Star履歴
+## スター履歴
 
 <a href="https://www.star-history.com/#ryantsai/KKTerm&Date">
   <picture>
@@ -466,12 +303,12 @@ Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand ·
   </picture>
 </a>
 
-ここまで読んでまだスターをつけていないなら——何を待っているの？これが個人的な招待状だ。
+ここまで読んでまだスターを付けていないなら——何を待っている、個人的な招待状か？これがその個人的な招待状だ。
 
-⭐ **[GitHubでKKTermにスターをつける](https://github.com/ryantsai/KKTerm)** — 1クリックのコストで、メンテナーの1週間が輝く。ラックに置くデジタルな乖乖だと思って。
+⭐ **[GitHub で KKTerm にスターを付ける](https://github.com/ryantsai/KKTerm)** — ワンクリックで、メンテナーの一週間がまるごと明るくなる。ラックに置くデジタルな乖乖だと思ってほしい。
 
 ---
 
 ## ライセンス
 
-MIT。[LICENSE](LICENSE) を参照。使って、フォークして、出荷して、誰も辿り着けないホームラボに置いて——それがこのアプリとの約束だ。
+MIT。[LICENSE](LICENSE) を参照。使って、フォークして、出荷して、誰にも見つからないホームラボに入れて——それがこの取引だ。

--- a/README.ko.md
+++ b/README.ko.md
@@ -5,19 +5,19 @@
 <h1 align="center">KKTerm</h1>
 
 <p align="center">
-  <strong>AI 도구 시대가 깜빡 잊고 만들지 않은, 진짜 Windows 네이티브 관리자 Workspace — 터미널, SSH, SFTP, RDP/VNC, Dashboard, 그리고 나만의 도구 Widget을 만들어 주는 AI.</strong>
+  <strong>터미널, SSH, SFTP, RDP/VNC, Dashboard를 하나의 Windows 네이티브 창에 — 게다가 요청하면 당신만의 작은 도구를 만들어 주는 AI까지.</strong>
 </p>
 
 <p align="center">
-  <em>작업 표시줄이 슬롯머신처럼 보여서는 안 되니까요.</em>
+  <em>당신의 작업 표시줄이 라스베이거스 슬롯머신처럼 보일 필요는 없으니까.</em>
 </p>
 
 <p align="center">
-  <sub><strong>乖乖 (Kuāi Kuāi, 괴괴/쿠아이쿠아이)</strong>의 이름을 따왔습니다. 대만 시스템 관리자들이 서버 위에 올려 두는 초록색 코코넛 맛 과자인데, 서버가 말 잘 듣도록 해 준다고 합니다. 이 앱도 랙 위의 한자리를 차지할 자격을 얻었으면 좋겠습니다.</sub>
+  <sub>이름은 <strong>乖乖 (Kuāi Kuāi, 과이과이)</strong>에서 왔다. 대만 시스템 관리자들이 서버가 얌전히 돌아가길 바라며 그 위에 올려두는 초록색 코코넛 맛 옥수수 과자다. 이 앱도 랙 위 한 자리를 얻을 수 있기를.</sub>
 </p>
 
 <p align="center">
-  <strong><a href="https://github.com/ryantsai/KKTerm/releases/latest">최신 Windows 설치 프로그램(.exe) 다운로드</a></strong>
+  <strong><a href="https://github.com/ryantsai/KKTerm/releases/latest">최신 Windows 설치 프로그램 (.exe) 다운로드</a></strong>
 </p>
 
 <p align="center">
@@ -38,14 +38,8 @@
   </a>
   <br />
   <img src="https://img.shields.io/badge/Windows%E2%80%91first-by%20design-0078D6?style=flat-square&logo=windows" alt="Windows-first by design" />
-  <img src="https://img.shields.io/badge/built%20with-Tauri%20v2-FFC131?style=flat-square&logo=tauri" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/Rust-russh-orange?style=flat-square&logo=rust" alt="Rust" />
-  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react" alt="React 19" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
   <br />
-</p>
-
-<p align="center">
   <sub>
     <a href="README.md">English</a> ·
     <a href="README.zh-TW.md">繁體中文</a> ·
@@ -66,56 +60,58 @@
 
 ---
 
-## 45초 요약
+## 45초 소개
 
-당신은 시스템 관리자 / DevOps / 홈랩 / 바이브 코더입니다. 지금 이 순간 당신의 화면에는:
+당신은 시스템 관리자 / DevOps / 홈랩 애호가 / 바이브 코더, 그런 부류다. 지금 손에 든 것들：
 
-- 터미널 에뮬레이터
-- 별도의 SSH 클라이언트 (주말 한 번 다 바쳐서 만든 프로필 목록 포함)
-- 어떻게든 아직 살아 있는 2007년산 SFTP 클라이언트
-- 항상 엉뚱한 모니터에서 사라지는 창에 띄워 둔 원격 데스크톱
-- 리눅스 박스 한 대를 위한 VNC 뷰어
-- 공유기 관리 UI를 위한 브라우저 탭
-- Wi-Fi가 재채기를 할 때마다 끊기는, 원격 개발 서버의 `claude` / `codex` Session
-- 비밀번호가 적힌 포스트잇 *(괜찮아요, 아무한테도 말 안 합니다)*
+- 터미널 에뮬레이터 하나
+- 별도의 SSH 클라이언트 (그 프로필 목록 만드는 데 주말 하나를 다 썼다)
+- 2007년산 SFTP 클라이언트 (어째선지 아직도 살아 있다)
+- 자꾸 엉뚱한 모니터에서 잃어버리는 창에 떠 있는 원격 데스크톱
+- 그 리눅스 한 대 때문에 켜둔 VNC 뷰어
+- 라우터 관리 페이지를 띄운 브라우저 탭
+- 원격 머신에서 도는 `claude` / `codex` 세션 (Wi-Fi가 재채기만 해도 끊긴다)
+- 비밀번호를 적은 포스트잇 *(걱정 마, 말 안 한다)*
 
-**KKTerm은 이 모든 것을 하나의 창으로 해결합니다.** Windows 네이티브로 설계했습니다 — *나머지 개발 도구 세계가 Mac 먼저 출시하고 Windows는 각주 취급할 때, 우리는 의도적으로 반대 방향을 택했습니다* — Rust + Tauri v2로 작성되었고, 단일 인스톨러로 배포되며, 어디에도 전화하지 않습니다.
+**KKTerm은 이 모든 걸 하나의 창에 담는다.** Windows 네이티브 — *다른 개발 도구들이 mac을 먼저 내놓고 당신의 OS를 각주 취급하는 와중에, 의도적으로* — 설치 프로그램 하나로 끝, 그리고 절대 집에 전화하지 않는다.
 
-그리고 몰랐지만 원하게 될 기능들도 있습니다:
+덤으로, 당신이 필요한 줄도 몰랐던 것들 몇 가지：
 
-- AI에게 *"30초마다 공유기에 핑을 보내는 Widget을 만들어 줘"* 라고 말하면 Dashboard 그리드 위에 샌드박스 환경으로 나타나는 **Dashboard**.
-- Wi-Fi가 몇 번을 끊겨도 원격 `claude` / `codex` Session이 살아남는, **named tmux session에 자동 연결되는 SSH 창**.
-- Claude Code와 Codex의 쿼터를 **Dashboard**와 상태 표시줄에 보여주는 **AI 코딩 사용량 Widget** — 5시간 윈도우, 주간 윈도우, 현재 플랜, 계정 이메일. 새벽 3시에 레이트 리밋 벽에 부딪히고 놀라는 일이 없어집니다.
-- Node, Python, Docker, WSL, AI 코딩 CLI와 평소 브라우저 탭을 뒤져 찾던 작은 유틸리티까지, 큐레이션된 Windows 개발 도구 카탈로그를 감지, 설치, 업데이트, 제거, 실행하는 **Installer Helper Module**.
-- 외부 코딩 에이전트(Claude Code, Codex, Copilot, Antigravity, OpenCode)가 큐레이션·안전 게이트 처리된 툴 표면을 통해 당신의 Workspace와 Dashboard를 조작할 수 있게 해주는 **내장 MCP 서버**(`kkterm-cli`) — Connection 목록 조회, 터미널 버퍼 읽기, Widget 배치 등. AI와 AI 간의 소통이, 당신의 머신 위에서, 클라우드 릴레이 없이.
-- 예, `matrix` 포함, 스물한 가지 **애니메이션 캔버스 배경**. 우리도 그 정도 취향은 있습니다.
+- **Dashboard**에서 AI에게 *"라우터를 30초마다 ping하는 위젯 만들어 줘"*라고 말하면, 샌드박스에 갇힌 채 당신의 그리드 위에 나타난다.
+- **원격 `claude` / `codex` 세션에 자동으로 다시 붙는 SSH Pane**. Wi-Fi가 아무리 떼를 써도 6시간짜리 작업이 살아남는다.
+- **AI 사용량 미터**. 새벽 3시에 레이트 리밋 벽에 들이받고 놀랄 일이 없어진다.
+- **Installer Helper**. 평소엔 브라우저 탭 열 개를 헤매며 찾던 Windows 개발 도구를 찾고·설치하고·업데이트하고·실행한다.
+- Dashboard용 **애니메이션 배경 25종**(그래, `matrix`도 있다). 좀 과하긴 한데, 후회는 없다.
 
-그리고 AI 어시스턴트는 한 문장을 실제로 계속 쓰게 되는 작은 Dashboard 도구로 바꿀 수 있습니다.
+그리고 가장 좋은 부분：AI 어시스턴트는 한 문장을, 당신이 실제로 계속 쓰게 될 작은 Dashboard 도구로 바꿔 준다.
 
-> ⭐ **이게 지난 6년 동안 직접 만들어야겠다고 생각해 왔던 앱처럼 느껴진다면 — 누군가 보고 있다는 걸 알 수 있게 별을 눌러 주세요. 진심으로 도움이 됩니다.**
+> ⭐ **이게 지난 6년 동안 만들려고 벼르던 바로 그 앱처럼 들린다면 — 리포지터리에 스타를 눌러 누군가 보고 있다는 걸 알려 달라. 정말로 도움이 된다.**
 
----
-
-## 왜 "KKTerm"인가요?
-
-대만 데이터 센터에 가면 랙 맨 위를 한번 봐 보세요. TSMC 팹, 타이베이 지하철 관제실, 국태은행 서버실, 중화전신 교환 장비 — 어디서든 작은 초록색 봉투를 발견할 수 있습니다. 바로 乖乖 (Kuāi Kuāi, 괴괴/쿠아이쿠아이), 1960년대부터 이어져 온 코코넛 맛 옥수수 과자입니다.
-
-이름의 뜻은 그야말로 **"착하게 굴어라"**, **"얌전히 있어라"**입니다. IT 업계의 이 전통은 단순하고, 완전히 진지합니다:
-
-- **반드시 초록색(코코넛 맛)이어야 합니다.** 노란색(카레)은 *결근 예보*; 빨간색(매운맛)은 서버를 화나게 합니다. 초록색만 허용.
-- **유통기한이 남아 있어야 합니다.** 상한 괴괴는 오히려 역효과가 납니다. 엔지니어들은 성실하게 교체합니다.
-- **눈에 잘 보여야 합니다.** 서버가 거기 있다는 걸 알아야 합니다.
-- **먹으면 안 됩니다.** 그 봉투는 지금 근무 중입니다.
-
-아시아에서 가장 크고 지루하고 업타임에 집착하는 시스템들이 섀시에 테이프로 붙인 과자 봉투와 함께 돌아가고 있습니다. 효과가 있는 이유는, 그것을 관리하는 사람들이 효과가 있다고 믿기 때문입니다 — 대부분의 IT 문화를 정직하게 묘사하는 말이기도 합니다.
-
-**KKTerm**은 **Kuai Kuai Term** — 그 과자와 똑같은 역할을 지향하는 관리자 Workspace입니다: 중요한 기계 옆에 조용히 자리 잡고 그것들이 얌전히 작동하도록 돕는 것. 로컬 우선. 원격 측정 없음. 승인이 필요한 AI. 지루하고 믿음직스러운 소프트웨어.
-
-인스톨러에 실제 괴괴 봉투를 동봉하는 것은 아직 구현하지 못했습니다. v2 항목입니다.
+다음에 뭘 해야 할지 의견이 있다면? 공개 피드백 스레드로 오시라：
+**[KKTerm은 Windows-first 관리 워크플로에서 무엇을 우선해야 할까?](https://github.com/ryantsai/KKTerm/discussions/141)**
 
 ---
 
-## 실제로 움직이는 모습
+## 왜 "KKTerm"인가?
+
+대만의 데이터센터 어디든 들어가서 랙 위쪽을 봐라. TSMC 팹, 타이베이 메트로 관제실, 캐세이 은행 서버홀, 중화전신 교환 장비를 지나다 보면 — 작은 초록 봉지 하나가 눈에 띌 것이다. **乖乖 (Kuāi Kuāi)**, 1960년대부터 이어진 코코넛 맛 옥수수 과자다.
+
+이름은 말 그대로 **"착하게 굴어라"**, **"얌전히 있어라"**라는 뜻이다. IT 업계의 전통은 단순하고, 그리고 완전히 진지하다：
+
+- **초록(코코넛)이어야 한다.** 노랑(카레)은 *오늘 출근하지 말라*는 뜻이고, 빨강(매운맛)은 서버를 화나게 한다. 오직 초록.
+- **유통기한이 지나면 안 된다.** 상한 과이과이는 오히려 해롭다. 엔지니어들은 부지런히 갈아 끼운다.
+- **보여야 한다.** 서버가 그게 거기 있다는 걸 알아야 한다.
+- **먹지 마라.** 그 봉지는 근무 중이다.
+
+아시아에서 가장 크고, 가장 지루하고, 가장 가동률에 집착하는 시스템 중 일부가 섀시에 테이프로 붙인 옥수수 과자 봉지와 함께 돌아간다. 그게 효과가 있는 건 그걸 유지하는 사람들이 효과가 있다고 믿기 때문이다 — 대부분의 IT 문화에 대한 놀랍도록 정직한 묘사이기도 하다.
+
+**KKTerm**은 **Kuai Kuai Term**이다 — 그 과자와 같은 일을 꿈꾸는 관리 워크스페이스다: 당신의 중요한 기계들 옆에 조용히 앉아 얌전히 굴도록 돕는 것. 로컬 우선. 텔레메트리 없음. 승인 게이트가 달린 AI. 지루하지만 믿음직한 종류의 소프트웨어.
+
+진짜 과이과이 한 봉지를 설치 프로그램에 동봉하는 건 아직 못 했다. 그건 v2 과제다.
+
+---
+
+## 움직이는 모습 보기
 
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
@@ -127,339 +123,177 @@
   </a>
 </p>
 
-<p align="center"><sub><em>(데모 GIF가 들어갈 자리입니다. 이미지 하나가 글머리표 천 개의 가치를 지닌다는데, 글머리표가 이미 바닥났습니다.)</em></sub></p>
+<p align="center"><sub><em>(데모 GIF는 여기에. 한 장의 그림이 천 개의 글머리표를 이긴다. 그리고 글머리표는 거의 다 떨어졌다.)</em></sub></p>
 
 ---
 
-## 사람들이 하루 종일 켜 두는 이유
+## 하나의 창, 모든 연결
 
-### Windows 우선, 의도적으로
-
-2026년 개발 도구 생태계를 둘러보세요. Claude Code: Mac/Linux 우선, Windows는 "WSL을 쓰세요." Codex CLI: 마찬가지. `gemini-cli`, Homebrew의 절반, 반짝이는 새 TUI들: Mac/Linux 우선, Windows 사용자는 README에 달린 `# Windows: contributions welcome` 주석과 실행도 안 되는 fish 자동완성 스크립트만 받습니다.
-
-그런데 실제로 기업을 온라인 상태로 유지하는 사람들 — 기업 IT, MSP, Hyper-V, AD, SCCM, IIS, 혹은 일부 인턴보다 오래된 도메인 컨트롤러를 운영하는 사람들 — 은 Windows 앞에 앉아서 왜 새로운 도구마다 자신의 OS를 불편함 취급하는지 의아해하고 있습니다.
-
-**KKTerm은 반대 방향의 선택입니다.** 우리는 Windows 네이티브를 먼저 만들고, macOS / Linux 포팅은 그 다음입니다. 덕분에 이식성 레이어로 덮는 대신 실제로 중요한 Windows API를 사용할 수 있습니다:
-
-- **ConPTY** 로컬 셸용 — 번역 심이 아닌 진짜 Windows 의사 콘솔. PowerShell, `cmd.exe`, WSL 배포판이 모두 포커스, 리사이즈, 플랫폼 동작에 맞는 VT 시퀀스 처리를 갖춘 올바른 PTY로 실행됩니다.
-- **WebView2** 전체 UI 및 내장 URL **Connection**용 — 시스템 런타임을 사용하는 인프로세스 Chromium. 이것이 인스톨러가 작고 빠르게 시작하는 이유 중 하나입니다.
-- **Microsoft RDP ActiveX (`mstscax.dll`)** RDP용 — *Microsoft가 실제로 배포하는 바로 그것*. 원격 데스크톱 연결(`mstsc.exe`)과 같은 컨트롤. 서드파티 재구현이 아니고, FreeRDP-in-a-wrapper도 아닙니다. RDP를 쓰는 사람은 5초 만에 차이를 느낄 것입니다.
-- **Windows Credential Manager** 모든 비밀 정보용. SSH 비밀번호, FTP 비밀번호, API 키, URL Connection 자격 증명 — OS keychain에 저장되며 `credwiz.exe`로 감사할 수 있습니다.
-- **NSIS 현재 사용자 인스톨러** (SHA-256 포함), 네이티브 트레이 메뉴, 절전 방지 전원 어설션, 호스트 CPU/RAM/네트워크 샘플링, 실제 PNG 아이콘이 있는 네이티브 Tauri 컨텍스트 메뉴, 네이티브 열기/저장 대화상자. 이 중 모의 구현은 단 하나도 없습니다.
-- **WSL은 우회 방법이 아닌 일급 셸입니다.** 같은 창에서 PowerShell 창 옆에 Ubuntu, 그 옆에 SSH Session, 그 옆에 RDP **Tab**을 나란히 열 수 있습니다.
-
-macOS와 Linux 빌드는 로드맵에 있으며 같은 수준의 정성을 기울일 것입니다. 하지만 누군가 먼저가 아닌 *처음부터* 제대로 된 Windows 관리 도구를 만들어 주기를 기다려 왔다면 — 바로 이겁니다.
-
-### 로컬 우선이란 진짜 로컬을 의미합니다
-
-저장된 **Connection**은 내 기기의 SQLite 파일에 있습니다. 비밀번호는 바이너리 옆 JSON이 아닌 **Windows Credential Manager**에 있습니다. 앱은 분석 데이터를 보내지 않고, 시작 시 외부에 연결하지 않으며, 실행하는 데 클라우드 계정이 필요하지 않습니다. "동기화하려면 로그인하세요"가 없는 이유는, 동기화 자체가 없기 때문입니다.
-
-네트워크 케이블에 불이 붙어도 KKTerm은 열립니다.
-
-### 하나의 Workspace, 모든 연결 유형
-
-| 하고 싶은 것 | KKTerm이 제공하는 것 |
+| 당신이 하고 싶었던 것 | KKTerm은 이렇게 한다 |
 | --- | --- |
-| 로컬 PowerShell / cmd / WSL 셸 열기 | ConPTY 기반 로컬 터미널 **Session** |
-| 서버에 SSH 접속 | 에이전트 / 키 / 비밀번호 인증, 호스트 키 신뢰 흐름, ProxyJump, 포트 포워딩을 지원하는 네이티브 `russh` |
-| 해당 서버의 파일 탐색 | SSH **Connection**에서 실행되는 SFTP, 듀얼 패널, 재귀 전송, chmod/chown |
-| 2012년산 NAS에 FTP 연결 | 동일한 SFTP 스타일 브라우저의 FTP / FTPS **Connection** |
-| 오래된 장비에 Telnet | 네, 맞습니다, Telnet도 들어 있습니다 |
-| 시리얼 포트 통신 | Serial **Connection** 종류, COM 포트 + 보율, 추가 도구 불필요 |
-| Windows 박스에 원격 접속 | Microsoft ActiveX 컨트롤을 통한 네이티브 RDP (진짜입니다, 클론이 아닙니다) |
-| 파이에 VNC 접속 | Workspace에 직접 렌더링되는 Rust `vnc-rs` framebuffer |
-| 공유기 웹 UI 열기 | 자격 증명 자동 입력이 있는 내장 WebView2 **URL Connection** |
-| 호스트 CPU 모니터링 | 실시간 상태 표시줄 + 드래그/리사이즈 Widget이 있는 **Dashboard** 모듈 |
+| 로컬 PowerShell / cmd / WSL 셸 열기 | 로컬 터미널, 나란히 |
+| 서버로 SSH | 키·agent·비밀번호·점프 호스트·포트 포워딩을 지원하는 SSH |
+| 그 서버의 파일 둘러보기 | SSH 연결에서 바로 SFTP — 듀얼 페인, 드래그로 전송 |
+| 2012년산 NAS로 FTP | FTP / FTPS, 같은 파일 브라우저 안에서 |
+| 골동품 장비로 Telnet | 네, Telnet도 들어 있습니다 |
+| 시리얼 포트와 대화 | Serial 연결 — COM 포트와 보드레이트만 고르면 끝 |
+| Windows 머신으로 원격 | 진짜 Microsoft 원격 데스크톱을 내장 |
+| Pi로 VNC | VNC, 워크스페이스에 곧장 렌더링 |
+| 라우터 웹 UI 열기 | 로그인 정보를 저장할 수 있는 내장 브라우저 탭 |
+| 호스트 CPU 보기 | 실시간 상태 표시줄과, 직접 쌓아 올릴 수 있는 Dashboard |
 
-모두 같은 앱입니다. 같은 창. 같은 단축키. 눈이 아프지 않기를 바라는 같은 테마.
+같은 앱. 같은 창. 같은 단축키. 같은, 부디 눈이 아프지 않기를 바라는 테마.
 
-### 정신을 잃지 않는 터미널
+---
 
-- **Tab** 안에서 창 분할.
-- WebGL 가속 xterm.js 렌더링, 불가능할 때는 우아하게 폴백.
-- 스크롤백 검색.
-- tmux 기반 SSH 창: 창별 안정적인 Session에 연결하여 재연결이 진짜 *재연결*을 의미하게 합니다 — "지난 한 시간을 없었던 일로 하고 다시 시작"이 아닙니다.
-- **Tab** 전환이 **Session**을 종료하지 **않습니다**. **Tab**을 닫아야 종료됩니다. 내부적으로 종교 전쟁 수준의 논쟁이 있었습니다. 우리가 이겼습니다.
+## 왜 사람들은 하루 종일 켜 두는가
 
-### 내 도구를 만들어 주는 AI 어시스턴트
+### 의도적으로 Windows 우선
 
-"터미널에 AI를" 데모 대부분은 채팅에서 멈춥니다. KKTerm의 어시스턴트는 실제 작업 방식에 맞는 작고 지속되는 Dashboard Widget도 만들 수 있습니다. 위험한 작업은 여전히 두 가지 스위치 뒤에 둡니다:
+지금의 개발 도구 판을 둘러보라. Claude Code: mac/linux 먼저, Windows는 "WSL 쓰세요." Codex CLI: 마찬가지. 반짝이는 새 도구의 절반은 mac 우선으로 나오고, Windows 사용자에겐 `# contributions welcome` 주석과 돌아가지도 않는 자동완성 스크립트를 남긴다.
 
-- **도구 패밀리** (Dashboard / Connections / Live Sessions) — 카테고리별로 켜고 끄기.
-- **작성기의 권한 모드** — `Prompt` (기본값, 매번 확인) 또는 `Allow All` (성인임을 선언하고 면책 동의서에 서명한 분).
+한편, 실제로 회사를 온라인 상태로 유지하는 사람들 — 기업 IT, MSP, 일부 인턴보다 나이 많은 도메인 컨트롤러를 관리하는 사람들 — 은 Windows 머신 앞에 앉아, 왜 모든 새 도구가 자기 OS를 골칫거리 취급하는지 의아해한다.
 
-OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA, 또는 OpenAI 호환 엔드포인트와 대화할 수 있습니다. API 키는 OS keychain으로. `rm -rf`를 제안하는 모델은 위험으로 분류되어 명시적인 인간 승인이 필요합니다. AI는 맨 페이지의 프롬프트 인젝션에 누군가가 영리한 짓을 해도 파괴적인 명령을 조용히 실행할 수 없습니다.
+**KKTerm은 반대의 거래를 택한다.** 우리는 Windows 네이티브를 먼저 만들기에, Windows 사용자가 신경 쓰는 것들이 그냥 작동한다: *진짜* Microsoft 원격 데스크톱(`mstsc.exe`와 같은 그것, 짝퉁이 아니다), 진짜 PowerShell / cmd / WSL 셸, Windows 자격 증명 관리자에 보관되는 비밀번호, 제대로 된 트레이 아이콘, 네이티브 메뉴와 대화상자. macOS와 Linux 빌드는 로드맵에 있고 같은 정성으로 만든다. 하지만 누군가가 *좋은* Windows 관리 도구를 마지막이 아니라 처음으로 만들어 주기를 기다려 왔다면 — 그게 바로 이 거래다.
+
+### 로컬 우선은 정말로 로컬이라는 뜻
+
+저장한 연결은 당신 머신의 파일에 들어간다. 비밀번호는 앱 옆 텍스트 파일이 아니라 Windows 자격 증명 관리자에 들어간다. KKTerm은 분석 데이터를 보내지 않고, 시작할 때 집에 전화하지 않으며, 실행에 클라우드 계정이 필요 없다. "로그인해서 동기화"가 없는 건 애초에 동기화가 없기 때문이다.
+
+네트워크 케이블에 불이 붙어도 KKTerm은 멀쩡히 열린다.
+
+### 정신줄을 놓지 않는 터미널
+
+- Tab 안에서 페인 분할.
+- 빠르고 매끄러운 렌더링, 검색 가능한 스크롤백.
+- 재연결은 정말로 *재연결*이다 — 원격 세션은 멈췄던 곳에서 이어진다. "처음부터 다시 시작하고 방금 한 시간은 없던 일로 치자"가 아니다.
+- Tab을 전환해도 Session은 죽지 **않는다**. Tab을 닫으면 죽는다. 이 구분은 내부에서 종교 전쟁이었다; 우리가 이겼다.
+
+### 도구를 만들어 주는 AI 어시스턴트
+
+대부분의 "터미널 속 AI" 데모는 채팅에서 멈춘다. KKTerm의 어시스턴트는 당신이 실제로 일하는 방식에 맞춰 작고 오래가는 Dashboard 위젯도 만든다 — 그리고 위험한 건 스위치 뒤에 둔다：
+
+- **무엇을 건드릴 수 있는지 정한다** — 도구 묶음(Dashboard / Connections / Live Sessions)을 통째로 켜고 끄기.
+- **어떻게 물어볼지 정한다** — `Prompt`(기본, 매번 묻기) 또는 `Allow All`(당신은 성인이고, 각서에 서명했다).
+
+`rm -rf`처럼 보이는 건 전부 위험으로 표시되어 사람의 명시적인 예스를 기다린다. 누군가 man page에 프롬프트 인젝션을 심어 잔머리를 굴려도, AI가 파괴적인 명령을 몰래 실행하는 일은 없다.
+
+OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA, 또는 OpenAI 호환 엔드포인트 무엇과도 대화한다. API 키는 OS 키체인에 들어간다.
 
 ### Grafana인 척하지 않는 Dashboard
 
-**Dashboard** 모듈은 12열 드래그/리사이즈 그리드의 Widget 인스턴스 모음입니다. 페타바이트급 관측 가능성을 위한 것이 아닙니다 — "즐겨 사용하는 앱 다섯 개를 실행하는 버튼과 SSH 호스트 업타임 패널을 채팅 *옆에* 두고 싶다"는 분을 위한 것입니다.
+Dashboard는 드래그·리사이즈 가능한 위젯 그리드다. 페타바이트급 관측을 위한 게 아니다 — "내가 좋아하는 앱 다섯 개를 실행하는 버튼과, 내 SSH 호스트 가동 시간을 보여주는 패널을, *내 채팅 옆에* 두고 싶다"를 위한 것이다.
 
-#### AI가 만드는 Widget — 설명하면 나타납니다
+#### AI가 만든 위젯 — 말로 하면, 나온다
 
-이건 우리가 진심으로 흥분하는 부분입니다. 마켓플레이스에서 고르거나 JavaScript를 직접 작성할 필요가 없습니다. **AI 어시스턴트에게 원하는 것을 말하면**, 바로 Dashboard 위에 Widget을 만들어 줍니다:
+이 부분은 우리가 정말로 신나는 지점이다. 마켓플레이스에서 고르지도, JavaScript를 쓰지도 않는다. **AI 어시스턴트에게 원하는 걸 말하면**, 바로 당신의 Dashboard 위에 위젯을 만들어 준다：
 
-> *"메인 레포의 최근 커밋 5개를 목록으로 보여주는 Widget을 추가해 줘."*
-> *"온콜 치트시트를 저장할 수 있는 스티키 노트 Widget을 만들어 줘."*
-> *"30초마다 홈 공유기에 핑을 보내고 초록/빨강으로 표시하는 Widget을 만들어 줘."*
-> *"스톱워치가 필요해. 스타일링은 네가 알아서 해줘."*
+> *"내 메인 repo의 최근 커밋 5개를 목록으로 보여주는 위젯 추가해 줘."*
+> *"온콜 치트시트를 담아둘 포스트잇 위젯 만들어 줘."*
+> *"우리 집 라우터를 30초마다 ping해서 초록/빨강을 보여주는 위젯 만들어 줘."*
+> *"스톱워치가 필요해. 스타일은 알아서, 놀래켜 봐."*
 
-두 가지 종류:
+어떤 건 단순한 표시 패널(markdown, 체크리스트, 큼직한 숫자 하나)이고, 어떤 건 당신이 승인한 격리 샌드박스 안에서 실시간 코드를 돌린다. 남겨둔 위젯은 전부 당신 것이다 — 고유한 색·아이콘·제목을 달고 저장되며, 크기가 다른 사본을 여러 개 둘 수 있다. 질리면 우클릭으로 삭제.
 
-- **콘텐츠 Widget** — 선언적 JSON: 마크다운, kv 목록, 체크리스트, 크게 표시되는 단일 통계. 설계상 안전하며 스크립트 없음. "그냥 Dashboard에 있었으면 좋겠는" 요청의 대부분이 여기에 해당합니다.
-- **스크립트 Widget** — 명시적으로 선언된 권한(`network` 허용 목록, `pollSeconds` 예산)이 있는 격리된 `iframe srcdoc` 샌드박스 내에서 실행되는 JavaScript. AI가 스크립트를 작성하고, 사용자가 권한을 승인하며, Widget은 앱의 나머지 부분에 접근할 수 없는 박스 안에서 실행됩니다.
+#### Dashboard 애니메이션 배경 (그냥 하고 싶어서)
 
-유지한 Widget은 모두 내 것입니다. **Connection** 옆 SQLite에 저장되며, 각각의 시각적 프리셋(`panel` / `ambient` / `hero`), 강조 색상, 아이콘, 제목을 가집니다. 같은 Widget의 여러 인스턴스가 완전히 다른 크기와 스타일로 공존할 수 있습니다. 식상해지면 우클릭으로 삭제하면 됩니다.
+Dashboard 뷰마다 **25종**의 캔버스 애니메이션 배경에서 기분을 고를 수 있다：
 
-#### 애니메이션 Dashboard 배경 (우리가 원했으니까)
-
-Dashboard에는 **Dashboard View**별로 선택할 수 있는 캔버스 애니메이션 배경이 스물한 가지 있습니다:
-
-| 분위기 | 배경 |
+| 기분 | 배경 |
 | --- | --- |
-| 차분한 | `aurora`, `clouds`, `ocean`, `raindrops`, `snow`, `sakura`, `fireflies`, `bubbles`, `ricefield`, `lanterns` |
-| 우주적인 | `starfield`, `nebula` |
-| 따뜻한 | `embers`, `lava` |
-| 덕후스러운 | `matrix`, `topo`, `synthwave` |
-| 혼란스러운 | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti` |
+| 잔잔 | `aurora`, `clouds`, `ocean`, `raindrops`, `rainywindow`, `frostedWindow`, `snow`, `sakura`, `fireflies`, `bubbles`, `aquarium`, `ricefield`, `lanterns` |
+| 우주 | `starfield`, `nebula` |
+| 따뜻 | `embers`, `lava` |
+| 긱 | `matrix`, `topo`, `synthwave` |
+| 들썩 | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti`, `particleCursor` |
 
-단일 공유 `requestAnimationFrame`으로 실행되며 창 포커스를 존중하므로, 다른 작업을 할 때는 거의 CPU를 소비하지 않습니다. `matrix`와 AI 어시스턴트를 조합하면 "나는 엄청나게 생산적이며 동시에 워쇼스키 영화 속에 있는 것 같기도 하다"는 분위기가 납니다. 아니면 `ocean`를 골라서 진지한 사람처럼 보일 수도 있습니다. 어느 쪽이든 판단하지 않습니다.
+다른 화면에 있을 땐 멈추므로 비용은 거의 0이다. `matrix`를 AI 어시스턴트와 짝지으면 "나는 극도로 생산적이며 아마도 워쇼스키 영화 속에 있다"는 분위기가 난다. 아니면 `ocean`을 골라 진지한 사람처럼 보이거나. 어느 쪽이든 우리는 평가하지 않는다.
 
-### 원격 서버에서 AI 코딩 에이전트를 올바르게 실행하기
+### 원격 AI 에이전트를 살아 있게 유지
 
-이것이 두 번째로 사람들이 사랑에 빠지는 기능입니다. KKTerm의 SSH 터미널은 원격 호스트의 **named tmux session**으로 바로 진입할 수 있습니다 — 기본값은 재연결 후에도 살아남는 `kkterm-cockpit001` 같은 자동 생성된 친근한 이름입니다:
+이게 사람들이 빠져드는 두 번째 기능이다. KKTerm의 SSH 터미널은 재연결을 견뎌내는 원격 호스트의 **이름 붙은 tmux 세션** 안으로 당신을 곧장 떨어뜨릴 수 있다：
 
-- tmux를 활성화한 상태로 SSH **Connection**을 엽니다.
-- 창 안에서 `claude`, `codex`, `gemini-cli`, `cursor-agent`, 또는 원하는 장시간 실행 코딩 에이전트를 시작합니다. 이것들은 전체화면 TUI 앱이며, tmux가 바로 그 자리입니다.
-- 노트북을 닫습니다. 다시 엽니다. 창이 조용히 같은 tmux session에 재연결됩니다. 에이전트는 아직 실행 중이고, 스크롤백도 있으며, 하던 일을 계속하고 있습니다.
-- SSH 트랜스포트에 네트워크 순단이 발생했나요? KKTerm이 같은 tmux id로 조용히 제한된 재연결을 시도하며 귀찮게 하지 않습니다.
-- AI 어시스턴트가 에이전트가 뭘 하는지 보길 원하나요? "Add terminal buffer to context"는 SSH를 통해 `capture_tmux_pane`을 호출하여 전체 tmux 스크롤백 — 화면에 보이는 것만이 아닌 전체 session — 을 대화에 가져옵니다. 로컬 어시스턴트가 이제 원격 에이전트의 작업에 대해 추론할 수 있습니다.
+- tmux를 켠 SSH 연결을 열고 `claude`, `codex`, `gemini-cli`, `cursor-agent`, 또는 좋아하는 장시간 에이전트를 실행한다.
+- 노트북을 닫는다. 다시 연다. Pane은 조용히 다시 붙는다 — 에이전트는 여전히 돌고 있고, 스크롤백도 남아 있고, 하던 일을 그대로 하고 있다.
+- 네트워크가 깜빡? KKTerm은 당신을 귀찮게 하지 않고 같은 세션으로 조용히 다시 연결한다.
+- 어시스턴트의 도움이 필요하다면? "터미널 버퍼를 컨텍스트에 추가"로 원격 세션 전체가 대화에 들어와, 로컬 AI가 원격 에이전트의 작업을 추론할 수 있다.
 
-불안정한 호텔 Wi-Fi 때문에 6시간 짜리 `claude` 또는 `codex` Session을 날려 본 적이 있다면, 이 기능 하나만으로도 앱값을 합니다. 앱은 무료입니다. 기능은 여전히 그만한 가치가 있습니다.
+호텔의 불안정한 Wi-Fi 때문에 6시간짜리 `claude`나 `codex` 세션을 날려본 적이 있다면, 이 기능 하나로 본전은 뽑는다. (앱은 무료다. 그래도 이 기능은 그만한 가치가 있다.)
 
-### 남은 AI 양 파악하기
+### AI가 얼마나 남았는지 알기
 
-코딩 에이전트는 월 단위가 아니라 플랜 윈도우 단위로 과금합니다. Claude Code에는 5시간 윈도우와 주간 윈도우가 있습니다. Codex도 자체 버전이 있습니다. 둘 다 당신이 회의 중일 때 백그라운드에서 즐겁게 쿼터를 먹어치울 수 있습니다.
+코딩 에이전트는 월 단위가 아니라 요금제 윈도 단위로 과금하고, 당신이 회의에 들어가 있는 동안에도 기꺼이 할당량을 먹어 치운다. **AI 사용량 미터**가 그걸 늘 보이게 한다：
 
-**AI 코딩 사용량** Widget이 그것을 가시화합니다:
+- **Claude Code**와 **Codex**를 나란히 보여주는 Dashboard 위젯: 연결된 계정, 요금제, 현재 윈도와 이번 주 사용량, 다음 리셋 시각.
+- 같은 숫자를 비추는 간결한 **상태 표시줄 인디케이터**. Dashboard를 닫아두어도 다음 대규모 리팩터링 전에 여유가 있는지 한눈에 안다.
+- 다시 로그인해야 하는지 미리 알려준다 — 긴 작업 *전에*, 도중이 아니라.
 
-- **Claude Code**와 **Codex**를 나란히 보여주는 Dashboard Widget: 연결된 계정, 플랜 등급, 현재 5시간 윈도우 사용률, 이번 주 사용률, 다음 리셋 시각.
-- 같은 숫자를 비추는 **컴팩트한 상태 표시줄 인디케이터**. Dashboard가 닫혀 있어도 다음 큰 리팩토링을 시작하기 전에 여유가 있는지 한눈에 알 수 있습니다.
-- 인증 상태가 직접 표시(`connected` / `expired` / `error`)되어, 긴 작업 중간이 아니라 작업 *전에* 재로그인이 필요하다는 사실을 알 수 있습니다.
-- 리프레시 정책은 레이트 리밋을 존중합니다. Widget을 볼 때마다 상류 API를 두드리는 대신 자체 페이스로 폴링합니다.
+### 다른 AI가 KKTerm을 조종하게 하기
 
-### 내장 MCP 서버 — 다른 AI들이 KKTerm을 운전하게 하기
+KKTerm은 자체 MCP 서버를 내장하고 있어, 외부 코딩 에이전트(Claude Code, Codex, Copilot, Antigravity, OpenCode)가 당신처럼 워크스페이스를 쓸 수 있다 — 연결 목록 보기, 하나 열기, 터미널 버퍼 읽기, Dashboard에 위젯 놓기. AI 대 AI, 당신의 머신 위에서, 클라우드 중계 없이. 변경을 가하는 더 위험한 동작들은 기본적으로 **꺼져 있는** 단일 안전 토글 뒤에 있다.
 
-당신의 터미널은 Claude Code, Codex, Copilot 에이전트 모드, Antigravity, 그리고 MCP를 말하는 나머지 세계가 일하고 싶어 하는 곳이기도 합니다. 그래서 KKTerm은 자체 **stdio MCP 서버**, [`kkterm-cli`](docs/MCP.md)을 함께 제공하여 앱의 큐레이션된 일부를 노출합니다:
-
-- **Workspace 모듈** (`kkterm.workspace.*`): 저장된 **Connection** 목록 조회, id로 Connection 열기, 활성 **Session** 목록 조회, 터미널 창에 입력 전송, 터미널 버퍼 스냅샷 읽기.
-- **Dashboard 모듈** (`kkterm.dashboard.*`): Dashboard 상태 로드, AI 작성 Widget의 소스 읽기, View 생성 / 수정 / 삭제, Widget 인스턴스 배치 / 이동 / 제거, 일괄 레이아웃 적용.
-- **위험 서브 네임스페이스** (`kkterm.<module>.dangerous.*`): 실행 가능한 표면 변경 — 스크립트 Widget 생성, 원격 데스크톱 클릭, Dashboard 와이프 — 은 단일 설정(`built_in_mcp_allow_all_dangerous`) 뒤에 게이트되어 있으며, 기본값은 **꺼짐**입니다.
-
-`kkterm-cli`는 얇은 포워더입니다. MCP 클라이언트와는 stdio JSON-RPC로 대화하고, 실행 중인 KKTerm 창과는 실행 단위 인증된 Windows 명명 파이프로 통신합니다. KKTerm이 닫혀 있을 때도 `tools/list`는 동작하지만(클라이언트가 표면을 인트로스펙트 가능), `tools/call`은 구조화된 `app_not_running` 에러를 반환합니다.
-
-좋아하는 클라이언트에 연결하면 당신의 AI가 이제 당신처럼 KKTerm을 사용합니다:
-
-```json
-{
-  "mcpServers": {
-    "kkterm": { "command": "<kkterm-cli-경로>", "args": [] }
-  }
-}
-```
-
-설정 → AI Assistant → **내장 MCP 서버**에는 해석된 바이너리 경로가 미리 채워진 JSON 및 TOML 스니펫과 복사 가능한 `claude mcp add` / `codex mcp add` 명령이 들어 있는 원클릭 "설정 표시" 다이얼로그가 있습니다.
-
----
-
-## 구조
-
-```mermaid
-flowchart LR
-    User([You]) --> Shell[KKTerm Window<br/>Tauri v2 + React 19]
-    Shell --> Rail[Activity Rail]
-    Rail --> WS[Workspace Module]
-    Rail --> Dash[Dashboard Module]
-    Rail --> Inst[Installer Helper Module]
-    Rail -.-> FE[File Explorer<br/>planned]
-    Rail --> Set[Settings]
-
-    WS --> Tabs[Tabs &amp; Panes]
-    Tabs --> Term[Terminal<br/>ConPTY / russh]
-    Tabs --> SFTP[SFTP / FTP]
-    Tabs --> Web[WebView2 URL]
-    Tabs --> RD[RDP / VNC]
-
-    Shell -.calls.-> Rust[Rust Backend]
-    Rust --> SQLite[(SQLite<br/>Connections)]
-    Rust --> Keychain[(OS Keychain<br/>Secrets)]
-    Rust --> AI[AI Providers<br/>OpenAI-compat]
-
-    AI -. approval gate .-> Tabs
-
-    classDef local fill:#1f6feb,stroke:#1f6feb,color:#fff
-    classDef ai fill:#8a63d2,stroke:#8a63d2,color:#fff
-    class SQLite,Keychain local
-    class AI ai
-```
-
-핵심 구조: 지속되는 저장 데이터(**Connection**)는 실시간 런타임 상태(**Session**)와 분리되어 있고, 그것은 다시 UI 컨테이너(**Tab**)와 분리되어 있습니다. **Tab**을 닫으면 **Session**이 종료됩니다. **Tab**을 전환해도 종료되지 않습니다. 이것이 앱을 멀쩡하게 유지하는 규칙입니다.
-
----
-
-## 현재 기능 목록
-
-| 영역 | 현재 구현 |
-| --- | --- |
-| **Connections** | SQLite 기반 트리, 폴더/하위 폴더, 검색, 드래그/드롭 정렬, 이름 변경, 복제, 삭제, **Quick Connect**, 사용자 정의 아이콘, 고정/활성 Activity Rail 단축키 |
-| **Terminal** | 로컬 셸, SSH, Telnet, Serial, 창 분할, xterm.js + 기회적 WebGL, 스크롤백 검색, 로컬 시작 디렉터리/스크립트 |
-| **SSH** | 네이티브 `russh`, 에이전트/키/비밀번호 인증, 호스트 키 신뢰 흐름, 선택적 시스템 SSH 폴백, ProxyJump, 포트 포워딩, **자동 named tmux session(`kkterm-<공상과학-이름><n>`)과 트랜스포트 순단 시 조용한 재연결** — 장시간 실행 원격 코딩 에이전트(Claude Code, Codex, gemini-cli 등)에 최적 |
-| **SFTP / FTP** | SSH 기반 SFTP 및 FTP/FTPS **Connection**, 듀얼 패널 브라우저, 재귀 전송, 큐/취소/기록 초기화, 충돌 처리, 속성, 지원되는 경우 chmod/chown |
-| **URL WebView** | 내장 WebView2 URL **Session**, 탐색 도구 모음, 파비콘 캡처, 저장된 웹사이트 자격 증명 메타데이터/입력, 데이터 파티션 메타데이터 |
-| **Remote Desktop** | 지오메트리 범위 오버레이 파킹이 있는 Windows ActiveX를 통한 RDP; Workspace 캔버스에 렌더링되는 `vnc-rs` framebuffer를 통한 VNC |
-| **Dashboard** | 지속 View, Widget 인스턴스, 편집 모드, 드래그/리사이즈, App Launcher, **AI 작성 콘텐츠/스크립트 Widget**(선언적 JSON 또는 권한이 있는 샌드박스 iframe JS), Widget별 프리셋 / 강조색 / 아이콘 / 제목, **23가지 애니메이션 캔버스 배경**(aurora, clouds, ocean, raindrops, rainywindow, snow, sakura, fireflies, bubbles, ricefield, lanterns, starfield, nebula, embers, lava, matrix, topo, synthwave, cyberpunk, taipei101, thunderstorm, confetti, particleCursor) |
-| **AI Assistant** | 스트리밍 채팅, OpenAI 호환 런타임, 공급자 레지스트리, 명령 제안 안전 분류, 스크린샷/컨텍스트 첨부, **Dashboard Widget 작성(콘텐츠 + 샌드박스 스크립트)**, 원격 Session의 대화 컨텍스트로서의 **tmux 창 캡처**, **Connection** 관리 도구, 터미널, RDP/VNC, SFTP/FTP를 위한 실시간 **Session** 도구 |
-| **AI 코딩 사용량** | **Claude Code**와 **Codex**의 쿼터 사용량을 추적하는 **Dashboard Widget + 상태 표시줄 인디케이터**: 연결된 계정, 플랜 등급, 5시간 및 주간 윈도우 사용률, 다음 리셋 시각, 인증 상태(`connected` / `expired` / `error`), 레이트 리밋을 의식한 리프레시 정책 |
-| **내장 MCP 서버** | 외부 코딩 에이전트(Claude Code, Codex, Copilot, Antigravity, OpenCode)에 큐레이션된 Workspace 및 Dashboard 도구를 노출하는 stdio MCP 서버(`kkterm-cli`); 인증된 명명 파이프 브리지; 모듈별 `dangerous.*` 네임스페이스가 단일 안전 토글 뒤에서 게이트됨; 해석된 바이너리 경로의 JSON / TOML 스니펫과 `claude mcp add` / `codex mcp add` 명령이 들어 있는 설정 다이얼로그 |
-| **Installer Helper** | 번들된 Windows 개발 도구 카탈로그용 Activity Rail Module: 설치된 도구 감지, 최신 버전 비교, 설치/업데이트/제거, Update all에서 도구 제외, 명령 로그 스트리밍, 지원되는 관리 앱 실행 |
-| **Settings** | 일반, 외관, 자격 증명, AI, SSH, 터미널, 터미널 배경, URL, RDP, VNC, Dashboard, Installer Helper, 정보; 사용자 정의 UI 폰트; 트레이로 최소화; 절전 방지; 백업/가져오기 |
-| **Localization** | i18next UI, 영어 소스, 동적 로케일 번들: zh-TW, zh-CN, ja, ko, fr, de, es, es-MX, it, pt-BR, th, id, vi |
-
-### AI 공급자
-
-OpenAI · Anthropic · OpenRouter · DeepSeek · Grok · Azure OpenAI · LiteLLM · GitHub Copilot · Ollama · NVIDIA · OpenAI 호환 엔드포인트 모두.
-
-공급자 메타데이터는 [`src/ai/providerRegistry/`](src/ai/providerRegistry/)에, Rust 어댑터는 [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/)에 있습니다. API 키는 OS keychain을 통하며, SQLite에는 절대 저장되지 않습니다.
-
----
-
-## 빠른 시작
-
-필요한 것:
-
-- **Windows** (주요 지원 플랫폼)
-- **Node.js + npm**
-- **Rust 툴체인**
-- **WebView2** 포함 **Windows용 Tauri v2 사전 요구사항**
-
-```bash
-npm install
-npm run tauri dev
-```
-
-진짜 네이티브 창이 나타나야 합니다. 대신 스택 트레이스가 나타난다면 이슈를 등록해 주세요 — 우리는 좋은 재현 케이스를 좋아합니다.
-
-### 일반 검사
-
-```bash
-npm run check                                              # TypeScript
-npm run build                                              # Vite build
-cargo check --manifest-path src-tauri/Cargo.toml           # Rust
-cargo test  --manifest-path src-tauri/Cargo.toml           # Rust tests
-```
-
-### Windows 인스톨러 빌드
-
-```bash
-npm run package:installer
-```
-
-인스톨러 스크립트는 `artifacts/kkterm-<version>-windows-x64-setup.exe`와 매칭되는 `.sha256` 파일을 생성합니다. 현재 **서명되지 않은** 상태입니다 — 릴리스 서명이 로드맵에 있지만, 그 전까지 바이러스 백신이 눈을 흘길 수 있습니다. 정상입니다.
+설정 → AI Assistant → **Built-in MCP Server**에 모든 게 미리 채워진 원클릭 "설정 표시" 대화상자가 있고, 복사 가능한 `claude mcp add` / `codex mcp add` 명령도 들어 있다.
 
 ---
 
 ## KKTerm이 아닌 것
 
-짧은 목록입니다. 솔직함이 신뢰를 만드니까요:
+짧은 목록, 정직함이 신뢰를 벌기 때문이다：
 
-- **클라우드 제품이 아닙니다.** 동기화 없음, 팀 계정 없음, SaaS 티어 없음. "KKTerm에 로그인" 대화상자를 보게 된다면, 뭔가 심각하게 잘못된 것입니다.
-- **크로스플랫폼인 척하지 않습니다.** 우리는 의도적으로 Windows 우선입니다; macOS와 Linux는 로드맵에 있으며 같은 Tauri v2 쉘을 사용할 것입니다. 지금 당장 Mac 우선 도구가 필요하다면 선택지가 수백 가지입니다. 우리는 Windows 관리자들이 조용히 기다려 온 그것을 만들고 있습니다.
-- **자율 AI 에이전트가 아닙니다.** 어시스턴트가 제안하면 사람이 결정합니다. `Allow All`은 사용자의 선택이지 기본값이 아닙니다.
-- **Grafana / Datadog 대체품이 아닙니다.** Dashboard는 개인 제어판용이지 10,000개 호스트 관측 가능성용이 아닙니다.
-- **Kubernetes IDE가 아닙니다.** 터미널 우선 관리자 Workspace입니다. Helm 차트를 렌더링해 달라고 하지 마세요.
+- **클라우드 제품이 아니다.** 동기화 없음, 팀 계정 없음, SaaS 요금제 없음. 언젠가 "KKTerm에 로그인" 대화상자를 본다면, 뭔가 치명적으로 잘못된 것이다.
+- **크로스 플랫폼인 척하지 않는다.** 우리는 의도적으로 Windows 우선이다; macOS와 Linux는 로드맵에 있다. 오늘 mac 우선 도구가 필요하다면 선택지는 수백 개다. 우리는 Windows 관리자들이 조용히 기다려 온 그 하나를 만들고 있다.
+- **자율 AI 에이전트가 아니다.** 어시스턴트는 제안하고, 사람이 결정한다. `Allow All`은 기본값이 아니라 당신이 내리는 선택이다.
+- **Grafana / Datadog 대체재가 아니다.** Dashboard는 개인용 제어판을 위한 것이지, 1만 대 규모 관측을 위한 게 아니다.
+- **Kubernetes IDE가 아니다.** 이건 터미널 중심의 관리 워크스페이스다. Helm 차트를 그려달라고 하지 말아 달라.
 
-이 중 어떤 것이 결정적인 거절 이유였다면 — 충분히 이해합니다, v2에서 만나요.
-
----
-
-## 네이티브 디버깅
-
-검증에는 진짜 Tauri 런타임을 사용하세요:
-
-```bash
-npm run tauri dev
-```
-
-Vite 브라우저 미리보기는 일부 프론트엔드 검사에 유용하지만, 실제 WebView2, ConPTY, RDP ActiveX, VNC framebuffer, keychain, 또는 네이티브 메뉴 서피스를 **호스팅하지 않습니다**. 해당 기능을 건드리는 기능이라면 실제 데스크톱 런타임에서 검증하세요.
-
-VS Code 사용자: `Run KKTerm exe` 실행 구성은 `RUST_BACKTRACE=1`과 함께 `src-tauri/target/debug/kkterm.exe`를 시작합니다. 페어링된 `Attach KKTerm WebView2` 구성은 실제 WebView2 호스트 내부에서 DevTools를 제공합니다.
+그중 무엇이든 *예전엔* 거래 결렬 사유였다면 — 좋다, v2에서 보자.
 
 ---
 
-## 현재 제한 사항 (알고 있습니다)
+## KKTerm 받기
 
-- 인스톨러가 현재 서명되지 않았습니다. 릴리스 서명이 설정될 때까지 업데이트 확인은 비활성화되어 있습니다.
-- 네이티브 SFTP 경로에서 ProxyJump를 통한 SFTP는 아직 지원되지 않습니다.
-- 파일 전송 재개, 폴더 동기화/비교, 압축/해제, 원격 편집은 미루어졌습니다.
-- SSH 설정 가져오기는 구현되었으나 Settings의 사용자 대면 항목이 아직 노출되지 않았습니다.
-- RDP와 VNC는 출시되었으며; 더 풍부한 클립보드/장치 동기화 및 품질 제어는 아직 발전 중입니다.
-- macOS와 Linux 빌드는 로드맵에 있습니다. 제대로 할 것입니다 — "거기서도 어느 정도 작동함" 포팅으로 서두르지 않겠습니다.
-- AI 어시스턴트는 설정된 권한 경계 내에서 활성화된 도구를 제안하고 작동할 수 있습니다 — 무인 로봇으로 취급하지 마세요. 어시스턴트는 당신의 CEO가 원하는 것을 실제로 알지 못합니다.
+**[최신 Windows 설치 프로그램 (.exe) 다운로드](https://github.com/ryantsai/KKTerm/releases/latest)** 후 실행하면 된다. 설치 프로그램은 현재 **서명되지 않았다** — 릴리스 서명은 로드맵에 있으므로, 그전까지는 백신이 당신을 엄한 눈으로 볼 수 있다. 정상이다.
+
+소스에서 빌드하거나 기여하고 싶다면? 필요한 건 전부 [`CONTRIBUTING.md`](CONTRIBUTING.md)에 있다.
 
 ---
 
-## 로드맵 (간략 버전)
+## 로드맵 (짧은 버전)
 
 - macOS + Linux 빌드
-- 서명된 인스톨러 + 자동 업데이트
-- 네이티브 경로에서 ProxyJump를 통한 SFTP
-- 파일 전송 재개, 폴더 동기화, 압축/해제
-- 더 풍부한 RDP 클립보드/장치 리디렉션
-- 더 많은 내장 **Dashboard** Widget (및 AI 작성을 위한 공개 스키마)
+- 서명된 설치 프로그램 + 자동 업데이트
+- 더 강력한 파일 전송 (이어받기, 폴더 동기화, 압축/해제)
+- 더 풍부한 원격 데스크톱 클립보드·장치 공유
+- 더 많은 내장 Dashboard 위젯
 
-전체 및 자주 업데이트되는 버전: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+전체이며 자주 갱신되는 버전: [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
 ---
 
 ## 기여하기
 
-도움을 환영합니다. 진심으로. 작은 것도 중요합니다:
+손을 보태주면 정말 좋겠다. 진심이다. 작은 것도 중요하다：
 
-- **개발 빌드를 사용해 보고** 뭔가 이상하다 싶으면 이슈를 등록해 주세요. "이상하게 느껴졌다"는 것도 합법적인 버그 리포트입니다; 같이 파고들겠습니다.
-- **로케일을 번역해 주세요.** 영어는 [`src/i18n/locales/en.json`](src/i18n/locales/en.json)에 있는 소스 언어이고; 12개의 다른 로케일이 옆에 있으며 요청 시 로드됩니다. 미번역 문자열은 [`docs/localization_todo/`](docs/localization_todo/)에 키별로 추적됩니다 — 하나를 골라, 번역하고, 파일을 삭제하세요.
-- **Dashboard Widget을 추가해 주세요.** 내장 Widget은 [`src/modules/dashboard/widgets/builtin/`](src/modules/dashboard/widgets/builtin/)에 있습니다. 작은 아이디어를 골라, 출시하고, 패턴을 익히세요.
-- **AI 도구 표면을 다듬어 주세요.** 공급자 어댑터는 [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/)에; 프론트엔드 레지스트리는 [`src/ai/providerRegistry/`](src/ai/providerRegistry/)에 있습니다.
-- **매뉴얼을 개선해 주세요.** 최종 사용자 문서는 [`docs/manual/`](docs/manual/)에 있습니다. UI 모듈당 한 챕터. 기능을 사용했는데 문서가 도움이 안 됐다면, 그것을 고치는 PR은 금값입니다.
+- **dev 빌드를 써보고**, 뭔가 이상하면 issue를 남겨 달라. "어딘가 이상했다"도 정당한 버그 리포트다; 함께 파보겠다.
+- **로케일을 번역하라.** 영어가 source of truth이고, 그 옆에 다른 13개 언어가 산다.
+- **Dashboard 위젯을 추가하라.** 작은 아이디어를 골라 출시하고 패턴을 익혀라.
+- **매뉴얼을 개선하라.** 어떤 기능을 썼는데 문서가 도움이 안 됐다면, 그걸 고치는 PR은 금이다.
 
-전체 설정, 프로젝트 구조, PR 체크리스트, "제발 이것만은 깨뜨리지 마세요" 규칙 목록은 [`CONTRIBUTING.md`](CONTRIBUTING.md)에 있습니다. 30초 요약:
-
-- **사용자 대면 용어를 변경하기 전에 [`CONTEXT.md`](CONTEXT.md)를 읽으세요.** **Connection**, **Session**, **Tab**, **Quick Connect**는 특정 의미를 갖습니다; 흔들지 마세요.
-- **모든 사용자에게 보이는 문자열은 `t()`를 거칩니다.** JSX에 노출된 영어 텍스트는 없습니다.
-- **프론트엔드 닫기 훅 없음.** Tauri v2의 타이틀바 닫기는 `onCloseRequested` 패턴으로 여섯 번이나 망가진 적이 있습니다. 이제 작동하는 형태가 있으니, 다시 도입하지 마세요.
-- **PR을 열기 전에 검사를 실행하세요** (`npm run check && npm run build && cargo check && cargo test`).
-
-시작점을 찾고 계신가요? [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 또는 [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) 라벨로 오픈 이슈를 필터링해 보세요. 태그된 이슈가 없다면 작업하고 싶은 것을 설명하는 이슈를 열어 주세요 — 범위를 잡는 데 도움을 드리겠습니다.
+전체 설정, 프로젝트 구조, PR 체크리스트는 [`CONTRIBUTING.md`](CONTRIBUTING.md)에 있다. 진입점을 찾고 있나? open issue를 [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 또는 [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)로 걸러 보라.
 
 ---
 
 ## 프로젝트 문서
 
 - [제품 컨텍스트](CONTEXT.md) — 맞춰야 할 도메인 언어
-- [아키텍처](docs/ARCHITECTURE.md) — 모듈 맵, 새 코드를 어디에 넣을지
+- [아키텍처](docs/ARCHITECTURE.md) — 모듈 지도, 새 코드를 둘 곳
 - [로드맵](docs/ROADMAP.md)
 - [Dashboard 아키텍처](docs/DASHBOARD.md)
-- [AI 공급자 가이드](docs/AI_PROVIDERS.md)
-- [성능 참고사항](docs/PERFORMANCE.md)
-- [릴리스 노트 및 게이트](docs/RELEASE.md)
+- [AI 프로바이더 가이드](docs/AI_PROVIDERS.md)
 
 ---
 
-## 스택
-
-Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand · xterm.js · SQLite · WebView2 · `russh` · `russh-sftp` · `vnc-rs` · `suppaftp` · OS keychain 스토리지.
-
----
-
-## Star 히스토리
+## 스타 히스토리
 
 <a href="https://www.star-history.com/#ryantsai/KKTerm&Date">
   <picture>
@@ -469,12 +303,12 @@ Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand ·
   </picture>
 </a>
 
-여기까지 읽었는데 아직 별을 누르지 않으셨다면 — 뭘 기다리시는 건가요, 개인 초대장이라도 필요하신가요? 이것이 그 개인 초대장입니다.
+여기까지 읽고도 아직 스타를 안 눌렀다면 — 뭘 기다리나, 직접 쓴 초대장이라도? 이게 바로 그 직접 쓴 초대장이다.
 
-⭐ **[GitHub에서 KKTerm에 별을 눌러 주세요](https://github.com/ryantsai/KKTerm)** — 클릭 한 번이면 되고, 메인테이너의 한 주가 환해집니다. 랙 위에 乖乖를 올려두는 것과 같은 디지털 버전이라고 생각해 주세요.
+⭐ **[GitHub에서 KKTerm에 스타 누르기](https://github.com/ryantsai/KKTerm)** — 클릭 한 번이면 메인테이너의 한 주가 통째로 환해진다. 랙 위에 올려두는 디지털 과이과이라고 생각해 달라.
 
 ---
 
 ## 라이선스
 
-MIT. [LICENSE](LICENSE) 참조. 사용하고, 포크하고, 배포하고, 아무도 못 찾을 홈랩에 넣어도 됩니다 — 그게 거래 조건입니다.
+MIT. [LICENSE](LICENSE) 참고. 쓰고, 포크하고, 출시하고, 아무도 못 찾는 홈랩에 넣어두라 — 그게 이 거래다.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">KKTerm</h1>
 
 <p align="center">
-  <strong>The native Windows admin workspace the AI-tools era forgot to build — terminals, SSH, SFTP, RDP/VNC, dashboards, and an AI that builds your own tool widgets.</strong>
+  <strong>One native Windows window for terminals, SSH, SFTP, RDP/VNC, and a dashboard — plus an AI that builds your own little tools on request.</strong>
 </p>
 
 <p align="center">
@@ -38,9 +38,6 @@
   </a>
   <br />
   <img src="https://img.shields.io/badge/Windows%E2%80%91first-by%20design-0078D6?style=flat-square&logo=windows" alt="Windows-first by design" />
-  <img src="https://img.shields.io/badge/built%20with-Tauri%20v2-FFC131?style=flat-square&logo=tauri" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/Rust-russh-orange?style=flat-square&logo=rust" alt="Rust" />
-  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react" alt="React 19" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
   <br />
   <sub>
@@ -63,31 +60,30 @@
 
 ---
 
-## The Pitch (45 seconds)
+## The 45-Second Pitch
 
-You're a sysadmin / DevOps / homelab / vibe-coder person. Right now you have:
+You're a sysadmin / DevOps / homelab tinkerer / vibe-coder. Right now you've got:
 
 - A terminal emulator
 - A separate SSH client (with a profile list it took you a weekend to build)
 - An SFTP client from 2007 that somehow still ships
 - Remote Desktop in a window you keep losing on the wrong monitor
 - A VNC viewer for that one Linux box
-- A browser tab for the router admin UI
-- A `claude` / `codex` session running on a remote dev box that drops every time your Wi-Fi sneezes
+- A browser tab for the router's admin page
+- A `claude` / `codex` session on a remote box that dies every time your Wi-Fi sneezes
 - A sticky note with passwords *(don't worry, we won't tell)*
 
-**KKTerm is one window for all of that.** Native on Windows — *on purpose, while the rest of the dev tools world ships mac-first and treats your OS like a footnote* — written in Rust + Tauri v2, ships as a single installer, and refuses to phone home.
+**KKTerm is one window for all of that.** Native on Windows — *on purpose, while the rest of the dev-tools world ships mac-first and treats your OS like a footnote* — in a single installer that refuses to phone home.
 
 Plus a few things you didn't know you wanted:
 
-- A **Dashboard** where you tell an AI *"build me a widget that pings my router every 30 seconds"* and it appears, sandboxed, on your grid.
-- **SSH panes that auto-attach to named tmux sessions** so your remote `claude` / `codex` session survives every Wi-Fi tantrum your laptop throws.
-- An **AI Coding usage widget** that shows your Claude Code and Codex quotas — 5-hour window, weekly window, current plan, account email — on the **Dashboard** and in the status bar, so you stop being surprised by the rate-limit wall at 3 AM.
-- An **Installer Helper** Module that detects, installs, updates, uninstalls, and launches a curated Windows developer-tool catalog — Node, Python, Docker, WSL, AI coding CLIs, and the small utilities you usually end up chasing through browser tabs.
-- A **built-in MCP server** (`kkterm-cli`) that lets external coding agents (Claude Code, Codex, Copilot, Antigravity, OpenCode) drive your Workspace and Dashboard — list Connections, read terminal buffers, place widgets — over a curated, safety-gated tool surface. AI-to-AI, on your machine, no cloud relay.
-- Twenty-one **animated canvas backgrounds** (yes, including `matrix`) for the dashboard, because we are not above it.
+- A **Dashboard** where you tell an AI *"build me a widget that pings my router every 30 seconds"* and it appears, in its own sandbox, on your grid.
+- **SSH panes that reattach to your remote `claude` / `codex` session** after every Wi-Fi tantrum, so a six-hour job survives a dropped connection.
+- An **AI usage meter** so you stop hitting the rate-limit wall at 3 AM by surprise.
+- An **Installer Helper** that finds, installs, updates, and launches the Windows dev tools you usually chase through ten browser tabs.
+- **Twenty-five animated backgrounds** for the dashboard (yes, including `matrix`), because we are not above it.
 
-Oh, and the AI assistant can turn a sentence into a tiny dashboard tool you actually keep using.
+And the best part: the AI assistant can turn a single sentence into a tiny dashboard tool you actually keep using.
 
 > ⭐ **If this sounds like the app you've been meaning to build for the last six years — star the repo so we know someone's watching. It genuinely helps.**
 
@@ -131,88 +127,77 @@ We have not yet been able to ship an actual bag of Kuai Kuai with the installer.
 
 ---
 
+## One Window, Every Connection
+
+| You wanted to… | KKTerm does it |
+| --- | --- |
+| Open a local PowerShell / cmd / WSL shell | Local terminals, side by side |
+| SSH into a server | SSH with keys, agent, passwords, jump hosts, and port forwarding |
+| Browse files on that server | SFTP from the SSH connection — dual-pane, drag to transfer |
+| FTP to a NAS from 2012 | FTP / FTPS in the same file browser |
+| Telnet to ancient gear | Yes, Telnet's in there too |
+| Talk to a serial port | Serial connections — pick a COM port and baud |
+| Remote into a Windows box | The real Microsoft Remote Desktop, built right in |
+| VNC into a Pi | VNC, rendered straight into the workspace |
+| Open the router's web UI | An embedded browser tab with saved logins |
+| Watch CPU on the host | A live status bar and a dashboard you can build on |
+
+Same app. Same window. Same hotkeys. Same hopefully-not-eye-bleeding theme.
+
+---
+
 ## Why People Keep It Open All Day
 
 ### Windows-first, on purpose
 
-Look around the 2026 dev tooling landscape. Claude Code: ships mac/linux first, Windows is "use WSL." Codex CLI: same. `gemini-cli`, half of Homebrew, every shiny new TUI: mac/linux first, Windows users get a `# Windows: contributions welcome` comment in the README and a fish-completion script that doesn't run.
+Look around the dev-tooling landscape. Claude Code: mac/linux first, Windows is "use WSL." Codex CLI: same. Half the shiny new tools ship mac-first and leave Windows users a `# contributions welcome` comment and a completion script that doesn't run.
 
-Meanwhile, the people who actually keep companies online — corporate IT, MSPs, anyone running Hyper-V or AD or SCCM or IIS or a domain controller older than some interns — are sitting at Windows boxes wondering why every new tool acts like their OS is an inconvenience.
+Meanwhile the people who actually keep companies online — corporate IT, MSPs, anyone running a domain controller older than some of the interns — are on Windows boxes wondering why every new tool treats their OS like an inconvenience.
 
-**KKTerm is the opposite trade.** We build native Windows first, and macOS / Linux ports follow. That means we get to use the Windows APIs that actually matter, instead of papering over them with a portability layer:
-
-- **ConPTY** for local shells — the real Windows pseudo-console, not a translation shim. PowerShell, `cmd.exe`, WSL distros, all hosted as proper PTYs with focus, resize, and VT sequence handling that match the platform's behavior.
-- **WebView2** for the entire UI and embedded URL **Connections** — in-process Chromium using the system runtime, which is one of the reasons the installer is small and starts fast.
-- **Microsoft RDP ActiveX (`mstscax.dll`)** for RDP — *the actual one Microsoft ships*. Same control as Remote Desktop Connection (`mstsc.exe`). Not a third-party reimplementation, not FreeRDP-in-a-wrapper. RDP people will notice the difference in five seconds.
-- **Windows Credential Manager** for all secrets. SSH passwords, FTP passwords, API keys, URL Connection credentials — they live in the OS keychain and `credwiz.exe` can audit them.
-- **NSIS current-user installer** with a matching SHA-256, native tray menu, Don't-Sleep power assertion, host CPU/RAM/network sampling, native Tauri context menus with real PNG icons, native Open/Save dialogs. Not a single one of these is mocked.
-- **WSL is a first-class shell, not a workaround.** Spin up Ubuntu next to a PowerShell pane next to an SSH session next to an RDP **Tab** in the same window.
-
-The macOS and Linux builds are on the roadmap and will get the same care. But if you've been waiting for someone to build the *good* Windows admin tool first instead of last — that's the deal.
+**KKTerm takes the opposite trade.** We build native Windows first, so the things Windows people care about just work: the *actual* Microsoft Remote Desktop (the same one as `mstsc.exe`, not a clone), real PowerShell / cmd / WSL shells, secrets kept in the Windows Credential Manager, a proper tray icon, native menus and dialogs. macOS and Linux builds are on the roadmap and will get the same care. But if you've been waiting for someone to build the *good* Windows admin tool first instead of last — that's the deal.
 
 ### Local-first means actually local
 
-Your saved **Connections** live in a SQLite file on your machine. Passwords live in the **Windows Credential Manager**, not in a JSON next to the binary. The app does not ship analytics, does not call home on startup, and does not need a cloud account to launch. There is no "sign in to sync" because there is no sync.
+Your saved connections live in a file on your machine. Passwords live in the Windows Credential Manager, not in a text file next to the app. KKTerm ships no analytics, doesn't call home on startup, and needs no cloud account to launch. There is no "sign in to sync" because there is no sync.
 
 If your network cable catches fire, KKTerm still opens.
 
-### One workspace, every connection type
-
-| You wanted to… | KKTerm has |
-| --- | --- |
-| Open a local PowerShell / cmd / WSL shell | ConPTY-backed local terminal **Sessions** |
-| SSH into a server | Native `russh` with agent / key / password auth, host-key trust flow, ProxyJump, port forwarding |
-| Browse files on that server | SFTP launched from the SSH **Connection**, dual-pane, recursive transfers, chmod/chown |
-| FTP to a NAS from 2012 | FTP / FTPS **Connections** in the same SFTP-style browser |
-| Telnet to ancient gear | Yes, fine, Telnet is in there too |
-| Talk to a serial port | Serial **Connection** kind, COM port + baud, no extra tooling |
-| Remote into a Windows box | Native RDP via the Microsoft ActiveX control (the real one, not a clone) |
-| VNC into a Pi | Rust `vnc-rs` framebuffer rendered straight into the workspace |
-| Open the router's web UI | Embedded WebView2 **URL Connection** with credential fill |
-| Watch CPU on the host | Live status bar + a **Dashboard** module with drag/resize widgets |
-
-It's all the same app. Same window. Same hotkeys. Same hopefully-not-eye-bleeding theme.
-
 ### Terminals that don't lose their minds
 
-- Split panes inside a **Tab**.
-- WebGL-accelerated xterm.js rendering, falling back gracefully when it can't.
-- Scrollback search.
-- tmux-backed SSH panes that can attach to stable per-pane sessions, so reconnecting actually means *reconnecting*, not "starting over and pretending the last hour didn't happen."
-- Switching **Tabs** does **not** kill the **Session**. Closing the **Tab** does. This distinction was a religious war internally; we won.
+- Split panes inside a tab.
+- Fast, smooth rendering with searchable scrollback.
+- Reconnecting actually means *reconnecting* — your remote session picks up where it was, not "start over and pretend the last hour didn't happen."
+- Switching tabs does **not** kill the session. Closing the tab does. This distinction was a religious war internally; we won.
 
-### An AI Assistant that builds your tools
+### An AI assistant that builds your tools
 
-Most "AI in your terminal" demos stop at chat. KKTerm's assistant can also build small, durable dashboard widgets for the way you actually work. It still keeps the dangerous stuff behind two switches:
+Most "AI in your terminal" demos stop at chat. KKTerm's assistant can also build small, durable dashboard widgets for the way you actually work — and it keeps the dangerous stuff behind a switch:
 
-- **Tool families** (Dashboard / Connections / Live Sessions) — toggle them on or off per category.
-- **Permission mode** in the composer — `Prompt` (default, asks every time) or `Allow All` (you're an adult, you signed the waiver).
+- **Pick what it can touch** — toggle whole tool families (Dashboard / Connections / Live Sessions) on or off.
+- **Pick how it asks** — `Prompt` (default, asks every time) or `Allow All` (you're an adult, you signed the waiver).
 
-Talk to OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA, or anything OpenAI-compatible. API keys go to the OS keychain. Models that propose `rm -rf` get classified as dangerous and require explicit human approval. The AI cannot quietly run a destructive command because somebody got clever with a prompt injection in a man page.
+Anything that looks like `rm -rf` gets flagged as dangerous and waits for an explicit human yes. The AI can't quietly run a destructive command because somebody got clever with a prompt injection in a man page.
+
+It talks to OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA, or anything OpenAI-compatible. Your API keys go to the OS keychain.
 
 ### A Dashboard that doesn't pretend to be Grafana
 
-The **Dashboard** module is a 12-column drag/resize grid of widget instances. It's not for petabyte observability — it's for "I want a button to launch my five favorite apps and a panel showing my SSH host's uptime, *next to* my chat."
+The Dashboard is a drag-and-resize grid of widgets. It's not for petabyte observability — it's for "I want a button to launch my five favorite apps and a panel showing my SSH host's uptime, *next to* my chat."
 
 #### AI-Created Widgets — describe it, get it
 
-This is the part we are genuinely excited about. You don't pick from a marketplace and you don't write JavaScript. You **tell the AI assistant what you want**, and it builds the widget right there on your dashboard:
+This is the part we're genuinely excited about. You don't pick from a marketplace and you don't write JavaScript. You **tell the AI assistant what you want**, and it builds the widget right there on your dashboard:
 
 > *"Add a widget showing the last 5 commits on my main repo as a list."*
 > *"Make me a sticky-note widget that holds my on-call cheat sheet."*
 > *"Build a widget that pings my home router every 30 seconds and shows green/red."*
 > *"I need a stopwatch. Surprise me on the styling."*
 
-Two flavors:
-
-- **Content widgets** — declarative JSON: markdown, kv lists, checklists, single big stat. Safe by construction, no script. Most "I just need this on my dashboard" requests land here.
-- **Script widgets** — JavaScript hosted inside an isolated `iframe srcdoc` sandbox with explicit, declared permissions (`network` allowlist, `pollSeconds` budget). The AI writes the script, you approve the permissions, the widget runs in a box that cannot reach the rest of the app.
-
-Every widget you keep is yours. They persist in SQLite next to your **Connections**, with their own visual preset (`panel` / `ambient` / `hero`), accent color, icon, and title. Multiple instances of the same widget can coexist with totally different sizes and styling. Delete them with a right-click when the magic wears off.
+Some are simple display panels (markdown, checklists, a single big stat); others run live code in an isolated sandbox you approve. Every widget you keep is yours — it persists with its own color, icon, and title, and you can have several copies at different sizes. Delete one with a right-click when the magic wears off.
 
 #### Animated dashboard backgrounds (because we wanted to)
 
-The dashboard has twenty-five canvas-animated backgrounds you can pick per **Dashboard View**:
+Pick a mood per dashboard view from **twenty-five** canvas-animated backgrounds:
 
 | Mood | Backgrounds |
 | --- | --- |
@@ -222,148 +207,32 @@ The dashboard has twenty-five canvas-animated backgrounds you can pick per **Das
 | Geeky | `matrix`, `topo`, `synthwave` |
 | Erratic | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti`, `particleCursor` |
 
-They run on a single shared `requestAnimationFrame` and respect window focus, so they cost roughly nothing when you're elsewhere. Pair `matrix` with your AI assistant for a vibe that says "I am extremely productive and also possibly in a Wachowski film." Or pick `ocean` and look like a serious person. We do not judge either choice.
+They pause when you're elsewhere, so they cost roughly nothing. Pair `matrix` with your AI assistant for a vibe that says "I am extremely productive and also possibly in a Wachowski film." Or pick `ocean` and look like a serious person. We do not judge either choice.
 
-### Running AI coding agents on a server, the right way
+### Keep your remote AI agents alive
 
-This is the second feature people fall in love with. KKTerm's SSH terminals can launch directly into a **named tmux session** on the remote host — by default, an auto-generated friendly id like `kkterm-cockpit001` that survives reconnect:
+This is the second feature people fall in love with. KKTerm's SSH terminals can drop you straight into a **named tmux session** on the remote host that survives reconnect:
 
-- Open an SSH **Connection** with tmux enabled.
-- Inside the pane, start `claude`, `codex`, `gemini-cli`, `cursor-agent`, or whatever long-running coding agent you prefer. They are full-screen TUI apps; tmux is exactly where they want to live.
-- Close the laptop. Open it again. The pane silently re-attaches to the same tmux session. The agent is still running, still has its scrollback, still in the middle of whatever it was doing.
-- Network blip on the SSH transport? KKTerm makes a bounded silent reattach attempt to the same tmux id without bothering you.
-- Want the AI assistant to see what the agent is doing? "Add terminal buffer to context" calls `capture_tmux_pane` over SSH and pulls the full tmux scrollback — not just what's on-screen, the whole session — into the conversation. Your local assistant can now reason about your remote agent's work.
+- Open an SSH connection with tmux enabled and start `claude`, `codex`, `gemini-cli`, `cursor-agent`, or whatever long-running agent you like.
+- Close the laptop. Open it again. The pane silently re-attaches — the agent is still running, still has its scrollback, still in the middle of whatever it was doing.
+- Network blip? KKTerm quietly reconnects to the same session without bothering you.
+- Want the assistant to help? "Add terminal buffer to context" pulls the whole remote session into the conversation, so your local AI can reason about what your remote agent is doing.
 
-If you have ever lost a six-hour `claude` or `codex` session to a flaky hotel Wi-Fi, this single feature pays for the app. The app is free. The feature is still worth it.
+If you've ever lost a six-hour `claude` or `codex` session to flaky hotel Wi-Fi, this one feature pays for the app. (The app is free. The feature is still worth it.)
 
-### Knowing how much AI you have left
+### Know how much AI you have left
 
-Coding agents charge by plan window, not by month. Claude Code has a 5-hour window and a weekly window. Codex does its own version. Both will happily eat your quota in the background while you're in a meeting.
+Coding agents charge by plan window, not by month, and they'll happily eat your quota while you're in a meeting. The **AI usage meter** keeps it visible:
 
-The **AI Coding Usage** widget keeps that visible:
+- A Dashboard widget showing **Claude Code** and **Codex** side by side: connected account, plan, how much you've used in the current window and this week, and the next reset time.
+- A compact **status-bar indicator** mirroring the same numbers, so even with the Dashboard closed you can tell at a glance whether you've got headroom before the next big refactor.
+- It tells you up front if you need to re-login — *before* a long task, not in the middle of one.
 
-- A Dashboard widget showing **Claude Code** and **Codex** side-by-side: connected account, plan tier, percent used in the current 5-hour window, percent used this week, and the next reset time.
-- A compact **status-bar indicator** that mirrors the same numbers, so even with the Dashboard closed you can tell at a glance whether you still have headroom before you kick off the next big refactor.
-- Auth state is surfaced directly (`connected` / `expired` / `error`) so you find out *before* a long task that you need to re-login, not in the middle of one.
-- Refresh policy respects rate limits; the widget polls on its own cadence instead of hammering the upstream APIs whenever you look at it.
+### Let other AIs drive KKTerm
 
-### A built-in MCP server — let other AIs drive KKTerm
+KKTerm ships its own built-in MCP server, so external coding agents (Claude Code, Codex, Copilot, Antigravity, OpenCode) can use your workspace the way you do — list connections, open one, read a terminal buffer, place widgets on the dashboard. AI-to-AI, on your machine, no cloud relay. The mutating, riskier actions stay behind a single safety toggle that's **off** by default.
 
-Your terminal is also where Claude Code, Codex, Copilot agent mode, Antigravity, and the rest of the MCP-speaking world want to do work. So KKTerm ships its own **stdio MCP server**, [`kkterm-cli`](docs/MCP.md), that exposes a curated slice of the app:
-
-- **Workspace Module** (`kkterm.workspace.*`): list saved **Connections**, open a Connection by id, list live **Sessions**, send input to a terminal pane, read a terminal buffer snapshot.
-- **Dashboard Module** (`kkterm.dashboard.*`): load Dashboard state, read AI-Created Widget source, create / update / remove views, place / move / remove widget instances, apply bulk layouts.
-- **Dangerous sub-namespaces** (`kkterm.<module>.dangerous.*`): mutating the executable surface — creating script widgets, clicking into remote desktops, wiping the Dashboard — is gated behind a single setting (`built_in_mcp_allow_all_dangerous`), defaulting **off**.
-
-`kkterm-cli` is a thin forwarder. It speaks stdio JSON-RPC to your MCP client and talks to the running KKTerm window over a per-launch authenticated Windows named pipe. When KKTerm is closed, `tools/list` still works (so clients can introspect the surface), but `tools/call` returns a structured `app_not_running` error instead of doing anything.
-
-Wire it into your favorite client and your AI can now use KKTerm the way you do:
-
-```json
-{
-  "mcpServers": {
-    "kkterm": { "command": "<path-to-kkterm-cli>", "args": [] }
-  }
-}
-```
-
-Settings → AI Assistant → **Built-in MCP Server** has a one-click "Show config" dialog with JSON and TOML snippets pre-filled with the resolved binary path, plus copyable `claude mcp add` / `codex mcp add` commands.
-
----
-
-## How It Fits Together
-
-```mermaid
-flowchart LR
-    User([You]) --> Shell[KKTerm Window<br/>Tauri v2 + React 19]
-    Shell --> Rail[Activity Rail]
-    Rail --> WS[Workspace Module]
-    Rail --> Dash[Dashboard Module]
-    Rail --> Inst[Installer Helper Module]
-    Rail -.-> FE[File Explorer<br/>planned]
-    Rail --> Set[Settings]
-
-    WS --> Tabs[Tabs &amp; Panes]
-    Tabs --> Term[Terminal<br/>ConPTY / russh]
-    Tabs --> SFTP[SFTP / FTP]
-    Tabs --> Web[WebView2 URL]
-    Tabs --> RD[RDP / VNC]
-
-    Shell -.calls.-> Rust[Rust Backend]
-    Rust --> SQLite[(SQLite<br/>Connections)]
-    Rust --> Keychain[(OS Keychain<br/>Secrets)]
-    Rust --> AI[AI Providers<br/>OpenAI-compat]
-
-    AI -. approval gate .-> Tabs
-
-    classDef local fill:#1f6feb,stroke:#1f6feb,color:#fff
-    classDef ai fill:#8a63d2,stroke:#8a63d2,color:#fff
-    class SQLite,Keychain local
-    class AI ai
-```
-
-The shape that matters: durable saved data (**Connection**) is separate from live runtime state (**Session**), which is separate from the UI container (**Tab**). Closing a **Tab** ends the **Session**. Switching **Tabs** does not. This is the rule that keeps the app sane.
-
----
-
-## Current Feature Map
-
-| Area | Implemented today |
-| --- | --- |
-| **Connections** | SQLite-backed tree, folders/subfolders, search, drag/drop order, rename, duplicate, delete, **Quick Connect**, custom icons, pinned/active rail shortcuts |
-| **Terminal** | Local shells, SSH, Telnet, Serial, split panes, xterm.js + opportunistic WebGL, scrollback search, local startup directory/script |
-| **SSH** | Native `russh`, agent/key/password auth, host-key trust flow, optional system SSH fallback, ProxyJump, port forwarding, **auto-named tmux sessions (`kkterm-<scifi-name><n>`) with silent reattach on transport blip** — perfect for long-running remote coding agents (Claude Code, Codex, gemini-cli, etc.) |
-| **SFTP / FTP** | SSH-launched SFTP plus FTP/FTPS **Connections**, dual-pane browser, recursive transfers, queue/cancel/clear history, conflicts, properties, chmod/chown where supported |
-| **URL WebView** | Embedded WebView2 URL **Sessions**, navigation toolbar, favicon capture, stored website credential metadata/fill, data partition metadata |
-| **Remote Desktop** | RDP through Windows ActiveX with geometry-scoped overlay parking; VNC through `vnc-rs` framebuffer rendered in the workspace canvas |
-| **Dashboard** | Durable views, widget instances, edit mode, drag/resize, App Launcher, **AI-authored content/script widgets** (declarative JSON or sandboxed iframe JS with permissions), per-widget presets / accent / icon / title, **25 animated canvas backgrounds** (aurora, clouds, ocean, raindrops, rainywindow, frostedWindow, snow, sakura, fireflies, bubbles, aquarium, ricefield, lanterns, starfield, nebula, embers, lava, matrix, topo, synthwave, cyberpunk, taipei101, thunderstorm, confetti, particleCursor) |
-| **AI Assistant** | Streaming chat, OpenAI-compatible runtime, provider registry, command proposal safety classification, screenshot/context attachments, **Dashboard widget authoring (content + sandboxed script)**, **tmux pane capture** as conversation context for remote sessions, **Connection** management tools, and live **Session** tools for terminal, RDP/VNC, and SFTP/FTP |
-| **AI Coding Usage** | **Dashboard widget + status-bar indicator** tracking **Claude Code** and **Codex** quota usage: connected account, plan tier, 5-hour and weekly window percentages, next reset time, auth state (`connected` / `expired` / `error`), rate-limit-aware refresh policy |
-| **Built-in MCP Server** | Stdio MCP server (`kkterm-cli`) exposing curated Workspace and Dashboard tools to external coding agents (Claude Code, Codex, Copilot, Antigravity, OpenCode); authenticated named-pipe bridge; per-Module `dangerous.*` namespaces gated behind a single safety toggle; Settings dialog with one-click JSON / TOML snippets and `claude mcp add` / `codex mcp add` commands |
-| **Installer Helper** | Activity Rail Module for a bundled Windows developer-tool catalog: detect installed tools, compare latest versions, install/update/uninstall, pin tools out of Update all, stream command logs, and launch supported managed apps |
-| **Settings** | General, Appearance, Credentials, AI, SSH, Terminal, terminal backgrounds, URL, RDP, VNC, Dashboard, Installer Helper, About; custom UI fonts; minimize-to-tray; Don't Sleep; backup/import |
-| **Localization** | i18next UI with English source and dynamic locale bundles: zh-TW, zh-CN, ja, ko, fr, de, es, es-MX, it, pt-BR, th, id, vi |
-
-### AI Providers
-
-OpenAI · Anthropic · OpenRouter · DeepSeek · Grok · Azure OpenAI · LiteLLM · GitHub Copilot · Ollama · NVIDIA · any OpenAI-compatible endpoint.
-
-Provider metadata lives in [`src/ai/providerRegistry/`](src/ai/providerRegistry/); Rust adapters in [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/). API keys go through the OS keychain, never SQLite.
-
----
-
-## Quick Start
-
-You need:
-
-- **Windows** (primary supported platform)
-- **Node.js + npm**
-- **Rust toolchain**
-- **Tauri v2 prerequisites for Windows** including **WebView2**
-
-```bash
-npm install
-npm run tauri dev
-```
-
-That should produce a real native window. If it produces a stack trace instead, please file an issue — we love a good repro.
-
-### Common checks
-
-```bash
-npm run check                                              # TypeScript
-npm run build                                              # Vite build
-cargo check --manifest-path src-tauri/Cargo.toml           # Rust
-cargo test  --manifest-path src-tauri/Cargo.toml           # Rust tests
-```
-
-### Build the Windows installer
-
-```bash
-npm run package:installer
-```
-
-The installer script writes `artifacts/kkterm-<version>-windows-x64-setup.exe` and a matching `.sha256` file. It is currently **unsigned** — release signing is on the roadmap, but until then your antivirus may give you a stern look. That's normal.
+Settings → AI Assistant → **Built-in MCP Server** has a one-click "Show config" dialog with everything pre-filled, plus copyable `claude mcp add` / `codex mcp add` commands.
 
 ---
 
@@ -372,7 +241,7 @@ The installer script writes `artifacts/kkterm-<version>-windows-x64-setup.exe` a
 A short list, because honesty earns trust:
 
 - **Not a cloud product.** No sync, no team accounts, no SaaS tier. If you ever see a "Sign in to KKTerm" dialog, something has gone catastrophically wrong.
-- **Not pretending to be cross-platform.** We are Windows-first on purpose; macOS and Linux are on the roadmap and will use the same Tauri v2 shell. If you need a mac-first tool today, you have hundreds of options. We're building the one Windows admins have been quietly waiting for.
+- **Not pretending to be cross-platform.** We are Windows-first on purpose; macOS and Linux are on the roadmap. If you need a mac-first tool today, you have hundreds of options. We're building the one Windows admins have been quietly waiting for.
 - **Not an autonomous AI agent.** The assistant proposes; the human disposes. `Allow All` is a choice you make, not a default.
 - **Not a Grafana / Datadog replacement.** The Dashboard is for personal control surfaces, not 10k-host observability.
 - **Not a Kubernetes IDE.** It is a terminal-first admin workspace. Please don't ask it to render a Helm chart.
@@ -381,29 +250,11 @@ If any of those *was* a dealbreaker — fair enough, we'll see you in v2.
 
 ---
 
-## Native Debugging
+## Get KKTerm
 
-Use the real Tauri runtime for validation:
+**[Download the latest Windows installer (.exe)](https://github.com/ryantsai/KKTerm/releases/latest)** and run it. The installer is currently **unsigned** — release signing is on the roadmap, so until then your antivirus may give you a stern look. That's normal.
 
-```bash
-npm run tauri dev
-```
-
-A Vite browser preview is useful for some frontend inspection, but it does **not** host a real WebView2, ConPTY, RDP ActiveX, VNC framebuffer, keychain, or native menu surface. If a feature touches any of those, validate it in the actual desktop runtime.
-
-VS Code users: the `Run KKTerm exe` launch config starts `src-tauri/target/debug/kkterm.exe` with `RUST_BACKTRACE=1`. The paired `Attach KKTerm WebView2` config gives you DevTools inside the real WebView2 host.
-
----
-
-## Current Limits (yes, we know)
-
-- The installer is currently unsigned. Update checks are disabled until release signing is configured.
-- SFTP over ProxyJump is not yet supported in the native SFTP path.
-- File transfer resume, folder sync/diff, archive/extract, and remote editing are deferred.
-- SSH config import is implemented but the user-facing entry in Settings is not yet exposed.
-- RDP and VNC are shipping; richer clipboard/device sync and quality controls are still evolving.
-- macOS and Linux builds are on the roadmap. They are coming, and they will be done properly — not rushed out as a "we also kinda work over there" port.
-- The AI assistant proposes and can operate enabled tools within the configured permission boundary — please do not treat it as an unattended robot. It does not, in fact, know what your CEO wants.
+Want to build from source or contribute? Everything you need is in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ---
 
@@ -411,10 +262,9 @@ VS Code users: the `Run KKTerm exe` launch config starts `src-tauri/target/debug
 
 - macOS + Linux builds
 - Signed installer + auto-update
-- SFTP over ProxyJump in the native path
-- File transfer resume, folder sync, archive/extract
-- Richer RDP clipboard/device redirection
-- More built-in **Dashboard** widgets (and a public schema for AI-authored ones)
+- More file-transfer power (resume, folder sync, archive/extract)
+- Richer remote-desktop clipboard and device sharing
+- More built-in dashboard widgets
 
 Full and frequently-updated version: [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
@@ -425,19 +275,11 @@ Full and frequently-updated version: [`docs/ROADMAP.md`](docs/ROADMAP.md).
 We would love a hand. Genuinely. Even small things matter:
 
 - **Try the dev build** and file an issue when something feels off. "It felt off" is a legitimate bug report; we'll dig with you.
-- **Translate a locale.** English is the source of truth at [`src/i18n/locales/en.json`](src/i18n/locales/en.json); 12 other locales live next to it and load on demand. Pending strings are tracked per-key under [`docs/localization_todo/`](docs/localization_todo/) — pick one, translate it, delete the file.
-- **Add a Dashboard widget.** Built-in widgets live in [`src/modules/dashboard/widgets/builtin/`](src/modules/dashboard/widgets/builtin/). Pick a small idea, ship it, learn the pattern.
-- **Tighten the AI tool surface.** Provider adapters live in [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/); the frontend registry is in [`src/ai/providerRegistry/`](src/ai/providerRegistry/).
-- **Improve the manual.** End-user docs live in [`docs/manual/`](docs/manual/). One chapter per UI module. If you used a feature and the docs didn't help, a PR fixing that is gold.
+- **Translate a locale.** English is the source of truth; thirteen other languages live next to it.
+- **Add a Dashboard widget.** Pick a small idea, ship it, learn the pattern.
+- **Improve the manual.** If you used a feature and the docs didn't help, a PR fixing that is gold.
 
-Full setup, project layout, PR checklist, and the list of "please do not break these" rules live in [`CONTRIBUTING.md`](CONTRIBUTING.md). The 30-second highlights:
-
-- **Read [`CONTEXT.md`](CONTEXT.md) before renaming user-facing terms.** **Connection**, **Session**, **Tab**, and **Quick Connect** mean specific things; please don't drift.
-- **Every user-visible string goes through `t()`.** No bare English text in JSX.
-- **No frontend close hooks.** Tauri v2's title-bar close has been broken by `onCloseRequested` patterns a half-dozen times. We finally have a working shape; please don't reintroduce them.
-- **Run the checks** (`npm run check && npm run build && cargo check && cargo test`) before opening a PR.
-
-Looking for an entry point? Filter open issues by [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) or [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22). If there aren't any tagged yet, open an issue describing what you'd like to work on and we'll help scope it.
+Full setup, project layout, and the PR checklist live in [`CONTRIBUTING.md`](CONTRIBUTING.md). Looking for an entry point? Filter open issues by [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) or [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
 
 ---
 
@@ -448,14 +290,6 @@ Looking for an entry point? Filter open issues by [`good first issue`](https://g
 - [Roadmap](docs/ROADMAP.md)
 - [Dashboard architecture](docs/DASHBOARD.md)
 - [AI provider guide](docs/AI_PROVIDERS.md)
-- [Performance notes](docs/PERFORMANCE.md)
-- [Release notes and gates](docs/RELEASE.md)
-
----
-
-## Stack
-
-Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand · xterm.js · SQLite · WebView2 · `russh` · `russh-sftp` · `vnc-rs` · `suppaftp` · OS keychain storage.
 
 ---
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -5,19 +5,19 @@
 <h1 align="center">KKTerm</h1>
 
 <p align="center">
-  <strong>O workspace nativo para administradores Windows que a era das ferramentas de IA esqueceu de criar — terminais, SSH, SFTP, RDP/VNC, dashboards, e uma IA que cria seus próprios widgets de ferramentas.</strong>
+  <strong>Uma única janela nativa do Windows para terminais, SSH, SFTP, RDP/VNC e um painel — mais uma IA que constrói as suas próprias ferramentinhas sob demanda.</strong>
 </p>
 
 <p align="center">
-  <em>Porque a sua barra de tarefas não deveria parecer uma caça-níqueis em Las Vegas.</em>
+  <em>Porque a sua barra de tarefas não devia parecer um caça-níquel de Las Vegas.</em>
 </p>
 
 <p align="center">
-  <sub>Batizado em homenagem à <strong>乖乖 (Kuāi Kuāi)</strong>, o salgadinho de coco verde que os sysadmins taiwaneses colocam em cima dos servidores para que se comportem bem. Esperamos que este app mereça um lugar no rack.</sub>
+  <sub>Batizado em homenagem ao <strong>乖乖 (Kuāi Kuāi)</strong>, o salgadinho verde de coco que os sysadmins taiwaneses colocam sobre os servidores para que se comportem. Esperamos que este app conquiste seu lugar no rack.</sub>
 </p>
 
 <p align="center">
-  <strong><a href="https://github.com/ryantsai/KKTerm/releases/latest">Baixar o instalador Windows mais recente (.exe)</a></strong>
+  <strong><a href="https://github.com/ryantsai/KKTerm/releases/latest">Baixar o instalador mais recente do Windows (.exe)</a></strong>
 </p>
 
 <p align="center">
@@ -38,9 +38,6 @@
   </a>
   <br />
   <img src="https://img.shields.io/badge/Windows%E2%80%91first-by%20design-0078D6?style=flat-square&logo=windows" alt="Windows-first by design" />
-  <img src="https://img.shields.io/badge/built%20with-Tauri%20v2-FFC131?style=flat-square&logo=tauri" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/Rust-russh-orange?style=flat-square&logo=rust" alt="Rust" />
-  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react" alt="React 19" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
   <br />
   <sub>
@@ -63,66 +60,58 @@
 
 ---
 
-## O Argumento (45 segundos)
+## O pitch em 45 segundos
 
-Você é sysadmin / DevOps / homelab / aquele que programa no feeling. Neste exato momento, você tem aberto:
+Você é sysadmin / DevOps / entusiasta de homelab / vibe-coder. Agora mesmo você tem:
 
 - Um emulador de terminal
-- Um cliente SSH separado (com uma lista de perfis que levou um fim de semana inteiro para montar)
-- Um cliente SFTP de 2007 que milagrosamente ainda funciona
-- Remote Desktop numa janela que você vive perdendo no monitor errado
-- Um VNC viewer para aquela máquina Linux
-- Uma aba do navegador com a interface de administração do roteador
-- Uma sessão do `claude` / `codex` rodando num servidor remoto que cai toda vez que o Wi-Fi espirra
-- Um post-it com senhas *(não se preocupa, a gente não conta)*
+- Um cliente SSH à parte (com uma lista de perfis que levou um fim de semana inteiro pra montar)
+- Um cliente SFTP de 2007 que, sabe-se lá como, ainda existe
+- A Área de Trabalho Remota numa janela que você sempre perde no monitor errado
+- Um visualizador VNC só por causa daquela máquina Linux
+- Uma aba do navegador pra interface de administração do roteador
+- Uma sessão `claude` / `codex` numa máquina remota que cai toda vez que o Wi-Fi espirra
+- Um post-it com senhas *(relaxa, a gente não conta)*
 
-**KKTerm é uma janela só para tudo isso.** Nativo no Windows — *de propósito, enquanto o resto do mundo das ferramentas de dev lança tudo pro mac primeiro e trata o seu sistema operacional como nota de rodapé* — escrito em Rust + Tauri v2, distribuído como um único instalador, e que não liga pra casa.
+**KKTerm é uma única janela pra tudo isso.** Nativo no Windows — *de propósito, enquanto o resto do mundo de ferramentas pra dev lança primeiro pro mac e trata o seu SO como uma nota de rodapé* — num único instalador que se recusa a telefonar pra casa.
 
-Mais algumas coisas que você não sabia que queria:
+Mais umas coisas que você não sabia que queria:
 
-- Um **Dashboard** onde você fala pra uma IA *"cria um widget que faz ping no meu roteador a cada 30 segundos"* e ele aparece, em sandbox, na sua grade.
-- **Panes de SSH com auto-attach a sessões tmux nomeadas** para que sua sessão remota do `claude` / `codex` sobreviva a qualquer birra de Wi-Fi que o seu notebook resolver ter.
-- Um **widget de uso de IA para codar** que mostra suas cotas do Claude Code e do Codex — janela de 5 horas, janela semanal, plano atual, e-mail da conta — no **Dashboard** e na barra de status, para você parar de bater na parede do rate-limit às 3 da manhã.
-- Um módulo **Installer Helper** que detecta, instala, atualiza, desinstala e inicia um catálogo curado de ferramentas de desenvolvimento para Windows — Node, Python, Docker, WSL, CLIs de codificação com IA e aquelas utilidades pequenas que você normalmente acaba caçando em abas do navegador.
-- Um **servidor MCP integrado** (`kkterm-cli`) que deixa agentes de codificação externos (Claude Code, Codex, Copilot, Antigravity, OpenCode) dirigirem seu Workspace e Dashboard — listar Connections, ler buffers de terminal, posicionar widgets — sobre uma superfície de ferramentas curada e com aprovação. IA-para-IA, na sua máquina, sem relay na nuvem.
-- Vinte e um **fundos animados em canvas** (sim, incluindo `matrix`) para o dashboard, porque a gente não tem vergonha disso não.
+- Um **Dashboard** onde você fala pra uma IA *«monta um widget que dá ping no meu roteador a cada 30 segundos»* e ele aparece, na própria sandbox, na sua grade.
+- **Painéis SSH que se reconectam à sua sessão remota `claude` / `codex`** depois de cada chilique do Wi-Fi, pra um trabalho de seis horas sobreviver a uma queda.
+- Um **medidor de uso de IA** pra você parar de bater de surpresa no muro do limite de uso às 3 da manhã.
+- Um **Installer Helper** que acha, instala, atualiza e abre as ferramentas pra dev do Windows que você normalmente caça por dez abas do navegador.
+- **Vinte e cinco fundos animados** pro painel (sim, incluindo `matrix`), porque a gente não tem vergonha.
 
-Ah, e o AI assistant pode transformar uma frase numa pequena ferramenta de dashboard que você realmente continua usando.
+E a melhor parte: o assistente de IA consegue transformar uma única frase numa pequena ferramenta de painel que você realmente continua usando.
 
-> ⭐ **Se isso parece o app que você sempre quis mas nunca teve tempo de construir — dá uma estrela no repositório pra gente saber que tem alguém por aí. Ajuda de verdade.**
+> ⭐ **Se isso parece o app que você vinha querendo construir nos últimos seis anos — dá uma estrela no repo pra gente saber que tem alguém de olho. Ajuda de verdade.**
 
----
-
-## Por que "KKTerm"?
-
-Entre em qualquer datacenter taiwanês e olhe para o topo dos racks. Nas fábricas da TSMC, nas salas de controle do Metrô de Taipei, nos halls de servidores do Cathay Bank, nos equipamentos de switching da Chunghwa Telecom — você vai encontrar um saquinho verde de 乖乖 (Kuāi Kuāi), um salgadinho de milho com sabor de coco dos anos 1960.
-
-O nome significa literalmente **"seja bonzinho"**, **"se comporte"**. A tradição de TI é direta e absolutamente séria:
-
-- **Precisa ser o sabor verde (coco).** Amarelo (curry) significa *fica em casa*; vermelho (picante) deixa o servidor nervoso. Verde somente.
-- **Precisa estar dentro do prazo de validade.** Um Kuai Kuai vencido trabalha contra você. Os engenheiros os trocam com diligência.
-- **Precisa estar visível.** O servidor precisa saber que está lá.
-- **Não pode comer.** Aquele saquinho está de plantão.
-
-Alguns dos maiores, mais entediantes e mais obcecados com uptime sistemas da Ásia funcionam com um saquinho de pipoca de milho colado no chassi. Funciona porque as pessoas que os mantêm acreditam que funciona — o que é uma descrição surpreendentemente honesta da maior parte da cultura de TI.
-
-**KKTerm** é **Kuai Kuai Term** — um workspace de administração que aspira ao mesmo papel do salgadinho: sentar quietinho do lado das suas máquinas importantes e ajudá-las a se comportar. Local-first. Sem telemetria. IA com aprovação obrigatória. O tipo de software chato e confiável.
-
-Ainda não conseguimos incluir um saquinho de Kuai Kuai de verdade com o instalador. Isso vai para a v2.
+Tem uma opinião sobre o que deveria vir a seguir? Entra na thread pública de feedback:
+**[O que o KKTerm deveria priorizar para fluxos de administração Windows-first?](https://github.com/ryantsai/KKTerm/discussions/141)**
 
 ---
 
-## Veja em Movimento
+## Por que «KKTerm»?
 
-<!--
-  TODO: Substitua este placeholder por um GIF de demonstração real.
-  Recomendado:
-    - 5-10 segundos, em loop
-    - Mostrar: abrir uma Connection -> dividir um pane -> upload SFTP -> IA propondo um comando
-    - Cerca de 5 MB para que o GitHub renderize inline sem lazy-loading
-  Caminho sugerido: docs/assets/demo.gif
-  Depois altere o <img src=...> abaixo para: src="docs/assets/demo.gif"
--->
+Entre em qualquer data center taiwanês e olhe o topo dos racks. Passando pelas fábricas da TSMC, salas de controle do metrô de Taipei, salas de servidores do banco Cathay, equipamentos de comutação da Chunghwa Telecom — você vai avistar um saquinho verde de 乖乖 (Kuāi Kuāi), um salgadinho de milho com sabor de coco dos anos 1960.
+
+O nome significa literalmente **«seja bonzinho»**, **«comporte-se»**. A tradição de TI é simples e totalmente séria:
+
+- **Tem que ser verde (coco).** Amarelo (curry) significa *fique em casa hoje*; vermelho (apimentado) deixa o servidor com raiva. Só verde.
+- **Não pode estar vencido.** Um Kuai Kuai passado joga contra você. Os engenheiros trocam com diligência.
+- **Tem que estar visível.** O servidor precisa saber que ele está ali.
+- **Não coma.** Aquele saquinho está de plantão.
+
+Alguns dos sistemas maiores, mais entediantes e mais obcecados por uptime da Ásia rodam com um saquinho de salgadinho de milho colado no chassi. Funciona porque quem os mantém acredita que funciona, o que é uma descrição notavelmente honesta de grande parte da cultura de TI.
+
+**KKTerm** é **Kuai Kuai Term** — um espaço de administração que aspira ao mesmo trabalho do salgadinho: sentar quietinho ao lado das suas máquinas importantes e ajudá-las a se comportar. Local primeiro. Sem telemetria. IA com aprovação. Aquele tipo de software entediante e confiável.
+
+Ainda não conseguimos enviar um saquinho de Kuai Kuai de verdade junto com o instalador. Isso é item pra v2.
+
+---
+
+## Ver em movimento
 
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
@@ -134,339 +123,177 @@ Ainda não conseguimos incluir um saquinho de Kuai Kuai de verdade com o instala
   </a>
 </p>
 
-<p align="center"><sub><em>(O GIF de demo vai aqui. Uma imagem vale mil bullet points, e a gente ficou sem bullet points.)</em></sub></p>
+<p align="center"><sub><em>(O GIF de demonstração vai aqui. Uma imagem vale mais que mil bullet points, e nossos bullet points acabaram.)</em></sub></p>
 
 ---
 
-## Por que as Pessoas Mantêm Aberto o Dia Todo
+## Uma janela, cada conexão
 
-### Windows-first, de propósito
-
-Dê uma olhada no ecossistema de ferramentas de dev em 2026. Claude Code: lança para mac/linux primeiro, Windows é "usa o WSL." Codex CLI: a mesma coisa. `gemini-cli`, metade do Homebrew, todo novo TUI bacana: mac/linux primeiro, e os usuários Windows ganham um comentário `# Windows: contributions welcome` no README e um script de fish-completion que não roda.
-
-Enquanto isso, as pessoas que de fato mantêm empresas no ar — TI corporativo, MSPs, qualquer um rodando Hyper-V ou AD ou SCCM ou IIS ou um domain controller mais velho que alguns estagiários — estão em frente a máquinas Windows se perguntando por que toda ferramenta nova age como se o sistema operacional deles fosse um inconveniente.
-
-**KKTerm é a aposta contrária.** A gente constrói nativo para Windows primeiro, e os ports para macOS / Linux vêm depois. Isso significa que podemos usar as APIs do Windows que realmente importam, em vez de cobri-las com uma camada de portabilidade:
-
-- **ConPTY** para shells locais — o pseudoconsole real do Windows, não um shim de tradução. PowerShell, `cmd.exe`, distribuições WSL, todos hospedados como PTYs de verdade com foco, resize e tratamento de sequências VT que batem com o comportamento da plataforma.
-- **WebView2** para toda a interface e **Connections** de URL embutidas — Chromium em processo usando o runtime do sistema, que é um dos motivos pelo qual o instalador é pequeno e inicia rápido.
-- **Microsoft RDP ActiveX (`mstscax.dll`)** para RDP — *o mesmo que a Microsoft distribui*. Mesmo controle que o Remote Desktop Connection (`mstsc.exe`). Não é uma reimplementação de terceiros, não é FreeRDP dentro de um wrapper. Quem mexe com RDP percebe a diferença em cinco segundos.
-- **Windows Credential Manager** para todos os segredos. Senhas de SSH, senhas de FTP, chaves de API, credenciais de URL Connection — tudo vive no OS keychain e o `credwiz.exe` pode auditá-los.
-- **Instalador NSIS para o usuário atual** com SHA-256 correspondente, menu de bandeja nativo, asserção de energia Don't-Sleep, amostragem de CPU/RAM/rede do host, menus de contexto Tauri nativos com ícones PNG reais, diálogos Open/Save nativos. Nenhum deles é simulado.
-- **WSL é um shell de primeira classe, não um paliativo.** Abra Ubuntu ao lado de um pane PowerShell ao lado de uma sessão SSH ao lado de uma **Tab** RDP, tudo na mesma janela.
-
-Os builds para macOS e Linux estão no roadmap e receberão o mesmo cuidado. Mas se você estava esperando alguém construir a ferramenta de administração Windows *boa* — em vez de deixá-la por último — esse é o acordo.
-
-### Local-first significa realmente local
-
-Suas **Connections** salvas ficam num arquivo SQLite na sua máquina. As senhas ficam no **Windows Credential Manager**, não num JSON ao lado do binário. O app não inclui analytics, não liga pra casa ao iniciar e não precisa de uma conta em nuvem para abrir. Não existe "faça login para sincronizar" porque não existe sincronização.
-
-Se o cabo de rede pegar fogo, o KKTerm ainda abre.
-
-### Um workspace, todo tipo de conexão
-
-| Você queria… | KKTerm tem |
+| Você queria… | O KKTerm faz |
 | --- | --- |
-| Abrir um shell PowerShell / cmd / WSL local | **Sessions** de terminal local com ConPTY |
-| Entrar por SSH num servidor | `russh` nativo com auth por agente / chave / senha, fluxo de confiança de host-key, ProxyJump, port forwarding |
-| Navegar pelos arquivos desse servidor | SFTP aberto pela **Connection** SSH, painel duplo, transferências recursivas, chmod/chown |
-| FTP num NAS de 2012 | **Connections** FTP / FTPS no mesmo navegador estilo SFTP |
-| Telnet para equipamento antigo | Sim, pronto, Telnet está lá também |
-| Falar com uma porta serial | Tipo de **Connection** serial, COM port + baud, sem ferramentas extras |
-| Acessar remotamente uma máquina Windows | RDP nativo via controle Microsoft ActiveX (o de verdade, não um clone) |
-| VNC num Raspberry Pi | Framebuffer Rust `vnc-rs` renderizado direto no workspace |
-| Abrir a interface web do roteador | **URL Connection** WebView2 embutido com preenchimento de credenciais |
-| Monitorar CPU do host | Barra de status em tempo real + módulo **Dashboard** com widgets arrastáveis e redimensionáveis |
+| Abrir um shell local PowerShell / cmd / WSL | Terminais locais, lado a lado |
+| SSH num servidor | SSH com chaves, agent, senhas, jump hosts e encaminhamento de portas |
+| Navegar pelos arquivos desse servidor | SFTP a partir da conexão SSH — painel duplo, arraste para transferir |
+| FTP num NAS de 2012 | FTP / FTPS no mesmo navegador de arquivos |
+| Telnet num equipamento pré-histórico | Sim, Telnet também está aí |
+| Falar com uma porta serial | Conexões seriais — escolha porta COM e baud |
+| Acessar remotamente uma máquina Windows | A verdadeira Área de Trabalho Remota da Microsoft, embutida |
+| VNC num Pi | VNC, renderizado direto no espaço de trabalho |
+| Abrir a interface web do roteador | Uma aba de navegador embutida com logins salvos |
+| Acompanhar a CPU do host | Uma barra de status ao vivo e um painel que você mesmo monta |
 
-É tudo o mesmo app. Mesma janela. Mesmos atalhos de teclado. Mesmo tema que esperamos não agredir seus olhos.
+O mesmo app. A mesma janela. Os mesmos atalhos. O mesmo tema, que tomara não faça seus olhos sangrarem.
 
-### Terminais que não enlouquecem
+---
 
-- Panes divididos dentro de uma **Tab**.
-- Renderização xterm.js acelerada por WebGL, com fallback gracioso quando não está disponível.
-- Busca no scrollback.
-- Panes de SSH com tmux que fazem attach a sessões estáveis por pane, de forma que reconectar realmente significa *reconectar*, e não "começar do zero e fingir que a última hora não aconteceu."
-- Trocar de **Tab** **não** mata a **Session**. Fechar a **Tab** sim. Essa distinção foi uma guerra religiosa internamente; a gente ganhou.
+## Por que as pessoas deixam aberto o dia inteiro
 
-### Um AI Assistant que cria suas ferramentas
+### Windows primeiro, de propósito
 
-A maioria das demos de "IA no seu terminal" para no chat. O assistente do KKTerm também pode criar pequenos widgets de dashboard, duráveis, para o jeito como você realmente trabalha. Ainda assim, ele mantém as coisas perigosas atrás de dois controles:
+Olhe o cenário das ferramentas pra dev. Claude Code: mac/linux primeiro, Windows é «usa WSL». Codex CLI: a mesma coisa. Metade das ferramentas novas e brilhantes sai primeiro pro mac e deixa pros usuários de Windows um comentário `# contributions welcome` e um script de autocompletar que não roda.
 
-- **Famílias de ferramentas** (Dashboard / Connections / Live Sessions) — ative ou desative por categoria.
-- **Modo de permissão** no composer — `Prompt` (padrão, pergunta sempre) ou `Allow All` (você é adulto, assinou o termo de responsabilidade).
+Enquanto isso, quem de fato mantém as empresas no ar — TI corporativa, MSPs, qualquer um administrando um controlador de domínio mais velho que alguns estagiários — está sentado em máquinas Windows se perguntando por que toda ferramenta nova trata o SO deles como um incômodo.
 
-Converse com OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA, ou qualquer endpoint compatível com OpenAI. As chaves de API vão para o OS keychain. Modelos que propõem `rm -rf` são classificados como perigosos e exigem aprovação humana explícita. A IA não consegue silenciosamente executar um comando destrutivo porque alguém achou graça numa injeção de prompt em uma página de manual.
+**O KKTerm faz o trato oposto.** Construímos nativo pro Windows primeiro, então o que importa pra quem está no Windows simplesmente funciona: a *verdadeira* Área de Trabalho Remota da Microsoft (a mesma do `mstsc.exe`, não um clone), shells reais de PowerShell / cmd / WSL, segredos guardados no Gerenciador de Credenciais do Windows, um ícone de bandeja de verdade, menus e diálogos nativos. As builds de macOS e Linux estão no roadmap e vão receber o mesmo cuidado. Mas se você estava esperando alguém construir a *boa* ferramenta de administração do Windows primeiro em vez de por último — esse é o trato.
 
-### Um Dashboard que não finge ser o Grafana
+### Local primeiro significa de verdade local
 
-O módulo **Dashboard** é uma grade de 12 colunas arrastável e redimensionável de instâncias de widget. Não é para observabilidade de petabytes — é para "quero um botão para abrir meus cinco apps favoritos e um painel mostrando o uptime do meu host SSH, *ao lado* do meu chat."
+Suas conexões salvas vivem num arquivo na sua máquina. As senhas vivem no Gerenciador de Credenciais do Windows, não num arquivo de texto ao lado do app. O KKTerm não envia analytics, não telefona pra casa ao iniciar e não precisa de conta na nuvem pra abrir. Não tem «faça login pra sincronizar» porque não tem sincronização.
 
-#### Widgets criados pela IA — descreva e receba
+Se o seu cabo de rede pegar fogo, o KKTerm abre do mesmo jeito.
 
-Essa é a parte que a gente está genuinamente animado. Você não escolhe num marketplace e não escreve JavaScript. Você **fala para o AI assistant o que quer**, e ele constrói o widget ali mesmo no seu dashboard:
+### Terminais que não piram
 
-> *"Adiciona um widget mostrando os últimos 5 commits do meu repositório principal como uma lista."*
-> *"Me faz um widget de sticky note para o meu roteiro de plantão."*
-> *"Constrói um widget que faz ping no meu roteador doméstico a cada 30 segundos e mostra verde/vermelho."*
-> *"Preciso de um cronômetro. Me surpreende no estilo."*
+- Painéis divididos dentro de uma Tab.
+- Renderização rápida e fluida, com scrollback pesquisável.
+- Reconectar significa de verdade *reconectar* — sua sessão remota retoma de onde parou, não «começar do zero e fingir que a última hora não aconteceu».
+- Trocar de Tab **não** mata a Session. Fechar a Tab, sim. Essa distinção foi uma guerra religiosa interna; a gente ganhou.
 
-Dois sabores:
+### Um assistente de IA que constrói suas ferramentas
 
-- **Content widgets** — JSON declarativo: markdown, listas chave-valor, checklists, stat grande único. Seguros por construção, sem script. A maioria dos pedidos "só preciso disso no dashboard" cai aqui.
-- **Script widgets** — JavaScript hospedado dentro de um sandbox `iframe srcdoc` isolado com permissões explícitas e declaradas (lista de permissões de `network`, orçamento de `pollSeconds`). A IA escreve o script, você aprova as permissões, o widget roda numa caixa que não consegue alcançar o resto do app.
+A maioria das demos de «IA no seu terminal» para no chat. O assistente do KKTerm também consegue construir pequenos widgets de painel duráveis, no formato de como você realmente trabalha — e mantém o perigoso atrás de um interruptor:
 
-Todo widget que você mantém é seu. Eles persistem no SQLite ao lado das suas **Connections**, com seu próprio preset visual (`panel` / `ambient` / `hero`), cor de destaque, ícone e título. Múltiplas instâncias do mesmo widget podem coexistir com tamanhos e estilos completamente diferentes. Delete-os com botão direito quando a magia acabar.
+- **Decida o que ele pode tocar** — ligue ou desligue famílias inteiras de ferramentas (Dashboard / Connections / Live Sessions).
+- **Decida como ele pergunta** — `Prompt` (padrão, pergunta toda vez) ou `Allow All` (você é adulto, assinou o termo).
 
-#### Fundos animados para o dashboard (porque a gente quis)
+Qualquer coisa parecida com `rm -rf` é marcada como perigosa e espera um sim humano explícito. A IA não consegue rodar escondido um comando destrutivo só porque alguém deu uma de esperto com um prompt injection numa man page.
 
-O dashboard tem vinte e um fundos animados em canvas que você pode escolher por **Dashboard View**:
+Ele conversa com OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA ou qualquer endpoint compatível com OpenAI. Suas chaves de API vão pro chaveiro do SO.
+
+### Um painel que não finge ser o Grafana
+
+O Dashboard é uma grade de widgets que você arrasta e redimensiona. Não é pra observabilidade em escala de petabytes — é pra «quero um botão que abra meus cinco apps favoritos e um painel mostrando o uptime do meu host SSH, *do lado* do meu chat».
+
+#### Widgets criados pela IA — descreva, e pronto
+
+Essa é a parte que a gente fica genuinamente animado. Você não escolhe de um marketplace nem escreve JavaScript. Você **diz ao assistente de IA o que quer**, e ele constrói o widget ali mesmo, no seu painel:
+
+> *«Adiciona um widget mostrando os últimos 5 commits do meu repo principal em lista.»*
+> *«Faz um widget de post-it pra minha cola de plantão.»*
+> *«Constrói um widget que dá ping no meu roteador de casa a cada 30 segundos e mostra verde/vermelho.»*
+> *«Preciso de um cronômetro. Me surpreende no estilo.»*
+
+Alguns são simples painéis de exibição (markdown, listas de tarefas, um número grandão); outros rodam código ao vivo numa sandbox isolada que você aprova. Cada widget que você guarda é seu — fica salvo com a própria cor, ícone e título, e você pode ter várias cópias de tamanhos diferentes. Apague um com o botão direito quando a mágica passar.
+
+#### Fundos animados do painel (porque a gente quis)
+
+Escolha um clima por visão do painel entre **vinte e cinco** fundos animados em canvas:
 
 | Clima | Fundos |
 | --- | --- |
-| Calmo | `aurora`, `clouds`, `ocean`, `raindrops`, `snow`, `sakura`, `fireflies`, `bubbles`, `ricefield`, `lanterns` |
+| Calmo | `aurora`, `clouds`, `ocean`, `raindrops`, `rainywindow`, `frostedWindow`, `snow`, `sakura`, `fireflies`, `bubbles`, `aquarium`, `ricefield`, `lanterns` |
 | Espacial | `starfield`, `nebula` |
-| Aconchegante | `embers`, `lava` |
-| Nerd | `matrix`, `topo`, `synthwave` |
-| Caótico | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti` |
+| Quente | `embers`, `lava` |
+| Geek | `matrix`, `topo`, `synthwave` |
+| Agitado | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti`, `particleCursor` |
 
-Eles rodam num único `requestAnimationFrame` compartilhado e respeitam o foco da janela, então custam praticamente nada quando você está em outra janela. Combine `matrix` com seu assistente de IA para um visual que diz "sou extremamente produtivo e possivelmente estou num filme dos Wachowski." Ou escolha `ocean` e pareça uma pessoa séria. A gente não julga nenhuma das opções.
+Eles pausam quando você está em outro lugar, então custam quase nada. Combine `matrix` com o seu assistente de IA pra um clima que diz «sou extremamente produtivo e provavelmente estou dentro de um filme das Wachowski». Ou escolha `ocean` e pareça uma pessoa séria. Não julgamos nenhuma das duas escolhas.
 
-### Rodando agentes de IA em servidor, do jeito certo
+### Mantenha vivos os seus agentes de IA remotos
 
-Essa é a segunda funcionalidade de que as pessoas se apaixonam. Os terminais SSH do KKTerm podem ser abertos diretamente numa **sessão tmux nomeada** no host remoto — por padrão, um id amigável gerado automaticamente como `kkterm-cockpit001` que sobrevive à reconexão:
+Essa é a segunda função pela qual as pessoas se apaixonam. Os terminais SSH do KKTerm podem te jogar direto numa **sessão tmux nomeada** no host remoto que sobrevive à reconexão:
 
-- Abra uma **Connection** SSH com tmux habilitado.
-- Dentro do pane, inicie `claude`, `codex`, `gemini-cli`, `cursor-agent`, ou qualquer agente de código de longa duração que você preferir. São apps TUI de tela cheia; tmux é exatamente onde eles querem estar.
-- Feche o notebook. Abra de novo. O pane silenciosamente faz re-attach à mesma sessão tmux. O agente ainda está rodando, ainda tem seu scrollback, ainda no meio do que estava fazendo.
-- Queda de rede na conexão SSH? O KKTerm faz uma tentativa silenciosa e limitada de re-attach ao mesmo id tmux sem te incomodar.
-- Quer que o AI assistant veja o que o agente está fazendo? "Add terminal buffer to context" chama `capture_tmux_pane` via SSH e puxa o scrollback completo do tmux — não só o que está na tela, a sessão inteira — para a conversa. Seu assistente local agora consegue raciocinar sobre o trabalho do seu agente remoto.
+- Abra uma conexão SSH com tmux ativado e inicie `claude`, `codex`, `gemini-cli`, `cursor-agent` ou o agente de longa duração que você preferir.
+- Feche o notebook. Abra de novo. O painel se reconecta em silêncio — o agente ainda está rodando, mantém seu scrollback, no meio do que estava fazendo.
+- Uma piscada na rede? O KKTerm reconecta discretamente à mesma sessão sem te incomodar.
+- Quer a ajuda do assistente? «Adicionar o buffer do terminal ao contexto» puxa a sessão remota inteira pra conversa, pra sua IA local raciocinar sobre o que o seu agente remoto está fazendo.
 
-Se você já perdeu uma sessão de seis horas do `claude` ou `codex` por causa do Wi-Fi ruim de um hotel, essa única funcionalidade já valeria o preço do app. O app é gratuito. A funcionalidade ainda assim vale.
+Se você já perdeu uma sessão `claude` ou `codex` de seis horas pro Wi-Fi instável de um hotel, essa função sozinha já paga o app. (O app é grátis. A função vale a pena mesmo assim.)
 
-### Saber quanta IA ainda sobra
+### Saber quanta IA ainda te resta
 
-Agentes de codificação cobram por janela de plano, não por mês. Claude Code tem janela de 5 horas e janela semanal. Codex tem a versão dele. Os dois conseguem devorar sua cota tranquilamente em background enquanto você está numa reunião.
+Os agentes de programação cobram por janela do plano, não por mês, e devoram alegremente a sua cota enquanto você está numa reunião. O **medidor de uso de IA** mantém isso à vista:
 
-O widget **Uso de IA para codar** mantém isso visível:
+- Um widget de painel mostrando **Claude Code** e **Codex** lado a lado: conta conectada, plano, consumo da janela atual e desta semana, hora do próximo reset.
+- Um **indicador compacto na barra de status** que espelha os mesmos números, pra que mesmo com o painel fechado você veja num relance se tem folga antes da próxima grande refatoração.
+- Ele te avisa com antecedência se você precisa logar de novo — *antes* de uma tarefa longa, não no meio dela.
 
-- Um widget de Dashboard mostrando **Claude Code** e **Codex** lado a lado: conta conectada, nível do plano, percentual usado na janela de 5 horas atual, percentual usado nesta semana, próximo horário de reset.
-- Um **indicador compacto na barra de status** que reflete os mesmos números, para que mesmo com o Dashboard fechado dê para ver de relance se ainda tem margem antes de chutar o próximo refactor grande.
-- O estado de auth é exibido direto (`connected` / `expired` / `error`) para você descobrir *antes* de uma tarefa longa que precisa relogar, não no meio dela.
-- A política de refresh respeita os rate limits; o widget faz polling no próprio ritmo, em vez de martelar as APIs upstream cada vez que você olha.
+### Deixe outras IAs pilotarem o KKTerm
 
-### Um servidor MCP integrado — deixe outras IAs dirigirem o KKTerm
+O KKTerm traz o próprio servidor MCP, pra que agentes de programação externos (Claude Code, Codex, Copilot, Antigravity, OpenCode) usem o seu espaço de trabalho como você usa — listar conexões, abrir uma, ler um buffer de terminal, posicionar widgets no painel. De IA pra IA, na sua máquina, sem relay na nuvem. As ações que modificam, as mais arriscadas, ficam atrás de um único interruptor de segurança **desligado** por padrão.
 
-Seu terminal também é onde Claude Code, Codex, o modo agent do Copilot, Antigravity e o resto do mundo que fala MCP querem trabalhar. Por isso o KKTerm já vem com seu próprio **servidor MCP via stdio**, [`kkterm-cli`](docs/MCP.md), que expõe uma fatia curada do app:
-
-- **Módulo Workspace** (`kkterm.workspace.*`): listar **Connections** salvas, abrir uma Connection por id, listar **Sessions** ativas, enviar input para um pane de terminal, ler um snapshot do buffer.
-- **Módulo Dashboard** (`kkterm.dashboard.*`): carregar o estado do Dashboard, ler a fonte de um widget criado por IA, criar / atualizar / remover views, posicionar / mover / remover instâncias de widget, aplicar layouts em lote.
-- **Sub-namespaces perigosos** (`kkterm.<module>.dangerous.*`): mutar a superfície executável — criar widgets de script, clicar em remote desktops, esvaziar o Dashboard — está protegido por uma única configuração (`built_in_mcp_allow_all_dangerous`), desligada por padrão.
-
-`kkterm-cli` é um forwarder leve. Ele fala stdio JSON-RPC com seu cliente MCP e se comunica com a janela do KKTerm em execução por um named pipe Windows autenticado por lançamento. Com o KKTerm fechado, `tools/list` continua funcionando (clientes podem introspectar a superfície), mas `tools/call` devolve um erro estruturado `app_not_running` em vez de fazer alguma coisa.
-
-Plugue no seu cliente preferido e sua IA passa a usar o KKTerm como você usa:
-
-```json
-{
-  "mcpServers": {
-    "kkterm": { "command": "<caminho-para-kkterm-cli>", "args": [] }
-  }
-}
-```
-
-Settings → AI Assistant → **Servidor MCP integrado** tem um diálogo "Mostrar config" de um clique com snippets JSON e TOML pré-preenchidos com o caminho do binário resolvido, além de comandos `claude mcp add` / `codex mcp add` copiáveis.
+Configurações → AI Assistant → **Built-in MCP Server** tem um diálogo «Mostrar configuração» de um clique, já preenchido, além de comandos `claude mcp add` / `codex mcp add` pra copiar.
 
 ---
 
-## Como Tudo Se Encaixa
+## O que o KKTerm não é
 
-```mermaid
-flowchart LR
-    User([You]) --> Shell[KKTerm Window<br/>Tauri v2 + React 19]
-    Shell --> Rail[Activity Rail]
-    Rail --> WS[Workspace Module]
-    Rail --> Dash[Dashboard Module]
-    Rail --> Inst[Installer Helper Module]
-    Rail -.-> FE[File Explorer<br/>planned]
-    Rail --> Set[Settings]
+Uma lista curta, porque honestidade conquista confiança:
 
-    WS --> Tabs[Tabs &amp; Panes]
-    Tabs --> Term[Terminal<br/>ConPTY / russh]
-    Tabs --> SFTP[SFTP / FTP]
-    Tabs --> Web[WebView2 URL]
-    Tabs --> RD[RDP / VNC]
-
-    Shell -.calls.-> Rust[Rust Backend]
-    Rust --> SQLite[(SQLite<br/>Connections)]
-    Rust --> Keychain[(OS Keychain<br/>Secrets)]
-    Rust --> AI[AI Providers<br/>OpenAI-compat]
-
-    AI -. approval gate .-> Tabs
-
-    classDef local fill:#1f6feb,stroke:#1f6feb,color:#fff
-    classDef ai fill:#8a63d2,stroke:#8a63d2,color:#fff
-    class SQLite,Keychain local
-    class AI ai
-```
-
-O que importa nessa forma: dados salvos duráveis (**Connection**) são separados do estado em tempo de execução (**Session**), que é separado do contêiner de interface (**Tab**). Fechar uma **Tab** encerra a **Session**. Trocar de **Tab** não. Essa é a regra que mantém o app sensato.
-
----
-
-## Mapa de Funcionalidades Atual
-
-| Área | Implementado hoje |
-| --- | --- |
-| **Connections** | Árvore com SQLite, pastas/subpastas, busca, ordenação por arrastar/soltar, renomear, duplicar, deletar, **Quick Connect**, ícones personalizados, atalhos fixados/ativos no rail |
-| **Terminal** | Shells locais, SSH, Telnet, Serial, panes divididos, xterm.js + WebGL oportunístico, busca no scrollback, diretório/script de inicialização local |
-| **SSH** | `russh` nativo, auth por agente/chave/senha, fluxo de confiança de host-key, fallback opcional para SSH do sistema, ProxyJump, port forwarding, **sessões tmux com nome automático (`kkterm-<scifi-name><n>`) com re-attach silencioso em queda de transporte** — perfeito para agentes de código remotos de longa duração (Claude Code, Codex, gemini-cli, etc.) |
-| **SFTP / FTP** | SFTP via SSH mais **Connections** FTP/FTPS, navegador de painel duplo, transferências recursivas, fila/cancelamento/histórico, conflitos, propriedades, chmod/chown onde suportado |
-| **URL WebView** | **Sessions** de URL WebView2 embutidas, barra de navegação, captura de favicon, metadados/preenchimento de credenciais de site salvas, metadados de partição de dados |
-| **Remote Desktop** | RDP via ActiveX Windows com parking de overlay com escopo geométrico; VNC via framebuffer `vnc-rs` renderizado no canvas do workspace |
-| **Dashboard** | Views duráveis, instâncias de widget, modo de edição, arrastar/redimensionar, App Launcher, **widgets de conteúdo/script criados pela IA** (JSON declarativo ou iframe JS sandboxed com permissões), presets / destaque / ícone / título por widget, **23 fundos animados em canvas** (aurora, clouds, ocean, raindrops, rainywindow, snow, sakura, fireflies, bubbles, ricefield, lanterns, starfield, nebula, embers, lava, matrix, topo, synthwave, cyberpunk, taipei101, thunderstorm, confetti, particleCursor) |
-| **AI Assistant** | Chat em streaming, runtime compatível com OpenAI, registro de provedores, classificação de segurança de propostas de comandos, anexos de screenshot/contexto, **criação de widgets para Dashboard (conteúdo + script sandboxed)**, **captura de pane tmux** como contexto de conversa para sessões remotas, ferramentas de gerenciamento de **Connection** e ferramentas de **Session** ao vivo para terminal, RDP/VNC e SFTP/FTP |
-| **Uso de IA para codar** | **Widget do Dashboard + indicador na barra de status** que rastreiam o uso das cotas do **Claude Code** e do **Codex**: conta conectada, nível do plano, percentuais das janelas de 5 horas e semanal, próximo horário de reset, estado de auth (`connected` / `expired` / `error`), política de refresh ciente do rate-limit |
-| **Servidor MCP integrado** | Servidor MCP via stdio (`kkterm-cli`) que expõe ferramentas curadas de Workspace e Dashboard a agentes de codificação externos (Claude Code, Codex, Copilot, Antigravity, OpenCode); bridge de named pipe autenticado; sub-namespaces `dangerous.*` por Módulo atrás de um único toggle de segurança; diálogo nas Settings com snippets JSON / TOML de um clique e comandos `claude mcp add` / `codex mcp add` |
-| **Installer Helper** | Módulo do Activity Rail para um catálogo incluído de ferramentas de desenvolvimento Windows: detectar ferramentas instaladas, comparar versões mais recentes, instalar/atualizar/desinstalar, excluir ferramentas do Update all, transmitir logs de comando e iniciar apps gerenciados compatíveis |
-| **Settings** | Geral, Aparência, Credenciais, IA, SSH, Terminal, fundos do terminal, URL, RDP, VNC, Dashboard, Installer Helper, Sobre; fontes de interface personalizadas; minimizar para bandeja; Don't Sleep; backup/importação |
-| **Localization** | Interface i18next com inglês como fonte original e pacotes de locale dinâmicos: zh-TW, zh-CN, ja, ko, fr, de, es, es-MX, it, pt-BR, th, id, vi |
-
-### Provedores de IA
-
-OpenAI · Anthropic · OpenRouter · DeepSeek · Grok · Azure OpenAI · LiteLLM · GitHub Copilot · Ollama · NVIDIA · qualquer endpoint compatível com OpenAI.
-
-Os metadados de provedores ficam em [`src/ai/providerRegistry/`](src/ai/providerRegistry/); adaptadores Rust em [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/). As chaves de API passam pelo OS keychain, nunca pelo SQLite.
-
----
-
-## Quick Start
-
-Você precisa de:
-
-- **Windows** (plataforma primária suportada)
-- **Node.js + npm**
-- **Rust toolchain**
-- **Pré-requisitos do Tauri v2 para Windows** incluindo **WebView2**
-
-```bash
-npm install
-npm run tauri dev
-```
-
-Isso deve gerar uma janela nativa de verdade. Se gerar um stack trace em vez disso, abra uma issue — adoramos uma boa reprodução.
-
-### Verificações comuns
-
-```bash
-npm run check                                              # TypeScript
-npm run build                                              # Vite build
-cargo check --manifest-path src-tauri/Cargo.toml           # Rust
-cargo test  --manifest-path src-tauri/Cargo.toml           # Rust tests
-```
-
-### Build do instalador Windows
-
-```bash
-npm run package:installer
-```
-
-O script do instalador grava `artifacts/kkterm-<version>-windows-x64-setup.exe` e um arquivo `.sha256` correspondente. Atualmente está **sem assinatura** — a assinatura para release está no roadmap, mas até lá seu antivírus pode te olhar torto. Isso é normal.
-
----
-
-## O que KKTerm Não É
-
-Uma lista curta, porque honestidade gera confiança:
-
-- **Não é um produto em nuvem.** Sem sincronização, sem contas de equipe, sem camada SaaS. Se você algum dia ver um diálogo "Entrar no KKTerm", algo deu terrivelmente errado.
-- **Não finge ser cross-platform.** Somos Windows-first de propósito; macOS e Linux estão no roadmap e usarão o mesmo shell Tauri v2. Se você precisa de uma ferramenta mac-first hoje, tem centenas de opções. A gente está construindo aquela que os admins Windows ficaram quietinhos esperando.
+- **Não é um produto de nuvem.** Sem sincronização, sem contas de equipe, sem plano SaaS. Se você um dia vir um diálogo «Entrar no KKTerm», algo deu catastroficamente errado.
+- **Não finge ser multiplataforma.** Somos Windows-first de propósito; macOS e Linux estão no roadmap. Se você precisa de uma ferramenta mac-first hoje, tem centenas de opções. Estamos construindo aquela que os admins de Windows vinham esperando em silêncio.
 - **Não é um agente de IA autônomo.** O assistente propõe; o humano decide. `Allow All` é uma escolha que você faz, não um padrão.
-- **Não é substituto do Grafana / Datadog.** O Dashboard é para painéis de controle pessoais, não para observabilidade de 10 mil hosts.
-- **Não é uma IDE para Kubernetes.** É um workspace de administração voltado para terminal. Por favor, não peça pra ele renderizar um Helm chart.
+- **Não é um substituto pro Grafana / Datadog.** O Dashboard é pra superfícies de controle pessoais, não pra observabilidade de 10 mil hosts.
+- **Não é uma IDE de Kubernetes.** É um espaço de administração centrado no terminal. Por favor, não peça pra ele renderizar um chart do Helm.
 
-Se alguma dessas *foi* um dealbreaker — sem problemas, a gente se vê na v2.
-
----
-
-## Debug Nativo
-
-Use o runtime Tauri de verdade para validação:
-
-```bash
-npm run tauri dev
-```
-
-Uma prévia do Vite no navegador é útil para alguma inspeção de frontend, mas **não** hospeda um WebView2 real, ConPTY, RDP ActiveX, framebuffer VNC, keychain ou superfície de menu nativo. Se uma funcionalidade toca qualquer um desses, valide-a no runtime desktop de verdade.
-
-Usuários do VS Code: a config de launch `Run KKTerm exe` inicia `src-tauri/target/debug/kkterm.exe` com `RUST_BACKTRACE=1`. A config pareada `Attach KKTerm WebView2` oferece DevTools dentro do host WebView2 real.
+Se algum desses pontos *era* um motivo de desistência — justo, a gente se vê na v2.
 
 ---
 
-## Limitações Atuais (sim, a gente sabe)
+## Pegue o KKTerm
 
-- O instalador está atualmente sem assinatura. As verificações de atualização estão desativadas até que a assinatura para release seja configurada.
-- SFTP via ProxyJump ainda não é suportado no caminho SFTP nativo.
-- Retomada de transferência de arquivos, sincronização/diff de pastas, compactação/extração e edição remota foram adiados.
-- A importação de config SSH está implementada, mas a entrada para o usuário nas Settings ainda não está exposta.
-- RDP e VNC estão disponíveis; sincronização mais rica de área de transferência/dispositivos e controles de qualidade ainda estão evoluindo.
-- Os builds para macOS e Linux estão no roadmap. Estão chegando, e serão feitos da forma correta — não às pressas como um port "a gente também funciona mais ou menos por aí".
-- O AI assistant propõe e pode operar ferramentas habilitadas dentro do limite de permissão configurado — por favor, não o trate como um robô sem supervisão. Ele, de fato, não sabe o que seu CEO quer.
+**[Baixe o instalador mais recente do Windows (.exe)](https://github.com/ryantsai/KKTerm/releases/latest)** e execute. O instalador no momento está **sem assinatura** — a assinatura de release está no roadmap, então até lá o seu antivírus pode te olhar torto. É normal.
+
+Quer compilar do código-fonte ou contribuir? Tudo que você precisa está em [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ---
 
 ## Roadmap (versão curta)
 
-- Builds para macOS + Linux
+- Builds macOS + Linux
 - Instalador assinado + atualização automática
-- SFTP via ProxyJump no caminho nativo
-- Retomada de transferência de arquivos, sincronização de pastas, compactação/extração
-- Redirecionamento mais rico de área de transferência/dispositivos do RDP
-- Mais widgets integrados ao **Dashboard** (e um schema público para os criados pela IA)
+- Mais poder na transferência de arquivos (retomar, sync de pastas, arquivar/extrair)
+- Compartilhamento de área de transferência e dispositivos mais rico na Área de Trabalho Remota
+- Mais widgets de painel embutidos
 
-Versão completa e atualizada frequentemente: [`docs/ROADMAP.md`](docs/ROADMAP.md).
-
----
-
-## Contribuindo
-
-Adoraríamos uma ajuda. De verdade. Até coisas pequenas importam:
-
-- **Teste o build de desenvolvimento** e abra uma issue quando algo parecer errado. "Parecia estranho" é um bug report legítimo; vamos investigar com você.
-- **Traduza um locale.** O inglês é a fonte da verdade em [`src/i18n/locales/en.json`](src/i18n/locales/en.json); outros 12 locales ficam ao lado e carregam sob demanda. Strings pendentes são rastreadas por chave em [`docs/localization_todo/`](docs/localization_todo/) — escolha uma, traduza, delete o arquivo.
-- **Adicione um widget ao Dashboard.** Os widgets integrados ficam em [`src/modules/dashboard/widgets/builtin/`](src/modules/dashboard/widgets/builtin/). Escolha uma ideia pequena, entregue, aprenda o padrão.
-- **Aperte a superfície de ferramentas da IA.** Adaptadores de provedores ficam em [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/); o registro do frontend está em [`src/ai/providerRegistry/`](src/ai/providerRegistry/).
-- **Melhore o manual.** A documentação para usuários finais fica em [`docs/manual/`](docs/manual/). Um capítulo por módulo de interface. Se você usou uma funcionalidade e a documentação não ajudou, um PR corrigindo isso vale ouro.
-
-Setup completo, estrutura do projeto, checklist de PR e a lista de regras "por favor não quebre essas" ficam em [`CONTRIBUTING.md`](CONTRIBUTING.md). Os destaques em 30 segundos:
-
-- **Leia [`CONTEXT.md`](CONTEXT.md) antes de renomear termos visíveis ao usuário.** **Connection**, **Session**, **Tab** e **Quick Connect** têm significados específicos; por favor, não desvie.
-- **Toda string visível ao usuário passa pelo `t()`.** Sem texto em inglês puro em JSX.
-- **Sem hooks de fechamento no frontend.** O fechamento da barra de título do Tauri v2 foi quebrado por padrões `onCloseRequested` meia dúzia de vezes. Finalmente temos uma forma que funciona; por favor, não a reintroduza.
-- **Rode as verificações** (`npm run check && npm run build && cargo check && cargo test`) antes de abrir um PR.
-
-Procurando um ponto de entrada? Filtre as issues abertas por [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) ou [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22). Se não houver nenhuma marcada ainda, abra uma issue descrevendo o que você gostaria de trabalhar e a gente ajuda a definir o escopo.
+Versão completa e atualizada com frequência: [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
 ---
 
-## Documentação do Projeto
+## Contribuir
 
-- [Contexto do produto](CONTEXT.md) — a linguagem de domínio que você deve seguir
-- [Arquitetura](docs/ARCHITECTURE.md) — mapa de módulos, onde colocar novo código
+A gente adoraria uma mão. De verdade. Até coisas pequenas importam:
+
+- **Teste a build de desenvolvimento** e abra uma issue quando algo parecer errado. «Pareceu estranho» é um relatório de bug legítimo; a gente investiga junto.
+- **Traduza um idioma.** O inglês é a fonte da verdade; outros treze idiomas vivem ao lado.
+- **Adicione um widget de painel.** Pegue uma ideia pequena, lance, aprenda o padrão.
+- **Melhore o manual.** Se você usou uma função e a documentação não ajudou, uma PR que conserta isso vale ouro.
+
+Setup completo, estrutura do projeto e checklist de PR estão em [`CONTRIBUTING.md`](CONTRIBUTING.md). Procurando um ponto de entrada? Filtre as issues abertas por [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) ou [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+
+---
+
+## Documentos do projeto
+
+- [Contexto de produto](CONTEXT.md) — a linguagem de domínio que você deve respeitar
+- [Arquitetura](docs/ARCHITECTURE.md) — mapa de módulos, onde colocar código novo
 - [Roadmap](docs/ROADMAP.md)
 - [Arquitetura do Dashboard](docs/DASHBOARD.md)
 - [Guia de provedores de IA](docs/AI_PROVIDERS.md)
-- [Notas de performance](docs/PERFORMANCE.md)
-- [Notas de release e gates](docs/RELEASE.md)
 
 ---
 
-## Stack
-
-Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand · xterm.js · SQLite · WebView2 · `russh` · `russh-sftp` · `vnc-rs` · `suppaftp` · OS keychain storage.
-
----
-
-## Histórico de Estrelas
+## Histórico de estrelas
 
 <a href="https://www.star-history.com/#ryantsai/KKTerm&Date">
   <picture>
@@ -476,12 +303,12 @@ Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand ·
   </picture>
 </a>
 
-Se você chegou até aqui e ainda não deu estrela — o que está esperando, um convite pessoal? Considere este o convite pessoal.
+Se você chegou até aqui e ainda não deu uma estrela — o que está esperando, um convite pessoal? Considere este o convite pessoal.
 
-⭐ **[Dê uma estrela no KKTerm no GitHub](https://github.com/ryantsai/KKTerm)** — custa um clique e faz a semana do mantenedor. Pense nisso como um 乖乖 digital no rack.
+⭐ **[Dê uma estrela ao KKTerm no GitHub](https://github.com/ryantsai/KKTerm)** — custa um clique e alegra a semana inteira do mantenedor. Pense nisso como um 乖乖 digital no rack.
 
 ---
 
 ## Licença
 
-MIT. Veja [LICENSE](LICENSE). Use, faça fork, distribua, coloque num homelab que mais ninguém consegue achar — esse é o acordo.
+MIT. Veja [LICENSE](LICENSE). Use, faça fork, publique, coloque num homelab que ninguém mais vai achar — esse é o trato.

--- a/README.th.md
+++ b/README.th.md
@@ -5,15 +5,15 @@
 <h1 align="center">KKTerm</h1>
 
 <p align="center">
-  <strong>Workspace สำหรับแอดมิน Windows แบบ native ที่ยุค AI tools ลืมสร้าง — terminal, SSH, SFTP, RDP/VNC, dashboard, และ AI ที่สร้าง widget เครื่องมือของคุณเอง</strong>
+  <strong>หน้าต่างเนทีฟของ Windows หน้าต่างเดียวสำหรับเทอร์มินัล, SSH, SFTP, RDP/VNC และแดชบอร์ด — พร้อม AI ที่สร้างเครื่องมือเล็ก ๆ ของคุณเองได้ตามสั่ง</strong>
 </p>
 
 <p align="center">
-  <em>เพราะ taskbar ของคุณไม่ควรดูเหมือนตู้สล็อตในลาสเวกัส</em>
+  <em>เพราะทาสก์บาร์ของคุณไม่ควรหน้าตาเหมือนตู้สล็อตที่ลาสเวกัส</em>
 </p>
 
 <p align="center">
-  <sub>ตั้งชื่อตาม <strong>乖乖 (Kuāi Kuāi / กวาย กวาย)</strong> ขนมข้าวโพดรสมะพร้าวสีเขียวที่ sysadmin ชาวไต้หวันวางไว้บนเซิร์ฟเวอร์เพื่อให้มันอยู่ดีมีสุข หวังว่าแอปนี้จะสมควรได้นั่งบน rack ของคุณเช่นกัน</sub>
+  <sub>ตั้งชื่อตาม <strong>乖乖 (Kuāi Kuāi / กวายกวาย)</strong> ขนมข้าวโพดสีเขียวรสมะพร้าวที่แอดมินระบบชาวไต้หวันวางไว้บนเซิร์ฟเวอร์เพื่อให้มันทำงานดี ๆ เราหวังว่าแอปนี้จะได้ที่ทางบนแร็คเช่นกัน</sub>
 </p>
 
 <p align="center">
@@ -38,9 +38,6 @@
   </a>
   <br />
   <img src="https://img.shields.io/badge/Windows%E2%80%91first-by%20design-0078D6?style=flat-square&logo=windows" alt="Windows-first by design" />
-  <img src="https://img.shields.io/badge/built%20with-Tauri%20v2-FFC131?style=flat-square&logo=tauri" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/Rust-russh-orange?style=flat-square&logo=rust" alt="Rust" />
-  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react" alt="React 19" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
   <br />
   <sub>
@@ -63,52 +60,54 @@
 
 ---
 
-## Pitch สั้น ๆ (45 วินาที)
+## พิตช์ใน 45 วินาที
 
-คุณเป็น sysadmin / DevOps / homelab / vibe-coder ตอนนี้คุณมี:
+คุณเป็นแอดมินระบบ / DevOps / คนเล่นโฮมแล็บ / vibe-coder ตอนนี้คุณมี:
 
-- Terminal emulator
-- SSH client แยกต่างหาก (พร้อม profile list ที่คุณใช้เวลาทั้งวีกเอนด์สร้าง)
-- SFTP client จากปี 2007 ที่ยังไม่ยอมตาย
-- Remote Desktop ใน window ที่คุณวางผิดจอเป็นประจำ
-- VNC viewer สำหรับกล่อง Linux ตัวนั้นโดยเฉพาะ
-- Browser tab สำหรับ admin UI ของ router
-- Session `claude` / `codex` ที่รันบน remote dev box แล้วหลุดทุกครั้งที่ Wi-Fi จาม
-- โพสต์อิทที่มีรหัสผ่านเขียนไว้ *(ไม่เป็นไร เราจะไม่บอกใคร)*
+- โปรแกรมจำลองเทอร์มินัล
+- SSH client แยกต่างหาก (พร้อมรายการโปรไฟล์ที่ใช้เวลาทั้งสุดสัปดาห์กว่าจะสร้างเสร็จ)
+- SFTP client จากปี 2007 ที่ไม่รู้ว่ายังอยู่ได้ยังไง
+- Remote Desktop ในหน้าต่างที่คุณมักหาไม่เจอเพราะไปอยู่ผิดจอ
+- VNC viewer เพื่อเครื่อง Linux เครื่องเดียวนั้น
+- แท็บเบราว์เซอร์สำหรับหน้าแอดมินของเราเตอร์
+- เซสชัน `claude` / `codex` บนเครื่องรีโมตที่หลุดทุกครั้งที่ Wi-Fi จาม
+- โพสต์อิตที่จดรหัสผ่านไว้ *(ไม่ต้องห่วง เราไม่บอกใคร)*
 
-**KKTerm คือหน้าต่างเดียวสำหรับทั้งหมดนั้น** Native บน Windows — *โดยตั้งใจ ในขณะที่เครื่องมือ dev ส่วนใหญ่ออก mac ก่อนแล้วมองข้าม OS ของคุณเหมือนหัวข้อย่อย* — เขียนด้วย Rust + Tauri v2, ติดตั้งด้วยไฟล์เดียว และไม่ยอมโทรหาบ้าน
+**KKTerm คือหน้าต่างเดียวสำหรับทั้งหมดนั้น** เนทีฟบน Windows — *ตั้งใจ ในขณะที่โลกเครื่องมือ dev ที่เหลือออกเวอร์ชัน mac ก่อนและปฏิบัติต่อ OS ของคุณเหมือนเชิงอรรถ* — ในตัวติดตั้งเดียว และปฏิเสธที่จะโทรกลับบ้าน
 
-พร้อมสิ่งที่คุณไม่รู้ว่าอยากได้อีกสองสามอย่าง:
+แถมด้วยอีกสองสามอย่างที่คุณไม่รู้ว่าตัวเองอยากได้:
 
-- **Dashboard** ที่คุณบอก AI ว่า *"สร้าง widget ping router ทุก 30 วินาทีให้หน่อย"* แล้วมันก็โผล่ขึ้น sandbox บน grid ของคุณเลย
-- **SSH pane ที่ auto-attach เข้า tmux session ที่ตั้งชื่อไว้** ให้ session remote `claude` / `codex` ของคุณรอดจากทุก Wi-Fi tantrum ที่แล็ปท็อปพ่น
-- **Widget แสดงการใช้งาน AI Coding** ที่โชว์โควต้า Claude Code และ Codex ของคุณ — หน้าต่าง 5 ชั่วโมง, หน้าต่างรายสัปดาห์, แผนปัจจุบัน, อีเมลบัญชี — บน **Dashboard** และในแถบสถานะ เพื่อให้คุณไม่ต้องตกใจกับกำแพง rate-limit ตอนตีสาม
-- **Installer Helper Module** ที่ตรวจจับ ติดตั้ง อัปเดต ถอนการติดตั้ง และเปิดใช้แคตตาล็อกเครื่องมือพัฒนา Windows ที่คัดสรรไว้ — Node, Python, Docker, WSL, AI coding CLI และยูทิลิตีเล็ก ๆ ที่ปกติคุณต้องไล่หาในแท็บเบราว์เซอร์
-- **MCP server แบบ built-in** (`kkterm-cli`) ที่ให้ coding agent ภายนอก (Claude Code, Codex, Copilot, Antigravity, OpenCode) ควบคุม Workspace และ Dashboard ของคุณ — list Connection, อ่าน terminal buffer, วาง widget — ผ่าน surface ของ tool ที่คัดสรรและมี safety gate AI ต่อ AI บนเครื่องของคุณ ไม่มี cloud relay
-- Nine **animated canvas background** (ใช่ รวม `matrix` ด้วย) สำหรับ dashboard เพราะเราไม่ได้ถือตัวเกินไปขนาดนั้น
+- **Dashboard** ที่คุณบอก AI ว่า *"สร้าง widget ที่ ping เราเตอร์ของฉันทุก 30 วินาทีให้หน่อย"* แล้วมันก็ปรากฏขึ้นบนกริดของคุณ ในแซนด์บ็อกซ์ของมันเอง
+- **SSH pane ที่กลับไปเชื่อมต่อเซสชัน `claude` / `codex` รีโมตของคุณใหม่อัตโนมัติ** หลังจาก Wi-Fi งอแงทุกครั้ง เพื่อให้งานหกชั่วโมงรอดจากการหลุดสาย
+- **มาตรวัดการใช้ AI** เพื่อให้คุณเลิกชนกำแพง rate limit แบบไม่ทันตั้งตัวตอนตีสาม
+- **Installer Helper** ที่ค้นหา ติดตั้ง อัปเดต และเปิดเครื่องมือ dev ของ Windows ที่ปกติคุณต้องไล่หาผ่านสิบแท็บเบราว์เซอร์
+- **พื้นหลังเคลื่อนไหวยี่สิบห้าแบบ** สำหรับแดชบอร์ด (ใช่ รวมถึง `matrix` ด้วย) เพราะเราก็ไม่ได้สูงส่งเกินไป
 
-แถม AI assistant ยังเปลี่ยนประโยคเดียวให้เป็นเครื่องมือ dashboard เล็ก ๆ ที่คุณใช้งานต่อจริงได้
+และส่วนที่ดีที่สุด: ผู้ช่วย AI สามารถเปลี่ยนประโยคเดียวให้กลายเป็นเครื่องมือแดชบอร์ดเล็ก ๆ ที่คุณใช้ต่อจริง ๆ
 
-> ⭐ **ถ้านี่ฟังดูเหมือนแอปที่คุณตั้งใจจะสร้างมาหกปีแล้ว — กด star ให้ repo หน่อยเพื่อให้รู้ว่ามีคนดูอยู่ มันช่วยได้จริง ๆ**
+> ⭐ **ถ้าฟังดูเหมือนแอปที่คุณตั้งใจจะสร้างมาตลอดหกปีที่ผ่านมา — กดดาวให้ repo เพื่อให้เรารู้ว่ามีคนกำลังดูอยู่ มันช่วยได้จริง ๆ**
+
+มีความเห็นว่าควรทำอะไรต่อ? เข้าร่วมเธรดฟีดแบ็กสาธารณะ:
+**[KKTerm ควรให้ความสำคัญกับอะไรก่อนสำหรับเวิร์กโฟลว์แอดมินแบบ Windows-first?](https://github.com/ryantsai/KKTerm/discussions/141)**
 
 ---
 
 ## ทำไมถึงชื่อ "KKTerm"?
 
-เดินเข้าไปใน data center ของไต้หวันสักแห่งแล้วมองไปที่ด้านบนของ rack โรงงาน TSMC, ห้องควบคุม Taipei Metro, ห้อง server ของ Cathay Bank, อุปกรณ์ switching ของ Chunghwa Telecom — คุณจะเห็นถุงสีเขียวเล็ก ๆ ของ 乖乖 (Kuāi Kuāi / กวาย กวาย) ขนมข้าวโพดรสมะพร้าวจากยุค 1960s
+เดินเข้าไปในดาต้าเซ็นเตอร์ไต้หวันที่ไหนก็ได้แล้วมองที่ด้านบนของแร็ค ผ่านโรงงาน TSMC, ห้องควบคุมรถไฟฟ้าไทเป, ห้องเซิร์ฟเวอร์ของธนาคาร Cathay, อุปกรณ์ชุมสายของ Chunghwa Telecom — คุณจะเห็นถุงเล็ก ๆ สีเขียวของ 乖乖 (Kuāi Kuāi) ขนมข้าวโพดรสมะพร้าวจากยุค 1960
 
-ชื่อแปลตรง ๆ ว่า **"เชื่องๆ ดีๆ"** **"อยู่นิ่ง ๆ"** ธรรมเนียม IT นั้นตรงไปตรงมาและจริงจังมาก:
+ชื่อนี้แปลตรงตัวว่า **"เป็นเด็กดี"**, **"อยู่ในโอวาท"** ธรรมเนียมในวงการไอทีนั้นเรียบง่ายและจริงจังสุด ๆ:
 
-- **ต้องเป็นรสเขียว (มะพร้าว)** รสเหลือง (แกง) หมายถึง *อยู่บ้านเสีย*; รสแดง (เผ็ด) ทำให้เซิร์ฟเวอร์โกรธ ต้องเขียวเท่านั้น
-- **ต้องยังไม่หมดอายุ** กวาย กวายเก่าจะย้อนมาหลอกหลอนคุณ วิศวกรสลับถุงใหม่อย่างสม่ำเสมอ
-- **ต้องมองเห็นได้** เซิร์ฟเวอร์ต้องรู้ว่ามันอยู่ที่นั่น
+- **ต้องเป็นสีเขียว (มะพร้าว)** สีเหลือง (กะหรี่) หมายถึง *วันนี้อยู่บ้านเถอะ*; สีแดง (เผ็ด) ทำให้เซิร์ฟเวอร์โกรธ เขียวเท่านั้น
+- **ต้องไม่หมดอายุ** Kuai Kuai ที่หมดอายุกลับทำร้ายคุณ วิศวกรจึงหมั่นเปลี่ยนใหม่
+- **ต้องมองเห็นได้** เซิร์ฟเวอร์ต้องรู้ว่ามันอยู่ตรงนั้น
 - **ห้ามกิน** ถุงนั้นกำลังปฏิบัติหน้าที่อยู่
 
-ระบบที่ใหญ่ที่สุด น่าเบื่อที่สุด และหมกมุ่นกับ uptime มากที่สุดในเอเชียทำงานอยู่กับถุงข้าวโพดพองติดอยู่ที่ chassis มันได้ผลเพราะคนที่ดูแลระบบเหล่านั้นเชื่อว่ามันได้ผล ซึ่งเป็นคำอธิบายวัฒนธรรม IT ที่ซื่อสัตย์ที่สุดเท่าที่จะมีได้
+ระบบที่ใหญ่ที่สุด น่าเบื่อที่สุด และหมกมุ่นกับ uptime ที่สุดบางระบบในเอเชียทำงานอยู่กับถุงขนมข้าวโพดที่แปะอยู่บนตัวเครื่อง มันได้ผลเพราะคนที่ดูแลมันเชื่อว่ามันได้ผล ซึ่งเป็นคำอธิบายที่ซื่อตรงอย่างน่าทึ่งต่อวัฒนธรรมไอทีส่วนใหญ่
 
-**KKTerm** คือ **Kuai Kuai Term** — admin workspace ที่มุ่งมั่นทำหน้าที่เดียวกับขนมนั้น: นั่งอยู่เงียบ ๆ ข้างเครื่องสำคัญของคุณและช่วยให้ทุกอย่างเป็นระเบียบ Local-first ไม่มี telemetry AI ที่ต้องขออนุมัติ ซอฟต์แวร์แบบน่าเบื่อ น่าเชื่อถือ
+**KKTerm** คือ **Kuai Kuai Term** — พื้นที่ทำงานแอดมินที่มุ่งหวังงานเดียวกับขนมชิ้นนั้น: นั่งเงียบ ๆ ข้างเครื่องสำคัญของคุณและช่วยให้มันทำงานดี ๆ โลคัลมาก่อน ไม่มี telemetry AI ต้องผ่านการอนุมัติ ซอฟต์แวร์ประเภทน่าเบื่อแต่ไว้ใจได้
 
-เรายังส่งถุงกวาย กวายจริง ๆ มาพร้อม installer ไม่ได้ นั่นเป็นไอเทมของ v2
+เรายังไม่สามารถแถมถุง Kuai Kuai จริง ๆ ไปกับตัวติดตั้งได้ นั่นเป็นรายการของ v2
 
 ---
 
@@ -124,339 +123,177 @@
   </a>
 </p>
 
-<p align="center"><sub><em>(Demo GIF ไปอยู่ที่นี่ ภาพหนึ่งภาพมีค่าเท่ากับ bullet point พันตัว แล้วเราหมด bullet point แล้ว)</em></sub></p>
+<p align="center"><sub><em>(GIF เดโมอยู่ตรงนี้ ภาพหนึ่งภาพมีค่ามากกว่าหัวข้อย่อยพันหัวข้อ และเราก็ใช้หัวข้อย่อยหมดแล้ว)</em></sub></p>
 
 ---
 
-## ทำไมคนถึงเปิดมันทิ้งไว้ทั้งวัน
+## หน้าต่างเดียว ทุกการเชื่อมต่อ
 
-### Windows-first โดยตั้งใจ
-
-มองดูแนวโน้ม dev tooling ปี 2026 สักครั้ง Claude Code: ออก mac/linux ก่อน Windows คือ "ใช้ WSL ไป" Codex CLI: เหมือนกัน `gemini-cli`, ครึ่งหนึ่งของ Homebrew, TUI ใหม่ ๆ ทุกตัว: mac/linux ก่อน ผู้ใช้ Windows ได้ comment `# Windows: contributions welcome` ใน README กับ fish-completion script ที่รันไม่ได้
-
-ในขณะเดียวกัน คนที่ทำให้บริษัทออนไลน์อยู่ได้จริง ๆ — IT องค์กร, MSP, ใครก็ตามที่รัน Hyper-V หรือ AD หรือ SCCM หรือ IIS หรือ domain controller ที่เก่ากว่า intern บางคน — ยังนั่งอยู่หน้า Windows box และสงสัยว่าทำไมเครื่องมือใหม่ทุกตัวทำเหมือน OS ของพวกเขาเป็นความไม่สะดวก
-
-**KKTerm คือด้านตรงข้าม** เราสร้าง native Windows ก่อน แล้ว macOS / Linux ก็ตามมา นั่นหมายความว่าเราได้ใช้ Windows API ที่สำคัญจริง ๆ แทนที่จะทาทับด้วย portability layer:
-
-- **ConPTY** สำหรับ local shell — pseudo-console Windows จริง ๆ ไม่ใช่ translation shim PowerShell, `cmd.exe`, WSL distro, ทั้งหมดรันเป็น PTY จริงพร้อม focus, resize, และ VT sequence handling ที่ตรงกับพฤติกรรมของ platform
-- **WebView2** สำหรับ UI ทั้งหมดและ **Connection** URL แบบ embedded — Chromium in-process ที่ใช้ system runtime ซึ่งเป็นหนึ่งในเหตุผลที่ installer เล็กและเปิดเร็ว
-- **Microsoft RDP ActiveX (`mstscax.dll`)** สำหรับ RDP — *ตัวที่ Microsoft ส่งมาจริง ๆ* ตัวควบคุมเดียวกับ Remote Desktop Connection (`mstsc.exe`) ไม่ใช่ reimplementation จากบุคคลที่สาม ไม่ใช่ FreeRDP ห่อด้วยอะไรสักอย่าง คนใช้ RDP จะรู้สึกได้ภายในห้าวินาที
-- **Windows Credential Manager** สำหรับทุก secret SSH password, FTP password, API key, URL Connection credential — อยู่ใน OS keychain และ `credwiz.exe` สามารถ audit ได้
-- **NSIS current-user installer** พร้อม SHA-256 คู่กัน, native tray menu, Don't-Sleep power assertion, host CPU/RAM/network sampling, native Tauri context menu พร้อมไอคอน PNG จริง, native Open/Save dialog ไม่มีตัวไหนที่ mock
-- **WSL เป็น shell ชั้นหนึ่ง ไม่ใช่ workaround** เปิด Ubuntu ข้าง PowerShell pane ข้าง SSH session ข้าง RDP **Tab** ในหน้าต่างเดียวกัน
-
-บิลด์ macOS และ Linux อยู่ใน roadmap และจะได้รับการดูแลเหมือนกัน แต่ถ้าคุณรอใครมาสร้าง Windows admin tool ที่ดีก่อนแทนที่จะหลัง — นั่นคือข้อตกลง
-
-### Local-first แปลว่า local จริง ๆ
-
-**Connection** ที่บันทึกไว้อยู่ใน SQLite file บนเครื่องของคุณ Password อยู่ใน **Windows Credential Manager** ไม่ใช่ใน JSON ข้าง binary แอปไม่ส่ง analytics ไม่โทรหาบ้านตอน startup และไม่ต้องการ cloud account เพื่อเปิด ไม่มี "sign in to sync" เพราะไม่มี sync
-
-ถ้าสาย LAN ของคุณไฟไหม้ KKTerm ก็ยังเปิดได้
-
-### Workspace เดียว ทุก connection type
-
-| คุณอยากจะ… | KKTerm มี |
+| คุณอยากจะ… | KKTerm ทำได้ |
 | --- | --- |
-| เปิด local PowerShell / cmd / WSL shell | Local terminal **Session** พร้อม ConPTY |
-| SSH เข้า server | Native `russh` พร้อม agent / key / password auth, host-key trust flow, ProxyJump, port forwarding |
-| Browse file บน server นั้น | SFTP เปิดจาก SSH **Connection**, dual-pane, recursive transfer, chmod/chown |
-| FTP เข้า NAS จากปี 2012 | FTP / FTPS **Connection** ในรูปแบบ browser เหมือน SFTP |
-| Telnet เข้าอุปกรณ์โบราณ | ใช่แล้ว Telnet อยู่ในนั้นด้วย |
-| คุยกับ serial port | Serial **Connection** แบบ COM port + baud ไม่ต้องลง tool เพิ่ม |
-| Remote เข้า Windows box | Native RDP ผ่าน Microsoft ActiveX control (ของจริง ไม่ใช่ clone) |
-| VNC เข้า Pi | Rust `vnc-rs` framebuffer render ตรงเข้า workspace |
-| เปิด web UI ของ router | Embedded WebView2 **URL Connection** พร้อม credential fill |
-| ดู CPU บน host | Status bar แบบ live + **Dashboard** module พร้อม widget drag/resize |
+| เปิดเชลล์ในเครื่อง PowerShell / cmd / WSL | เทอร์มินัลในเครื่อง วางเรียงข้างกัน |
+| SSH เข้าเซิร์ฟเวอร์ | SSH พร้อมคีย์ agent รหัสผ่าน jump host และ port forwarding |
+| เรียกดูไฟล์บนเซิร์ฟเวอร์นั้น | SFTP จากการเชื่อมต่อ SSH — สองแผง ลากเพื่อถ่ายโอน |
+| FTP ไปยัง NAS จากปี 2012 | FTP / FTPS ในเบราว์เซอร์ไฟล์เดียวกัน |
+| Telnet ไปยังอุปกรณ์โบราณ | ใช่ Telnet ก็มีอยู่ในนั้น |
+| คุยกับพอร์ตอนุกรม | การเชื่อมต่อ Serial — เลือกพอร์ต COM และ baud |
+| รีโมตเข้าเครื่อง Windows | Microsoft Remote Desktop ของจริง ฝังมาในตัว |
+| VNC เข้า Pi | VNC เรนเดอร์ลงในพื้นที่ทำงานโดยตรง |
+| เปิดหน้าเว็บแอดมินของเราเตอร์ | แท็บเบราว์เซอร์ฝังในตัว พร้อมล็อกอินที่บันทึกไว้ |
+| ดู CPU ของโฮสต์ | แถบสถานะแบบเรียลไทม์ และแดชบอร์ดที่คุณต่อยอดได้เอง |
 
-ทั้งหมดคือแอปเดียวกัน หน้าต่างเดียวกัน hotkey เดียวกัน theme เดียวกันที่หวังว่าจะไม่ทำให้ตาพัง
+แอปเดียวกัน หน้าต่างเดียวกัน คีย์ลัดเดียวกัน ธีมเดียวกัน ที่หวังว่าจะไม่ทำเอาตาเลือดตก
 
-### Terminal ที่ไม่เสียสติ
+---
 
-- แบ่ง pane ใน **Tab** ได้
-- xterm.js rendering เร่งด้วย WebGL ถ้าทำไม่ได้ก็ fallback อย่างสง่างาม
-- ค้นหาใน scrollback
-- SSH pane พร้อม tmux ที่ attach เข้า session ต่อ pane แบบ stable ได้ ให้การ reconnect หมายถึง *การกลับมาต่อจริง ๆ* ไม่ใช่ "เริ่มใหม่และแกล้งทำเป็นว่าชั่วโมงที่แล้วไม่เคยเกิดขึ้น"
-- การสลับ **Tab** **ไม่** kill **Session** การปิด **Tab** ถึงจะ kill ความแตกต่างนี้เคยเป็นสงครามศาสนาภายใน เราชนะ
+## ทำไมคนถึงเปิดมันค้างไว้ทั้งวัน
 
-### AI Assistant ที่สร้างเครื่องมือของคุณ
+### Windows มาก่อน อย่างตั้งใจ
 
-Demo "AI ใน terminal" ส่วนใหญ่หยุดอยู่ที่ chat แต่ assistant ของ KKTerm ยังสร้าง widget dashboard เล็ก ๆ ที่คงอยู่และเข้ากับวิธีทำงานจริงของคุณได้ด้วย ส่วนที่อันตรายยังถูกคุมไว้หลังสวิตช์สองตัว:
+มองไปรอบ ๆ ในแวดวงเครื่องมือ dev กันดู Claude Code: mac/linux ก่อน Windows คือ "ใช้ WSL สิ" Codex CLI: เหมือนกัน เครื่องมือใหม่เป็นมันวาวครึ่งหนึ่งออกเวอร์ชัน mac ก่อน แล้วทิ้งคอมเมนต์ `# contributions welcome` กับสคริปต์เติมคำอัตโนมัติที่รันไม่ได้ไว้ให้ผู้ใช้ Windows
 
-- **Tool family** (Dashboard / Connections / Live Sessions) — toggle เปิด/ปิดแต่ละหมวด
-- **Permission mode** ใน composer — `Prompt` (ค่าเริ่มต้น ถามทุกครั้ง) หรือ `Allow All` (คุณเป็นผู้ใหญ่ คุณเซ็น waiver แล้ว)
+ในขณะเดียวกัน คนที่ทำให้บริษัทออนไลน์อยู่ได้จริง ๆ — IT องค์กร, MSP, ใครก็ตามที่ดูแล domain controller ที่แก่กว่าเด็กฝึกงานบางคน — กำลังนั่งอยู่หน้าเครื่อง Windows สงสัยว่าทำไมเครื่องมือใหม่ทุกตัวถึงปฏิบัติต่อ OS ของพวกเขาเหมือนเป็นเรื่องน่ารำคาญ
 
-คุยกับ OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA, หรืออะไรก็ตามที่ compatible กับ OpenAI API key ไปอยู่ใน OS keychain Model ที่เสนอ `rm -rf` จะถูกจัดว่าอันตรายและต้องการการอนุมัติจากมนุษย์อย่างชัดเจน AI ไม่สามารถรัน command ที่ทำลายข้อมูลแบบเงียบ ๆ ได้เพราะใครบางคนฉลาดแกมโกงด้วย prompt injection ใน man page
+**KKTerm เลือกข้อตกลงที่ตรงกันข้าม** เราสร้างเนทีฟ Windows ก่อน ดังนั้นสิ่งที่คนใช้ Windows ใส่ใจจึงทำงานได้เลย: Microsoft Remote Desktop *ของจริง* (ตัวเดียวกับ `mstsc.exe` ไม่ใช่ของเลียนแบบ), เชลล์ PowerShell / cmd / WSL ของจริง, ความลับที่เก็บใน Windows Credential Manager, ไอคอนถาดระบบที่ใช้ได้จริง, เมนูและไดอะล็อกเนทีฟ เวอร์ชัน macOS และ Linux อยู่ในโรดแมปและจะได้รับความใส่ใจเท่า ๆ กัน แต่ถ้าคุณรอให้ใครสักคนสร้างเครื่องมือแอดมิน Windows *ที่ดี* เป็นอันดับแรกแทนที่จะเป็นอันดับสุดท้าย — นี่แหละข้อตกลงนั้น
 
-### Dashboard ที่ไม่แกล้งทำเป็น Grafana
+### โลคัลมาก่อน หมายถึงโลคัลจริง ๆ
 
-**Dashboard** module คือ grid 12-column แบบ drag/resize ของ widget instance ไม่ได้ใช้สำหรับ observability ระดับ petabyte — มันสำหรับ "ฉันอยากมีปุ่ม launch แอปโปรดห้าตัวและ panel แสดง uptime ของ SSH host *ข้าง ๆ* แชทของฉัน"
+การเชื่อมต่อที่คุณบันทึกไว้อยู่ในไฟล์บนเครื่องของคุณ รหัสผ่านอยู่ใน Windows Credential Manager ไม่ใช่ไฟล์ข้อความข้าง ๆ แอป KKTerm ไม่ส่ง analytics ไม่โทรกลับบ้านตอนเปิด และไม่ต้องใช้บัญชีคลาวด์เพื่อเริ่มทำงาน ไม่มี "ลงชื่อเข้าใช้เพื่อซิงค์" เพราะไม่มีการซิงค์
 
-#### Widget ที่ AI สร้าง — บอกมา แล้วได้รับ
+ถ้าสายแลนของคุณไฟลุก KKTerm ก็ยังเปิดได้อยู่ดี
 
-นี่คือส่วนที่เราตื่นเต้นจริง ๆ คุณไม่ต้องเลือกจาก marketplace และไม่ต้องเขียน JavaScript คุณ **บอก AI assistant ว่าต้องการอะไร** แล้วมันสร้าง widget ขึ้นบน dashboard ของคุณเลย:
+### เทอร์มินัลที่ไม่เสียสติ
 
-> *"เพิ่ม widget แสดง commit ล่าสุด 5 รายการบน repo หลักของฉันเป็นรายการ"*
-> *"สร้าง sticky-note widget ที่เก็บ cheat sheet on-call ของฉัน"*
-> *"สร้าง widget ping home router ทุก 30 วินาทีและแสดงสีเขียว/แดง"*
-> *"ฉันต้องการ stopwatch ตกแต่งสไตล์ตามใจเลย"*
+- แบ่งแผงภายใน Tab
+- เรนเดอร์เร็วและลื่น พร้อม scrollback ที่ค้นหาได้
+- เชื่อมต่อใหม่หมายถึง *เชื่อมต่อใหม่* จริง ๆ — เซสชันรีโมตของคุณทำต่อจากที่ค้างไว้ ไม่ใช่ "เริ่มใหม่หมดและทำเป็นว่าชั่วโมงที่ผ่านมาไม่เคยเกิดขึ้น"
+- การสลับ Tab **ไม่** ฆ่า Session การปิด Tab ต่างหากที่ฆ่า ความแตกต่างนี้เคยเป็นสงครามศาสนาภายในทีม เราชนะ
 
-สองรูปแบบ:
+### ผู้ช่วย AI ที่สร้างเครื่องมือให้คุณ
 
-- **Content widget** — declarative JSON: markdown, kv list, checklist, stat ตัวใหญ่หนึ่งตัว ปลอดภัยโดยการออกแบบ ไม่มี script คำขอส่วนใหญ่แบบ "ฉันแค่อยากมีมันบน dashboard" ลงเอยที่นี่
-- **Script widget** — JavaScript ที่รันใน `iframe srcdoc` sandbox แบบ isolated พร้อม permission ที่ประกาศไว้อย่างชัดเจน (`network` allowlist, `pollSeconds` budget) AI เขียน script คุณอนุมัติ permission widget รันใน box ที่ไม่สามารถเข้าถึงส่วนอื่นของแอปได้
+เดโม "AI ในเทอร์มินัล" ส่วนใหญ่หยุดอยู่แค่แชต ผู้ช่วยของ KKTerm ยังสร้าง widget แดชบอร์ดเล็ก ๆ ที่อยู่ทนได้ ออกแบบมาตามวิธีที่คุณทำงานจริง — และเก็บของอันตรายไว้หลังสวิตช์:
 
-Widget ทุกตัวที่คุณเก็บไว้เป็นของคุณ มันอยู่ใน SQLite ข้าง **Connection** พร้อม visual preset ของตัวเอง (`panel` / `ambient` / `hero`), accent color, icon, และ title หลาย instance ของ widget เดียวกันสามารถอยู่ร่วมกันได้พร้อมขนาดและสไตล์ที่ต่างกันสิ้นเชิง ลบด้วย right-click เมื่อความมหัศจรรย์หมดอายุ
+- **เลือกว่ามันแตะอะไรได้บ้าง** — เปิดหรือปิดทั้งกลุ่มเครื่องมือ (Dashboard / Connections / Live Sessions)
+- **เลือกว่ามันถามยังไง** — `Prompt` (ค่าเริ่มต้น ถามทุกครั้ง) หรือ `Allow All` (คุณเป็นผู้ใหญ่แล้ว คุณเซ็นใบยินยอมแล้ว)
 
-#### Animated dashboard background (เพราะเราอยากทำ)
+อะไรก็ตามที่หน้าตาเหมือน `rm -rf` จะถูกทำเครื่องหมายว่าอันตรายและรอคำว่าใช่จากมนุษย์อย่างชัดเจน AI ไม่สามารถแอบรันคำสั่งทำลายล้างได้ เพียงเพราะมีใครเล่นแสบฝัง prompt injection ไว้ในหน้า man
 
-Dashboard มี 21 canvas-animated background ให้เลือกต่อ **Dashboard View**:
+มันคุยกับ OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA หรือ endpoint ใด ๆ ที่เข้ากันได้กับ OpenAI คีย์ API ของคุณไปอยู่ใน keychain ของ OS
 
-| อารมณ์ | Background |
+### แดชบอร์ดที่ไม่เสแสร้งว่าเป็น Grafana
+
+Dashboard คือกริดของ widget ที่ลากและปรับขนาดได้ มันไม่ได้มีไว้สำหรับ observability ระดับเพตะไบต์ — มันมีไว้สำหรับ "ฉันอยากได้ปุ่มเปิดแอปโปรด 5 ตัว และแผงแสดง uptime ของโฮสต์ SSH ของฉัน *ข้าง ๆ* แชตของฉัน"
+
+#### Widget ที่ AI สร้าง — บอกมา แล้วได้เลย
+
+นี่คือส่วนที่เราตื่นเต้นจริง ๆ คุณไม่ได้เลือกจากมาร์เก็ตเพลส และไม่ต้องเขียน JavaScript คุณแค่ **บอกผู้ช่วย AI ว่าคุณต้องการอะไร** แล้วมันก็สร้าง widget ตรงนั้นเลย บนแดชบอร์ดของคุณ:
+
+> *"เพิ่ม widget ที่แสดง 5 commit ล่าสุดของ repo หลักของฉันเป็นรายการ"*
+> *"ทำ widget โพสต์อิตให้ฉันเก็บโพยเวรอยู่เวรหน่อย"*
+> *"สร้าง widget ที่ ping เราเตอร์บ้านฉันทุก 30 วินาทีและแสดงเขียว/แดง"*
+> *"ฉันอยากได้นาฬิกาจับเวลา สไตล์ตามใจเลย เซอร์ไพรส์ฉันที"*
+
+บางอันเป็นแผงแสดงผลธรรมดา (markdown, เช็กลิสต์, ตัวเลขใหญ่ ๆ ตัวเดียว); บางอันรันโค้ดสด ๆ ในแซนด์บ็อกซ์แยกที่คุณอนุมัติ ทุก widget ที่คุณเก็บไว้เป็นของคุณ — มันถูกบันทึกพร้อมสี ไอคอน และชื่อของมันเอง และคุณมีหลายชุดขนาดต่างกันได้ ลบทิ้งด้วยคลิกขวาเมื่อความวิเศษจางหาย
+
+#### พื้นหลังเคลื่อนไหวของแดชบอร์ด (เพราะเราอยากทำ)
+
+เลือกอารมณ์ต่อมุมมองแดชบอร์ดจากพื้นหลังเคลื่อนไหวบน canvas **ยี่สิบห้าแบบ**:
+
+| อารมณ์ | พื้นหลัง |
 | --- | --- |
-| เงียบสงบ | `aurora`, `clouds`, `ocean`, `raindrops`, `snow`, `sakura`, `fireflies`, `bubbles`, `ricefield`, `lanterns` |
+| สงบ | `aurora`, `clouds`, `ocean`, `raindrops`, `rainywindow`, `frostedWindow`, `snow`, `sakura`, `fireflies`, `bubbles`, `aquarium`, `ricefield`, `lanterns` |
 | อวกาศ | `starfield`, `nebula` |
 | อบอุ่น | `embers`, `lava` |
-| geek | `matrix`, `topo`, `synthwave` |
-| คาดเดาไม่ได้ | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti` |
+| กี๊ก | `matrix`, `topo`, `synthwave` |
+| ปั่นป่วน | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti`, `particleCursor` |
 
-รันบน `requestAnimationFrame` ร่วมกันตัวเดียวและเคารพ window focus ดังนั้นแทบไม่กินทรัพยากรเมื่อคุณไปทำอย่างอื่น จับคู่ `matrix` กับ AI assistant เพื่อ vibe ที่บอกว่า "ฉัน productive มากและอาจจะอยู่ในหนัง Wachowski ด้วย" หรือเลือก `ocean` แล้วดูเป็นคนจริงจัง เราไม่ตัดสินทั้งสองตัวเลือก
+มันหยุดชั่วคราวเมื่อคุณไปอยู่ที่อื่น จึงแทบไม่กินทรัพยากร จับคู่ `matrix` กับผู้ช่วย AI ของคุณ เพื่ออารมณ์ที่บอกว่า "ฉันโปรดักทีฟสุด ๆ และอาจจะอยู่ในหนังของพี่น้อง Wachowski" หรือเลือก `ocean` แล้วดูเป็นคนจริงจัง เราไม่ตัดสินทั้งสองทางเลือก
 
-### รัน AI coding agent บน server อย่างถูกต้อง
+### ทำให้เอเจนต์ AI รีโมตของคุณยังมีชีวิต
 
-นี่คือ feature ที่สองที่คนตกหลุมรัก SSH terminal ของ KKTerm สามารถ launch ตรงเข้า **named tmux session** บน remote host ได้ — โดยค่าเริ่มต้นคือ id ที่สร้างอัตโนมัติแบบ friendly เช่น `kkterm-cockpit001` ที่รอดจากการ reconnect:
+นี่คือฟีเจอร์ที่สองที่คนตกหลุมรัก เทอร์มินัล SSH ของ KKTerm สามารถส่งคุณเข้าไปใน **เซสชัน tmux ที่ตั้งชื่อไว้** บนโฮสต์รีโมตได้โดยตรง ซึ่งรอดจากการเชื่อมต่อใหม่:
 
-- เปิด SSH **Connection** พร้อม tmux ที่เปิดใช้งาน
-- ใน pane เริ่ม `claude`, `codex`, `gemini-cli`, `cursor-agent`, หรือ coding agent ที่รันนานที่คุณชอบ พวกมันเป็นแอป TUI full-screen; tmux คือที่ที่พวกมันอยากอยู่
-- ปิดแล็ปท็อป เปิดใหม่ Pane จะ re-attach เข้า tmux session เดิมอย่างเงียบ ๆ Agent ยังรันอยู่ ยังมี scrollback อยู่ ยังทำอะไรอยู่ตรงกลางนั้น
-- Wi-Fi กระพริบบน SSH transport? KKTerm พยายาม reattach เงียบ ๆ แบบ bounded เข้า tmux id เดิมโดยไม่รบกวนคุณ
-- อยากให้ AI assistant เห็นว่า agent ทำอะไรอยู่? "Add terminal buffer to context" เรียก `capture_tmux_pane` ผ่าน SSH และดึง tmux scrollback ทั้งหมด — ไม่ใช่แค่ที่แสดงบนหน้าจอ แต่ session ทั้งหมด — เข้าสู่การสนทนา Local assistant ของคุณตอนนี้สามารถวิเคราะห์งานของ remote agent ได้แล้ว
+- เปิดการเชื่อมต่อ SSH ที่เปิด tmux แล้วเริ่ม `claude`, `codex`, `gemini-cli`, `cursor-agent` หรือเอเจนต์ที่รันยาว ๆ ตัวไหนก็ได้ที่คุณชอบ
+- ปิดฝาแล็ปท็อป เปิดอีกครั้ง แผงจะกลับไปเชื่อมต่อใหม่อย่างเงียบ ๆ — เอเจนต์ยังรันอยู่ ยังมี scrollback อยู่ ยังอยู่กลางคันของสิ่งที่มันทำ
+- เน็ตกระตุก? KKTerm เชื่อมต่อกลับเข้าเซสชันเดิมอย่างเงียบ ๆ โดยไม่รบกวนคุณ
+- อยากให้ผู้ช่วยช่วยไหม? "เพิ่ม terminal buffer เข้า context" จะดึงเซสชันรีโมตทั้งหมดเข้ามาในบทสนทนา เพื่อให้ AI ในเครื่องของคุณเข้าใจว่าเอเจนต์รีโมตกำลังทำอะไรอยู่
 
-ถ้าคุณเคยสูญเสีย `claude` หรือ `codex` session หกชั่วโมงเพราะ Wi-Fi โรงแรมห่วย feature เดียวนี้คุ้มค่าแอปแล้ว แอปฟรีอยู่แล้ว feature นั้นก็ยังคุ้มค่า
+ถ้าคุณเคยเสียเซสชัน `claude` หรือ `codex` ที่รันมาหกชั่วโมงให้กับ Wi-Fi โรงแรมที่ไม่นิ่ง ฟีเจอร์เดียวนี้ก็คุ้มค่าแอปแล้ว (แอปฟรี แต่ฟีเจอร์นี้ก็ยังคุ้มอยู่ดี)
 
-### รู้ว่าคุณยังมี AI เหลือเท่าไหร่
+### รู้ว่าเหลือ AI อีกเท่าไหร่
 
-Coding agent คิดเงินตามหน้าต่างของแผน ไม่ใช่ตามเดือน Claude Code มีหน้าต่าง 5 ชั่วโมงและหน้าต่างรายสัปดาห์ Codex ก็มีเวอร์ชันของตัวเอง ทั้งสองสามารถเขมือบโควต้าของคุณใน background อย่างมีความสุขขณะที่คุณกำลังประชุม
+เอเจนต์เขียนโค้ดคิดเงินตามหน้าต่างแพ็กเกจ ไม่ใช่รายเดือน และมันยินดีจะกินโควต้าของคุณขณะที่คุณอยู่ในที่ประชุม **มาตรวัดการใช้ AI** ทำให้เรื่องนั้นมองเห็นได้ตลอด:
 
-Widget **การใช้งาน AI Coding** ทำให้สิ่งนั้นมองเห็นได้:
+- widget แดชบอร์ดที่แสดง **Claude Code** และ **Codex** เคียงข้างกัน: บัญชีที่เชื่อมต่อ แพ็กเกจ ปริมาณที่ใช้ในหน้าต่างปัจจุบันและสัปดาห์นี้ และเวลารีเซ็ตครั้งถัดไป
+- **ตัวบ่งชี้บนแถบสถานะ** แบบกะทัดรัดที่สะท้อนตัวเลขชุดเดียวกัน เพื่อให้แม้ปิดแดชบอร์ดไว้ คุณก็ดูปราดเดียวรู้ว่ายังมีพื้นที่เหลือก่อนรีแฟกเตอร์ครั้งใหญ่ถัดไปหรือไม่
+- มันบอกคุณล่วงหน้าว่าต้องล็อกอินใหม่หรือเปล่า — *ก่อน* งานยาว ไม่ใช่ตอนกลางคัน
 
-- Widget Dashboard ที่แสดง **Claude Code** และ **Codex** เคียงข้างกัน: บัญชีที่เชื่อมต่อ, ระดับแผน, เปอร์เซ็นต์ที่ใช้ในหน้าต่าง 5 ชั่วโมงปัจจุบัน, เปอร์เซ็นต์ที่ใช้ในสัปดาห์นี้, เวลา reset ครั้งถัดไป
-- **ตัวบ่งชี้แถบสถานะกะทัดรัด** ที่สะท้อนตัวเลขเดียวกัน เพื่อให้แม้ Dashboard ปิดอยู่คุณก็ดูได้ปราดเดียวว่ายังมีพื้นที่ก่อนจะเริ่ม refactor ครั้งใหญ่ถัดไปหรือไม่
-- สถานะ auth แสดงตรง ๆ (`connected` / `expired` / `error`) เพื่อให้คุณรู้ *ก่อน* งานยาวว่าต้อง re-login ไม่ใช่ตอนกลาง ๆ
-- นโยบาย refresh เคารพ rate limit; widget poll ในจังหวะของตัวเองแทนที่จะค้อน API upstream ทุกครั้งที่คุณมอง
+### ให้ AI ตัวอื่นขับ KKTerm
 
-### MCP server แบบ built-in — ให้ AI อื่นขับ KKTerm
+KKTerm มาพร้อมเซิร์ฟเวอร์ MCP ของตัวเอง เพื่อให้เอเจนต์เขียนโค้ดภายนอก (Claude Code, Codex, Copilot, Antigravity, OpenCode) ใช้พื้นที่ทำงานของคุณได้เหมือนที่คุณใช้ — แสดงรายการการเชื่อมต่อ เปิดอันหนึ่ง อ่าน terminal buffer วาง widget บนแดชบอร์ด AI ต่อ AI บนเครื่องของคุณ ไม่มีรีเลย์คลาวด์ การกระทำที่แก้ไขข้อมูลและเสี่ยงกว่าจะอยู่หลังสวิตช์ความปลอดภัยตัวเดียวที่ **ปิด** ไว้เป็นค่าเริ่มต้น
 
-terminal ของคุณก็เป็นที่ที่ Claude Code, Codex, Copilot agent mode, Antigravity และโลกที่พูด MCP ที่เหลืออยากทำงานเหมือนกัน ดังนั้น KKTerm จึงส่ง **stdio MCP server** ของตัวเอง [`kkterm-cli`](docs/MCP.md) ที่เปิดเผยส่วนที่คัดสรรของแอป:
-
-- **Module Workspace** (`kkterm.workspace.*`): list **Connection** ที่บันทึก, เปิด Connection ตาม id, list **Session** ที่ยังอยู่, ส่ง input ไปยัง terminal pane, อ่าน snapshot ของ buffer
-- **Module Dashboard** (`kkterm.dashboard.*`): โหลด state ของ Dashboard, อ่าน source ของ AI-Created Widget, สร้าง / อัปเดต / ลบ view, วาง / ย้าย / ลบ instance ของ widget, apply layout เป็นชุด
-- **sub-namespace อันตราย** (`kkterm.<module>.dangerous.*`): การ mutate surface ที่ executable — สร้าง widget script, คลิกใน remote desktop, wipe Dashboard — ถูก gate ด้วย setting เดียว (`built_in_mcp_allow_all_dangerous`) ค่าเริ่มต้น **ปิด**
-
-`kkterm-cli` เป็น forwarder ที่บาง พูด stdio JSON-RPC กับ MCP client ของคุณและสื่อสารกับหน้าต่าง KKTerm ที่กำลังรันผ่าน Windows named pipe ที่ authenticate ต่อการเปิดแอป เมื่อ KKTerm ปิด `tools/list` ยังทำงานอยู่ (client introspect surface ได้) แต่ `tools/call` คืน error แบบมีโครงสร้าง `app_not_running` แทนที่จะทำอะไร
-
-เสียบเข้ากับ client ที่ชอบและ AI ของคุณก็ใช้ KKTerm ได้เหมือนคุณแล้ว:
-
-```json
-{
-  "mcpServers": {
-    "kkterm": { "command": "<path-ไปยัง-kkterm-cli>", "args": [] }
-  }
-}
-```
-
-Settings → AI Assistant → **Built-in MCP Server** มี dialog "Show config" แบบคลิกเดียวพร้อม snippet JSON และ TOML ที่ pre-fill path ของ binary ที่ resolve แล้ว บวกกับคำสั่ง `claude mcp add` / `codex mcp add` ที่คัดลอกได้
+ตั้งค่า → AI Assistant → **Built-in MCP Server** มีไดอะล็อก "แสดงคอนฟิก" คลิกเดียว กรอกไว้ให้พร้อม พร้อมคำสั่ง `claude mcp add` / `codex mcp add` ที่คัดลอกได้
 
 ---
 
-## มันทำงานร่วมกันอย่างไร
-
-```mermaid
-flowchart LR
-    User([You]) --> Shell[KKTerm Window<br/>Tauri v2 + React 19]
-    Shell --> Rail[Activity Rail]
-    Rail --> WS[Workspace Module]
-    Rail --> Dash[Dashboard Module]
-    Rail --> Inst[Installer Helper Module]
-    Rail -.-> FE[File Explorer<br/>planned]
-    Rail --> Set[Settings]
-
-    WS --> Tabs[Tabs &amp; Panes]
-    Tabs --> Term[Terminal<br/>ConPTY / russh]
-    Tabs --> SFTP[SFTP / FTP]
-    Tabs --> Web[WebView2 URL]
-    Tabs --> RD[RDP / VNC]
-
-    Shell -.calls.-> Rust[Rust Backend]
-    Rust --> SQLite[(SQLite<br/>Connections)]
-    Rust --> Keychain[(OS Keychain<br/>Secrets)]
-    Rust --> AI[AI Providers<br/>OpenAI-compat]
-
-    AI -. approval gate .-> Tabs
-
-    classDef local fill:#1f6feb,stroke:#1f6feb,color:#fff
-    classDef ai fill:#8a63d2,stroke:#8a63d2,color:#fff
-    class SQLite,Keychain local
-    class AI ai
-```
-
-รูปแบบที่สำคัญ: ข้อมูลที่บันทึกถาวร (**Connection**) แยกจาก live runtime state (**Session**) ซึ่งแยกจาก UI container (**Tab**) การปิด **Tab** จบ **Session** การสลับ **Tab** ไม่จบ นี่คือกฎที่ทำให้แอปไม่เสียสติ
-
----
-
-## แผนที่ Feature ปัจจุบัน
-
-| หมวด | ที่ implement แล้ววันนี้ |
-| --- | --- |
-| **Connections** | tree ที่พึ่ง SQLite, folder/subfolder, ค้นหา, drag/drop order, เปลี่ยนชื่อ, duplicate, ลบ, **Quick Connect**, icon custom, rail shortcut แบบ pinned/active |
-| **Terminal** | Local shell, SSH, Telnet, Serial, split pane, xterm.js + WebGL แบบ opportunistic, scrollback search, local startup directory/script |
-| **SSH** | Native `russh`, agent/key/password auth, host-key trust flow, optional system SSH fallback, ProxyJump, port forwarding, **auto-named tmux session (`kkterm-<scifi-name><n>`) พร้อม silent reattach เมื่อ transport มีปัญหา** — เหมาะมากสำหรับ remote coding agent ที่รันนาน (Claude Code, Codex, gemini-cli, ฯลฯ) |
-| **SFTP / FTP** | SSH-launched SFTP พร้อม FTP/FTPS **Connection**, dual-pane browser, recursive transfer, queue/cancel/clear history, conflict, properties, chmod/chown ตามที่รองรับ |
-| **URL WebView** | Embedded WebView2 URL **Session**, navigation toolbar, favicon capture, website credential metadata/fill ที่บันทึกไว้, data partition metadata |
-| **Remote Desktop** | RDP ผ่าน Windows ActiveX พร้อม geometry-scoped overlay parking; VNC ผ่าน `vnc-rs` framebuffer render ใน workspace canvas |
-| **Dashboard** | Durable view, widget instance, edit mode, drag/resize, App Launcher, **AI-authored content/script widget** (declarative JSON หรือ sandboxed iframe JS พร้อม permission), per-widget preset / accent / icon / title, **23 animated canvas background** (aurora, clouds, ocean, raindrops, rainywindow, snow, sakura, fireflies, bubbles, ricefield, lanterns, starfield, nebula, embers, lava, matrix, topo, synthwave, cyberpunk, taipei101, thunderstorm, confetti, particleCursor) |
-| **AI Assistant** | Streaming chat, OpenAI-compatible runtime, provider registry, command proposal safety classification, screenshot/context attachment, **Dashboard widget authoring (content + sandboxed script)**, **tmux pane capture** เป็น conversation context สำหรับ remote session, **Connection** management tool, และ live **Session** tool สำหรับ terminal, RDP/VNC, และ SFTP/FTP |
-| **การใช้งาน AI Coding** | **Widget Dashboard + ตัวบ่งชี้แถบสถานะ** ที่ติดตามการใช้โควต้าของ **Claude Code** และ **Codex**: บัญชีที่เชื่อมต่อ, ระดับแผน, เปอร์เซ็นต์หน้าต่าง 5 ชั่วโมงและรายสัปดาห์, เวลา reset ครั้งถัดไป, สถานะ auth (`connected` / `expired` / `error`), นโยบาย refresh ที่ตระหนักถึง rate-limit |
-| **MCP Server แบบ Built-in** | stdio MCP server (`kkterm-cli`) ที่เปิดเผย tool Workspace และ Dashboard ที่คัดสรรให้ coding agent ภายนอก (Claude Code, Codex, Copilot, Antigravity, OpenCode); bridge named pipe ที่ authenticate; sub-namespace `dangerous.*` ต่อ Module ถูก gate ด้วย safety toggle เดียว; dialog ใน Settings พร้อม snippet JSON / TOML แบบคลิกเดียวและคำสั่ง `claude mcp add` / `codex mcp add` |
-| **Installer Helper** | Activity Rail Module สำหรับแคตตาล็อกเครื่องมือพัฒนา Windows ที่ bundle มากับแอป: ตรวจจับ tool ที่ติดตั้งแล้ว, เทียบเวอร์ชันล่าสุด, install/update/uninstall, pin tool ออกจาก Update all, stream command log และเปิด managed app ที่รองรับ |
-| **Settings** | General, Appearance, Credentials, AI, SSH, Terminal, พื้นหลังเทอร์มินัล, URL, RDP, VNC, Dashboard, Installer Helper, About; custom UI font; minimize-to-tray; Don't Sleep; backup/import |
-| **Localization** | i18next UI พร้อม English source และ dynamic locale bundle: zh-TW, zh-CN, ja, ko, fr, de, es, es-MX, it, pt-BR, th, id, vi |
-
-### AI Provider
-
-OpenAI · Anthropic · OpenRouter · DeepSeek · Grok · Azure OpenAI · LiteLLM · GitHub Copilot · Ollama · NVIDIA · ทุก OpenAI-compatible endpoint
-
-Provider metadata อยู่ใน [`src/ai/providerRegistry/`](src/ai/providerRegistry/); Rust adapter ใน [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/) API key ผ่าน OS keychain ไม่เคยผ่าน SQLite
-
----
-
-## เริ่มต้นเร็ว
-
-คุณต้องการ:
-
-- **Windows** (platform หลักที่รองรับ)
-- **Node.js + npm**
-- **Rust toolchain**
-- **Tauri v2 prerequisites for Windows** รวมถึง **WebView2**
-
-```bash
-npm install
-npm run tauri dev
-```
-
-ควรจะได้ native window จริง ๆ ถ้าได้ stack trace แทน กรุณา file an issue — เราชอบ repro ที่ดี
-
-### ตรวจสอบทั่วไป
-
-```bash
-npm run check                                              # TypeScript
-npm run build                                              # Vite build
-cargo check --manifest-path src-tauri/Cargo.toml           # Rust
-cargo test  --manifest-path src-tauri/Cargo.toml           # Rust tests
-```
-
-### Build Windows installer
-
-```bash
-npm run package:installer
-```
-
-Script installer เขียน `artifacts/kkterm-<version>-windows-x64-setup.exe` และไฟล์ `.sha256` คู่กัน ปัจจุบัน **ยังไม่ได้ sign** — release signing อยู่ใน roadmap แต่จนกว่านั้น antivirus ของคุณอาจจ้องมองอย่างเข้มงวด เรื่องปกติ
-
----
-
-## สิ่งที่ KKTerm ไม่ใช่
+## KKTerm ไม่ใช่อะไร
 
 รายการสั้น ๆ เพราะความซื่อสัตย์สร้างความไว้วางใจ:
 
-- **ไม่ใช่ cloud product** ไม่มี sync ไม่มี team account ไม่มี SaaS tier ถ้าคุณเห็น dialog "Sign in to KKTerm" บางอย่างเกิดขึ้นอย่างหายนะ
-- **ไม่ได้แกล้งทำเป็น cross-platform** เราเป็น Windows-first โดยตั้งใจ; macOS และ Linux อยู่ใน roadmap และจะใช้ Tauri v2 shell เดิม ถ้าคุณต้องการ mac-first tool วันนี้ คุณมีตัวเลือกหลายร้อยตัว เรากำลังสร้างตัวที่ Windows admin รอคอยอย่างเงียบ ๆ
-- **ไม่ใช่ autonomous AI agent** assistant เสนอ มนุษย์ตัดสินใจ `Allow All` คือตัวเลือกที่คุณทำ ไม่ใช่ค่าเริ่มต้น
-- **ไม่ใช่ตัวแทน Grafana / Datadog** Dashboard สำหรับ personal control surface ไม่ใช่ observability ระดับ 10k host
-- **ไม่ใช่ Kubernetes IDE** มันเป็น terminal-first admin workspace กรุณาอย่าขอให้มัน render Helm chart
+- **ไม่ใช่ผลิตภัณฑ์คลาวด์** ไม่มีซิงค์ ไม่มีบัญชีทีม ไม่มีแพ็กเกจ SaaS ถ้าวันไหนคุณเห็นไดอะล็อก "ลงชื่อเข้าใช้ KKTerm" แปลว่ามีบางอย่างผิดพลาดอย่างหายนะ
+- **ไม่เสแสร้งว่าเป็นข้ามแพลตฟอร์ม** เราเป็น Windows-first อย่างตั้งใจ; macOS และ Linux อยู่ในโรดแมป ถ้าคุณต้องการเครื่องมือ mac-first วันนี้ คุณมีตัวเลือกเป็นร้อย เรากำลังสร้างตัวที่แอดมิน Windows รออย่างเงียบ ๆ
+- **ไม่ใช่เอเจนต์ AI อัตโนมัติ** ผู้ช่วยเสนอ มนุษย์ตัดสิน `Allow All` เป็นทางเลือกที่คุณเลือกเอง ไม่ใช่ค่าเริ่มต้น
+- **ไม่ใช่ของทดแทน Grafana / Datadog** Dashboard มีไว้สำหรับหน้าควบคุมส่วนตัว ไม่ใช่ observability สำหรับโฮสต์หมื่นเครื่อง
+- **ไม่ใช่ Kubernetes IDE** มันคือพื้นที่ทำงานแอดมินที่เน้นเทอร์มินัล กรุณาอย่าขอให้มันเรนเดอร์ Helm chart
 
-ถ้าสิ่งใดสิ่งหนึ่งเหล่านั้น *เป็น* dealbreaker — โอเค เจอกันใน v2
-
----
-
-## Native Debugging
-
-ใช้ Tauri runtime จริงสำหรับการ validate:
-
-```bash
-npm run tauri dev
-```
-
-Vite browser preview มีประโยชน์สำหรับ frontend inspection บางส่วน แต่มัน **ไม่ได้** host WebView2 จริง, ConPTY, RDP ActiveX, VNC framebuffer, keychain, หรือ native menu surface ถ้า feature แตะสิ่งใดสิ่งหนึ่งเหล่านั้น validate ใน desktop runtime จริง
-
-VS Code users: launch config `Run KKTerm exe` เริ่ม `src-tauri/target/debug/kkterm.exe` พร้อม `RUST_BACKTRACE=1` config `Attach KKTerm WebView2` คู่กันให้ DevTools ใน WebView2 host จริง
+ถ้าข้อใดข้อหนึ่ง *เคย* เป็นจุดตัดสินใจ — ก็ยุติธรรมดี เจอกันใน v2
 
 ---
 
-## ข้อจำกัดปัจจุบัน (ใช่ เรารู้)
+## รับ KKTerm
 
-- Installer ยังไม่ได้ sign ปัจจุบัน Update check ปิดอยู่จนกว่าจะ configure release signing
-- SFTP over ProxyJump ยังไม่รองรับใน native SFTP path
-- File transfer resume, folder sync/diff, archive/extract, และ remote editing ถูก defer ออกไป
-- SSH config import implement แล้วแต่ยังไม่ expose user-facing entry ใน Settings
-- RDP และ VNC กำลัง ship; clipboard/device sync ที่ดีกว่าและ quality control ยังพัฒนาต่อ
-- macOS และ Linux build อยู่ใน roadmap กำลังมา และจะทำอย่างถูกต้อง — ไม่รีบออกมาเป็น port แบบ "เราก็ทำงานได้อยู่บ้างนะ"
-- AI assistant เสนอและสามารถใช้ tool ที่เปิดใช้งานตาม permission boundary ที่กำหนด — กรุณาอย่าปฏิบัติกับมันเหมือน robot ไร้คนดูแล มันไม่รู้จริง ๆ ว่า CEO ของคุณต้องการอะไร
+**[ดาวน์โหลดตัวติดตั้ง Windows ล่าสุด (.exe)](https://github.com/ryantsai/KKTerm/releases/latest)** แล้วรันมัน ตอนนี้ตัวติดตั้ง **ยังไม่ได้เซ็น** — การเซ็นรีลีสอยู่ในโรดแมป ดังนั้นจนกว่าจะถึงตอนนั้น แอนติไวรัสของคุณอาจมองคุณด้วยสายตาเข้มงวด นั่นเป็นเรื่องปกติ
+
+อยากบิลด์จากซอร์สหรือมีส่วนร่วม? ทุกอย่างที่คุณต้องการอยู่ใน [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 ---
 
-## Roadmap (เวอร์ชั่นสั้น)
+## โรดแมป (ฉบับสั้น)
 
-- macOS + Linux build
-- Signed installer + auto-update
-- SFTP over ProxyJump ใน native path
-- File transfer resume, folder sync, archive/extract
-- RDP clipboard/device redirection ที่ดีกว่า
-- **Dashboard** widget built-in เพิ่มเติม (และ public schema สำหรับ AI-authored)
+- บิลด์ macOS + Linux
+- ตัวติดตั้งที่เซ็นแล้ว + อัปเดตอัตโนมัติ
+- การถ่ายโอนไฟล์ที่ทรงพลังขึ้น (รับโอนต่อ, ซิงค์โฟลเดอร์, บีบอัด/แตกไฟล์)
+- การแชร์คลิปบอร์ดและอุปกรณ์ของ Remote Desktop ที่สมบูรณ์ขึ้น
+- widget แดชบอร์ดในตัวเพิ่มขึ้น
 
-เวอร์ชั่นเต็มและอัพเดตบ่อย: [`docs/ROADMAP.md`](docs/ROADMAP.md)
-
----
-
-## การมีส่วนร่วม
-
-เราอยากได้มือช่วย จริง ๆ แม้แต่เรื่องเล็กน้อยก็มีความหมาย:
-
-- **ลอง dev build** แล้ว file an issue เมื่อรู้สึกว่ามีอะไรผิด "รู้สึกแปลก" คือ bug report ที่ถูกต้อง เราจะขุดหาสาเหตุด้วยกัน
-- **แปล locale** English เป็น source of truth ที่ [`src/i18n/locales/en.json`](src/i18n/locales/en.json); locale อื่นอีก 12 ตัวอยู่ข้าง ๆ และโหลดตาม demand string ที่ยังค้างอยู่ติดตามต่อ key ใน [`docs/localization_todo/`](docs/localization_todo/) — เลือกตัว แปล ลบไฟล์
-- **เพิ่ม Dashboard widget** Built-in widget อยู่ใน [`src/modules/dashboard/widgets/builtin/`](src/modules/dashboard/widgets/builtin/) เลือก idea เล็ก ๆ ship มัน เรียนรู้ pattern
-- **ทำให้ AI tool surface แน่นขึ้น** Provider adapter อยู่ใน [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/); frontend registry อยู่ใน [`src/ai/providerRegistry/`](src/ai/providerRegistry/)
-- **ปรับปรุง manual** End-user doc อยู่ใน [`docs/manual/`](docs/manual/) หนึ่ง chapter ต่อ UI module ถ้าคุณใช้ feature แล้ว doc ไม่ช่วย PR ที่แก้ปัญหานั้นถือว่าทองคำ
-
-Setup เต็ม, project layout, PR checklist, และรายการ "กรุณาอย่าทำลายสิ่งเหล่านี้" อยู่ใน [`CONTRIBUTING.md`](CONTRIBUTING.md) highlight 30 วินาที:
-
-- **อ่าน [`CONTEXT.md`](CONTEXT.md) ก่อนเปลี่ยนชื่อ term ที่ user เห็น** **Connection**, **Session**, **Tab**, และ **Quick Connect** มีความหมายเฉพาะ กรุณาอย่าเบี่ยงเบน
-- **ทุก string ที่ user เห็นผ่าน `t()`** ไม่มี text ภาษาอังกฤษโล่ง ๆ ใน JSX
-- **ไม่มี frontend close hook** Tauri v2's title-bar close พังด้วย `onCloseRequested` pattern มาครึ่งโหลครั้งแล้ว ตอนนี้เรามี shape ที่ทำงานได้ กรุณาอย่า reintroduce
-- **รัน check** (`npm run check && npm run build && cargo check && cargo test`) ก่อนเปิด PR
-
-หา entry point? กรอง open issue ด้วย [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) หรือ [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) ถ้ายังไม่มีติด tag เปิด issue อธิบายว่าอยากทำอะไรแล้วเราจะช่วย scope
+ฉบับเต็มและอัปเดตบ่อย: [`docs/ROADMAP.md`](docs/ROADMAP.md)
 
 ---
 
-## เอกสาร Project
+## มีส่วนร่วม
 
-- [Product context](CONTEXT.md) — ภาษา domain ที่คุณควรใช้ให้ตรงกัน
-- [Architecture](docs/ARCHITECTURE.md) — module map, วางโค้ดใหม่ที่ไหน
-- [Roadmap](docs/ROADMAP.md)
-- [Dashboard architecture](docs/DASHBOARD.md)
-- [AI provider guide](docs/AI_PROVIDERS.md)
-- [Performance notes](docs/PERFORMANCE.md)
-- [Release notes and gates](docs/RELEASE.md)
+เรายินดีมากถ้ามีคนช่วย จริง ๆ แม้แต่เรื่องเล็ก ๆ ก็มีความหมาย:
 
----
+- **ลองบิลด์ dev** แล้วเปิด issue เมื่อมีอะไรรู้สึกแปลก ๆ "รู้สึกแปลก ๆ" เป็นรายงานบั๊กที่ถูกต้อง เราจะขุดไปกับคุณ
+- **แปลภาษา** ภาษาอังกฤษคือแหล่งความจริง มีอีกสิบสามภาษาอยู่ข้าง ๆ
+- **เพิ่ม widget แดชบอร์ด** หยิบไอเดียเล็ก ๆ ส่งมันออกมา เรียนรู้รูปแบบ
+- **ปรับปรุงคู่มือ** ถ้าคุณใช้ฟีเจอร์หนึ่งแล้วเอกสารช่วยไม่ได้ PR ที่แก้เรื่องนั้นมีค่าดั่งทอง
 
-## Stack
-
-Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand · xterm.js · SQLite · WebView2 · `russh` · `russh-sftp` · `vnc-rs` · `suppaftp` · OS keychain storage
+การตั้งค่าครบถ้วน โครงสร้างโปรเจกต์ และเช็กลิสต์ PR อยู่ใน [`CONTRIBUTING.md`](CONTRIBUTING.md) หาจุดเริ่มต้นอยู่หรือ? กรอง issue ที่เปิดอยู่ด้วย [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) หรือ [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
 
 ---
 
-## Star History
+## เอกสารโปรเจกต์
+
+- [บริบทผลิตภัณฑ์](CONTEXT.md) — ภาษาเฉพาะโดเมนที่คุณควรยึดตาม
+- [สถาปัตยกรรม](docs/ARCHITECTURE.md) — แผนที่โมดูล ที่ที่ควรวางโค้ดใหม่
+- [โรดแมป](docs/ROADMAP.md)
+- [สถาปัตยกรรม Dashboard](docs/DASHBOARD.md)
+- [คู่มือผู้ให้บริการ AI](docs/AI_PROVIDERS.md)
+
+---
+
+## ประวัติดาว
 
 <a href="https://www.star-history.com/#ryantsai/KKTerm&Date">
   <picture>
@@ -466,12 +303,12 @@ Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand ·
   </picture>
 </a>
 
-ถ้าคุณอ่านมาถึงตรงนี้แล้วยังไม่ได้กด star — รอเชิญส่วนตัวอยู่หรือไง? นี่คือเชิญส่วนตัวแล้ว
+ถ้าคุณมาถึงตรงนี้แล้วยังไม่ได้กดดาว — รออะไรอยู่ บัตรเชิญส่วนตัวหรือ? ถือว่านี่คือบัตรเชิญส่วนตัวนั้น
 
-⭐ **[Star KKTerm บน GitHub](https://github.com/ryantsai/KKTerm)** — ใช้แค่คลิกเดียวและทำให้ maintainer ดีใจทั้งสัปดาห์ คิดว่ามันเหมือนถุง乖乖ดิจิทัลบน rack
+⭐ **[กดดาวให้ KKTerm บน GitHub](https://github.com/ryantsai/KKTerm)** — แค่คลิกเดียว ทำให้ทั้งสัปดาห์ของผู้ดูแลสดใส คิดเสียว่าเป็น 乖乖 ดิจิทัลบนแร็ค
 
 ---
 
-## License
+## สัญญาอนุญาต
 
-MIT ดู [LICENSE](LICENSE) ใช้มัน, fork มัน, ship มัน, วางมันไว้ใน homelab ที่ไม่มีใครหาเจอ — นั่นคือข้อตกลง
+MIT ดู [LICENSE](LICENSE) ใช้มัน fork มัน ส่งมันออกไป เอามันไปไว้ในโฮมแล็บที่ไม่มีใครหาเจอ — นั่นแหละข้อตกลง

--- a/README.vi.md
+++ b/README.vi.md
@@ -5,19 +5,19 @@
 <h1 align="center">KKTerm</h1>
 
 <p align="center">
-  <strong>Không gian quản trị Windows native mà kỷ nguyên AI-tools đã quên xây — terminal, SSH, SFTP, RDP/VNC, dashboard, và một AI build các widget công cụ của riêng bạn.</strong>
+  <strong>Một cửa sổ Windows native duy nhất cho terminal, SSH, SFTP, RDP/VNC và một dashboard — cộng thêm một AI dựng cho bạn những công cụ nhỏ của riêng bạn theo yêu cầu.</strong>
 </p>
 
 <p align="center">
-  <em>Vì thanh taskbar của bạn không nên trông như máy đánh bạc ở Vegas.</em>
+  <em>Vì thanh tác vụ của bạn không nên trông như một cái máy đánh bạc ở Las Vegas.</em>
 </p>
 
 <p align="center">
-  <sub>Đặt tên theo <strong>乖乖 (Kuāi Kuāi)</strong>, gói snack bắp vị dừa màu xanh mà các sysadmin Đài Loan đặt lên máy chủ để cầu cho chúng "ngoan". Hy vọng app này cũng xứng đáng có một chỗ trên rack.</sub>
+  <sub>Đặt tên theo <strong>乖乖 (Kuāi Kuāi)</strong>, món snack bắp vị dừa màu xanh mà các sysadmin Đài Loan đặt lên server để chúng ngoan ngoãn. Mong rằng app này cũng giành được chỗ của nó trên rack.</sub>
 </p>
 
 <p align="center">
-  <strong><a href="https://github.com/ryantsai/KKTerm/releases/latest">Tải trình cài đặt Windows mới nhất (.exe)</a></strong>
+  <strong><a href="https://github.com/ryantsai/KKTerm/releases/latest">Tải bộ cài Windows mới nhất (.exe)</a></strong>
 </p>
 
 <p align="center">
@@ -38,9 +38,6 @@
   </a>
   <br />
   <img src="https://img.shields.io/badge/Windows%E2%80%91first-by%20design-0078D6?style=flat-square&logo=windows" alt="Windows-first by design" />
-  <img src="https://img.shields.io/badge/built%20with-Tauri%20v2-FFC131?style=flat-square&logo=tauri" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/Rust-russh-orange?style=flat-square&logo=rust" alt="Rust" />
-  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react" alt="React 19" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
   <br />
   <sub>
@@ -63,56 +60,58 @@
 
 ---
 
-## Pitch trong 45 giây
+## Lời chào trong 45 giây
 
-Bạn là sysadmin / DevOps / dân homelab / vibe-coder. Hiện tại bạn đang có:
+Bạn là sysadmin / DevOps / dân chơi homelab / vibe-coder. Ngay lúc này bạn có:
 
-- Một terminal emulator
-- Một SSH client riêng (với danh sách profile bạn phải dành nguyên một cuối tuần để dựng lên)
-- Một SFTP client từ năm 2007 mà không hiểu sao vẫn chạy
-- Remote Desktop nằm trong một cửa sổ bạn cứ lạc mất sang sai màn hình
-- Một VNC viewer chỉ để dùng cho đúng một con Linux nào đó
-- Một tab trình duyệt mở trang admin của router
-- Một phiên `claude` / `codex` đang chạy trên dev box từ xa, rớt mạng mỗi khi Wi-Fi của bạn hắt hơi
-- Một tờ giấy nhớ ghi mật khẩu *(yên tâm, chúng tôi không nói ra đâu)*
+- Một trình giả lập terminal
+- Một SSH client riêng (với danh sách profile mà bạn mất cả cuối tuần để dựng)
+- Một SFTP client từ 2007 mà chẳng hiểu sao vẫn còn sống
+- Remote Desktop trong một cửa sổ mà bạn cứ lạc mất ở sai màn hình
+- Một trình xem VNC chỉ vì đúng một cái máy Linux đó
+- Một tab trình duyệt cho trang quản trị của router
+- Một phiên `claude` / `codex` trên máy từ xa, rớt mỗi lần Wi-Fi hắt hơi
+- Một tờ giấy nhớ ghi mật khẩu *(yên tâm, tụi mình không nói đâu)*
 
-**KKTerm gom tất cả vào một cửa sổ.** Native trên Windows — *cố tình, trong khi cả thế giới dev tools còn lại ra mac-first và coi OS của bạn như một footnote* — viết bằng Rust + Tauri v2, đóng gói thành một installer duy nhất, và từ chối "gọi điện về nhà".
+**KKTerm là một cửa sổ duy nhất cho tất cả những thứ đó.** Native trên Windows — *có chủ đích, trong khi phần còn lại của thế giới công cụ dev ra bản mac trước và coi hệ điều hành của bạn như một dòng chú thích cuối trang* — trong một bộ cài duy nhất và từ chối gọi về nhà.
 
-Cộng thêm vài thứ bạn còn không biết là mình muốn:
+Cộng thêm vài thứ bạn không biết là mình muốn:
 
-- Một **Dashboard** nơi bạn bảo AI *"build cho tôi một widget ping router mỗi 30 giây"* và nó hiện ra ngay trên grid của bạn, chạy trong sandbox.
-- **SSH pane tự động attach vào tmux session có tên** để phiên `claude` / `codex` từ xa sống sót qua mọi cơn dỗi hờn của Wi-Fi laptop.
-- Một **widget theo dõi mức dùng AI Coding** hiển thị quota Claude Code và Codex của bạn — cửa sổ 5 giờ, cửa sổ tuần, gói hiện tại, email tài khoản — trên **Dashboard** và status bar, để bạn không còn bị đập vào tường rate-limit lúc 3 giờ sáng.
-- Một Module **Installer Helper** phát hiện, cài đặt, cập nhật, gỡ cài đặt và launch một catalog công cụ developer Windows được tuyển chọn — Node, Python, Docker, WSL, AI coding CLI và các tiện ích nhỏ mà bình thường bạn phải lục qua nhiều tab trình duyệt.
-- Một **MCP server tích hợp sẵn** (`kkterm-cli`) cho phép các coding agent bên ngoài (Claude Code, Codex, Copilot, Antigravity, OpenCode) điều khiển Workspace và Dashboard của bạn — list Connection, đọc buffer terminal, đặt widget — qua bề mặt tool được tuyển chọn và có safety gate. AI-tới-AI, trên máy bạn, không qua relay cloud.
-- Hai mươi mốt nền **canvas có animation** (vâng, gồm cả `matrix`) cho dashboard, vì chúng tôi không ngại làm chuyện đó.
+- Một **Dashboard** nơi bạn bảo AI *"dựng cho tôi một widget ping router của tôi mỗi 30 giây"* và nó hiện ra, trong sandbox riêng, trên lưới của bạn.
+- **Các pane SSH tự gắn lại vào phiên `claude` / `codex` từ xa của bạn** sau mỗi cơn dỗi của Wi-Fi, để một công việc sáu tiếng sống sót qua một lần rớt mạng.
+- Một **đồng hồ đo mức dùng AI** để bạn thôi đâm sầm vào bức tường rate limit một cách bất ngờ lúc 3 giờ sáng.
+- Một **Installer Helper** tìm, cài, cập nhật và mở các công cụ dev Windows mà thường bạn phải lùng qua mười tab trình duyệt.
+- **Hai mươi lăm hình nền động** cho dashboard (đúng vậy, có cả `matrix`), vì tụi mình cũng chẳng sĩ diện gì.
 
-À, và AI assistant có thể biến một câu thành một công cụ dashboard nhỏ mà bạn thực sự tiếp tục dùng.
+Và phần hay nhất: trợ lý AI có thể biến một câu duy nhất thành một công cụ dashboard nhỏ mà bạn thực sự dùng tiếp.
 
-> ⭐ **Nếu đây nghe giống cái app bạn đã ấp ủ định viết trong sáu năm qua — hãy star repo để chúng tôi biết có người đang theo dõi. Nó thực sự rất giúp ích.**
+> ⭐ **Nếu nghe giống cái app mà bạn đã định dựng suốt sáu năm qua — hãy gắn sao cho repo để tụi mình biết có người đang theo dõi. Thật sự rất giúp ích.**
+
+Có ý kiến về việc nên làm gì tiếp theo? Tham gia luồng góp ý công khai:
+**[KKTerm nên ưu tiên gì cho các luồng công việc quản trị Windows-first?](https://github.com/ryantsai/KKTerm/discussions/141)**
 
 ---
 
-## Tại sao là "KKTerm"?
+## Vì sao là "KKTerm"?
 
-Bước vào bất kỳ data center nào ở Đài Loan và nhìn lên đỉnh các rack. Đi qua các nhà máy TSMC, phòng điều khiển Taipei Metro, sảnh server Cathay Bank, thiết bị chuyển mạch Chunghwa Telecom — bạn sẽ thấy một gói nhỏ màu xanh lá: 乖乖 (Kuāi Kuāi), một loại snack bắp vị dừa từ những năm 1960.
+Bước vào bất kỳ trung tâm dữ liệu nào ở Đài Loan và nhìn lên đỉnh các rack. Vượt qua các fab của TSMC, phòng điều khiển Metro Đài Bắc, phòng máy chủ của ngân hàng Cathay, thiết bị chuyển mạch của Chunghwa Telecom — bạn sẽ thấy một túi nhỏ màu xanh 乖乖 (Kuāi Kuāi), món snack bắp vị dừa từ thập niên 1960.
 
-Cái tên dịch sát nghĩa là **"ngoan ngoãn"**, **"biết nghe lời"**. Truyền thống IT cực kỳ thẳng thắn và rất nghiêm túc:
+Cái tên dịch nghĩa đen là **"ngoan nào"**, **"cư xử cho đàng hoàng"**. Truyền thống trong giới IT đơn giản và hoàn toàn nghiêm túc:
 
-- **Phải là vị xanh (dừa).** Vàng (cà ri) nghĩa là *nghỉ ở nhà đi làm gì*; đỏ (cay) sẽ làm server nổi giận. Chỉ xanh thôi.
-- **Phải còn hạn.** Gói Kuai Kuai hết hạn sẽ chống lại bạn. Các kỹ sư siêng năng thay gói mới.
+- **Phải là màu xanh (dừa).** Vàng (cà ri) nghĩa là *hôm nay ở nhà đi*; đỏ (cay) làm server nổi giận. Chỉ xanh thôi.
+- **Không được hết hạn.** Một gói Kuai Kuai để lâu lại phản tác dụng. Kỹ sư siêng năng thay mới.
 - **Phải nhìn thấy được.** Server phải biết là nó ở đó.
-- **Đừng ăn.** Gói đó đang làm nhiệm vụ.
+- **Đừng ăn.** Túi đó đang làm nhiệm vụ.
 
-Một số hệ thống lớn nhất, chán nhất, ám ảnh uptime nhất ở châu Á đang chạy với một bịch snack bắp dán vào khung máy. Nó hiệu quả vì những người duy trì nó tin rằng nó hiệu quả — đó cũng là mô tả thẳng thắn đến đáng ngạc nhiên về phần lớn văn hóa IT.
+Một số hệ thống lớn nhất, buồn tẻ nhất và ám ảnh uptime nhất ở châu Á đang chạy với một túi bắp dán trên thân máy. Nó hiệu nghiệm vì những người bảo trì tin là nó hiệu nghiệm, mà đó lại là mô tả thành thật đến lạ về phần lớn văn hóa IT.
 
-**KKTerm** là **Kuai Kuai Term** — một không gian quản trị có cùng tham vọng với gói snack đó: ngồi yên cạnh những cỗ máy quan trọng của bạn và giúp chúng cư xử tử tế. Local-first. Không telemetry. AI cần được phê duyệt. Loại phần mềm chán nhưng đáng tin.
+**KKTerm** là **Kuai Kuai Term** — một không gian quản trị mong làm đúng công việc của món snack: ngồi lặng lẽ bên cạnh các cỗ máy quan trọng của bạn và giúp chúng cư xử đàng hoàng. Local-first. Không telemetry. AI phải được phê duyệt. Loại phần mềm buồn tẻ mà đáng tin cậy.
 
-Chúng tôi chưa thể đính kèm một gói Kuai Kuai thật vào installer. Đó là việc của v2.
+Tụi mình vẫn chưa thể kèm một túi Kuai Kuai thật vào bộ cài. Đó là việc của v2.
 
 ---
 
-## Xem nó chạy
+## Xem nó chuyển động
 
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
@@ -124,339 +123,177 @@ Chúng tôi chưa thể đính kèm một gói Kuai Kuai thật vào installer. 
   </a>
 </p>
 
-<p align="center"><sub><em>(Demo GIF sẽ ở đây. Một bức ảnh đáng giá hơn một ngàn bullet point, và chúng tôi cũng đã sắp hết bullet point.)</em></sub></p>
+<p align="center"><sub><em>(GIF demo đặt ở đây. Một bức ảnh đáng giá nghìn gạch đầu dòng, mà tụi mình thì hết gạch đầu dòng rồi.)</em></sub></p>
 
 ---
 
-## Tại sao người ta để nó mở cả ngày
+## Một cửa sổ, mọi kết nối
 
-### Windows-first, có chủ đích
-
-Nhìn quanh thế giới dev tooling năm 2026. Claude Code: ra mac/linux trước, Windows là "dùng WSL đi". Codex CLI: y chang. `gemini-cli`, một nửa Homebrew, mọi TUI mới bóng bẩy: mac/linux trước, người dùng Windows nhận được một dòng `# Windows: contributions welcome` trong README và một script fish-completion không chạy được.
-
-Trong khi đó, những người thực sự giữ cho công ty còn online — IT doanh nghiệp, MSP, bất cứ ai chạy Hyper-V hay AD hay SCCM hay IIS hay một domain controller già hơn vài intern — đang ngồi trước máy Windows và tự hỏi tại sao mọi công cụ mới đều cư xử như OS của họ là sự bất tiện.
-
-**KKTerm đi ngược lại.** Chúng tôi build native Windows trước, macOS / Linux port theo sau. Điều đó nghĩa là chúng tôi được dùng các Windows API thực sự quan trọng, thay vì che đậy chúng bằng một lớp portability:
-
-- **ConPTY** cho shell local — pseudo-console Windows thật, không phải lớp dịch giả lập. PowerShell, `cmd.exe`, các distro WSL, đều được host như PTY đúng nghĩa với focus, resize, và xử lý VT sequence khớp với hành vi của nền tảng.
-- **WebView2** cho toàn bộ UI và **URL Connection** nhúng — Chromium in-process dùng runtime của hệ thống, một trong những lý do installer nhỏ và khởi động nhanh.
-- **Microsoft RDP ActiveX (`mstscax.dll`)** cho RDP — *đúng cái mà Microsoft ship*. Cùng control với Remote Desktop Connection (`mstsc.exe`). Không phải re-implementation của bên thứ ba, không phải FreeRDP đóng gói lại. Dân RDP sẽ nhận ra sự khác biệt trong 5 giây.
-- **Windows Credential Manager** cho mọi bí mật. Mật khẩu SSH, mật khẩu FTP, API key, credential cho URL Connection — chúng sống trong OS keychain và `credwiz.exe` có thể audit chúng.
-- **NSIS current-user installer** kèm SHA-256, tray menu native, Don't-Sleep power assertion, sampling CPU/RAM/network của host, native Tauri context menu với icon PNG thật, dialog Open/Save native. Không một thứ nào trong số này bị mock.
-- **WSL là shell hạng nhất, không phải workaround.** Mở Ubuntu cạnh một pane PowerShell cạnh một SSH session cạnh một **Tab** RDP, tất cả trong cùng một cửa sổ.
-
-Các bản macOS và Linux nằm trong roadmap và sẽ được chăm chút tương tự. Nhưng nếu bạn đã chờ ai đó build công cụ admin Windows *tử tế* trước thay vì sau cùng — đây chính là deal.
-
-### Local-first nghĩa là thật sự local
-
-Các **Connection** đã lưu của bạn nằm trong một file SQLite trên máy bạn. Mật khẩu nằm trong **Windows Credential Manager**, không phải trong một JSON cạnh binary. App không ship analytics, không gọi về nhà khi khởi động, và không cần tài khoản cloud để chạy. Không có "Sign in to sync" vì không có sync.
-
-Nếu dây mạng nhà bạn cháy, KKTerm vẫn mở lên được.
-
-### Một workspace, mọi loại kết nối
-
-| Bạn muốn… | KKTerm có |
+| Bạn muốn… | KKTerm làm được |
 | --- | --- |
-| Mở shell local PowerShell / cmd / WSL | Terminal **Session** local dựa trên ConPTY |
-| SSH vào server | `russh` native với auth agent / key / password, host-key trust flow, ProxyJump, port forwarding |
-| Duyệt file trên server đó | SFTP khởi động từ SSH **Connection**, dual-pane, transfer đệ quy, chmod/chown |
-| FTP vào một NAS từ 2012 | FTP / FTPS **Connection** trong cùng trình duyệt phong cách SFTP |
-| Telnet vào thiết bị cổ đại | Có, Telnet cũng nằm đây |
-| Nói chuyện với cổng serial | Loại **Connection** Serial, chọn COM port + baud, không cần tool phụ |
-| Remote vào máy Windows | RDP native qua Microsoft ActiveX control (đồ thật, không phải clone) |
-| VNC vào con Pi | Framebuffer `vnc-rs` của Rust render thẳng vào workspace |
-| Mở UI web của router | **URL Connection** WebView2 nhúng với fill credential |
-| Theo dõi CPU host | Status bar live + module **Dashboard** với widget kéo/thả/resize |
+| Mở shell cục bộ PowerShell / cmd / WSL | Terminal cục bộ, kề nhau |
+| SSH vào một server | SSH với khóa, agent, mật khẩu, jump host và port forwarding |
+| Duyệt tệp trên server đó | SFTP từ kết nối SSH — hai khung, kéo để truyền |
+| FTP đến một NAS từ 2012 | FTP / FTPS trong cùng trình duyệt tệp |
+| Telnet đến thiết bị cổ lỗ | Đúng, Telnet cũng có trong đó |
+| Nói chuyện với cổng serial | Kết nối serial — chọn cổng COM và baud |
+| Remote vào một máy Windows | Remote Desktop Microsoft xịn, tích hợp sẵn |
+| VNC vào một con Pi | VNC, render thẳng vào không gian làm việc |
+| Mở giao diện web của router | Một tab trình duyệt nhúng với thông tin đăng nhập đã lưu |
+| Theo dõi CPU của host | Một thanh trạng thái thời gian thực và một dashboard bạn tự dựng |
 
-Tất cả là cùng một app. Cùng cửa sổ. Cùng phím tắt. Cùng theme hy-vọng-không-làm-mắt-chảy-máu.
+Cùng một app. Cùng một cửa sổ. Cùng phím tắt. Cùng một theme, mong là không làm mắt bạn chảy máu.
+
+---
+
+## Vì sao người ta để mở nó cả ngày
+
+### Windows trước, có chủ đích
+
+Nhìn quanh bức tranh công cụ dev mà xem. Claude Code: mac/linux trước, Windows là "dùng WSL đi". Codex CLI: y hệt. Một nửa các công cụ mới bóng bẩy ra bản mac trước và để lại cho người dùng Windows một dòng `# contributions welcome` và một script tự động hoàn thành không chạy được.
+
+Trong khi đó, những người thực sự giữ cho doanh nghiệp online — IT doanh nghiệp, MSP, bất kỳ ai quản một domain controller già hơn cả vài thực tập sinh — đang ngồi ở máy Windows tự hỏi vì sao công cụ mới nào cũng coi hệ điều hành của họ như một sự phiền toái.
+
+**KKTerm chọn hướng ngược lại.** Tụi mình dựng native Windows trước, nên những thứ người Windows quan tâm cứ thế mà chạy: Remote Desktop Microsoft *xịn* (chính cái của `mstsc.exe`, không phải bản nhái), shell PowerShell / cmd / WSL thật, bí mật được giữ trong Windows Credential Manager, một icon khay hệ thống đàng hoàng, menu và hộp thoại native. Các bản macOS và Linux nằm trong roadmap và sẽ được chăm chút như nhau. Nhưng nếu bạn đã chờ ai đó dựng công cụ quản trị Windows *cho tử tế* đầu tiên thay vì cuối cùng — thì đây là giao kèo.
+
+### Local-first nghĩa là thật sự cục bộ
+
+Các kết nối đã lưu của bạn nằm trong một tệp trên máy bạn. Mật khẩu nằm trong Windows Credential Manager, không phải trong một tệp văn bản cạnh app. KKTerm không gửi analytics, không gọi về nhà khi khởi động và không cần tài khoản đám mây để chạy. Không có "đăng nhập để đồng bộ" vì chẳng có đồng bộ.
+
+Nếu dây mạng của bạn bốc cháy, KKTerm vẫn mở được.
 
 ### Terminal không phát điên
 
-- Split pane trong một **Tab**.
-- Render xterm.js gia tốc WebGL, fallback mềm khi không thể.
-- Tìm kiếm scrollback.
-- SSH pane dựa trên tmux có thể attach vào session per-pane bền vững, nên reconnect thực sự có nghĩa là *reconnect*, không phải "bắt đầu lại và giả vờ một tiếng vừa qua không tồn tại".
-- Chuyển **Tab** **không** giết **Session**. Đóng **Tab** thì có. Sự phân biệt này từng là chiến tranh tôn giáo nội bộ; chúng tôi đã thắng.
+- Chia khung bên trong một Tab.
+- Render nhanh và mượt, scrollback tìm kiếm được.
+- Kết nối lại nghĩa là *kết nối lại* thật sự — phiên từ xa của bạn tiếp tục từ chỗ đang dở, chứ không phải "làm lại từ đầu và giả vờ một tiếng vừa rồi chưa từng xảy ra".
+- Chuyển Tab **không** giết Session. Đóng Tab thì có. Sự phân biệt này từng là một cuộc thánh chiến nội bộ; tụi mình thắng.
 
-### Một AI Assistant build công cụ của bạn
+### Một trợ lý AI dựng công cụ cho bạn
 
-Hầu hết demo "AI trong terminal của bạn" dừng ở chat. Assistant của KKTerm cũng có thể build những widget dashboard nhỏ, bền vững, theo đúng cách bạn làm việc. Những việc nguy hiểm vẫn được giữ sau hai công tắc:
+Phần lớn các demo "AI trong terminal" dừng ở chat. Trợ lý của KKTerm còn dựng được những widget dashboard nhỏ, bền, hợp với cách bạn làm việc thật — và giữ những thứ nguy hiểm phía sau một công tắc:
 
-- **Tool families** (Dashboard / Connections / Live Sessions) — bật/tắt theo từng loại.
-- **Permission mode** trong composer — `Prompt` (mặc định, hỏi mọi lần) hoặc `Allow All` (bạn là người lớn, bạn đã ký waiver).
+- **Quyết định nó được chạm vào gì** — bật hoặc tắt cả nhóm công cụ (Dashboard / Connections / Live Sessions).
+- **Quyết định nó hỏi thế nào** — `Prompt` (mặc định, hỏi mỗi lần) hoặc `Allow All` (bạn là người lớn, bạn đã ký giấy miễn trừ).
 
-Nói chuyện với OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA, hoặc bất cứ endpoint OpenAI-compatible nào. API key vào OS keychain. Model nào đề xuất `rm -rf` sẽ bị phân loại nguy hiểm và cần con người phê duyệt rõ ràng. AI không thể âm thầm chạy một lệnh phá hủy chỉ vì có ai đó khéo léo nhét prompt injection vào một man page.
+Bất cứ thứ gì trông giống `rm -rf` đều bị đánh dấu nguy hiểm và chờ một cái gật đầu rõ ràng của con người. AI không thể lén chạy một lệnh phá hủy chỉ vì ai đó khôn lỏi nhét một prompt injection vào một trang man.
 
-### Một Dashboard không giả vờ làm Grafana
+Nó nói chuyện với OpenAI, Anthropic, OpenRouter, DeepSeek, Grok, Azure OpenAI, LiteLLM, GitHub Copilot, Ollama, NVIDIA, hoặc bất kỳ endpoint nào tương thích OpenAI. Khóa API của bạn được đưa vào keychain của hệ điều hành.
 
-Module **Dashboard** là một grid widget instance 12 cột có kéo/resize. Nó không dành cho observability petabyte — nó dành cho "tôi muốn một nút launch năm app yêu thích và một panel hiển thị uptime của SSH host, *bên cạnh* chat của tôi."
+### Một dashboard không giả vờ làm Grafana
+
+Dashboard là một lưới widget mà bạn kéo và đổi kích thước. Nó không dành cho observability quy mô petabyte — nó dành cho "tôi muốn một nút mở năm app yêu thích và một bảng hiện uptime của host SSH, *bên cạnh* khung chat của tôi".
 
 #### Widget do AI tạo — mô tả là có
 
-Đây là phần chúng tôi thực sự hào hứng. Bạn không chọn từ marketplace và bạn không viết JavaScript. Bạn **nói cho AI assistant biết bạn muốn gì**, và nó build widget ngay trên dashboard:
+Đây là phần khiến tụi mình thực sự hào hứng. Bạn không chọn từ một marketplace và không viết JavaScript. Bạn **bảo trợ lý AI điều bạn muốn**, và nó dựng widget ngay tại đó, trên dashboard của bạn:
 
-> *"Thêm widget hiển thị 5 commit cuối trên repo main của tôi dưới dạng list."*
-> *"Làm cho tôi widget sticky-note giữ cheat sheet on-call."*
-> *"Build widget ping router nhà tôi mỗi 30 giây và hiện xanh/đỏ."*
-> *"Tôi cần một đồng hồ bấm giờ. Surprise tôi về styling."*
+> *"Thêm một widget hiện 5 commit gần nhất của repo chính của tôi dưới dạng danh sách."*
+> *"Làm cho tôi một widget giấy nhớ để lưu bảng tra trực của tôi."*
+> *"Dựng một widget ping router nhà tôi mỗi 30 giây và hiện xanh/đỏ."*
+> *"Tôi cần một đồng hồ bấm giờ. Phong cách thì tùy bạn, làm tôi bất ngờ đi."*
 
-Hai vị:
+Có cái là bảng hiển thị đơn giản (markdown, checklist, một con số to); có cái chạy mã trực tiếp trong một sandbox cô lập mà bạn phê duyệt. Mỗi widget bạn giữ là của bạn — nó được lưu cùng màu, icon và tiêu đề riêng, và bạn có thể có nhiều bản sao với kích thước khác nhau. Xóa một cái bằng chuột phải khi hết phép màu.
 
-- **Content widget** — JSON khai báo: markdown, danh sách kv, checklist, một con số to. An toàn từ trong thiết kế, không script. Phần lớn yêu cầu "tôi chỉ cần cái này trên dashboard" rơi vào đây.
-- **Script widget** — JavaScript host trong sandbox `iframe srcdoc` cách ly với permission khai báo rõ (`network` allowlist, ngân sách `pollSeconds`). AI viết script, bạn duyệt permission, widget chạy trong một hộp không thể với tới phần còn lại của app.
+#### Hình nền động của dashboard (vì tụi mình thích thế)
 
-Mỗi widget bạn giữ là của bạn. Chúng tồn tại trong SQLite cạnh các **Connection**, với preset thị giác riêng (`panel` / `ambient` / `hero`), accent color, icon, và title. Nhiều instance cùng một widget có thể cùng tồn tại với kích thước và phong cách hoàn toàn khác nhau. Xóa bằng click phải khi phép màu đã hết.
+Chọn một tâm trạng cho mỗi khung nhìn dashboard từ **hai mươi lăm** hình nền động trên canvas:
 
-#### Nền dashboard có animation (vì chúng tôi muốn)
-
-Dashboard có hai mươi mốt nền canvas có animation bạn có thể chọn cho từng **Dashboard View**:
-
-| Tâm trạng | Nền |
+| Tâm trạng | Hình nền |
 | --- | --- |
-| Tĩnh lặng | `aurora`, `clouds`, `ocean`, `raindrops`, `snow`, `sakura`, `fireflies`, `bubbles`, `ricefield`, `lanterns` |
+| Tĩnh lặng | `aurora`, `clouds`, `ocean`, `raindrops`, `rainywindow`, `frostedWindow`, `snow`, `sakura`, `fireflies`, `bubbles`, `aquarium`, `ricefield`, `lanterns` |
 | Vũ trụ | `starfield`, `nebula` |
-| Ấm áp | `embers`, `lava` |
-| Mọt sách | `matrix`, `topo`, `synthwave` |
-| Loạn | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti` |
+| Ấm | `embers`, `lava` |
+| Geek | `matrix`, `topo`, `synthwave` |
+| Bồn chồn | `cyberpunk`, `taipei101`, `thunderstorm`, `confetti`, `particleCursor` |
 
-Chúng chạy trên một `requestAnimationFrame` chia sẻ duy nhất và tôn trọng focus cửa sổ, nên gần như không tốn gì khi bạn ở chỗ khác. Ghép `matrix` với AI assistant để có vibe "tôi cực kỳ năng suất và có thể đang ở trong phim của anh em Wachowski". Hoặc chọn `ocean` và trông như người nghiêm túc. Chúng tôi không phán xét lựa chọn nào.
+Chúng tạm dừng khi bạn ở chỗ khác, nên gần như chẳng tốn gì. Ghép `matrix` với trợ lý AI của bạn cho một bầu không khí nói rằng "tôi cực kỳ năng suất và có lẽ đang ở trong phim của anh em Wachowski". Hoặc chọn `ocean` và trông như một người nghiêm túc. Tụi mình không phán xét lựa chọn nào cả.
 
-### Chạy AI coding agent trên server, đúng cách
+### Giữ cho các agent AI từ xa của bạn sống
 
-Đây là tính năng thứ hai khiến người ta phải lòng. Terminal SSH của KKTerm có thể khởi động trực tiếp vào **tmux session có tên** trên host từ xa — mặc định là một id thân thiện được tự sinh như `kkterm-cockpit001` sống sót qua reconnect:
+Đây là tính năng thứ hai khiến người ta mê. Terminal SSH của KKTerm có thể thả bạn thẳng vào một **phiên tmux có tên** trên host từ xa, sống sót qua việc kết nối lại:
 
-- Mở **Connection** SSH với tmux bật.
-- Trong pane, khởi động `claude`, `codex`, `gemini-cli`, `cursor-agent`, hoặc bất kỳ coding agent chạy dài nào bạn thích. Chúng là app TUI full-screen; tmux đúng là nơi chúng muốn sống.
-- Đóng laptop. Mở lại. Pane âm thầm re-attach vào cùng tmux session. Agent vẫn đang chạy, vẫn giữ scrollback, vẫn đang dở việc.
-- Mạng SSH chớp tắt? KKTerm thực hiện một lần silent reattach có giới hạn vào cùng tmux id mà không làm phiền bạn.
-- Muốn AI assistant thấy agent đang làm gì? "Add terminal buffer to context" gọi `capture_tmux_pane` qua SSH và kéo toàn bộ scrollback tmux — không chỉ những gì trên màn hình, mà cả session — vào cuộc hội thoại. Assistant local của bạn giờ có thể suy luận về công việc của agent từ xa.
+- Mở một kết nối SSH bật tmux rồi khởi động `claude`, `codex`, `gemini-cli`, `cursor-agent`, hoặc agent chạy dài nào bạn thích.
+- Gập laptop lại. Mở ra lại. Pane lặng lẽ gắn lại — agent vẫn đang chạy, vẫn còn scrollback, vẫn ở giữa việc nó đang làm.
+- Mạng chớp một cái? KKTerm lặng lẽ nối lại vào đúng phiên đó mà không làm phiền bạn.
+- Muốn trợ lý giúp? "Thêm terminal buffer vào ngữ cảnh" hút trọn phiên từ xa vào cuộc trò chuyện, để AI cục bộ của bạn có thể suy luận về việc agent từ xa đang làm gì.
 
-Nếu bạn từng mất một phiên `claude` hay `codex` sáu tiếng vì Wi-Fi khách sạn chập chờn, riêng tính năng này đã đủ giá trị. App miễn phí. Tính năng vẫn đáng giá.
+Nếu bạn từng mất một phiên `claude` hay `codex` sáu tiếng vì Wi-Fi khách sạn chập chờn, riêng tính năng này đã đủ đáng tiền app. (App miễn phí. Tính năng vẫn đáng giá như thường.)
 
 ### Biết bạn còn bao nhiêu AI
 
-Coding agent tính tiền theo cửa sổ gói, không phải theo tháng. Claude Code có cửa sổ 5 giờ và cửa sổ tuần. Codex có phiên bản riêng. Cả hai đều có thể ngấu nghiến quota của bạn trong background trong khi bạn đang họp.
+Các agent lập trình tính tiền theo cửa sổ gói, không theo tháng, và chúng vui vẻ xơi hết hạn mức của bạn trong lúc bạn đang họp. **Đồng hồ đo mức dùng AI** giữ cho điều đó luôn hiện rõ:
 
-Widget **Mức dùng AI Coding** giữ điều đó hiển thị:
+- Một widget dashboard hiện **Claude Code** và **Codex** cạnh nhau: tài khoản đang kết nối, gói, mức đã dùng trong cửa sổ hiện tại và tuần này, thời điểm reset kế tiếp.
+- Một **chỉ báo gọn trên thanh trạng thái** phản chiếu cùng những con số, để cả khi đóng dashboard bạn vẫn liếc một cái là biết còn dư địa trước lần refactor lớn kế tiếp hay không.
+- Nó báo trước cho bạn nếu cần đăng nhập lại — *trước* một tác vụ dài, chứ không phải giữa chừng.
 
-- Một widget Dashboard hiển thị **Claude Code** và **Codex** cạnh nhau: tài khoản đã kết nối, mức gói, phần trăm đã dùng trong cửa sổ 5 giờ hiện tại, phần trăm đã dùng tuần này, thời gian reset kế tiếp.
-- Một **chỉ báo status bar gọn gàng** phản ánh cùng các con số, để ngay cả khi Dashboard đóng bạn vẫn nhìn một cái biết còn dư không trước khi khởi động đợt refactor lớn tiếp theo.
-- Trạng thái auth hiển thị trực tiếp (`connected` / `expired` / `error`) để bạn biết *trước* một task dài rằng cần đăng nhập lại, không phải đang giữa chừng.
-- Policy refresh tôn trọng rate limit; widget poll theo nhịp riêng thay vì đập API upstream mỗi lần bạn nhìn.
+### Để các AI khác lái KKTerm
 
-### Một MCP server tích hợp sẵn — để AI khác điều khiển KKTerm
+KKTerm mang theo server MCP của riêng nó, để các agent lập trình bên ngoài (Claude Code, Codex, Copilot, Antigravity, OpenCode) dùng không gian làm việc của bạn như chính bạn — liệt kê kết nối, mở một cái, đọc một terminal buffer, đặt widget lên dashboard. AI tới AI, trên máy bạn, không có relay đám mây. Các hành động làm thay đổi, rủi ro hơn, nằm sau một công tắc an toàn duy nhất **tắt** theo mặc định.
 
-Terminal của bạn cũng là nơi Claude Code, Codex, chế độ agent của Copilot, Antigravity và phần còn lại của thế giới biết nói MCP muốn làm việc. Nên KKTerm có **MCP server stdio** riêng, [`kkterm-cli`](docs/MCP.md), expose một lát cắt được tuyển chọn của app:
-
-- **Workspace Module** (`kkterm.workspace.*`): list **Connection** đã lưu, mở Connection theo id, list **Session** đang sống, gửi input đến terminal pane, đọc snapshot buffer.
-- **Dashboard Module** (`kkterm.dashboard.*`): load state Dashboard, đọc source AI-Created Widget, tạo / cập nhật / xóa view, đặt / di chuyển / xóa instance widget, apply layout hàng loạt.
-- **Sub-namespace nguy hiểm** (`kkterm.<module>.dangerous.*`): mutate bề mặt executable — tạo widget script, click vào remote desktop, wipe Dashboard — được gate sau một setting duy nhất (`built_in_mcp_allow_all_dangerous`), mặc định **tắt**.
-
-`kkterm-cli` là forwarder mỏng. Nó nói stdio JSON-RPC với MCP client của bạn và giao tiếp với window KKTerm đang chạy qua named pipe Windows được xác thực theo mỗi lần khởi động. Khi KKTerm đóng, `tools/list` vẫn chạy (client có thể introspect bề mặt), nhưng `tools/call` trả về lỗi có cấu trúc `app_not_running` thay vì làm gì.
-
-Nối nó vào client yêu thích và AI của bạn giờ dùng KKTerm như bạn:
-
-```json
-{
-  "mcpServers": {
-    "kkterm": { "command": "<đường-dẫn-tới-kkterm-cli>", "args": [] }
-  }
-}
-```
-
-Settings → AI Assistant → **Built-in MCP Server** có dialog "Show config" một-click với snippet JSON và TOML đã pre-fill đường dẫn binary đã resolve, cộng với command `claude mcp add` / `codex mcp add` có thể copy.
+Cài đặt → AI Assistant → **Built-in MCP Server** có hộp thoại "Hiện cấu hình" một cú nhấp, điền sẵn, kèm các lệnh `claude mcp add` / `codex mcp add` để sao chép.
 
 ---
 
-## Mọi thứ ráp lại thế nào
+## KKTerm không phải là gì
 
-```mermaid
-flowchart LR
-    User([You]) --> Shell[KKTerm Window<br/>Tauri v2 + React 19]
-    Shell --> Rail[Activity Rail]
-    Rail --> WS[Workspace Module]
-    Rail --> Dash[Dashboard Module]
-    Rail --> Inst[Installer Helper Module]
-    Rail -.-> FE[File Explorer<br/>planned]
-    Rail --> Set[Settings]
+Một danh sách ngắn, vì sự trung thực đổi lấy niềm tin:
 
-    WS --> Tabs[Tabs &amp; Panes]
-    Tabs --> Term[Terminal<br/>ConPTY / russh]
-    Tabs --> SFTP[SFTP / FTP]
-    Tabs --> Web[WebView2 URL]
-    Tabs --> RD[RDP / VNC]
+- **Không phải sản phẩm đám mây.** Không đồng bộ, không tài khoản nhóm, không gói SaaS. Nếu một ngày bạn thấy hộp thoại "Đăng nhập vào KKTerm", thì có gì đó đã sai một cách thảm họa.
+- **Không giả vờ đa nền tảng.** Tụi mình Windows-first có chủ đích; macOS và Linux nằm trong roadmap. Nếu hôm nay bạn cần một công cụ mac-first, bạn có hàng trăm lựa chọn. Tụi mình đang dựng cái mà các admin Windows đã lặng lẽ chờ đợi.
+- **Không phải agent AI tự hành.** Trợ lý đề xuất; con người quyết định. `Allow All` là lựa chọn bạn đưa ra, không phải mặc định.
+- **Không phải bản thay thế Grafana / Datadog.** Dashboard dành cho các bề mặt điều khiển cá nhân, không phải observability cho 10.000 host.
+- **Không phải IDE Kubernetes.** Đây là một không gian quản trị lấy terminal làm trung tâm. Xin đừng bắt nó render một Helm chart.
 
-    Shell -.calls.-> Rust[Rust Backend]
-    Rust --> SQLite[(SQLite<br/>Connections)]
-    Rust --> Keychain[(OS Keychain<br/>Secrets)]
-    Rust --> AI[AI Providers<br/>OpenAI-compat]
-
-    AI -. approval gate .-> Tabs
-
-    classDef local fill:#1f6feb,stroke:#1f6feb,color:#fff
-    classDef ai fill:#8a63d2,stroke:#8a63d2,color:#fff
-    class SQLite,Keychain local
-    class AI ai
-```
-
-Hình dạng quan trọng: dữ liệu lưu trữ bền vững (**Connection**) tách biệt khỏi trạng thái runtime sống (**Session**), tách biệt khỏi container UI (**Tab**). Đóng một **Tab** kết thúc **Session**. Chuyển **Tab** thì không. Đây là quy tắc giữ cho app tỉnh táo.
+Nếu một trong số đó *từng* là yếu tố quyết định — cũng phải thôi, hẹn gặp ở v2.
 
 ---
 
-## Bản đồ tính năng hiện tại
+## Tải KKTerm
 
-| Khu vực | Đã có hôm nay |
-| --- | --- |
-| **Connections** | Tree dựa trên SQLite, folder/subfolder, search, kéo/thả sắp xếp, rename, duplicate, delete, **Quick Connect**, icon tùy chỉnh, shortcut pinned/active trên rail |
-| **Terminal** | Local shell, SSH, Telnet, Serial, split pane, xterm.js + WebGL cơ hội, search scrollback, thư mục/script khởi động local |
-| **SSH** | `russh` native, auth agent/key/password, flow trust host-key, fallback system SSH tùy chọn, ProxyJump, port forwarding, **tmux session tự đặt tên (`kkterm-<scifi-name><n>`) với silent reattach khi transport chớp tắt** — hoàn hảo cho coding agent từ xa chạy dài (Claude Code, Codex, gemini-cli, v.v.) |
-| **SFTP / FTP** | SFTP khởi động bởi SSH cộng với **Connection** FTP/FTPS, trình duyệt dual-pane, transfer đệ quy, queue/cancel/clear history, conflict, properties, chmod/chown nơi hỗ trợ |
-| **URL WebView** | URL **Session** WebView2 nhúng, navigation toolbar, capture favicon, metadata/fill credential website đã lưu, metadata data partition |
-| **Remote Desktop** | RDP qua Windows ActiveX với overlay parking phạm vi geometry; VNC qua framebuffer `vnc-rs` render trong canvas workspace |
-| **Dashboard** | View bền vững, widget instance, edit mode, kéo/resize, App Launcher, **content/script widget do AI viết** (JSON khai báo hoặc JS iframe sandbox với permission), preset / accent / icon / title per-widget, **23 nền canvas có animation** (aurora, clouds, ocean, raindrops, rainywindow, snow, sakura, fireflies, bubbles, ricefield, lanterns, starfield, nebula, embers, lava, matrix, topo, synthwave, cyberpunk, taipei101, thunderstorm, confetti, particleCursor) |
-| **AI Assistant** | Streaming chat, runtime OpenAI-compatible, provider registry, phân loại an toàn đề xuất lệnh, đính kèm screenshot/context, **viết widget cho Dashboard (content + script sandbox)**, **capture tmux pane** làm context hội thoại cho session từ xa, tool quản lý **Connection**, và tool live **Session** cho terminal, RDP/VNC, và SFTP/FTP |
-| **Mức dùng AI Coding** | **Widget Dashboard + chỉ báo status bar** theo dõi mức dùng quota của **Claude Code** và **Codex**: tài khoản đã kết nối, mức gói, phần trăm cửa sổ 5 giờ và tuần, thời gian reset kế tiếp, trạng thái auth (`connected` / `expired` / `error`), policy refresh nhận biết rate-limit |
-| **MCP Server tích hợp** | MCP server stdio (`kkterm-cli`) expose tool Workspace và Dashboard được tuyển chọn cho coding agent bên ngoài (Claude Code, Codex, Copilot, Antigravity, OpenCode); bridge named pipe có xác thực; sub-namespace `dangerous.*` theo Module được gate sau một safety toggle duy nhất; dialog Settings với snippet JSON / TOML một-click và command `claude mcp add` / `codex mcp add` |
-| **Installer Helper** | Activity Rail Module cho catalog công cụ developer Windows được bundling: phát hiện tool đã cài, so sánh version mới nhất, install/update/uninstall, pin tool khỏi Update all, stream command log, và launch managed app được hỗ trợ |
-| **Settings** | General, Appearance, Credentials, AI, SSH, Terminal, nền terminal, URL, RDP, VNC, Dashboard, Installer Helper, About; font UI tùy chỉnh; minimize-to-tray; Don't Sleep; backup/import |
-| **Localization** | UI i18next với nguồn tiếng Anh và bundle locale tải động: zh-TW, zh-CN, ja, ko, fr, de, es, es-MX, it, pt-BR, th, id, vi |
+**[Tải bộ cài Windows mới nhất (.exe)](https://github.com/ryantsai/KKTerm/releases/latest)** rồi chạy nó. Bộ cài hiện **chưa được ký** — việc ký bản phát hành nằm trong roadmap, nên đến lúc đó phần mềm diệt virus của bạn có thể nhìn bạn nghiêm khắc. Đó là chuyện bình thường.
 
-### AI Providers
-
-OpenAI · Anthropic · OpenRouter · DeepSeek · Grok · Azure OpenAI · LiteLLM · GitHub Copilot · Ollama · NVIDIA · bất kỳ endpoint OpenAI-compatible nào.
-
-Metadata provider nằm ở [`src/ai/providerRegistry/`](src/ai/providerRegistry/); adapter Rust ở [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/). API key đi qua OS keychain, không bao giờ SQLite.
-
----
-
-## Quick Start
-
-Bạn cần:
-
-- **Windows** (nền tảng được hỗ trợ chính)
-- **Node.js + npm**
-- **Rust toolchain**
-- **Tauri v2 prerequisites cho Windows** gồm **WebView2**
-
-```bash
-npm install
-npm run tauri dev
-```
-
-Lý tưởng là nó sẽ ra một cửa sổ native thật. Nếu thay vào đó là một stack trace, vui lòng mở issue — chúng tôi yêu một repro tốt.
-
-### Kiểm tra thường gặp
-
-```bash
-npm run check                                              # TypeScript
-npm run build                                              # Vite build
-cargo check --manifest-path src-tauri/Cargo.toml           # Rust
-cargo test  --manifest-path src-tauri/Cargo.toml           # Rust tests
-```
-
-### Build installer Windows
-
-```bash
-npm run package:installer
-```
-
-Script installer ghi `artifacts/kkterm-<version>-windows-x64-setup.exe` và file `.sha256` tương ứng. Hiện **chưa ký** — release signing nằm trong roadmap, nhưng đến lúc đó antivirus của bạn có thể nhìn bạn nghiêm khắc. Bình thường thôi.
-
----
-
-## KKTerm Không Phải Là Gì
-
-Một danh sách ngắn, vì sự thẳng thắn tạo lòng tin:
-
-- **Không phải sản phẩm cloud.** Không sync, không tài khoản team, không tier SaaS. Nếu bạn thấy dialog "Sign in to KKTerm", có gì đó đã sai cực kỳ thảm khốc.
-- **Không giả vờ cross-platform.** Chúng tôi Windows-first có chủ đích; macOS và Linux nằm trong roadmap và sẽ dùng cùng shell Tauri v2. Nếu hôm nay bạn cần công cụ mac-first, bạn có hàng trăm lựa chọn. Chúng tôi đang xây cái mà admin Windows đã âm thầm chờ đợi.
-- **Không phải AI agent tự động.** Assistant đề xuất; con người quyết định. `Allow All` là một lựa chọn bạn đưa ra, không phải mặc định.
-- **Không thay thế Grafana / Datadog.** Dashboard là cho mặt điều khiển cá nhân, không phải observability 10k-host.
-- **Không phải Kubernetes IDE.** Đây là không gian admin lấy terminal làm trung tâm. Vui lòng đừng yêu cầu nó render Helm chart.
-
-Nếu bất kỳ điều nào ở trên *là* dealbreaker — không sao, gặp lại ở v2.
-
----
-
-## Debug Native
-
-Dùng runtime Tauri thật để validate:
-
-```bash
-npm run tauri dev
-```
-
-Vite browser preview hữu ích cho một số inspection frontend, nhưng nó **không** host WebView2 thật, ConPTY, RDP ActiveX, framebuffer VNC, keychain, hay bề mặt menu native. Nếu một tính năng chạm vào bất kỳ thứ nào trong số đó, validate nó trong desktop runtime thực sự.
-
-Người dùng VS Code: launch config `Run KKTerm exe` khởi động `src-tauri/target/debug/kkterm.exe` với `RUST_BACKTRACE=1`. Config đi cặp `Attach KKTerm WebView2` cho bạn DevTools bên trong host WebView2 thật.
-
----
-
-## Giới hạn hiện tại (vâng, chúng tôi biết)
-
-- Installer hiện chưa ký. Update check bị tắt cho đến khi release signing được cấu hình.
-- SFTP qua ProxyJump chưa được hỗ trợ trong đường dẫn SFTP native.
-- Resume transfer file, đồng bộ/diff folder, archive/extract, và chỉnh sửa từ xa bị hoãn lại.
-- Import SSH config đã implement nhưng entry user-facing trong Settings chưa lộ ra.
-- RDP và VNC đang được ship; clipboard/device sync phong phú hơn và quality control vẫn đang tiến hóa.
-- Build macOS và Linux nằm trong roadmap. Chúng đang đến và sẽ được làm tử tế — không vội vàng tung ra như port kiểu "chúng tôi cũng hơi chạy được trên đó".
-- AI assistant đề xuất và có thể vận hành tool đã bật trong ranh giới permission đã cấu hình — vui lòng đừng coi nó như robot không người trông coi. Nó thực sự không biết CEO của bạn muốn gì.
+Muốn build từ mã nguồn hay đóng góp? Mọi thứ bạn cần đều nằm trong [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ---
 
 ## Roadmap (bản ngắn)
 
-- Build macOS + Linux
-- Installer đã ký + auto-update
-- SFTP qua ProxyJump trên đường dẫn native
-- Resume transfer file, đồng bộ folder, archive/extract
-- RDP clipboard/device redirection phong phú hơn
-- Thêm **Dashboard** widget tích hợp sẵn (và schema công khai cho widget do AI viết)
+- Bản build macOS + Linux
+- Bộ cài đã ký + tự động cập nhật
+- Truyền tệp mạnh hơn (tiếp tục, đồng bộ thư mục, nén/giải nén)
+- Chia sẻ clipboard và thiết bị Remote Desktop phong phú hơn
+- Thêm widget dashboard có sẵn
 
-Phiên bản đầy đủ và cập nhật thường xuyên: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+Bản đầy đủ và cập nhật thường xuyên: [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
 ---
 
 ## Đóng góp
 
-Chúng tôi rất muốn có thêm tay giúp. Thật lòng. Cả việc nhỏ cũng quan trọng:
+Tụi mình rất mong có người chung tay. Thật đấy. Việc nhỏ cũng quan trọng:
 
-- **Thử dev build** và mở issue khi thấy gì đó kỳ lạ. "Thấy kỳ kỳ" là một bug report hợp lệ; chúng tôi sẽ đào cùng bạn.
-- **Dịch một locale.** Tiếng Anh là source of truth tại [`src/i18n/locales/en.json`](src/i18n/locales/en.json); 12 locale khác sống cạnh nó và load theo nhu cầu. Chuỗi pending được track per-key dưới [`docs/localization_todo/`](docs/localization_todo/) — chọn một, dịch nó, xóa file.
-- **Thêm widget Dashboard.** Widget tích hợp sống ở [`src/modules/dashboard/widgets/builtin/`](src/modules/dashboard/widgets/builtin/). Chọn một ý tưởng nhỏ, ship nó, học pattern.
-- **Siết chặt bề mặt AI tool.** Provider adapter sống ở [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/); registry frontend ở [`src/ai/providerRegistry/`](src/ai/providerRegistry/).
-- **Cải thiện manual.** Docs cho người dùng cuối ở [`docs/manual/`](docs/manual/). Mỗi chương cho một module UI. Nếu bạn dùng một tính năng và docs không giúp gì, một PR sửa lại là vàng.
+- **Thử bản build dev** và mở một issue khi thấy có gì đó sai sai. "Thấy là lạ" là một báo cáo lỗi hợp lệ; tụi mình sẽ đào cùng bạn.
+- **Dịch một ngôn ngữ.** Tiếng Anh là nguồn chân lý; mười ba ngôn ngữ khác sống ngay bên cạnh.
+- **Thêm một widget dashboard.** Chọn một ý nhỏ, ra mắt nó, học lấy mẫu hình.
+- **Cải thiện sổ tay.** Nếu bạn dùng một tính năng mà tài liệu không giúp được, một PR sửa điều đó quý như vàng.
 
-Setup đầy đủ, layout dự án, PR checklist, và danh sách "vui lòng không làm hỏng" sống ở [`CONTRIBUTING.md`](CONTRIBUTING.md). Tóm tắt 30 giây:
-
-- **Đọc [`CONTEXT.md`](CONTEXT.md) trước khi đổi tên thuật ngữ user-facing.** **Connection**, **Session**, **Tab**, và **Quick Connect** mang ý nghĩa cụ thể; vui lòng đừng trôi.
-- **Mọi chuỗi user-visible đi qua `t()`.** Không có text tiếng Anh trần trong JSX.
-- **Không hook close ở frontend.** Title-bar close của Tauri v2 đã bị pattern `onCloseRequested` phá vỡ nửa tá lần. Chúng tôi cuối cùng đã có hình dạng hoạt động; vui lòng đừng đưa chúng trở lại.
-- **Chạy checks** (`npm run check && npm run build && cargo check && cargo test`) trước khi mở PR.
-
-Tìm điểm bắt đầu? Lọc issue mở theo [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) hoặc [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22). Nếu chưa có cái nào được gắn tag, mở một issue mô tả điều bạn muốn làm và chúng tôi sẽ giúp xác định phạm vi.
+Toàn bộ thiết lập, cấu trúc dự án và checklist PR nằm trong [`CONTRIBUTING.md`](CONTRIBUTING.md). Đang tìm điểm khởi đầu? Lọc các issue đang mở theo [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) hoặc [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
 
 ---
 
-## Docs Dự Án
+## Tài liệu dự án
 
-- [Product context](CONTEXT.md) — ngôn ngữ domain bạn nên khớp
-- [Architecture](docs/ARCHITECTURE.md) — bản đồ module, đặt code mới ở đâu
+- [Bối cảnh sản phẩm](CONTEXT.md) — ngôn ngữ miền bạn nên tuân theo
+- [Kiến trúc](docs/ARCHITECTURE.md) — bản đồ module, đặt mã mới ở đâu
 - [Roadmap](docs/ROADMAP.md)
-- [Dashboard architecture](docs/DASHBOARD.md)
-- [AI provider guide](docs/AI_PROVIDERS.md)
-- [Performance notes](docs/PERFORMANCE.md)
-- [Release notes and gates](docs/RELEASE.md)
+- [Kiến trúc Dashboard](docs/DASHBOARD.md)
+- [Hướng dẫn nhà cung cấp AI](docs/AI_PROVIDERS.md)
 
 ---
 
-## Stack
-
-Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand · xterm.js · SQLite · WebView2 · `russh` · `russh-sftp` · `vnc-rs` · `suppaftp` · OS keychain storage.
-
----
-
-## Lịch sử Star
+## Lịch sử sao
 
 <a href="https://www.star-history.com/#ryantsai/KKTerm&Date">
   <picture>
@@ -466,12 +303,12 @@ Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand ·
   </picture>
 </a>
 
-Nếu bạn đọc đến đây mà chưa star — bạn đang chờ lời mời cá nhân à? Coi như đây là lời mời cá nhân.
+Nếu bạn đã đọc đến đây mà vẫn chưa gắn sao — còn chờ gì nữa, một lời mời riêng à? Coi như đây là lời mời riêng đó.
 
-⭐ **[Star KKTerm trên GitHub](https://github.com/ryantsai/KKTerm)** — tốn một click và làm maintainer vui cả tuần. Coi nó như một gói 乖乖 kỹ thuật số trên rack.
+⭐ **[Gắn sao cho KKTerm trên GitHub](https://github.com/ryantsai/KKTerm)** — chỉ tốn một cú nhấp và làm cả tuần của người bảo trì rạng rỡ. Cứ coi như một gói 乖乖 kỹ thuật số trên rack.
 
 ---
 
-## License
+## Giấy phép
 
-MIT. Xem [LICENSE](LICENSE). Dùng nó, fork nó, ship nó, đặt nó vào một homelab không ai khác tìm thấy — đó là deal.
+MIT. Xem [LICENSE](LICENSE). Dùng nó, fork nó, phát hành nó, đặt nó vào một homelab không ai khác tìm ra — đó là giao kèo.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,7 @@
 <h1 align="center">KKTerm</h1>
 
 <p align="center">
-  <strong>AI 工具时代忘记打造的原生 Windows 管理工作台——终端、SSH、SFTP、RDP/VNC、Dashboard，以及一个能为你打造专属工具 Widget 的 AI。</strong>
+  <strong>一扇 Windows 原生窗口，搞定终端、SSH、SFTP、RDP/VNC 和 Dashboard — 还附一个能照你要求打造专属小工具的 AI。</strong>
 </p>
 
 <p align="center">
@@ -13,11 +13,11 @@
 </p>
 
 <p align="center">
-  <sub>命名灵感来自 <strong>乖乖 (Guāi Guāi)</strong>——台湾系统管理员放在服务器上祈求乖乖运行的绿色椰子口味零食。希望这款应用也能在机架上赢得它的位置。</sub>
+  <sub>名称来自 <strong>乖乖</strong>，那包台湾系统管理员放在服务器上、希望它好好工作的绿色椰子味玉米点心。希望这个 app 也能争取到它在机架上的一席之地。</sub>
 </p>
 
 <p align="center">
-  <strong><a href="https://github.com/ryantsai/KKTerm/releases/latest">下载最新 Windows 安装程序（.exe）</a></strong>
+  <strong><a href="https://github.com/ryantsai/KKTerm/releases/latest">下载最新版 Windows 安装程序（.exe）</a></strong>
 </p>
 
 <p align="center">
@@ -38,9 +38,6 @@
   </a>
   <br />
   <img src="https://img.shields.io/badge/Windows%E2%80%91first-by%20design-0078D6?style=flat-square&logo=windows" alt="Windows-first by design" />
-  <img src="https://img.shields.io/badge/built%20with-Tauri%20v2-FFC131?style=flat-square&logo=tauri" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/Rust-russh-orange?style=flat-square&logo=rust" alt="Rust" />
-  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react" alt="React 19" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
   <br />
   <sub>
@@ -63,56 +60,58 @@
 
 ---
 
-## 45 秒卖点
+## 45 秒简报
 
-你是一名系统管理员 / DevOps 工程师 / 家庭实验室爱好者 / 氛围感程序员。现在你的桌面上有：
+你是 sysadmin / DevOps / 玩 homelab 的人 / vibe coder。现在你手上有：
 
 - 一个终端模拟器
-- 一个独立的 SSH 客户端（那份配置列表你花了整整一个周末才建好）
-- 一个 2007 年的 SFTP 客户端，不知为何还在存活
-- 一个老是在错误显示器上迷路的远程桌面窗口
-- 一个专门用来连那台 Linux 机器的 VNC 查看器
-- 一个路由器管理界面的浏览器标签页
-- 一个跑在远程开发机上的 `claude` / `codex` Session，Wi-Fi 一打喷嚏就断线
-- 一张写满密码的便利贴 *(别担心，我们不会说的)*
+- 一个独立的 SSH client（里面那份 profile 列表花了你整个周末才整理出来）
+- 一个 2007 年的 SFTP client，不知为何还活着
+- 远程桌面开在一个你一直在错误屏幕上找的窗口
+- 一个 VNC viewer，只为了那一台 Linux 主机
+- 一个浏览器标签页，开着路由器后台
+- 一个跑在远程主机上的 `claude` / `codex` session，每次 Wi-Fi 一打喷嚏就断
+- 一张写着密码的便利贴*（没事，我们不会说出去）*
 
-**KKTerm 把这一切塞进同一个窗口。** 原生 Windows 应用——*有意为之，而其他开发工具都在优先支持 Mac，把你的操作系统当脚注*——用 Rust + Tauri v2 编写，单个安装包搞定，从不偷偷打电话回家。
+**KKTerm 把这些塞进同一扇窗口。** 原生 Windows — *没错，是故意的，当整个开发工具圈都先做 mac 版、把你的操作系统当成脚注处理的时候* — 一个安装程序就搞定，而且绝不回家报告。
 
-此外还有几个你以为自己不需要、却会爱上的功能：
+顺便还帮你做了几件你不知道自己需要的事：
 
-- 一个 **Dashboard**，你只需告诉 AI *"给我建一个每 30 秒 ping 一次路由器的 Widget"*，它就出现在你的网格上，完全沙盒隔离。
-- **SSH Pane 自动挂载到命名 tmux Session**，让你远程跑的 `claude` / `codex` Session 扛得住笔记本每一次 Wi-Fi 发脾气。
-- 一个 **AI 编程用量 Widget**，在 **Dashboard** 和状态栏上展示你的 Claude Code 和 Codex 配额——5 小时窗口、每周窗口、当前套餐、账号邮箱——让你不会在凌晨 3 点撞上限速墙才一脸懵。
-- 一个 **Installer Helper** 模块，用来检测、安装、更新、卸载并启动精选的 Windows 开发工具目录——Node、Python、Docker、WSL、AI 编程 CLI，以及那些平时要翻好几个浏览器标签才找得到的小工具。
-- 一个**内置 MCP 服务器**（`kkterm-cli`），让外部编程 Agent（Claude Code、Codex、Copilot、Antigravity、OpenCode）能操控你的 Workspace 和 Dashboard——列出 Connection、读取终端缓冲区、放置 Widget——通过精选的、带安全门控的工具表面。AI 对 AI，全在你机器上，不走云端中转。
-- 二十一种 **动态 Canvas 背景**（是的，包括 `matrix`）可用于 Dashboard，因为我们就是有这个审美品位。
+- 一个 **Dashboard**，你可以对 AI 说 *「帮我做一个每 30 秒 ping 一次路由器的 widget」*，它就会在你的网格上凭空出现，而且关在自己的沙箱里。
+- **能自动 attach 回远程 `claude` / `codex` session 的 SSH pane**，这样每次 Wi-Fi 闹脾气，你那个跑了六小时的任务也不会阵亡。
+- 一个 **AI 用量计**，让你不会凌晨三点才被 rate-limit 墙撞个正着。
+- 一个 **Installer Helper**，帮你找到、安装、更新并启动那些平常得翻十个浏览器标签页才找得到的 Windows 开发工具。
+- Dashboard 用的**二十五种 canvas 动画背景**（对，包括 `matrix`），因为我们也没在客气。
 
-哦对了，AI 助手可以把一句话变成一个你真的会继续用的小型 Dashboard 工具。
+而最棒的部分：AI 助理可以把一句话变成一个你真的会继续使用的小型 Dashboard 工具。
 
-> ⭐ **如果这听起来正是你打算自己造了六年却一直没动手的工具——给仓库点个 Star 让我们知道有人在看。真的有用。**
+> ⭐ **如果这听起来就是你过去六年一直想做的那个 app — 请点个 star，让我们知道有人在看。这真的很有帮助。**
 
----
-
-## 为什么叫"KKTerm"？
-
-走进任何一家台湾数据中心，看看机架顶端。无论是台积电厂房、台北捷运控制室、国泰银行机房、中华电信的交换设备——你都会发现一小袋绿色的乖乖 (Guāi Guāi)，1960 年代就有的椰子口味玉米脆片。
-
-这个名字字面意思是**"听话"**、**"乖乖的"**。这项 IT 传统简单明了，也相当认真：
-
-- **必须是绿色口味（椰子）。** 黄色（咖喱）意味着*今天请假在家*；红色（辣味）会让服务器发火。只用绿色。
-- **必须在保质期内。** 过期的乖乖会适得其反。工程师会勤勤恳恳地定期更换。
-- **必须摆在看得见的地方。** 服务器要知道它在那里。
-- **不能吃掉它。** 那袋零食在执勤。
-
-亚洲一些规模最大、最无聊、最在乎在线时间的系统，机箱上都贴着一袋玉米脆片。它之所以有效，是因为维护它们的人相信它有效——这对大多数 IT 文化来说是一个相当诚实的描述。
-
-**KKTerm** 就是 **Kuai Kuai Term**——一个管理工作台，立志与那袋零食完成同样的使命：安静地陪在你重要的机器旁边，帮它们好好运行。本地优先。零遥测。需要审批的 AI。那种枯燥但可靠的软件。
-
-我们目前还无法随安装包一起寄出一袋真正的乖乖。这是 v2 的事项。
+对接下来该做什么有想法吗？来公开反馈帖聊聊：
+**[KKTerm 该为 Windows-first 管理工作流优先做什么？](https://github.com/ryantsai/KKTerm/discussions/141)**
 
 ---
 
-## 看它动起来
+## 为什么叫「KKTerm」？
+
+走进任何一座台湾的数据中心，抬头看机架顶端。从台积电晶圆厂、台北捷运控制室、国泰银行的服务器机房、中华电信的交换机房 — 你都会看到一小包绿色的 **乖乖**，那是 1960 年代就有的椰子味玉米点心。
+
+名字字面上就是「**乖乖的**」、「**听话**」。IT 圈的传统很简单，而且大家绝对是认真的：
+
+- **必须是绿色（椰子味）。** 黄色（咖喱）代表*今天请假*；红色（辣味）会把服务器惹毛。只有绿色。
+- **不能过期。** 过期的乖乖会反过来害你。工程师会勤奋地汰旧换新。
+- **必须看得到。** 服务器必须知道它在那里。
+- **不要吃它。** 那包乖乖正在值班。
+
+亚洲一些最大、最无聊、最执着于 uptime 的系统，就是这样靠着一包贴在机箱上的玉米脆果在运转。它有效，是因为维护它的人相信它有效 — 这也算是对 IT 文化最诚实的描述了。
+
+**KKTerm** 就是 **Kuai Kuai Term** — 一个跟那包点心一样有抱负的管理工作区：安静地坐在你那些重要机器旁边，帮它们乖一点。本地优先。零遥测。AI 全程要审批。那种无聊但可靠的软件。
+
+我们目前还没办法在 installer 里塞一包真正的乖乖。那是 v2 的待办事项。
+
+---
+
+## 亲眼看看
 
 <p align="center">
   <a href="https://github.com/ryantsai/KKTerm">
@@ -124,335 +123,173 @@
   </a>
 </p>
 
-<p align="center"><sub><em>（Demo GIF 放这里。一张图胜过一千条要点，而我们的要点已经写完了。）</em></sub></p>
+<p align="center"><sub><em>（demo GIF 放这里。一张图胜过一千个要点，而我们要点也快用完了。）</em></sub></p>
 
 ---
 
-## 为什么大家会一直开着它
+## 一扇窗口，所有连接
 
-### Windows 优先，有意为之
-
-看看 2026 年的开发工具市场。Claude Code：先出 Mac/Linux，Windows 版是"用 WSL 凑合"。Codex CLI：一样。`gemini-cli`、Homebrew 的一半、每一个光鲜的新 TUI：先出 Mac/Linux，Windows 用户在 README 里得到一行 `# Windows: contributions welcome` 注释，外加一个跑不起来的 fish 补全脚本。
-
-与此同时，那些真正让公司保持在线的人——企业 IT、MSP、运行着 Hyper-V、AD、SCCM、IIS 或某台比部分实习生还老的域控制器的人——坐在 Windows 机器前，疑惑为什么每个新工具都把他们的操作系统当成一种麻烦。
-
-**KKTerm 选择了反方向。** 我们先做原生 Windows，macOS / Linux 版本随后跟上。这意味着我们能使用真正有用的 Windows API，而不是用兼容层糊弄过去：
-
-- **ConPTY** 用于本地 Shell——真正的 Windows 伪终端，不是翻译垫片。PowerShell、`cmd.exe`、WSL 发行版，全都作为标准 PTY 托管，焦点、调整大小、VT 序列处理都与平台行为一致。
-- **WebView2** 驱动整个 UI 和嵌入式 URL **Connection**——使用系统运行时的进程内 Chromium，这也是安装包体积小、启动快的原因之一。
-- **Microsoft RDP ActiveX（`mstscax.dll`）** 用于 RDP——*微软自带的那个*。与远程桌面连接（`mstsc.exe`）使用同一个控件。不是第三方重实现，不是套壳 FreeRDP。用过 RDP 的人五秒钟就能感受到区别。
-- **Windows 凭据管理器** 存储所有密钥。SSH 密码、FTP 密码、API 密钥、URL Connection 凭据——全都住在 OS keychain 里，`credwiz.exe` 可以审计它们。
-- **NSIS 当前用户安装程序**，附带匹配的 SHA-256、原生托盘菜单、阻止休眠的电源申请、宿主 CPU/内存/网络采样、带真实 PNG 图标的原生 Tauri 右键菜单、原生打开/保存对话框。没有一个是模拟出来的。
-- **WSL 是一等公民 Shell，不是备选方案。** 同一个窗口里，Ubuntu 挨着 PowerShell Pane，挨着 SSH Session，挨着 RDP **Tab**。
-
-macOS 和 Linux 版本在路线图上，会得到同等用心的对待。但如果你一直在等有人先把*好的* Windows 管理工具做出来而不是最后才做——这就是了。
-
-### 本地优先，是真的本地
-
-你保存的 **Connection** 住在机器上的 SQLite 文件里。密码住在 **Windows 凭据管理器**里，不是放在二进制文件旁边的 JSON 里。应用不内置分析，不在启动时打电话回家，不需要云账号才能启动。没有"登录以同步"，因为没有同步这回事。
-
-就算你的网线着火了，KKTerm 照样能打开。
-
-### 一个工作台，覆盖所有连接类型
-
-| 你想要… | KKTerm 提供 |
+| 你想要… | KKTerm 帮你做到 |
 | --- | --- |
-| 打开本地 PowerShell / cmd / WSL Shell | 基于 ConPTY 的本地终端 **Session** |
-| SSH 连接到服务器 | 原生 `russh`，支持代理 / 密钥 / 密码认证、主机密钥信任流程、ProxyJump、端口转发 |
-| 浏览那台服务器上的文件 | 从 SSH **Connection** 启动的 SFTP，双栏面板、递归传输、chmod/chown |
-| FTP 连接到 2012 年的 NAS | FTP / FTPS **Connection**，与 SFTP 同款浏览器界面 |
-| Telnet 连接老旧设备 | 好的，Telnet 也在里面 |
-| 连接串口 | Serial **Connection** 类型，COM 口 + 波特率，无需额外工具 |
-| 远程登录 Windows 机器 | 通过 Microsoft ActiveX 控件实现的原生 RDP（真正的那个，不是克隆版） |
-| VNC 连接树莓派 | Rust `vnc-rs` framebuffer 直接渲染到工作台 |
-| 打开路由器的 Web 界面 | 嵌入式 WebView2 **URL Connection**，支持凭据自动填写 |
-| 监控宿主机 CPU | 实时状态栏 + 带拖拽/调整大小 Widget 的 **Dashboard** 模块 |
+| 开一个本机 PowerShell / cmd / WSL shell | 本机终端，并排摆着 |
+| SSH 进服务器 | SSH 支持密钥、agent、密码、跳板主机与 port forwarding |
+| 浏览那台服务器上的文件 | 从 SSH 连接直接开 SFTP — 双窗格、拖拽就能传 |
+| FTP 到 2012 年的 NAS | FTP / FTPS，同一个文件浏览器 |
+| Telnet 连上古董设备 | 对，Telnet 也在里面 |
+| 跟串口对话 | Serial 连接 — 选个 COM port 和波特率就好 |
+| 远程进一台 Windows 机器 | 内建货真价实的微软远程桌面 |
+| VNC 进一台 Pi | VNC，直接画进工作区 |
+| 开路由器的网页后台 | 内嵌浏览器标签页，还会帮你带入登录信息 |
+| 看主机的 CPU | 实时状态栏，加上一个你可以自己堆东西的 Dashboard |
 
-全是同一个应用。同一个窗口。同一套快捷键。同一套希望不会让你眼睛流血的主题。
+同一个 app。同一扇窗口。同一组快捷键。同一套但愿不会让你眼睛流血的主题。
 
-### 终端不再丢了魂
+---
 
-- 在 **Tab** 内分割 Pane。
-- WebGL 加速的 xterm.js 渲染，不支持时优雅降级。
-- 滚动搜索。
-- tmux 加持的 SSH Pane，可以挂载到稳定的按 Pane 命名的 Session，重连真的意味着*重连*，而不是"从头开始假装上一个小时什么都没发生"。
-- 切换 **Tab** **不会**终止 **Session**。关闭 **Tab** 才会。这个区分在内部是一场宗教战争；我们赢了。
+## 为什么大家整天开着它
 
-### AI 助手会打造你的工具
+### 故意做 Windows 优先
 
-大多数"终端里的 AI"演示止步于聊天。KKTerm 的助手还可以根据你的真实工作方式，打造小型、持久的 Dashboard Widget。危险操作仍然放在两个开关后面：
+看看现在的开发工具圈。Claude Code：先做 mac/linux，Windows 是「请用 WSL」。Codex CLI：一样。一半的新潮工具都先做 mac，留给 Windows 用户的是一句 `# contributions welcome` 注释，跟一个根本跑不起来的补全脚本。
 
-- **工具家族**（Dashboard / Connections / 实时 Session）——按类别独立开关。
-- **Composer 中的权限模式**——`Prompt`（默认，每次都问）或 `Allow All`（你是成年人，你签了免责声明）。
+而真正让公司不掉线的那群人 — 企业 IT、MSP、那些还在管比某些实习生年纪还大的 domain controller 的人 — 正坐在 Windows 机器前面，纳闷为什么每个新工具都把他们的操作系统当成麻烦。
 
-可对接 OpenAI、Anthropic、OpenRouter、DeepSeek、Grok、Azure OpenAI、LiteLLM、GitHub Copilot、Ollama、NVIDIA，或任何 OpenAI 兼容接口。API 密钥进 OS keychain。提出 `rm -rf` 的模型会被标记为危险并要求人工明确审批。AI 不能悄悄执行破坏性命令，哪怕有人在 man page 里玩了什么提示词注入的花样。
+**KKTerm 做相反的选择。** 我们先做 Windows 原生，所以 Windows 用户在意的东西就是会动：*货真价实*的微软远程桌面（就是 `mstsc.exe` 那个，不是仿冒品）、真正的 PowerShell / cmd / WSL shell、存进 Windows 凭据管理器的密码、像样的系统托盘图标、原生菜单和对话框。macOS 和 Linux 版本在 roadmap 上，也会得到同等的用心。但如果你一直在等有人把*好用的*那个 Windows 管理工具排在第一个做、而不是最后一个 — 这就是那个交易。
 
-### Dashboard 不假装自己是 Grafana
+### 本地优先就是真的本地
 
-**Dashboard** 模块是一个 12 列的可拖拽/调整大小的 Widget 实例网格。它不是用来做 PB 级可观测性的——它是用来做"我想要一个启动我五个常用应用的按钮，和一个显示 SSH 主机运行时间的面板，*就放在*我的聊天旁边"这种需求的。
+你存的连接就放在你机器上的一个文件里。密码存在 Windows 凭据管理器，不是放在 app 旁边的文本文件。KKTerm 不送任何分析数据、开机不回家报告、启动不需要云端账号。没有「登录以同步」这回事，因为根本没有同步。
 
-#### AI 创建的 Widget——描述需求，即刻生成
+就算你的网线着火了，KKTerm 还是打得开。
 
-这是我们真正兴奋的部分。你不用从市场里挑，也不用自己写 JavaScript。你**告诉 AI 助手你想要什么**，它就直接在你的 Dashboard 上构建出来：
+### 不会发疯的终端
 
-> *"添加一个显示我主仓库最近 5 次提交列表的 Widget。"*
-> *"给我做一个便利贴 Widget，用来存放我的值班备忘。"*
-> *"做一个每 30 秒 ping 我家路由器并显示绿色/红色的 Widget。"*
-> *"我需要一个秒表。样式随你发挥。"*
+- Tab 里可以分割窗格。
+- 又快又顺的渲染，scrollback 可搜索。
+- 重新连接就是真的*重新连接* — 你的远程 session 会接着上次的状态，而不是「从头来、假装刚刚那一小时没发生过」。
+- 切换 Tab **不会**杀掉 Session。关掉 Tab 才会。这个区别在内部曾是一场宗教战争；我们赢了。
 
-两种类型：
+### 一个会帮你打造工具的 AI 助理
 
-- **Content Widget**——声明式 JSON：Markdown、键值列表、清单、单一大数字统计。构造上安全，无脚本。大多数"我只是需要这个放在 Dashboard 上"的需求都在这里解决。
-- **Script Widget**——JavaScript 托管在隔离的 `iframe srcdoc` 沙盒内，具有明确声明的权限（`network` 白名单、`pollSeconds` 预算）。AI 写脚本，你审批权限，Widget 在一个无法触及应用其余部分的盒子里运行。
+大多数「终端里的 AI」demo 都停在聊天。KKTerm 的助理还能照你实际的工作方式，打造小而耐用的 Dashboard widget — 而且把危险的东西留在开关后面：
 
-你保留的每个 Widget 都是你的。它们与你的 **Connection** 一起持久化在 SQLite 里，有自己的视觉预设（`panel` / `ambient` / `hero`）、强调色、图标和标题。同一个 Widget 的多个实例可以共存，尺寸和样式完全不同。新鲜感退去后，右键单击删除即可。
+- **决定它能碰什么** — 整类工具（Dashboard / Connections / Live Sessions）可以一键开关。
+- **决定它怎么问** — `Prompt`（默认，每次都问）或 `Allow All`（你是成年人，你签了免责声明）。
 
-#### 动态 Dashboard 背景（因为我们就是想要）
+任何看起来像 `rm -rf` 的东西都会被标记为危险，等一个人类明确点头。AI 不会因为有人在某份 man page 里塞了 prompt injection，就偷偷跑一个破坏性命令。
 
-Dashboard 提供二十一种可按 **Dashboard View** 独立选择的 Canvas 动态背景：
+它能对接 OpenAI、Anthropic、OpenRouter、DeepSeek、Grok、Azure OpenAI、LiteLLM、GitHub Copilot、Ollama、NVIDIA，或任何 OpenAI 兼容的端点。你的 API 密钥会进到 OS keychain。
+
+### 一个不假装自己是 Grafana 的 Dashboard
+
+Dashboard 是一个可拖拽、可缩放的 widget 网格。它不是给你做 PB 级观测用的 — 它是给「我想要一个按钮启动我最爱的五个 app，旁边一个面板显示我 SSH 主机的 uptime，*再旁边*就是我的聊天窗口」用的。
+
+#### AI 打造的 Widget — 用讲的，它就生出来
+
+这部分是我们真心兴奋的。你不用从市场挑，也不用写 JavaScript。你**告诉 AI 助理你要什么**，它就直接在你的 Dashboard 上把 widget 做出来：
+
+> *「加一个 widget，把我主 repo 最近 5 条 commit 列成清单。」*
+> *「帮我做一个便利贴 widget，放我的 on-call 小抄。」*
+> *「做一个 widget，每 30 秒 ping 一次我家路由器，显示绿灯/红灯。」*
+> *「我要一个秒表。样式你自己发挥，给我点惊喜。」*
+
+有些是单纯的显示面板（markdown、checklist、一个大大的数字）；有些则在你批准过的隔离沙箱里跑实时代码。每个你留下的 widget 都是你的 — 它会带着自己的颜色、图标、标题保存下来，而且你可以放好几份不同大小。腻了就右键删掉。
+
+#### Dashboard 动画背景（因为我们就是想要）
+
+每个 Dashboard view 都能从**二十五种** canvas 动画背景里挑一种心情：
 
 | 心情 | 背景 |
 | --- | --- |
-| 平静 | `aurora`、`clouds`、`ocean`、`raindrops`、`snow`、`sakura`、`fireflies`、`bubbles`、`ricefield`、`lanterns` |
-| 宇宙感 | `starfield`、`nebula` |
+| 平静 | `aurora`、`clouds`、`ocean`、`raindrops`、`rainywindow`、`frostedWindow`、`snow`、`sakura`、`fireflies`、`bubbles`、`aquarium`、`ricefield`、`lanterns` |
+| 太空 | `starfield`、`nebula` |
 | 温暖 | `embers`、`lava` |
 | 极客 | `matrix`、`topo`、`synthwave` |
-| 混乱 | `cyberpunk`、`taipei101`、`thunderstorm`、`confetti` |
+| 躁动 | `cyberpunk`、`taipei101`、`thunderstorm`、`confetti`、`particleCursor` |
 
-它们运行在单个共享的 requestAnimationFrame 上，并尊重窗口焦点，所以你去干别的事的时候它们几乎不消耗资源。用 `matrix` 配上你的 AI 助手，打造出一种"我极度高效，同时可能正身处沃卓斯基电影中"的氛围。或者选 `ocean`，看起来像个严肃的人。我们两种选择都不评判。
+你切走的时候它们会暂停，所以几乎不耗资源。把 `matrix` 配上你的 AI 助理，气氛瞬间变成「我极度有生产力，而且大概人在沃卓斯基的电影里」。或者选 `ocean`，看起来像个正经人。两种选择我们都不评判。
 
-### 在服务器上跑 AI 编程 Agent，正确的方式
+### 让你的远程 AI agent 活着
 
-这是第二个让人一用就爱上的功能。KKTerm 的 SSH 终端可以直接启动到远程主机上的**命名 tmux Session**——默认会自动生成一个像 `kkterm-cockpit001` 这样的友好 ID，重连后依然存在：
+这是大家爱上的第二个功能。KKTerm 的 SSH 终端可以直接把你丢进远程主机上一个**命名的 tmux session**，而且它扛得过重连：
 
-- 开启一个启用了 tmux 的 SSH **Connection**。
-- 在 Pane 里启动 `claude`、`codex`、`gemini-cli`、`cursor-agent`，或任何你喜欢的长时间运行的编程 Agent。它们都是全屏 TUI 应用；tmux 正是它们想要的归宿。
-- 合上笔记本，再打开。Pane 会静默地重新挂载到同一个 tmux Session。Agent 还在跑，滚动历史还在，还在做着它之前做的事。
-- SSH 传输层发生网络抖动？KKTerm 会在不打扰你的情况下有限次地静默尝试重连同一个 tmux ID。
-- 想让 AI 助手看到 Agent 在做什么？"将终端缓冲区加入上下文"会通过 SSH 调用 `capture_tmux_pane`，将完整的 tmux 滚动历史——不只是屏幕上显示的内容，而是整个 Session——拉入对话。你的本地助手现在可以对你远程 Agent 的工作进行推理了。
+- 开一个启用 tmux 的 SSH 连接，然后启动 `claude`、`codex`、`gemini-cli`、`cursor-agent`，或任何你爱用的长时间 agent。
+- 合上笔记本。再打开。Pane 会悄悄重新 attach — agent 还在跑，scrollback 还在，还在做它刚才在做的事。
+- 网络抖了一下？KKTerm 会默默重连回同一个 session，不来烦你。
+- 想让助理帮忙？「把终端 buffer 加进 context」会把整个远程 session 拉进对话，让你的本地 AI 能推理你的远程 agent 在做什么。
 
-如果你曾经因为酒店 Wi-Fi 不稳定而丢失过一个跑了六小时的 `claude` 或 `codex` Session，这一个功能就值回应用的票价。这个应用是免费的。这个功能依然值。
+如果你曾经因为酒店那烂 Wi-Fi 而丢掉一个跑了六小时的 `claude` 或 `codex` session，光这一个功能就值回票价。（这 app 是免费的。但这功能还是值得。）
 
-### 知道你还剩多少 AI 可用
+### 知道你还剩多少 AI 额度
 
-编程 Agent 是按套餐窗口计费的，不是按月。Claude Code 有一个 5 小时窗口和一个每周窗口。Codex 有自己的版本。两者都能在你开会的时候，在后台悠闲地把你的配额吃光。
+编程 agent 是按方案窗口计费，不是按月，而且你在开会的时候它们会很乐意把你的配额吃光。**AI 用量计**让这件事一直看得见：
 
-**AI 编程用量** Widget 把这事摆在明面上：
+- 一个 Dashboard widget，把 **Claude Code** 和 **Codex** 并排显示：连接的账号、方案、当前窗口和本周用了多少、下次重置时间。
+- 一个精简的**状态栏指示器**，镜像同一组数字，所以就算 Dashboard 关着，你也能一眼看出在下一次大重构之前还剩多少余裕。
+- 它会提前告诉你需不需要重新登录 — 在长任务*之前*，而不是做到一半。
 
-- 一个 Dashboard Widget，把 **Claude Code** 和 **Codex** 并排显示：已连接账号、套餐等级、当前 5 小时窗口已用百分比、本周已用百分比、下次重置时间。
-- 一个**紧凑的状态栏指示器**，镜像同样的数字，即使关掉 Dashboard 你也能一眼看出在启动下一次大重构之前是否还有余量。
-- 认证状态直接可见（`connected` / `expired` / `error`），让你在长任务**之前**就发现需要重新登录，而不是任务跑到一半才发现。
-- 刷新策略遵守限速；Widget 按自己的节奏轮询，而不是每次你看它就去敲上游 API。
+### 让别的 AI 来操控 KKTerm
 
-### 内置 MCP 服务器 — 让其他 AI 来操作 KKTerm
+KKTerm 内建自己的 MCP 服务器，所以外部编程 agent（Claude Code、Codex、Copilot、Antigravity、OpenCode）能像你一样用你的工作区 — 列出连接、打开一个、读终端 buffer、把 widget 放到 Dashboard 上。AI 对 AI，全在你机器上，没有云端中继。会改动东西、比较有风险的操作，全部留在一个默认**关闭**的安全开关后面。
 
-你的终端也是 Claude Code、Codex、Copilot 的 Agent 模式、Antigravity 以及其余说 MCP 的世界想干活的地方。所以 KKTerm 自带一个 **stdio MCP 服务器**，[`kkterm-cli`](docs/MCP.md)，对外暴露 App 的一个精选切面：
-
-- **Workspace 模块**（`kkterm.workspace.*`）：列出已保存的 **Connection**、按 id 打开 Connection、列出活动 **Session**、向终端 Pane 发送输入、读取一份终端缓冲区快照。
-- **Dashboard 模块**（`kkterm.dashboard.*`）：加载 Dashboard 状态、读取 AI 创建的 Widget 源码、创建 / 更新 / 删除 View、放置 / 移动 / 删除 Widget 实例、批量应用布局。
-- **危险子命名空间**（`kkterm.<module>.dangerous.*`）：修改可执行表面——创建脚本 Widget、点击进入远程桌面、清空 Dashboard——被一个单一设置（`built_in_mcp_allow_all_dangerous`）门控，默认**关闭**。
-
-`kkterm-cli` 是一个轻量转发器。它通过 stdio JSON-RPC 与你的 MCP 客户端对话，并通过一个按启动认证的 Windows 命名管道与运行中的 KKTerm 窗口通信。当 KKTerm 关闭时，`tools/list` 仍能工作（客户端可以做内省），但 `tools/call` 会返回一个结构化的 `app_not_running` 错误，而不是真的去执行。
-
-把它接到你喜欢的客户端上，你的 AI 现在就能像你一样使用 KKTerm：
-
-```json
-{
-  "mcpServers": {
-    "kkterm": { "command": "<kkterm-cli-路径>", "args": [] }
-  }
-}
-```
-
-设置 → AI Assistant → **内置 MCP 服务器** 有一个一键"显示配置"对话框，里面预填了已解析二进制路径的 JSON 和 TOML 片段，外加可复制的 `claude mcp add` / `codex mcp add` 命令。
-
----
-
-## 整体架构
-
-```mermaid
-flowchart LR
-    User([You]) --> Shell[KKTerm Window<br/>Tauri v2 + React 19]
-    Shell --> Rail[Activity Rail]
-    Rail --> WS[Workspace Module]
-    Rail --> Dash[Dashboard Module]
-    Rail --> Inst[Installer Helper Module]
-    Rail -.-> FE[File Explorer<br/>planned]
-    Rail --> Set[Settings]
-
-    WS --> Tabs[Tabs &amp; Panes]
-    Tabs --> Term[Terminal<br/>ConPTY / russh]
-    Tabs --> SFTP[SFTP / FTP]
-    Tabs --> Web[WebView2 URL]
-    Tabs --> RD[RDP / VNC]
-
-    Shell -.calls.-> Rust[Rust Backend]
-    Rust --> SQLite[(SQLite<br/>Connections)]
-    Rust --> Keychain[(OS Keychain<br/>Secrets)]
-    Rust --> AI[AI Providers<br/>OpenAI-compat]
-
-    AI -. approval gate .-> Tabs
-
-    classDef local fill:#1f6feb,stroke:#1f6feb,color:#fff
-    classDef ai fill:#8a63d2,stroke:#8a63d2,color:#fff
-    class SQLite,Keychain local
-    class AI ai
-```
-
-关键的结构是：持久化保存的数据（**Connection**）与运行时活动状态（**Session**）分离，后者再与 UI 容器（**Tab**）分离。关闭 **Tab** 会终止 **Session**。切换 **Tab** 不会。这条规则让应用保持了理智。
-
----
-
-## 当前功能清单
-
-| 领域 | 已实现 |
-| --- | --- |
-| **Connections** | SQLite 树结构、文件夹/子文件夹、搜索、拖拽排序、重命名、复制、删除、**Quick Connect**、自定义图标、固定/活跃的 Activity Rail 快捷方式 |
-| **终端** | 本地 Shell、SSH、Telnet、Serial、分割 Pane、xterm.js + 机会性 WebGL、滚动搜索、本地启动目录/脚本 |
-| **SSH** | 原生 `russh`、代理/密钥/密码认证、主机密钥信任流程、可选系统 SSH 回退、ProxyJump、端口转发、**自动命名 tmux Session（`kkterm-<科幻名><n>`），传输层抖动时静默重连**——完美适配长时间运行的远程编程 Agent（Claude Code、Codex、gemini-cli 等） |
-| **SFTP / FTP** | SSH 启动的 SFTP 加上 FTP/FTPS **Connection**、双栏浏览器、递归传输、队列/取消/清除历史、冲突处理、属性、chmod/chown（支持时） |
-| **URL WebView** | 嵌入式 WebView2 URL **Session**、导航工具栏、favicon 捕获、存储的网站凭据元数据/填充、数据分区元数据 |
-| **远程桌面** | 通过 Windows ActiveX 实现的 RDP，含几何范围遮罩停靠；通过 `vnc-rs` framebuffer 在工作台 Canvas 中渲染的 VNC |
-| **Dashboard** | 持久化视图、Widget 实例、编辑模式、拖拽/调整大小、App Launcher、**AI 创作的 Content/Script Widget**（声明式 JSON 或带权限的沙盒 iframe JS）、按 Widget 的预设/强调色/图标/标题、**23 种动态 Canvas 背景**（aurora、clouds、ocean、raindrops、rainywindow、snow、sakura、fireflies、bubbles、ricefield、lanterns、starfield、nebula、embers、lava、matrix、topo、synthwave、cyberpunk、taipei101、thunderstorm、confetti、particleCursor） |
-| **AI 助手** | 流式聊天、OpenAI 兼容运行时、提供商注册表、命令提案安全分级、截图/上下文附件、**Dashboard Widget 创作（Content + 沙盒 Script）**、将 **tmux Pane 捕获**作为远程 Session 的对话上下文、**Connection** 管理工具，以及终端、RDP/VNC 和 SFTP/FTP 的实时 **Session** 工具 |
-| **AI 编程用量** | **Dashboard Widget + 状态栏指示器**，追踪 **Claude Code** 和 **Codex** 的配额使用情况：已连接账号、套餐等级、5 小时和每周窗口百分比、下次重置时间、认证状态（`connected` / `expired` / `error`）、限速友好的刷新策略 |
-| **内置 MCP 服务器** | stdio MCP 服务器（`kkterm-cli`），向外部编程 Agent（Claude Code、Codex、Copilot、Antigravity、OpenCode）暴露精选的 Workspace 和 Dashboard 工具；带认证的命名管道桥接；每个模块的 `dangerous.*` 命名空间由单一安全开关门控；设置中的对话框提供一键 JSON / TOML 片段以及 `claude mcp add` / `codex mcp add` 命令 |
-| **Installer Helper** | 活动轨道模块，提供随应用打包的 Windows 开发工具目录：检测已安装工具、比较最新版本、安装/更新/卸载、将工具排除在 Update all 之外、流式显示命令日志，并启动支持的受管理应用 |
-| **Settings** | 通用、外观、凭据、AI、SSH、终端、终端背景、URL、RDP、VNC、Dashboard、Installer Helper、关于；自定义 UI 字体；最小化到托盘；阻止休眠；备份/导入 |
-| **本地化** | 基于 i18next 的 UI，英文为源，动态语言包：zh-TW、zh-CN、ja、ko、fr、de、es、es-MX、it、pt-BR、th、id、vi |
-
-### AI 提供商
-
-OpenAI · Anthropic · OpenRouter · DeepSeek · Grok · Azure OpenAI · LiteLLM · GitHub Copilot · Ollama · NVIDIA · 任何 OpenAI 兼容接口。
-
-提供商元数据位于 [`src/ai/providerRegistry/`](src/ai/providerRegistry/)；Rust 适配器位于 [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/)。API 密钥经由 OS keychain，绝不进入 SQLite。
-
----
-
-## 快速开始
-
-你需要：
-
-- **Windows**（主要支持平台）
-- **Node.js + npm**
-- **Rust 工具链**
-- **Tauri v2 的 Windows 前置条件**，包括 **WebView2**
-
-```bash
-npm install
-npm run tauri dev
-```
-
-正常情况下会弹出一个真实的原生窗口。如果弹出的是堆栈跟踪——请提 Issue，我们喜欢好的复现步骤。
-
-### 常用检查
-
-```bash
-npm run check                                              # TypeScript
-npm run build                                              # Vite build
-cargo check --manifest-path src-tauri/Cargo.toml           # Rust
-cargo test  --manifest-path src-tauri/Cargo.toml           # Rust tests
-```
-
-### 打包 Windows 安装程序
-
-```bash
-npm run package:installer
-```
-
-安装程序脚本会生成 `artifacts/kkterm-<version>-windows-x64-setup.exe` 及配套的 `.sha256` 文件。目前**未签名**——发布签名在路线图上，但在此之前你的杀毒软件可能会瞪你一眼。这是正常的。
+设置 → AI Assistant → **Built-in MCP Server** 有一个一键「显示配置」对话框，全部帮你填好，还有可复制的 `claude mcp add` / `codex mcp add` 命令。
 
 ---
 
 ## KKTerm 不是什么
 
-简短说明，因为诚实能赢得信任：
+一份简短清单，因为诚实才能换到信任：
 
-- **不是云产品。** 没有同步，没有团队账户，没有 SaaS 层级。如果你看到"登录 KKTerm"的对话框，说明有什么事情严重出错了。
-- **不假装自己跨平台。** 我们有意将 Windows 放在首位；macOS 和 Linux 在路线图上，会使用同一个 Tauri v2 外壳。如果你今天需要一个 Mac 优先的工具，你有几百个选择。我们在打造 Windows 管理员一直在默默等待的那一个。
-- **不是自主 AI Agent。** 助手提议，人类决策。`Allow All` 是你主动做出的选择，不是默认设置。
-- **不是 Grafana / Datadog 的替代品。** Dashboard 是个人控制面板，不是万台主机的可观测性平台。
-- **不是 Kubernetes IDE。** 它是一个终端优先的管理工作台。请不要让它渲染 Helm chart。
+- **不是云端产品。** 没有同步、没有团队账号、没有 SaaS 套餐。如果你哪天看到「登录 KKTerm」对话框，那一定是出了什么天大的差错。
+- **不假装自己跨平台。** 我们是故意 Windows 优先；macOS 和 Linux 在 roadmap 上。如果你今天就需要 mac 优先的工具，你有上百个选择。我们在做的是 Windows 管理员默默等了很久的那一个。
+- **不是自主 AI agent。** 助理提议，人类决定。`Allow All` 是你自己做的选择，不是默认值。
+- **不是 Grafana / Datadog 的替代品。** Dashboard 是给个人控制面板用的，不是给一万台主机观测用的。
+- **不是 Kubernetes IDE。** 它是一个以终端为核心的管理工作区。拜托别叫它画 Helm chart。
 
-如果上面某条确实是你的硬性需求——没关系，v2 再见。
-
----
-
-## 原生调试
-
-使用真实的 Tauri 运行时进行验证：
-
-```bash
-npm run tauri dev
-```
-
-Vite 浏览器预览对前端检查有一定用处，但它**不会**托管真实的 WebView2、ConPTY、RDP ActiveX、VNC framebuffer、keychain 或原生菜单界面。如果某个功能涉及这些，请在实际的桌面运行时中验证。
-
-VS Code 用户：`Run KKTerm exe` 启动配置会以 `RUST_BACKTRACE=1` 启动 `src-tauri/target/debug/kkterm.exe`。配套的 `Attach KKTerm WebView2` 配置让你在真实 WebView2 宿主内使用 DevTools。
+如果上面任何一条*曾经*是你的雷点 — 公道，那我们 v2 见。
 
 ---
 
-## 当前限制（是的，我们知道）
+## 获取 KKTerm
 
-- 安装程序目前未签名。在配置发布签名之前，更新检查已禁用。
-- 原生 SFTP 路径尚不支持通过 ProxyJump 进行 SFTP。
-- 文件传输断点续传、文件夹同步/差异、归档/解压、远程编辑已延期。
-- SSH 配置导入已实现，但 Settings 中面向用户的入口尚未开放。
-- RDP 和 VNC 已上线；更丰富的剪贴板/设备同步和画质控制仍在完善中。
-- macOS 和 Linux 版本在路线图上。它们会来的，而且会做得正规——不会草草移植成一个"我们在那边也勉强能跑"的版本。
-- AI 助手可在配置的权限范围内提议并操作已启用的工具——请不要把它当成无人值守的机器人。它事实上并不知道你的 CEO 想要什么。
+**[下载最新版 Windows 安装程序（.exe）](https://github.com/ryantsai/KKTerm/releases/latest)** 然后运行它。这个安装程序目前**未签名** — 发行签名在 roadmap 上，在那之前你的杀毒软件可能会对你投以严厉的眼神。这是正常的。
+
+想从源码构建或贡献？你需要的一切都在 [`CONTRIBUTING.md`](CONTRIBUTING.md)。
 
 ---
 
-## 路线图（简版）
+## Roadmap（精简版）
 
 - macOS + Linux 版本
-- 签名安装程序 + 自动更新
-- 原生路径中的 ProxyJump SFTP
-- 文件传输断点续传、文件夹同步、归档/解压
-- 更丰富的 RDP 剪贴板/设备重定向
-- 更多内置 **Dashboard** Widget（以及 AI 创作 Widget 的公开 Schema）
+- 签名过的安装程序 + 自动更新
+- 更强的文件传输（续传、文件夹同步、压缩/解压）
+- 更完整的远程桌面剪贴板与设备共享
+- 更多内建 Dashboard widget
 
-完整且频繁更新的版本：[`docs/ROADMAP.md`](docs/ROADMAP.md)。
+完整且经常更新的版本：[`docs/ROADMAP.md`](docs/ROADMAP.md)。
 
 ---
 
-## 贡献
+## 参与贡献
 
-我们真的很欢迎帮忙。真的。哪怕是小事也有意义：
+我们很欢迎有人帮忙。真心的。小事也算数：
 
-- **试用开发版本**，遇到任何感觉不对劲的地方就提 Issue。"感觉哪里不对"是合法的 Bug 报告；我们会和你一起深挖。
-- **翻译一个语言包。** 英文是主源，位于 [`src/i18n/locales/en.json`](src/i18n/locales/en.json)；12 个其他语言包在旁边，按需加载。待翻译字符串按键名追踪于 [`docs/localization_todo/`](docs/localization_todo/)——挑一个，翻译它，删掉文件。
-- **添加一个 Dashboard Widget。** 内置 Widget 位于 [`src/modules/dashboard/widgets/builtin/`](src/modules/dashboard/widgets/builtin/)。想一个小点子，发布它，学习这个模式。
-- **收紧 AI 工具面。** 提供商适配器在 [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/)；前端注册表在 [`src/ai/providerRegistry/`](src/ai/providerRegistry/)。
-- **改进手册。** 用户文档位于 [`docs/manual/`](docs/manual/)。每个 UI 模块一章。如果你用了某个功能但文档没有帮到你，修复这个问题的 PR 就是黄金贡献。
+- **跑跑 dev 版本**，觉得哪里怪怪的就开个 issue。「感觉怪怪的」是合法的 bug 报告；我们会陪你一起挖。
+- **翻译一个语言。** 英文是 source of truth；旁边还住着另外十三种语言。
+- **加一个 Dashboard widget。** 挑个小点子，做出来，学会这套模式。
+- **改善手册。** 如果你用了某个功能、但文档帮不上忙，一个修好它的 PR 就是黄金。
 
-完整的开发环境搭建、项目结构、PR 检查清单，以及"请不要破坏这些"规则列表，都在 [`CONTRIBUTING.md`](CONTRIBUTING.md) 里。30 秒重点：
-
-- **重命名面向用户的术语前，先读 [`CONTEXT.md`](CONTEXT.md)。** **Connection**、**Session**、**Tab** 和 **Quick Connect** 各有特定含义；请不要随意漂移。
-- **每一条用户可见的字符串都要经过 `t()`。** JSX 里不出现裸英文文本。
-- **不要加前端关闭钩子。** Tauri v2 的标题栏关闭已经被 `onCloseRequested` 模式搞坏过好几次了。我们终于有了一个可用的形态；请不要重新引入它们。
-- **提 PR 前运行检查**（`npm run check && npm run build && cargo check && cargo test`）。
-
-在找入手点？按 [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 或 [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) 筛选 Issue。如果还没有打标签的，开一个 Issue 描述你想做的事，我们会帮你界定范围。
+完整的环境设置、项目结构与 PR 检查清单都在 [`CONTRIBUTING.md`](CONTRIBUTING.md)。在找切入点吗？用 [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 或 [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) 筛选 open issues。
 
 ---
 
 ## 项目文档
 
-- [产品背景](CONTEXT.md) — 你应该匹配的领域语言
-- [架构](docs/ARCHITECTURE.md) — 模块图，新代码放哪里
-- [路线图](docs/ROADMAP.md)
+- [产品脉络](CONTEXT.md) — 你该对齐的领域语言
+- [架构](docs/ARCHITECTURE.md) — 模块地图、新代码该放哪
+- [Roadmap](docs/ROADMAP.md)
 - [Dashboard 架构](docs/DASHBOARD.md)
-- [AI 提供商指南](docs/AI_PROVIDERS.md)
-- [性能说明](docs/PERFORMANCE.md)
-- [发布说明与门控](docs/RELEASE.md)
-
----
-
-## 技术栈
-
-Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand · xterm.js · SQLite · WebView2 · `russh` · `russh-sftp` · `vnc-rs` · `suppaftp` · OS keychain 存储。
+- [AI provider 指南](docs/AI_PROVIDERS.md)
 
 ---
 
@@ -466,12 +303,12 @@ Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand ·
   </picture>
 </a>
 
-你都看到这儿了还没点 Star——你还在等什么，需要个人邀请函吗？这就是你的个人邀请函。
+如果你看到这里却还没点 star — 你在等什么，等一张亲笔邀请函吗？这就是那张亲笔邀请函。
 
-⭐ **[在 GitHub 上 Star KKTerm](https://github.com/ryantsai/KKTerm)** — 只需一次点击，就能让维护者开心一整周。把它想成放在机架上的一个数字乖乖。
+⭐ **[在 GitHub 上给 KKTerm 点 star](https://github.com/ryantsai/KKTerm)** — 只要点一下，就能让维护者开心一整周。把它想成放在机架上的一包数字乖乖。
 
 ---
 
 ## 许可证
 
-MIT。详见 [LICENSE](LICENSE)。用它，fork 它，发布它，把它藏进一个没人能找到的家庭实验室——就是这么回事。
+MIT。见 [LICENSE](LICENSE)。用它、fork 它、拿去出货、把它放进一个没人找得到的 homelab — 这就是那个交易。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -5,7 +5,7 @@
 <h1 align="center">KKTerm</h1>
 
 <p align="center">
-  <strong>AI 工具當道的年代裡沒人想動手寫的那款 Windows 原生管理工作區 — 終端機、SSH、SFTP、RDP/VNC、Dashboard，加上一個能幫你打造專屬工具 Widget 的 AI。</strong>
+  <strong>一扇 Windows 原生視窗，搞定終端機、SSH、SFTP、RDP/VNC 和 Dashboard — 還附一個能照你要求打造專屬小工具的 AI。</strong>
 </p>
 
 <p align="center">
@@ -38,9 +38,6 @@
   </a>
   <br />
   <img src="https://img.shields.io/badge/Windows%E2%80%91first-by%20design-0078D6?style=flat-square&logo=windows" alt="Windows-first by design" />
-  <img src="https://img.shields.io/badge/built%20with-Tauri%20v2-FFC131?style=flat-square&logo=tauri" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/Rust-russh-orange?style=flat-square&logo=rust" alt="Rust" />
-  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react" alt="React 19" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
   <br />
   <sub>
@@ -73,23 +70,25 @@
 - 遠端桌面開在一個你一直在錯誤螢幕上找的視窗
 - 一個 VNC viewer，只為了那一台 Linux 主機
 - 一個瀏覽器分頁，開著路由器後台
-- 一個跑在遠端開發機上的 `claude` / `codex` session，每次 Wi-Fi 一打噴嚏就斷
+- 一個跑在遠端主機上的 `claude` / `codex` session，每次 Wi-Fi 一打噴嚏就斷
 - 一張寫著密碼的便利貼*（沒事，我們不會說出去）*
 
-**KKTerm 把這些塞進同一扇視窗。** 原生 Windows — *沒錯，是故意的，當整個開發工具圈都先做 mac 版、把你的作業系統當成備註處理的時候* — 用 Rust + Tauri v2 寫的，一個安裝程式就搞定，而且絕不回家報告。
+**KKTerm 把這些塞進同一扇視窗。** 原生 Windows — *沒錯，是故意的，當整個開發工具圈都先做 mac 版、把你的作業系統當成備註處理的時候* — 一個安裝程式就搞定，而且絕不回家報告。
 
 順便還幫你做了幾件你不知道自己需要的事：
 
-- 一個 **Dashboard**，你可以對 AI 說 *「幫我做一個每 30 秒 ping 一次路由器的 widget」*，它就會在你的網格上憑空出現，而且關在沙箱裡。
-- **可以自動 attach 到指定 tmux session 的 SSH pane**，這樣你那個跑在遠端的 `claude` / `codex` 就不會因為筆電每次鬧脾氣的 Wi-Fi 而陣亡。
-- 一個 **AI 編程用量 Widget**，在 **Dashboard** 和狀態列上秀出你的 Claude Code 與 Codex 配額——5 小時視窗、每週視窗、目前方案、帳號 Email——讓你不會凌晨三點才被 rate-limit 牆撞個正著。
-- 一個 **Installer Helper** 模組，幫你偵測、安裝、更新、解除安裝並啟動精選的 Windows 開發工具目錄——Node、Python、Docker、WSL、AI coding CLI，還有那些平常得翻好幾個瀏覽器分頁才找得到的小工具。
-- 一個**內建 MCP 伺服器**（`kkterm-cli`），讓外部編程 Agent（Claude Code、Codex、Copilot、Antigravity、OpenCode）能透過精選且有安全閘的工具表面操控你的 Workspace 與 Dashboard——列出 Connection、讀取終端機 buffer、放置 Widget。AI 對 AI，全在你機器上，沒有雲端中繼。
-- 二十一種 **canvas 動畫背景**（對，包括 `matrix`）給 Dashboard 用，因為我們也沒在客氣。
+- 一個 **Dashboard**，你可以對 AI 說 *「幫我做一個每 30 秒 ping 一次路由器的 widget」*，它就會在你的網格上憑空出現，而且關在自己的沙箱裡。
+- **能自動 attach 回遠端 `claude` / `codex` session 的 SSH pane**，這樣每次 Wi-Fi 鬧脾氣，你那個跑了六小時的工作也不會陣亡。
+- 一個 **AI 用量計**，讓你不會凌晨三點才被 rate-limit 牆撞個正著。
+- 一個 **Installer Helper**，幫你找到、安裝、更新並啟動那些平常得翻十個瀏覽器分頁才找得到的 Windows 開發工具。
+- Dashboard 用的**二十五種 canvas 動畫背景**（對，包括 `matrix`），因為我們也沒在客氣。
 
-喔對了，AI 助理可以把一句話變成一個你真的會繼續使用的小型 Dashboard 工具。
+而最棒的部分：AI 助理可以把一句話變成一個你真的會繼續使用的小型 Dashboard 工具。
 
 > ⭐ **如果這聽起來就是你過去六年一直想做的那個 app — 請按個星星，讓我們知道有人在看。這真的很有幫助。**
+
+對接下來該做什麼有想法嗎？來公開回饋串聊聊：
+**[KKTerm 該為 Windows-first 管理工作流優先做什麼？](https://github.com/ryantsai/KKTerm/discussions/141)**
 
 ---
 
@@ -128,335 +127,173 @@
 
 ---
 
-## 為什麼有人會整天開著它
+## 一扇視窗，所有連線
 
-### 原生 Windows，刻意為之
-
-看看 2026 年的開發者工具版圖。Claude Code：先做 mac/linux，Windows 是「請用 WSL」。Codex CLI：一樣。`gemini-cli`、Homebrew 一半的內容、每個閃亮新出的 TUI：mac/linux 優先，Windows 使用者拿到的是 README 裡那一句 `# Windows: contributions welcome`，外加一個跑不起來的 fish-completion script。
-
-可是真的把公司業務撐起來的那些人 — 企業 IT、MSP、跑 Hyper-V 或 AD 或 SCCM 或 IIS 或那台比某些實習生還老的 domain controller 的人 — 他們坐在 Windows 機器前，不懂為什麼每個新工具都當他們的 OS 是麻煩。
-
-**KKTerm 走的是反向路線。** 我們先做原生 Windows，macOS / Linux 之後跟上。這代表我們可以用上 Windows 真正重要的 API，而不是套一層 portability layer 矇混過去：
-
-- 本地 shell 用 **ConPTY** — 真正的 Windows pseudo-console，不是翻譯墊片。PowerShell、`cmd.exe`、各種 WSL distro，都用正規 PTY 承載，focus、resize、VT 序列處理全照平台規矩來。
-- 整個 UI 與內嵌 URL **Connection** 用 **WebView2** — 系統 runtime 提供的 in-process Chromium，這也是 installer 體積小、啟動快的原因之一。
-- RDP 用 **Microsoft RDP ActiveX（`mstscax.dll`）** — *就是微軟自己出貨的那個*。跟遠端桌面連線（`mstsc.exe`）用的是同一個元件。不是第三方重寫，也不是 FreeRDP 套殼。玩過 RDP 的人五秒內就感覺得出差別。
-- 所有密碼用 **Windows Credential Manager**。SSH 密碼、FTP 密碼、API key、URL Connection 憑證 — 全部住在 OS keychain 裡，`credwiz.exe` 可以幫你稽核。
-- **NSIS current-user installer** 附對應的 SHA-256，原生 tray menu、Don't-Sleep power assertion、主機 CPU/RAM/網路取樣、帶真實 PNG 圖示的原生 Tauri context menu、原生開啟/儲存對話框。沒有一項是用假的。
-- **WSL 是頭等公民 shell，不是替代方案。** 在同一個視窗裡，PowerShell pane 旁邊開一個 Ubuntu，再旁邊開一個 SSH session，再旁邊開一個 RDP **Tab**。
-
-macOS 與 Linux 版本在 roadmap 上，會用一樣的標準做出來。但如果你一直在等有人**先**好好做一個 Windows 管理工具、而不是最後才做 — 機會來了。
-
-### Local-first，是真的「本地」
-
-你儲存的 **Connection** 住在你電腦上的 SQLite 檔案。密碼住在 **Windows Credential Manager**，不是放在執行檔旁邊的 JSON。app 不出貨 analytics、啟動時不打電話回家、要跑也不需要雲端帳號。沒有「Sign in to sync」是因為根本沒有 sync。
-
-就算你的網路線著火，KKTerm 還是開得起來。
-
-### 一個工作區，包辦所有連線類型
-
-| 你想做的事… | KKTerm 提供 |
+| 你想要… | KKTerm 幫你做到 |
 | --- | --- |
-| 開本機 PowerShell / cmd / WSL shell | ConPTY 後端的本地終端 **Session** |
-| SSH 到伺服器 | 原生 `russh`，支援 agent / key / password 驗證、host-key 信任流程、ProxyJump、port forwarding |
-| 瀏覽該伺服器的檔案 | 從 SSH **Connection** 啟動 SFTP，雙欄、遞迴傳輸、chmod/chown |
-| FTP 到一台 2012 年的 NAS | 同樣的 SFTP 風格瀏覽器，FTP / FTPS **Connection** 都吃 |
-| Telnet 到上古機器 | 是，Telnet 也在裡面 |
-| 跟序列埠講話 | Serial **Connection** 類型，COM port + baud，不用額外工具 |
-| 遠端到 Windows 機器 | 透過 Microsoft ActiveX 控制項的原生 RDP（真貨，不是仿的） |
-| VNC 到 Pi | Rust `vnc-rs` framebuffer 直接畫進工作區 |
-| 開路由器後台 | 內嵌 WebView2 **URL Connection**，可填憑證 |
-| 看主機 CPU | 即時狀態列 + **Dashboard** 模組，含可拖曳/可縮放的 widget |
+| 開一個本機 PowerShell / cmd / WSL shell | 本機終端機，並排擺著 |
+| SSH 進伺服器 | SSH 支援金鑰、agent、密碼、跳板主機與 port forwarding |
+| 瀏覽那台伺服器上的檔案 | 從 SSH 連線直接開 SFTP — 雙窗格、拖曳就能傳 |
+| FTP 到 2012 年的 NAS | FTP / FTPS，同一個檔案瀏覽器 |
+| Telnet 連上古董設備 | 對，Telnet 也在裡面 |
+| 跟序列埠對話 | Serial 連線 — 選個 COM port 和 baud 就好 |
+| 遠端進一台 Windows 機器 | 內建貨真價實的微軟遠端桌面 |
+| VNC 進一台 Pi | VNC，直接畫進工作區 |
+| 開路由器的網頁後台 | 內嵌瀏覽器分頁，還會幫你帶入登入資訊 |
+| 看主機的 CPU | 即時狀態列，加上一個你可以自己堆東西的 Dashboard |
 
-全在同一個 app。同一扇視窗。同一組快捷鍵。同一個（希望）不刺眼的主題。
+同一個 app。同一扇視窗。同一組快捷鍵。同一套但願不會讓你眼睛流血的主題。
 
-### 終端機不會抽風
+---
 
-- **Tab** 裡可以分割 pane。
-- WebGL 加速的 xterm.js 渲染，撐不住時會優雅降級。
-- Scrollback 搜尋。
-- tmux 後端的 SSH pane 可以 attach 到穩定的 per-pane session，重新連線真的是*重新連線*，不是「重新開始假裝過去一小時不存在」。
-- 切 **Tab** **不會** 殺掉 **Session**。關 **Tab** 才會。這個區分我們內部吵過一場宗教戰爭；我們贏了。
+## 為什麼大家整天開著它
 
-### 一個會打造你工具的 AI 助理
+### 故意做 Windows 優先
 
-大部分「AI 在你終端機裡」的 demo 都停在聊天。KKTerm 的助理也能依照你實際工作的方式，打造小型、持久的 Dashboard Widget。危險操作仍然放在兩個開關後面：
+看看現在的開發工具圈。Claude Code：先做 mac/linux，Windows 是「請用 WSL」。Codex CLI：一樣。一半的新潮工具都先做 mac，留給 Windows 使用者的是一句 `# contributions welcome` 註解，跟一個根本跑不起來的補全腳本。
 
-- **工具家族**（Dashboard / Connection / Live Session）— 每個類別分別開關。
-- composer 裡的 **Permission mode** — `Prompt`（預設，每次都問）或 `Allow All`（你是大人，自己簽過免責聲明）。
+而真正讓公司不斷線的那群人 — 企業 IT、MSP、那些還在管比某些實習生年紀還大的 domain controller 的人 — 正坐在 Windows 機器前面，納悶為什麼每個新工具都把他們的作業系統當成麻煩。
 
-可以接 OpenAI、Anthropic、OpenRouter、DeepSeek、Grok、Azure OpenAI、LiteLLM、GitHub Copilot、Ollama、NVIDIA，或任何 OpenAI-compatible 端點。API key 收到 OS keychain。模型如果提議 `rm -rf` 會被歸類為危險，必須人類明確核可。AI 不可能因為有人在 man page 裡塞了 prompt injection 而偷偷跑掉破壞性指令。
+**KKTerm 做相反的選擇。** 我們先做 Windows 原生，所以 Windows 使用者在意的東西就是會動：*貨真價實*的微軟遠端桌面（就是 `mstsc.exe` 那個，不是仿冒品）、真正的 PowerShell / cmd / WSL shell、存進 Windows 認證管理員的密碼、像樣的系統匣圖示、原生選單和對話框。macOS 和 Linux 版本在 roadmap 上，也會得到同等的用心。但如果你一直在等有人把*好用的*那個 Windows 管理工具排在第一個做、而不是最後一個 — 這就是那個交易。
+
+### 本地優先就是真的本地
+
+你存的連線就放在你機器上的一個檔案裡。密碼存在 Windows 認證管理員，不是放在 app 旁邊的文字檔。KKTerm 不送任何分析數據、開機不回家報告、啟動不需要雲端帳號。沒有「登入以同步」這回事，因為根本沒有同步。
+
+就算你的網路線著火了，KKTerm 還是打得開。
+
+### 不會發瘋的終端機
+
+- Tab 裡可以分割窗格。
+- 又快又順的渲染，scrollback 可搜尋。
+- 重新連線就是真的*重新連線* — 你的遠端 session 會接著上次的狀態，而不是「從頭來、假裝剛剛那一小時沒發生過」。
+- 切換 Tab **不會**殺掉 Session。關掉 Tab 才會。這個區別在內部曾是一場宗教戰爭；我們贏了。
+
+### 一個會幫你打造工具的 AI 助理
+
+大多數「終端機裡的 AI」demo 都停在聊天。KKTerm 的助理還能照你實際的工作方式，打造小而耐用的 Dashboard widget — 而且把危險的東西留在開關後面：
+
+- **決定它能碰什麼** — 整類工具（Dashboard / Connections / Live Sessions）可以一鍵開關。
+- **決定它怎麼問** — `Prompt`（預設，每次都問）或 `Allow All`（你是成年人，你簽了切結書）。
+
+任何看起來像 `rm -rf` 的東西都會被標記為危險，等一個人類明確點頭。AI 不會因為有人在某份 man page 裡塞了 prompt injection，就偷偷跑一個破壞性指令。
+
+它能對接 OpenAI、Anthropic、OpenRouter、DeepSeek、Grok、Azure OpenAI、LiteLLM、GitHub Copilot、Ollama、NVIDIA，或任何 OpenAI 相容的端點。你的 API 金鑰會進到 OS keychain。
 
 ### 一個不假裝自己是 Grafana 的 Dashboard
 
-**Dashboard** 模組是 12 欄、可拖曳/縮放的 widget instance 網格。它不是給你做 petabyte 級觀測用的 — 它是給「我想要一個按鈕一鍵打開五個常用 app，旁邊還有一個顯示 SSH 主機 uptime 的面板，*再旁邊*是我的聊天視窗」用的。
+Dashboard 是一個可拖曳、可縮放的 widget 網格。它不是給你做 PB 級觀測用的 — 它是給「我想要一個按鈕啟動我最愛的五個 app，旁邊一個面板顯示我 SSH 主機的 uptime，*再旁邊*就是我的聊天視窗」用的。
 
-#### AI 建立的 Widget — 用講的，它就出現
+#### AI 打造的 Widget — 用講的，它就生出來
 
-這部分我們是真的興奮。你不用從某個 marketplace 挑，也不用寫 JavaScript。你**直接告訴 AI 助理你要什麼**，它就在你的 dashboard 上把 widget 蓋出來：
+這部分是我們真心興奮的。你不用從市集挑，也不用寫 JavaScript。你**告訴 AI 助理你要什麼**，它就直接在你的 Dashboard 上把 widget 做出來：
 
-> *「加一個 widget，把我 main repo 上最近 5 個 commit 用清單顯示。」*
-> *「給我一個便利貼 widget，裡面放我的 on-call 備忘錄。」*
-> *「做一個 widget，每 30 秒 ping 一次我家路由器，顯示綠燈或紅燈。」*
-> *「我需要一個碼錶。樣式你自己看著辦。」*
+> *「加一個 widget，把我主 repo 最近 5 筆 commit 列成清單。」*
+> *「幫我做一個便利貼 widget，放我的 on-call 小抄。」*
+> *「做一個 widget，每 30 秒 ping 一次我家路由器，顯示綠燈/紅燈。」*
+> *「我要一個碼錶。樣式你自己發揮，給我點驚喜。」*
 
-兩種口味：
+有些是單純的顯示面板（markdown、checklist、一個大大的數字）；有些則在你核准過的隔離沙箱裡跑即時程式碼。每個你留下的 widget 都是你的 — 它會帶著自己的顏色、圖示、標題保存下來，而且你可以放好幾份不同大小。膩了就右鍵刪掉。
 
-- **Content widget** — 宣告式 JSON：markdown、kv 清單、checklist、單一大數字。先天安全，沒有 script。大部分「我只是想把這個東西放在 dashboard 上」的需求都落在這裡。
-- **Script widget** — JavaScript，跑在隔離的 `iframe srcdoc` 沙箱裡，權限明確宣告（`network` allowlist、`pollSeconds` 預算）。AI 把 script 寫好，你核准權限，widget 就跑在一個碰不到 app 其他部分的盒子裡。
+#### Dashboard 動畫背景（因為我們就是想要）
 
-每個你留下來的 widget 都是你的。它們跟 **Connection** 一起存在 SQLite，帶有自己的視覺 preset（`panel` / `ambient` / `hero`）、accent 色、圖示、標題。同一個 widget 可以同時有多個 instance，大小與樣式都可以完全不同。新鮮感過了就右鍵刪除。
+每個 Dashboard view 都能從**二十五種** canvas 動畫背景裡挑一種心情：
 
-#### Dashboard 動畫背景（因為我們想要）
-
-Dashboard 有二十一種 canvas 動畫背景，每個 **Dashboard View** 都可以挑：
-
-| 氛圍 | 背景 |
+| 心情 | 背景 |
 | --- | --- |
-| 沉靜 | `aurora`、`clouds`、`ocean`、`raindrops`、`snow`、`sakura`、`fireflies`、`bubbles`、`ricefield`、`lanterns` |
+| 平靜 | `aurora`、`clouds`、`ocean`、`raindrops`、`rainywindow`、`frostedWindow`、`snow`、`sakura`、`fireflies`、`bubbles`、`aquarium`、`ricefield`、`lanterns` |
 | 太空 | `starfield`、`nebula` |
 | 溫暖 | `embers`、`lava` |
-| 阿宅 | `matrix`、`topo`、`synthwave` |
-| 失控 | `cyberpunk`、`taipei101`、`thunderstorm`、`confetti` |
+| 極客 | `matrix`、`topo`、`synthwave` |
+| 躁動 | `cyberpunk`、`taipei101`、`thunderstorm`、`confetti`、`particleCursor` |
 
-它們共用一個 `requestAnimationFrame`，會跟著視窗 focus 暫停，所以你不在的時候幾乎不耗資源。`matrix` 配 AI 助理可以散發出「我超有生產力，而且可能在駭客任務裡」的氣場。或者選 `ocean`，看起來像個正經人。兩種選擇我們都不會評判。
+你切走的時候它們會暫停，所以幾乎不耗資源。把 `matrix` 配上你的 AI 助理，氣氛瞬間變成「我極度有生產力，而且大概人在華卓斯基的電影裡」。或者選 `ocean`，看起來像個正經人。兩種選擇我們都不評判。
 
-### 在伺服器上跑 AI coding agent，用對的方式
+### 讓你的遠端 AI agent 活著
 
-這是大家會愛上的第二個功能。KKTerm 的 SSH 終端可以直接啟動到遠端主機上的 **named tmux session** — 預設會自動生成一個友善 id，像 `kkterm-cockpit001`，斷線重連也活著：
+這是大家愛上的第二個功能。KKTerm 的 SSH 終端機可以直接把你丟進遠端主機上一個**命名的 tmux session**，而且它撐得過重連：
 
-- 開一個啟用 tmux 的 SSH **Connection**。
-- 在 pane 裡跑 `claude`、`codex`、`gemini-cli`、`cursor-agent`，或你愛用的任何長時間運行的 coding agent。它們是全螢幕 TUI app；tmux 就是它們最舒服的家。
-- 把筆電蓋上。再打開。Pane 會悄悄地重新 attach 到同一個 tmux session。Agent 還在跑，scrollback 還在，還在做它原本在做的事。
-- SSH 傳輸層斷線？KKTerm 會用同一個 tmux id 嘗試有界次數的靜默 reattach，不會煩你。
-- 想讓 AI 助理看看那個 agent 在幹什麼？「Add terminal buffer to context」會透過 SSH 呼叫 `capture_tmux_pane`，把完整的 tmux scrollback — 不只是螢幕上看得到的，是整個 session — 拉進對話。你本地的助理就可以對你遠端 agent 的工作進行推理。
+- 開一個啟用 tmux 的 SSH 連線，然後啟動 `claude`、`codex`、`gemini-cli`、`cursor-agent`，或任何你愛用的長時間 agent。
+- 闔上筆電。再打開。Pane 會悄悄重新 attach — agent 還在跑，scrollback 還在，還在做它剛才在做的事。
+- 網路抖了一下？KKTerm 會默默重連回同一個 session，不來煩你。
+- 想讓助理幫忙？「把終端機 buffer 加進 context」會把整個遠端 session 拉進對話，讓你的本地 AI 能推理你的遠端 agent 在做什麼。
 
-如果你曾經因為飯店爛 Wi-Fi 弄丟過六小時的 `claude` 或 `codex` session，光這一個功能就值回票價了。Btw，app 是免費的。但這功能還是值得。
+如果你曾經因為飯店那爛 Wi-Fi 而丟掉一個跑了六小時的 `claude` 或 `codex` session，光這一個功能就值回票價。（這 app 是免費的。但這功能還是值得。）
 
-### 知道你的 AI 還剩多少額度
+### 知道你還剩多少 AI 額度
 
-Coding agent 是用方案的「視窗」收費的，不是按月。Claude Code 有 5 小時視窗跟每週視窗。Codex 有自己的版本。兩者都能在你開會的時候，在背景把你的配額吃光光。
+編程 agent 是按方案視窗計費，不是按月，而且你在開會的時候它們會很樂意把你的配額吃光。**AI 用量計**讓這件事一直看得見：
 
-**AI 編程用量** Widget 把這件事擺在你面前：
+- 一個 Dashboard widget，把 **Claude Code** 和 **Codex** 並排顯示：連線的帳號、方案、目前視窗和本週用了多少、下次重置時間。
+- 一個精簡的**狀態列指示器**，鏡像同一組數字，所以就算 Dashboard 關著，你也能一眼看出在下一次大重構之前還剩多少餘裕。
+- 它會提前告訴你需不需要重新登入 — 在長任務*之前*，而不是做到一半。
 
-- 一個 Dashboard Widget，把 **Claude Code** 跟 **Codex** 並排顯示：已連結帳號、方案等級、目前 5 小時視窗已用百分比、本週已用百分比、下次 reset 時間。
-- 一個**緊湊的狀態列指示器**，把同樣的數字鏡像顯示，所以就算關掉 Dashboard，你也能一眼看出在開下一個大重構之前還剩多少餘裕。
-- Auth 狀態直接顯示（`connected` / `expired` / `error`），讓你在長任務**之前**就發現要重登，而不是跑到一半才發現。
-- Refresh 策略尊重 rate limit；Widget 用自己的節奏 poll，而不是你每次看它就去敲上游 API。
+### 讓別的 AI 來操控 KKTerm
 
-### 內建 MCP 伺服器 — 讓其他 AI 來開 KKTerm
+KKTerm 內建自己的 MCP 伺服器，所以外部編程 agent（Claude Code、Codex、Copilot、Antigravity、OpenCode）能像你一樣用你的工作區 — 列出連線、打開一個、讀終端機 buffer、把 widget 放到 Dashboard 上。AI 對 AI，全在你機器上，沒有雲端中繼。會改動東西、比較有風險的操作，全部留在一個預設**關閉**的安全開關後面。
 
-你的終端機也是 Claude Code、Codex、Copilot 的 Agent 模式、Antigravity，以及其餘所有講 MCP 的世界想做事的地方。所以 KKTerm 自己附了一個 **stdio MCP 伺服器** [`kkterm-cli`](docs/MCP.md)，把 App 的精選切面開放出來：
-
-- **Workspace 模組**（`kkterm.workspace.*`）：列出已儲存的 **Connection**、用 id 開啟 Connection、列出活著的 **Session**、對終端機 Pane 送入輸入、讀一份終端機 buffer 的 snapshot。
-- **Dashboard 模組**（`kkterm.dashboard.*`）：載入 Dashboard 狀態、讀取 AI 建立的 Widget 原始碼、建立 / 更新 / 刪除 View、放置 / 移動 / 移除 Widget instance、批次套用佈局。
-- **危險子命名空間**（`kkterm.<module>.dangerous.*`）：變動可執行表面——建立 script Widget、點進遠端桌面、清空 Dashboard——一律被單一設定（`built_in_mcp_allow_all_dangerous`）擋著，預設**關閉**。
-
-`kkterm-cli` 是個薄薄的轉發器。它用 stdio JSON-RPC 跟你的 MCP client 對話，並透過每次啟動都會認證的 Windows 命名管道跟跑著的 KKTerm 視窗溝通。當 KKTerm 關起來時，`tools/list` 仍然能用（client 可以 introspect 表面），但 `tools/call` 會回一個結構化的 `app_not_running` 錯誤，而不是真的去做事。
-
-把它接到你喜歡的 client 上，你的 AI 從此就能像你一樣使用 KKTerm：
-
-```json
-{
-  "mcpServers": {
-    "kkterm": { "command": "<kkterm-cli-路徑>", "args": [] }
-  }
-}
-```
-
-設定 → AI Assistant → **內建 MCP 伺服器** 有一個一鍵「顯示設定」對話框，裡面預填好已解析的 binary 路徑的 JSON 與 TOML 片段，外加可複製的 `claude mcp add` / `codex mcp add` 指令。
-
----
-
-## 整體是怎麼湊在一起的
-
-```mermaid
-flowchart LR
-    User([You]) --> Shell[KKTerm Window<br/>Tauri v2 + React 19]
-    Shell --> Rail[Activity Rail]
-    Rail --> WS[Workspace Module]
-    Rail --> Dash[Dashboard Module]
-    Rail --> Inst[Installer Helper Module]
-    Rail -.-> FE[File Explorer<br/>planned]
-    Rail --> Set[Settings]
-
-    WS --> Tabs[Tabs &amp; Panes]
-    Tabs --> Term[Terminal<br/>ConPTY / russh]
-    Tabs --> SFTP[SFTP / FTP]
-    Tabs --> Web[WebView2 URL]
-    Tabs --> RD[RDP / VNC]
-
-    Shell -.calls.-> Rust[Rust Backend]
-    Rust --> SQLite[(SQLite<br/>Connections)]
-    Rust --> Keychain[(OS Keychain<br/>Secrets)]
-    Rust --> AI[AI Providers<br/>OpenAI-compat]
-
-    AI -. approval gate .-> Tabs
-
-    classDef local fill:#1f6feb,stroke:#1f6feb,color:#fff
-    classDef ai fill:#8a63d2,stroke:#8a63d2,color:#fff
-    class SQLite,Keychain local
-    class AI ai
-```
-
-關鍵分界：耐久儲存資料（**Connection**）獨立於 live runtime 狀態（**Session**），也獨立於 UI 容器（**Tab**）。關 **Tab** 會結束 **Session**。切 **Tab** 不會。這條規則是讓整個 app 保持清醒的關鍵。
-
----
-
-## 目前功能地圖
-
-| 區域 | 目前已實作 |
-| --- | --- |
-| **Connection** | SQLite 樹狀資料、資料夾/子資料夾、搜尋、拖放排序、重新命名、複製、刪除、**Quick Connect**、自訂圖示、釘選/作用中 rail 捷徑 |
-| **Terminal** | 本機 shell、SSH、Telnet、Serial、分割窗格、xterm.js + 機會性 WebGL、scrollback 搜尋、本機啟動目錄/啟動 script |
-| **SSH** | 原生 `russh`、agent/key/password 驗證、host-key 信任流程、可選 system SSH fallback、ProxyJump、port forwarding、**自動命名 tmux session（`kkterm-<scifi-name><n>`）並在傳輸層斷線時靜默 reattach** — 跑長期遠端 coding agent（Claude Code、Codex、gemini-cli 等）的完美搭檔 |
-| **SFTP / FTP** | 從 SSH 啟動的 SFTP 加上 FTP/FTPS **Connection**、雙欄瀏覽器、遞迴傳輸、佇列/取消/清除紀錄、衝突、屬性、支援的場合可 chmod/chown |
-| **URL WebView** | 內嵌 WebView2 URL **Session**、導覽工具列、favicon 擷取、儲存的網站憑證 metadata/fill、data partition metadata |
-| **Remote Desktop** | 透過 Windows ActiveX 的 RDP，含 geometry-scoped overlay parking；VNC 透過 `vnc-rs` framebuffer 繪製到工作區 canvas |
-| **Dashboard** | 持久 view、widget instance、edit mode、拖放/縮放、App Launcher、**AI 撰寫的 content/script widget**（宣告式 JSON 或帶權限的沙箱 iframe JS）、每個 widget 的 preset / accent / 圖示 / 標題、**23 種 canvas 動畫背景**（aurora、clouds、ocean、raindrops、rainywindow、snow、sakura、fireflies、bubbles、ricefield、lanterns、starfield、nebula、embers、lava、matrix、topo、synthwave、cyberpunk、taipei101、thunderstorm、confetti、particleCursor） |
-| **AI Assistant** | 串流聊天、OpenAI-compatible runtime、provider registry、指令提案安全分類、截圖/context 附件、**Dashboard widget 撰寫（content + 沙箱 script）**、把遠端 session 的 **tmux pane 捕捉**作為對話 context、**Connection** 管理工具，以及給終端、RDP/VNC、SFTP/FTP 的 live **Session** 工具 |
-| **AI 編程用量** | **Dashboard Widget + 狀態列指示器**，追蹤 **Claude Code** 與 **Codex** 的配額用量：已連結帳號、方案等級、5 小時與每週視窗百分比、下次 reset 時間、auth 狀態（`connected` / `expired` / `error`）、尊重 rate-limit 的 refresh 策略 |
-| **內建 MCP 伺服器** | stdio MCP 伺服器（`kkterm-cli`），對外部 coding agent（Claude Code、Codex、Copilot、Antigravity、OpenCode）開放精選的 Workspace 與 Dashboard 工具；經認證的 named pipe bridge；各模組的 `dangerous.*` 命名空間統一掛在單一安全切換之後；設定中的對話框提供一鍵 JSON / TOML 片段，以及 `claude mcp add` / `codex mcp add` 指令 |
-| **Installer Helper** | 活動軌道模組，提供打包隨附的 Windows 開發工具目錄：偵測已安裝工具、比對最新版本、安裝/更新/解除安裝、將工具排除於 Update all、串流指令日誌，並啟動支援的受管理 app |
-| **Settings** | General、Appearance、Credentials、AI、SSH、Terminal、終端機背景、URL、RDP、VNC、Dashboard、Installer Helper、About；自訂 UI 字型；minimize-to-tray；Don't Sleep；備份/匯入 |
-| **Localization** | i18next UI，英文為來源並動態載入 locale bundle：zh-TW、zh-CN、ja、ko、fr、de、es、es-MX、it、pt-BR、th、id、vi |
-
-### AI Provider
-
-OpenAI · Anthropic · OpenRouter · DeepSeek · Grok · Azure OpenAI · LiteLLM · GitHub Copilot · Ollama · NVIDIA · 任何 OpenAI-compatible 端點。
-
-Provider metadata 位於 [`src/ai/providerRegistry/`](src/ai/providerRegistry/)；Rust adapter 位於 [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/)。API key 走 OS keychain，絕不進 SQLite。
-
----
-
-## 快速開始
-
-需要：
-
-- **Windows**（主要支援平台）
-- **Node.js + npm**
-- **Rust toolchain**
-- **Windows 的 Tauri v2 prerequisites**，包含 **WebView2**
-
-```bash
-npm install
-npm run tauri dev
-```
-
-正常情況下應該會跑出一個原生視窗。如果跑出來的是 stack trace — 拜託開個 issue，我們愛看好用的重現步驟。
-
-### 常用檢查
-
-```bash
-npm run check                                              # TypeScript
-npm run build                                              # Vite build
-cargo check --manifest-path src-tauri/Cargo.toml           # Rust
-cargo test  --manifest-path src-tauri/Cargo.toml           # Rust tests
-```
-
-### 打包 Windows installer
-
-```bash
-npm run package:installer
-```
-
-Installer script 會產生 `artifacts/kkterm-<version>-windows-x64-setup.exe` 與對應的 `.sha256`。它目前**沒有簽章** — release signing 在 roadmap 上，但在那之前你的防毒軟體可能會對你投以嚴肅的眼神。屬於正常現象。
+設定 → AI Assistant → **Built-in MCP Server** 有一個一鍵「顯示設定」對話框，全部幫你填好，還有可複製的 `claude mcp add` / `codex mcp add` 指令。
 
 ---
 
 ## KKTerm 不是什麼
 
-簡短的清單，因為誠實才能換到信任：
+一份簡短清單，因為誠實才能換到信任：
 
-- **不是雲端產品。** 沒有 sync、沒有團隊帳號、沒有 SaaS 方案。如果你哪天看到「Sign in to KKTerm」對話框，那就出大事了。
-- **不假裝是跨平台。** 我們是刻意 Windows-first；macOS 與 Linux 在 roadmap 上，會用同樣的 Tauri v2 shell。如果你今天就需要一個 mac-first 的工具，你有幾百個選擇。我們在做的是 Windows 管理員默默等了很久的那一個。
-- **不是自主 AI agent。** 助理只提案；人類做決定。`Allow All` 是一個你主動做的選擇，不是預設。
-- **不是 Grafana / Datadog 的替代品。** Dashboard 是給你的個人控制面板用的，不是給萬台主機級觀測用的。
-- **不是 Kubernetes IDE。** 它是一個以終端為核心的管理工作區。拜託不要叫它幫你 render Helm chart。
+- **不是雲端產品。** 沒有同步、沒有團隊帳號、沒有 SaaS 方案。如果你哪天看到「登入 KKTerm」對話框，那一定是出了什麼天大的差錯。
+- **不假裝自己跨平台。** 我們是故意 Windows 優先；macOS 和 Linux 在 roadmap 上。如果你今天就需要 mac 優先的工具，你有上百個選擇。我們在做的是 Windows 管理員默默等了很久的那一個。
+- **不是自主 AI agent。** 助理提議，人類決定。`Allow All` 是你自己做的選擇，不是預設值。
+- **不是 Grafana / Datadog 的替代品。** Dashboard 是給個人控制面板用的，不是給一萬台主機觀測用的。
+- **不是 Kubernetes IDE。** 它是一個以終端機為核心的管理工作區。拜託別叫它畫 Helm chart。
 
-如果上面有任何一條對你是 dealbreaker — 沒關係，我們 v2 見。
-
----
-
-## 原生除錯
-
-請用真正的 Tauri runtime 驗證：
-
-```bash
-npm run tauri dev
-```
-
-Vite 瀏覽器 preview 對部分前端檢查有用，但它**不會**承載真正的 WebView2、ConPTY、RDP ActiveX、VNC framebuffer、keychain 或原生選單。任何摸到這些的功能，請在真正的桌面 runtime 裡驗證。
-
-VS Code 使用者：`Run KKTerm exe` 啟動設定會帶 `RUST_BACKTRACE=1` 啟動 `src-tauri/target/debug/kkterm.exe`。搭配的 `Attach KKTerm WebView2` 設定會讓你在真正的 WebView2 host 裡開 DevTools。
+如果上面任何一條*曾經*是你的雷點 — 公道，那我們 v2 見。
 
 ---
 
-## 目前的限制（沒錯，我們知道）
+## 取得 KKTerm
 
-- Installer 目前沒簽。Update check 在 release signing 設定好之前是關閉的。
-- 原生 SFTP 路徑還不支援 ProxyJump。
-- 檔案傳輸續傳、資料夾同步/diff、archive/extract、遠端編輯都還在後面排隊。
-- SSH config import 後端已實作，Settings 裡的入口還沒對外露出。
-- RDP 與 VNC 已出貨；更完整的 clipboard/裝置同步、品質控制仍在演進。
-- macOS 與 Linux 版本在 roadmap 上。它們會來，而且會用心做 — 不會以「我們在那邊也勉強能跑」的態度趕出來。
-- AI 助理會提案，並可以在設定的 permission 邊界內操作已啟用的工具 — 請不要把它當無人值守的機器人。它真的不知道你 CEO 在想什麼。
+**[下載最新版 Windows 安裝程式（.exe）](https://github.com/ryantsai/KKTerm/releases/latest)** 然後執行它。這個安裝程式目前**未簽章** — 發行簽章在 roadmap 上，在那之前你的防毒軟體可能會對你投以嚴厲的眼神。這是正常的。
+
+想從原始碼建置或貢獻？你需要的一切都在 [`CONTRIBUTING.md`](CONTRIBUTING.md)。
 
 ---
 
-## Roadmap（短版）
+## Roadmap（精簡版）
 
 - macOS + Linux 版本
-- 已簽章 installer + 自動更新
-- 原生路徑的 SFTP over ProxyJump
-- 檔案傳輸續傳、資料夾同步、archive/extract
-- 更完整的 RDP clipboard / 裝置 redirection
-- 更多內建 **Dashboard** widget（以及一份給 AI 撰寫用的公開 schema）
+- 簽章過的安裝程式 + 自動更新
+- 更強的檔案傳輸（續傳、資料夾同步、壓縮/解壓）
+- 更完整的遠端桌面剪貼簿與裝置共享
+- 更多內建 Dashboard widget
 
-完整、經常更新的版本：[`docs/ROADMAP.md`](docs/ROADMAP.md)。
+完整且時常更新的版本：[`docs/ROADMAP.md`](docs/ROADMAP.md)。
 
 ---
 
-## 一起來貢獻
+## 參與貢獻
 
-我們真的需要幫忙。小事也算數：
+我們很歡迎有人幫忙。真心的。小事也算數：
 
-- **試試 dev build**，覺得哪裡怪就開 issue。「總覺得怪怪的」是合法的 bug report；我們會陪你挖。
-- **翻一個 locale。** 來源真相是 [`src/i18n/locales/en.json`](src/i18n/locales/en.json)；旁邊住著另外 12 個 locale，按需載入。待翻譯字串以 per-key 形式追蹤在 [`docs/localization_todo/`](docs/localization_todo/) — 挑一個翻完，刪掉那個檔。
-- **加一個 Dashboard widget。** 內建 widget 在 [`src/modules/dashboard/widgets/builtin/`](src/modules/dashboard/widgets/builtin/)。挑個小點子，出貨它，順便學會 pattern。
-- **收緊 AI 工具的範圍。** Provider adapter 在 [`src-tauri/src/ai/providers/`](src-tauri/src/ai/providers/)；前端 registry 在 [`src/ai/providerRegistry/`](src/ai/providerRegistry/)。
-- **改善使用手冊。** 給終端使用者看的文件在 [`docs/manual/`](docs/manual/)。每個 UI 模組一章。如果你用了某個功能、文件卻幫不上忙，一個修正它的 PR 就是金。
+- **跑跑 dev 版本**，覺得哪裡怪怪的就開個 issue。「感覺怪怪的」是合法的 bug 回報；我們會陪你一起挖。
+- **翻譯一個語系。** 英文是 source of truth；旁邊還住著另外十三種語言。
+- **加一個 Dashboard widget。** 挑個小點子，做出來，學會這套模式。
+- **改善手冊。** 如果你用了某個功能、但文件幫不上忙，一個修好它的 PR 就是黃金。
 
-完整的設定、專案結構、PR checklist 與「請不要弄壞這些」的清單，全在 [`CONTRIBUTING.md`](CONTRIBUTING.md)。30 秒精華版：
-
-- **改動 user-facing 名詞之前，先讀 [`CONTEXT.md`](CONTEXT.md)。** **Connection**、**Session**、**Tab**、**Quick Connect** 各有特定意義；請不要漂移。
-- **每一個 user-visible 字串都要走 `t()`。** JSX 裡不要寫光禿禿的英文文字。
-- **不要在前端加 close hook。** Tauri v2 的標題列關閉行為被 `onCloseRequested` 模式弄壞過十幾次。我們終於有一個可運作的形狀；請不要把它們再請回來。
-- **PR 前跑檢查**（`npm run check && npm run build && cargo check && cargo test`）。
-
-找入口？篩選 [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 或 [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) 的 issue。如果還沒人貼這些標籤，開一個 issue 描述你想做什麼，我們會幫你拆分範圍。
+完整的環境設定、專案結構與 PR 檢查清單都在 [`CONTRIBUTING.md`](CONTRIBUTING.md)。在找切入點嗎？用 [`good first issue`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 或 [`help wanted`](https://github.com/ryantsai/KKTerm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) 篩選 open issues。
 
 ---
 
 ## 專案文件
 
-- [Product context](CONTEXT.md) — 你應該照著用的領域語言
-- [Architecture](docs/ARCHITECTURE.md) — 模組地圖、新程式碼放哪裡
+- [產品脈絡](CONTEXT.md) — 你該對齊的領域語言
+- [架構](docs/ARCHITECTURE.md) — 模組地圖、新程式碼該放哪
 - [Roadmap](docs/ROADMAP.md)
-- [Dashboard architecture](docs/DASHBOARD.md)
-- [AI provider guide](docs/AI_PROVIDERS.md)
-- [Performance notes](docs/PERFORMANCE.md)
-- [Release notes and gates](docs/RELEASE.md)
+- [Dashboard 架構](docs/DASHBOARD.md)
+- [AI provider 指南](docs/AI_PROVIDERS.md)
 
 ---
 
-## 技術棧
-
-Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand · xterm.js · SQLite · WebView2 · `russh` · `russh-sftp` · `vnc-rs` · `suppaftp` · OS keychain storage。
-
----
-
-## Star 紀錄
+## Star 歷史
 
 <a href="https://www.star-history.com/#ryantsai/KKTerm&Date">
   <picture>
@@ -466,12 +303,12 @@ Rust · Tauri v2 · React 19 · TypeScript · Vite · Tailwind CSS · Zustand ·
   </picture>
 </a>
 
-如果你看到這裡都還沒按星 — 是在等人家親自來邀請嗎？這就是親自邀請。
+如果你看到這裡卻還沒按星星 — 你在等什麼，等一張親筆邀請函嗎？這就是那張親筆邀請函。
 
-⭐ **[在 GitHub 為 KKTerm 點星](https://github.com/ryantsai/KKTerm)** — 一個 click，能讓 maintainer 開心整個禮拜。當作幫機架上放一包數位的乖乖。
+⭐ **[在 GitHub 上幫 KKTerm 按星星](https://github.com/ryantsai/KKTerm)** — 只要點一下，就能讓維護者開心一整週。把它想成放在機架上的一包數位乖乖。
 
 ---
 
 ## 授權
 
-MIT。詳見 [LICENSE](LICENSE)。用它、fork 它、出貨它、塞進一個別人找不到的 homelab — 這就是 deal。
+MIT。見 [LICENSE](LICENSE)。用它、fork 它、拿去出貨、把它放進一個沒人找得到的 homelab — 這就是那個交易。


### PR DESCRIPTION
## What

Rewrites `README.md` and all 13 translations (zh-TW, zh-CN, ja, ko, fr, de, es, es-MX, it, pt-BR, th, id, vi) to cut stale technical detail and lead with the fun, valuable, user-facing features — keeping the same voice in every language.

## Why

The old READMEs leaned heavily on implementation internals (much of it stale) instead of what users actually get. The animated-background count was also inconsistent across languages (pitch said 21, ja said 23, the table said 25).

## Removed

- The `mermaid` architecture diagram and "How It Fits Together"
- The giant "Current Feature Map" table and the "Stack" list
- Build/check commands, "Native Debugging", VS Code launch configs, installer-script paths
- Deep API name-drops in prose (ConPTY, WebView2, NSIS, named-pipe bridge mechanics)
- The framework-version badges (React 19 / Tauri v2 / Rust-russh) that go stale

## Kept / sharpened

- The 45-second pitch, the full 乖乖 (Kuāi Kuāi) origin story, "See It Move"
- "One Window, Every Connection" table, de-jargoned to benefits
- AI-built dashboard widgets, animated backgrounds, remote-agent tmux survival, AI usage meter, "let other AIs drive it," "What KKTerm Is Not"
- A short download/install section and trimmed roadmap/contributing/docs

## Notes

- Fixed the stale background count — now every language says **twenty-five** consistently (the actual list).
- Each file went from ~480 to a uniform **314 lines**, structurally identical, with the correct language bolded in each nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)