### PR TITLE
fix(ui): consistent dialog backgrounds, flat status pill, close-button margin

### DIFF
--- a/src/app/ui/dialog/dialogs.css
+++ b/src/app/ui/dialog/dialogs.css
@@ -7,7 +7,9 @@
 .kk-dlg,
 .kk-surface {
   --bg: var(--surface);
-  --bg-2: var(--surface-muted);
+  /* Footer shares the body surface — one consistent dialog background;
+     a hairline divider provides the separation, not a second fill. */
+  --bg-2: var(--surface);
   --chrome-2: var(--surface-muted);
   --sidebar: var(--surface-muted);
   --muted: var(--surface-muted);

--- a/src/modules/workspace/connections/sftp/sftp.css
+++ b/src/modules/workspace/connections/sftp/sftp.css
@@ -36,15 +36,11 @@
 .sftp-conn-pill {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  height: 21px;
-  padding: 0 9px 0 7px;
-  border-radius: 999px;
-  background: var(--surface-muted);
-  color: var(--text-muted);
-  font-size: 11px;
-  font-weight: 600;
+  gap: 6px;
   flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
 }
 .sftp-conn-pill .dot {
   width: 7px;

--- a/src/modules/workspace/connections/terminal/terminal.css
+++ b/src/modules/workspace/connections/terminal/terminal.css
@@ -1679,16 +1679,25 @@
   max-height: calc(100vh - 48px);
   padding: 0;
   overflow: hidden;
+  /* One consistent surface for the whole dialog (the grey field the panes
+     sit on); the white panes/toolbar/transfer bar are the only cards. */
+  background: var(--app-bg);
 }
 
 .sftp-popup-dialog .connection-dialog-header {
   flex: 0 0 auto;
-  padding: 16px 54px 12px 18px;
+  padding: 16px 56px 12px 18px;
+  border-bottom: 0;
 }
 
 .sftp-popup-dialog .connection-dialog-header h2 {
   margin: 0;
   font-size: 17px;
+}
+
+.sftp-popup-dialog .connection-dialog-close {
+  top: 14px;
+  right: 16px;
 }
 
 .sftp-popup-dialog-body {


### PR DESCRIPTION
Follow-up after #313. The SFTP popup showed three different surfaces (white dialog shell + white header, a grey workspace block, white panes) plus a separate chip behind the connected status. This makes dialog backgrounds consistent.

## Fixes

- **One consistent dialog surface.** The SFTP popup now uses a single grey field (`--app-bg`) across the header, body, and workspace instead of a white shell wrapping a grey workspace. The white panes, toolbar, and transfer bar remain the only "cards."
- **Flat status text.** The connected/connecting indicator no longer has its own pill background — it's now just a colored dot + text on the dialog surface.
- **Footer consistency (all sheet dialogs).** `ConfirmSheet` and every sheet built on the dialog kit now share the body surface in the footer instead of a separate grey fill; a hairline divider provides the separation. (The footer alias previously resolved to `--surface-muted`, rendering greyer than intended.)
- **Close-button margin.** The SFTP popup close button was flush to the top-right corner (the dialog has zero padding); it now has a sensible inset.

## Verification

`npm run build` passes. CSS-only change.

> Not yet validated in the live Tauri runtime — recommend a quick visual pass in Default + Dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)