### PR TITLE
feat(connections): align Add/Edit dialog with the design language

### DIFF
--- a/src/modules/workspace/connections/ConnectionSidebar.tsx
+++ b/src/modules/workspace/connections/ConnectionSidebar.tsx
@@ -30,7 +30,7 @@ import {
 import { confirmTrustedSshHostKey, connectionPasswordOwnerId, defaultPortForConnectionType, connectionTypeLabel, ftpPortForProtocolSelection, isRemoteDesktopConnectionType, localShellOptionsForPlatform, uniqueRuntimeId, type LocalShellOption } from "./utils";
 import { RECENT_CONNECTION_LIMIT, loadCollapsedFolderIds, loadRecentConnectionIds, notifyConnectionTreeInvalidated, saveCollapsedFolderIds, saveRecentConnectionIds } from "./connectionSidebarState";
 import { collectConnectionFolderIds, countConnections, countFolders, filterConnectedConnections, filterConnectionTree, findConnectionInTree, flattenConnections, flattenFolders, visibleFlatConnections as flattenVisibleConnections, withLiveConnectionStatuses } from "./treeUtils";
-import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, ChevronDown, ChevronRight, CircleDot, Folder, FolderPlus, KeyRound, LayoutDashboard, List, Maximize2, Minimize2, PanelRight, Pencil, Pin, PinOff, Play, Plus, RotateCcw, Save, Search, Settings, SquarePlus, Trash2, X } from "lucide-react";
+import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Check, ChevronDown, ChevronRight, CircleDot, Folder, FolderPlus, KeyRound, LayoutDashboard, List, Maximize2, Minimize2, PanelRight, Pencil, Pin, PinOff, Play, Plus, RotateCcw, Save, Search, Settings, SquarePlus, Trash2, X } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { FormEvent, MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from "react";
@@ -3674,14 +3674,22 @@ function ConnectionDialog({
           className={mode === "quick" ? "connection-dialog-header" : "connection-dialog-header compact"}
         >
           <div>
-            <p className="panel-label">
+            <p className="connection-dialog-eyebrow">
               {mode === "edit"
                 ? t("connections.connectionProperties")
                 : mode === "save"
                   ? t("connections.newConnectionTitle")
                   : t("connections.quickConnect")}
             </p>
-            {mode === "quick" ? <h2>{t("connections.openOneOffSession")}</h2> : null}
+            {connectionType ? (
+              <h2 className="connection-dialog-title">
+                {isEditMode
+                  ? initialConnection?.name || connectionTypeLabel(connectionType)
+                  : connectionTypeLabel(connectionType)}
+              </h2>
+            ) : mode === "quick" ? (
+              <h2 className="connection-dialog-title">{t("connections.openOneOffSession")}</h2>
+            ) : null}
           </div>
         </header>
 
@@ -3756,7 +3764,7 @@ function ConnectionDialog({
 
         <div className="dialog-actions">
           <button className="approve-button" disabled={!connectionType} type="submit">
-            <Save size={15} />
+            <Check size={15} />
             {mode === "quick" ? t("connections.saveAndConnect") : t("common.save")}
           </button>
           <button className="toolbar-button" type="button" onClick={onCancel}>

--- a/src/modules/workspace/connections/connections.css
+++ b/src/modules/workspace/connections/connections.css
@@ -716,14 +716,23 @@
   background: var(--surface-muted);
 }
 
-.connection-dialog-header .panel-label {
-  margin-bottom: 0;
+.connection-dialog-header .connection-dialog-eyebrow {
+  margin: 0 0 3px;
+  color: var(--text-faint);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.connection-dialog-header .connection-dialog-title {
+  margin: 0;
   color: var(--text);
   font-size: 17px;
   font-weight: 680;
   letter-spacing: -0.018em;
-  line-height: 1.25;
-  text-transform: none;
+  line-height: 1.2;
 }
 
 .connection-dialog-header.compact .panel-label {
@@ -1070,7 +1079,8 @@
   min-width: 0;
   padding: 10px;
   background: var(--surface-muted);
-  border-radius: 8px;
+  border-radius: 10px;
+  box-shadow: inset 0 0 0 0.5px var(--border);
 }
 
 .connection-endpoint-fields {
@@ -1190,7 +1200,8 @@ fieldset.connection-specific-options > legend {
   min-width: 0;
   padding: 10px;
   background: var(--surface-muted);
-  border-radius: 8px;
+  border-radius: 10px;
+  box-shadow: inset 0 0 0 0.5px var(--border);
 }
 
 .connection-specific-options-panel > .connection-session-toggle:first-child {
@@ -1201,14 +1212,16 @@ fieldset.connection-specific-options > legend {
 .connection-specific-options-panel > .connection-option-fields {
   padding: 8px 0;
   background: transparent;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--hairline);
   border-radius: 0;
+  box-shadow: none;
 }
 
 .connection-specific-options-panel > .connection-session-fields {
   padding: 0;
   background: transparent;
   border-radius: 0;
+  box-shadow: none;
 }
 
 .connection-session-toggle {
@@ -1254,11 +1267,40 @@ fieldset.connection-specific-options > legend {
 }
 
 .connection-dialog .connection-session-toggle input[type="checkbox"]:checked {
-  background: var(--accent);
+  background: var(--green);
 }
 
 .connection-dialog .connection-session-toggle input[type="checkbox"]:checked::after {
   transform: translateX(16px);
+}
+
+/* Popup-style select: blue rounded chevron box on the right (design language). */
+.connection-dialog select {
+  -webkit-appearance: none;
+  appearance: none;
+  padding-right: 34px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'%3E%3Crect width='20' height='20' rx='5' fill='%230a84ff'/%3E%3Cpath d='M7 9l3-3 3 3M7 11l3 3 3-3' fill='none' stroke='white' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 6px center;
+  background-size: 20px 20px;
+}
+.connection-dialog select:disabled {
+  opacity: 0.55;
+}
+
+/* Primary action is accent-blue (matches the design language), not green. */
+.connection-dialog .dialog-actions .approve-button {
+  color: #fff;
+  background: var(--accent);
+  border-color: transparent;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+.connection-dialog .dialog-actions .approve-button:hover:not(:disabled) {
+  background: var(--accent-press);
+}
+.connection-dialog .dialog-actions .approve-button.danger {
+  background: var(--red);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--red) 30%, transparent);
 }
 
 @keyframes fields-in {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -528,8 +528,8 @@ h2 {
   width: min(560px, calc(100vw - 40px));
   padding: 14px;
   overflow: hidden;
-  background: var(--chrome);
-  border-color: var(--border-strong);
+  background: var(--surface);
+  border-color: var(--border);
   box-shadow: var(--shadow);
   font-size: 13px;
 }


### PR DESCRIPTION
The Add/Edit Connection dialog was only lightly touched in the earlier sweep. This brings it in line with the reference design language across **all connection kinds** (they share the dialog shell + CSS): SSH, Local, RDP, VNC, Telnet, Serial, FTP, URL, File Explorer.

## Changes (match the reference)

- **Background:** white dialog surface (was grey `--chrome`).
- **Header:** uppercase eyebrow ("New Connection" / "Connection Properties" / "Quick Connect") + a title showing the connection **kind** (or the connection **name** when editing).
- **Primary button:** accent-**blue** with a **check** glyph (was a green floppy `approve-button`).
- **Switches:** turn **green** when on (were accent-blue).
- **Selects:** popup-style **blue rounded chevron box** on the right.
- **Grouped cards:** endpoint / auth / session / RDP-options panels get the hairline inset border so they read as cards on the white surface.

## Notes / known gap

- The RDP options panel is grouped as cards but does **not** yet have a per-row colored glyph for each option like the reference mock (that needs JSX changes in `RdpConnectionOptions`); the colors, switches, selects, button, header, and background now match. If you want the per-row option icons too, say so and I'll add them.
- The blue select chevron uses the Apple-blue accent (matches Default + Dark, the reference schemes).

## Verification

`tsc` clean, ESLint clean (pre-existing warnings only), `npm run build` passes. CSS + small JSX (header, save button). Worth a visual pass in Default + Dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)