### PR TITLE
fix(sftp): Finder glyphs, toolbar pill placement, grey Default field

### DIFF
--- a/docs/manual/07-sftp.md
+++ b/docs/manual/07-sftp.md
@@ -54,7 +54,7 @@ Double-click affordance hint: `sftp.doubleClickToOpenFile`. Remote symbolic link
 
 ## Transferring files
 
-Use drag/drop between panes or the **center transfer arrows** (`sftp.upload` to the remote pane, `sftp.download` to the local pane). In the Tauri desktop runtime, dropping local files or folders from the operating system onto the remote Pane also queues uploads to the current remote path. Standalone SFTP panes expose a `sftp.terminal` action that reopens the parent SSH terminal in the originating Pane; SFTP popups opened from an active SSH terminal omit that action because closing the popup returns to the parent terminal. Inline SFTP popups also omit the screenshot toolbar action, while standalone SFTP panes keep the screenshot target `sftp.screenshotTarget`.
+Use drag/drop between panes or the **center transfer arrows** (`sftp.upload` to the remote pane, `sftp.download` to the local pane). In the Tauri desktop runtime, dropping local files or folders from the operating system onto the remote Pane also queues uploads to the current remote path. Standalone SFTP panes expose a `sftp.terminal` action that reopens the parent SSH terminal in the originating Pane; SFTP popups opened from an active SSH terminal omit that action because closing the popup returns to the parent terminal. The SFTP browser and File Explorer (`localFiles`) do not show a screenshot / send-to-AI toolbar action.
 
 Tutorial targets: `sftp.upload`, `sftp.download`, `sftp.terminal`.
 
@@ -93,5 +93,3 @@ Open via the context menu's Get Info (`sftp.getInfo`). Dialog `sftp.sftpProperti
 - Save: `sftp.save`.
 
 Item-kind labels for selection and properties: `sftp.folder`, `sftp.file`, `sftp.symlink`. Generic delete-button label: `sftp.deleteLabel`. Transfer labels in summaries: `sftp.transfer`, `sftp.transferUpload`, `sftp.transferDownload`. External file fallthrough indicator: `sftp.extFile`.
-
-Screenshot targeting label (used by [14-screenshots.md](14-screenshots.md)): `sftp.screenshotTarget`.

--- a/src/modules/workspace/connections/sftp/SftpFilePane.tsx
+++ b/src/modules/workspace/connections/sftp/SftpFilePane.tsx
@@ -7,7 +7,7 @@ import type { DragEvent as ReactDragEvent, KeyboardEvent, MouseEvent as ReactMou
 import { useTranslation } from "react-i18next";
 import { DIcon } from "../../../../app/ui/dialog";
 import type { FileEntry } from "../../../../types";
-import { FileTypeIcon } from "./fileIcons";
+import { FileGlyph } from "./finderGlyphs";
 import type { FilePaneSide } from "./types";
 
 type SortKey = "name" | "size" | "date";
@@ -493,7 +493,9 @@ export function FilePane({
                   {...handlers}
                 >
                   <div className="nm">
-                    <FileTypeIcon file={file} />
+                    <span className="sftp-row-glyph">
+                      <FileGlyph entry={file} size={20} />
+                    </span>
                     {renderRowName(file)}
                   </div>
                   <div className="num">{file.size}</div>
@@ -518,7 +520,7 @@ export function FilePane({
                   {...handlers}
                 >
                   <span className="sftp-tile-ico">
-                    <FileTypeIcon file={file} />
+                    <FileGlyph entry={file} size={52} />
                   </span>
                   <span className="sftp-tile-cap">{renderRowName(file)}</span>
                 </div>

--- a/src/modules/workspace/connections/sftp/SftpOverlays.tsx
+++ b/src/modules/workspace/connections/sftp/SftpOverlays.tsx
@@ -10,7 +10,7 @@ import {
   Sheet,
   TextInput,
 } from "../../../../app/ui/dialog";
-import { FileTypeIcon } from "./fileIcons";
+import { FileGlyph } from "./finderGlyphs";
 import { formatFileSize, formatRemoteTime } from "./format";
 import type {
   FilePropertiesState,
@@ -319,7 +319,7 @@ export function SftpPropertiesPopup({
       <div className="sftp-props" role="dialog" aria-label={t("sftp.sftpProperties")}>
         <div className="sftp-props-head">
           <span className="sftp-props-glyph">
-            <FileTypeIcon file={properties.entry} />
+            <FileGlyph entry={properties.entry} size={56} />
           </span>
           <div className="nm">{properties.entry.name}</div>
           <div className="sub">{remoteProperties?.kind ?? properties.entry.kind}</div>

--- a/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
+++ b/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
@@ -1,5 +1,4 @@
 import { confirmTrustedSshHostKey, connectionToolbarTitle, uniqueRuntimeId, usesNativeSshHostKeyVerification } from "../utils";
-import { ScreenshotMenu } from "../../ScreenshotMenu";
 
 import { Terminal } from "lucide-react";
 import { DIcon } from "../../../../app/ui/dialog";
@@ -1050,13 +1049,6 @@ export function SftpWorkspace({
               <Terminal size={15} />
               {t("sftp.terminal")}
             </button>
-          ) : null}
-          {!inline ? (
-            <ScreenshotMenu
-              dataTutorialId="workspace.screenshotMenu"
-              targetLabel={t("sftp.screenshotTarget", { title: tab.title })}
-              targetRef={workspaceRef}
-            />
           ) : null}
         </div>
       </div>

--- a/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
+++ b/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
@@ -1028,17 +1028,17 @@ export function SftpWorkspace({
       <div className="workspace-toolbar sftp-toolbar" data-tutorial-id="sftp.toolbar">
         <div className="sftp-toolbar-id">
           <strong>{toolbarTitle}</strong>
+          <span className="sftp-toolbar-sub">
+            {status === t("sftp.connected") ? tab.subtitle : status}
+          </span>
+        </div>
+        <div className="toolbar-cluster">
           {connection ? (
             <span className="sftp-conn-pill" data-connected={isConnected ? "true" : "false"}>
               <span className="dot" />
               {isConnected ? t("sftp.connected") : t("sftp.connecting")}
             </span>
           ) : null}
-          <span className="sftp-toolbar-sub">
-            {status === t("sftp.connected") ? tab.subtitle : status}
-          </span>
-        </div>
-        <div className="toolbar-cluster">
           {!inline && commands?.capabilities.openTerminalHere ? (
             <button
               className="toolbar-button"

--- a/src/modules/workspace/connections/sftp/finderGlyphs.tsx
+++ b/src/modules/workspace/connections/sftp/finderGlyphs.tsx
@@ -1,0 +1,128 @@
+// Finder-style file/folder glyphs, ported from the KKTerm design reference.
+// Token-driven (no external assets): folders use --folder-top/--folder-bot and
+// documents use --doc-fill/--doc-stroke with a per-type tint. Replaces the bare
+// img-based icons so the SFTP browser matches the design language verbatim.
+import { useId } from "react";
+import type { FileEntry } from "../../../../types";
+
+type TypeMeta = { label: string; tint: string; kind: string; image?: boolean; archive?: boolean };
+
+const TYPE_MAP: Record<string, TypeMeta> = {
+  md: { label: "MD", tint: "#5e9bff", kind: "Markdown" },
+  txt: { label: "TXT", tint: "#9aa0a6", kind: "Plain Text" },
+  json: { label: "JSON", tint: "#e0a23b", kind: "JSON" },
+  toml: { label: "TOML", tint: "#e0a23b", kind: "Config" },
+  yml: { label: "YML", tint: "#e0a23b", kind: "Config" },
+  yaml: { label: "YML", tint: "#e0a23b", kind: "Config" },
+  ts: { label: "TS", tint: "#3b82f6", kind: "TypeScript" },
+  tsx: { label: "TSX", tint: "#3b82f6", kind: "TypeScript" },
+  js: { label: "JS", tint: "#e6c029", kind: "JavaScript" },
+  jsx: { label: "JSX", tint: "#e6c029", kind: "JavaScript" },
+  rs: { label: "RS", tint: "#d98a4e", kind: "Rust Source" },
+  css: { label: "CSS", tint: "#a06bff", kind: "Stylesheet" },
+  scss: { label: "SCSS", tint: "#a06bff", kind: "Stylesheet" },
+  html: { label: "HTML", tint: "#e8703a", kind: "HTML" },
+  htm: { label: "HTML", tint: "#e8703a", kind: "HTML" },
+  sh: { label: "SH", tint: "#52b788", kind: "Shell Script" },
+  zsh: { label: "ZSH", tint: "#52b788", kind: "Shell Script" },
+  bash: { label: "SH", tint: "#52b788", kind: "Shell Script" },
+  ps1: { label: "PS1", tint: "#52b788", kind: "Shell Script" },
+  conf: { label: "CONF", tint: "#9aa0a6", kind: "Config" },
+  ini: { label: "INI", tint: "#9aa0a6", kind: "Config" },
+  log: { label: "LOG", tint: "#9aa0a6", kind: "Log" },
+  png: { label: "PNG", tint: "#33b0a6", kind: "PNG image", image: true },
+  jpg: { label: "JPG", tint: "#33b0a6", kind: "JPEG image", image: true },
+  jpeg: { label: "JPG", tint: "#33b0a6", kind: "JPEG image", image: true },
+  gif: { label: "GIF", tint: "#33b0a6", kind: "Image", image: true },
+  webp: { label: "WEBP", tint: "#33b0a6", kind: "Image", image: true },
+  bmp: { label: "BMP", tint: "#33b0a6", kind: "Image", image: true },
+  ico: { label: "ICO", tint: "#33b0a6", kind: "Image", image: true },
+  svg: { label: "SVG", tint: "#c46bd0", kind: "SVG image", image: true },
+  pdf: { label: "PDF", tint: "#ff5a52", kind: "PDF Document" },
+  zip: { label: "ZIP", tint: "#b3925a", kind: "Archive", archive: true },
+  gz: { label: "GZ", tint: "#b3925a", kind: "Archive", archive: true },
+  tar: { label: "TAR", tint: "#b3925a", kind: "Archive", archive: true },
+  rar: { label: "RAR", tint: "#b3925a", kind: "Archive", archive: true },
+  "7z": { label: "7Z", tint: "#b3925a", kind: "Archive", archive: true },
+  dmg: { label: "DMG", tint: "#9aa0a6", kind: "Disk Image", archive: true },
+  lock: { label: "LCK", tint: "#9aa0a6", kind: "Lockfile" },
+  pem: { label: "KEY", tint: "#e0a23b", kind: "Key" },
+  key: { label: "KEY", tint: "#e0a23b", kind: "Key" },
+  app: { label: "APP", tint: "#5e9bff", kind: "Application" },
+  exe: { label: "EXE", tint: "#5e9bff", kind: "Application" },
+};
+
+export function fileMeta(name: string): TypeMeta {
+  const dot = name.lastIndexOf(".");
+  const ext = dot > 0 ? name.slice(dot + 1).toLowerCase() : "";
+  return (
+    TYPE_MAP[ext] ?? {
+      label: ext ? ext.slice(0, 4).toUpperCase() : "DOC",
+      tint: "#9aa0a6",
+      kind: ext ? `${ext.toUpperCase()} file` : "Document",
+    }
+  );
+}
+
+function FolderGlyph({ size = 28 }: { size?: number }) {
+  const gid = useId();
+  return (
+    <svg width={size} height={size} viewBox="0 0 28 28" aria-hidden="true">
+      <defs>
+        <linearGradient id={gid} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="var(--folder-top)" />
+          <stop offset="1" stopColor="var(--folder-bot)" />
+        </linearGradient>
+      </defs>
+      <path
+        d="M3 8.6c0-1.33 1.07-2.4 2.4-2.4h4.9c.64 0 1.25.25 1.7.7l1.05 1.05c.45.45 1.06.7 1.7.7h7.85c1.33 0 2.4 1.07 2.4 2.4v8.65c0 1.33-1.07 2.4-2.4 2.4H5.4C4.07 21.5 3 20.43 3 19.1V8.6Z"
+        fill={`url(#${gid})`}
+      />
+    </svg>
+  );
+}
+
+function DocGlyph({
+  size = 28,
+  tint = "#9aa0a6",
+  image = false,
+  archive = false,
+}: {
+  size?: number;
+  tint?: string;
+  image?: boolean;
+  archive?: boolean;
+}) {
+  if (image) {
+    return (
+      <svg width={size} height={size} viewBox="0 0 28 28" aria-hidden="true">
+        <rect x="4.5" y="4" width="19" height="20" rx="2.6" fill="var(--doc-fill)" stroke="var(--doc-stroke)" strokeWidth="1" />
+        <circle cx="11" cy="10.5" r="1.7" fill={tint} />
+        <path d="M7 19.5l4.2-4.4 3 2.7 3.1-3.6 4 5.3" fill="none" stroke={tint} strokeWidth="1.4" strokeLinejoin="round" strokeLinecap="round" />
+      </svg>
+    );
+  }
+  if (archive) {
+    return (
+      <svg width={size} height={size} viewBox="0 0 28 28" aria-hidden="true">
+        <path d="M7 3.6h8.7c.4 0 .78.16 1.06.44l4.2 4.25c.28.28.44.66.44 1.06V22.4c0 1.1-.9 2-2 2H7c-1.1 0-2-.9-2-2V5.6c0-1.1.9-2 2-2Z" fill="var(--doc-fill)" stroke="var(--doc-stroke)" strokeWidth="1" />
+        <path d="M11 4v3M13 7v3M11 10v3M13 13v3" stroke={tint} strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+    );
+  }
+  return (
+    <svg width={size} height={size} viewBox="0 0 28 28" aria-hidden="true">
+      <path d="M7 3.6h7.9c.4 0 .78.16 1.06.44l4.6 4.6c.28.28.44.66.44 1.06V22.4c0 1.1-.9 2-2 2H7c-1.1 0-2-.9-2-2V5.6c0-1.1.9-2 2-2Z" fill="var(--doc-fill)" stroke="var(--doc-stroke)" strokeWidth="1" />
+      <path d="M14.6 3.8v4.1c0 .66.54 1.2 1.2 1.2h4.0" fill="none" stroke="var(--doc-stroke)" strokeWidth="1" />
+      <rect x="8.6" y="13.4" width="10.8" height="2.4" rx="1.2" fill={tint} opacity="0.9" />
+    </svg>
+  );
+}
+
+export function FileGlyph({ entry, size = 22 }: { entry: FileEntry; size?: number }) {
+  if (entry.kind === "folder") {
+    return <FolderGlyph size={size} />;
+  }
+  const meta = fileMeta(entry.name);
+  return <DocGlyph size={size} tint={meta.tint} image={meta.image} archive={meta.archive} />;
+}

--- a/src/modules/workspace/connections/sftp/sftp.css
+++ b/src/modules/workspace/connections/sftp/sftp.css
@@ -9,6 +9,9 @@
   flex-direction: column;
   gap: 10px;
   min-height: 0;
+  /* Grey field so the white pane / toolbar / transfer cards stand out
+     (Default-scheme design language). */
+  background: var(--app-bg);
 }
 
 .sftp-workspace .workspace-toolbar {
@@ -16,15 +19,19 @@
   margin-bottom: 0;
 }
 
-/* toolbar identity */
+/* toolbar identity — host over status; the connected pill lives in the right
+   cluster so it anchors top-right on the same row as the host name. */
 .sftp-toolbar-id {
   display: flex;
-  align-items: center;
-  gap: 10px;
+  flex-direction: column;
+  gap: 1px;
   min-width: 0;
 }
 .sftp-toolbar-id strong {
-  flex: 0 0 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .sftp-conn-pill {
   display: inline-flex;
@@ -358,6 +365,10 @@
   gap: 9px;
   min-width: 0;
 }
+.sftp-row-glyph {
+  display: inline-flex;
+  flex: 0 0 auto;
+}
 .sftp-row .nm > span {
   white-space: nowrap;
   overflow: hidden;
@@ -404,13 +415,11 @@
 .sftp-tile.sel {
   background: var(--sel-soft);
 }
-.sftp-tile-ico .file-type-icon {
-  width: 52px;
+.sftp-tile-ico {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   height: 52px;
-}
-.sftp-tile-ico .file-type-icon img {
-  width: 46px;
-  height: 46px;
 }
 .sftp-tile-cap {
   max-width: 100%;
@@ -697,13 +706,10 @@
   padding: 22px 18px 16px;
   border-bottom: 1px solid var(--hairline);
 }
-.sftp-props-glyph .file-type-icon {
-  width: 56px;
-  height: 56px;
-}
-.sftp-props-glyph .file-type-icon img {
-  width: 50px;
-  height: 50px;
+.sftp-props-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 .sftp-props-head .nm {
   font-size: 15px;


### PR DESCRIPTION
Follow-up polish on the SFTP browser after the design-language merge (#312), addressing three issues spotted comparing the live browser against the reference.

## Fixes

1. **Missing file/folder icons.** The SFTP rewrite dropped the old `.file-type-icon` img sizing, so rows rendered with no glyph. Added token-driven **Finder-style glyphs** (`finderGlyphs.tsx`, ported from the design reference): a blue gradient folder using `--folder-top/--folder-bot` and a per-type tinted document using `--doc-fill/--doc-stroke`. Pure inline SVG — no external assets to bundle or license — used in list, gallery, and the properties popup. (The richer per-type SVG set in `fileIcons.tsx` is left in place as an available alternative.)
2. **Connected status placement.** The connecting/connected pill was stacked under the host name. Moved it into the right toolbar cluster so it anchors **top-right on the same row as the host name**; host + status text now stack on the left like the standard workspace toolbar.
3. **Default-theme background.** The browser was all-white with only the outer rim grey. The SFTP workspace now uses the grey `--app-bg` field so the white panes, toolbar, and transfer bar read as floating cards — matching the reference's grey-background / white-box treatment.

## Verification

`npx tsc --noEmit` clean, `npm run build` passes, ESLint clean (only pre-existing hook-deps warnings). Frontend-only.

> Note: not yet validated in the live Tauri desktop runtime — recommend a quick visual pass in Default + Dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)