### PR TITLE
fix(sftp): halve the titlebar height

### DIFF
--- a/src/modules/workspace/connections/sftp/sftp.css
+++ b/src/modules/workspace/connections/sftp/sftp.css
@@ -27,8 +27,17 @@
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
   gap: 12px;
-  min-height: 40px;
-  padding: 2px 6px 2px 14px;
+  min-height: 22px;
+  padding: 1px 6px 1px 14px;
+}
+/* Slim the action controls so they don't force the half-height titlebar taller. */
+.sftp-toolbar .toolbar-button {
+  height: 22px;
+  padding: 0 8px;
+}
+.sftp-toolbar .sftp-bar-close {
+  width: 22px;
+  height: 22px;
 }
 .sftp-bar-left {
   justify-self: start;


### PR DESCRIPTION
Follow-up after #315. Cuts the single-row SFTP titlebar to roughly half height.

- `min-height` 40px → 22px, trimmed vertical padding.
- Slimmed the action controls (Terminal button and close button) to 22px so they no longer force the row taller.

CSS-only; `npm run build` passes. Worth a quick visual pass in Default + Dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)