### PR TITLE
fix(workspace): use ConfirmSheet for Delete Workspace dialog

### DIFF
--- a/docs/DESIGN_LANGUAGE.md
+++ b/docs/DESIGN_LANGUAGE.md
@@ -62,6 +62,22 @@ KKTerm is Windows-first: the primary/confirm action comes **immediately before**
 Cancel, and the action group anchors bottom-right. `Actions` defaults to this via
 `DialogConventionProvider` value `windows`. Do not reorder per-dialog.
 
+### Footer & buttons
+
+Build every dialog footer from the kit — never hand-roll the action row:
+
+- Primitive dialogs (`Sheet`): pass `footer={<Actions … />}` built from `Btn`s.
+  `Actions` packs the group bottom-right in Windows order automatically.
+- Legacy `.connection-dialog` surfaces: use the styled `.dialog-actions` row
+  (right-anchored, gapped) with `.approve-button` primary + `.toolbar-button`
+  cancel, and put a glyph on the primary (e.g. lucide `<Save size={15} />`).
+- The primary action carries an icon; primary and Cancel share one button size.
+
+**Never use the `connection-dialog-footer` class.** It has no CSS rule, so it
+renders a left-aligned, gap-less, icon-less footer (the bug this paradigm
+exists to prevent). `tests/dialog-footer-policy.test.mjs` fails the build if it
+reappears or if the Delete Workspace confirmation stops using `ConfirmSheet`.
+
 ### Titles
 
 One concise title by default (no subtitle/explanatory header unless the flow
@@ -99,6 +115,8 @@ Copy Path / Get Info. Reuse `FilePane` and these patterns for new browser UIs.
 1. Read tokens; never hard-code colors.
 2. Compose from `src/app/ui/dialog` primitives; confirmations use `ConfirmSheet`.
 3. Windows button order; one concise title; close-X only without a footer dismiss.
+   Footer from `Actions`/`.dialog-actions` with an icon'd primary — never
+   `connection-dialog-footer`.
 4. Route every string through `t()`; add `en.json` keys + a
    `docs/localization_todo/` pending file (see that README).
 5. Verify in Default and Dark plus one extra scheme in the real Tauri runtime.

--- a/src/modules/workspace/WorkspaceRailDialogs.tsx
+++ b/src/modules/workspace/WorkspaceRailDialogs.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
+import { ConfirmSheet } from "../../app/ui/dialog";
 import { invokeCommand } from "../../lib/tauri";
 import type { Workspace } from "../../types";
 
@@ -33,36 +33,20 @@ export function DeleteWorkspaceDialog({
     }
   }
 
-  return createPortal(
-    <div className="dialog-backdrop connection-dialog-backdrop" role="presentation">
-      <div
-        aria-label={t("workspace.deleteWorkspace")}
-        aria-modal="true"
-        className="connection-dialog new-workspace-dialog"
-        role="dialog"
-      >
-        <header className="connection-dialog-header compact">
-          <h2>{t("workspace.deleteWorkspace")}</h2>
-        </header>
-        <div className="new-workspace-body">
+  return (
+    <ConfirmSheet
+      tone="danger"
+      title={t("workspace.deleteWorkspace")}
+      message={
+        <>
           <p>{t("workspace.deleteWorkspaceConfirm", { name: workspace.name })}</p>
-          {error ? <div className="settings-error">{error}</div> : null}
-        </div>
-        <footer className="connection-dialog-footer">
-          <button
-            className="toolbar-button danger"
-            disabled={submitting}
-            onClick={() => void handleDelete()}
-            type="button"
-          >
-            {t("common.delete")}
-          </button>
-          <button className="toolbar-button" onClick={onClose} type="button">
-            {t("common.cancel")}
-          </button>
-        </footer>
-      </div>
-    </div>,
-    document.body,
+          {error ? <p className="settings-error">{error}</p> : null}
+        </>
+      }
+      confirmLabel={t("common.delete")}
+      confirmIcon="trash"
+      onConfirm={() => void handleDelete()}
+      onCancel={onClose}
+    />
   );
 }

--- a/tests/dialog-footer-policy.test.mjs
+++ b/tests/dialog-footer-policy.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import test from "node:test";
+
+// Guard for the dialog footer paradigm (docs/DESIGN_LANGUAGE.md → "Footer &
+// buttons"). The legacy `connection-dialog-footer` class has NO CSS rule, so any
+// dialog that uses it falls back to default block flow: footer buttons stack to
+// the left, with no gap, no bottom-right anchor, and no consistent sizing. New
+// dialogs must build footers from the dialog-kit `Actions`/`Sheet` footer, or —
+// for legacy `.connection-dialog` surfaces — the styled, right-anchored
+// `.dialog-actions` row. Confirmations must use `ConfirmSheet`.
+
+const SRC_ROOT = new URL("../src/", import.meta.url);
+
+async function sourceFiles(directory, pattern = /\.(tsx|ts)$/) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const childUrl = new URL(`${entry.name}${entry.isDirectory() ? "/" : ""}`, directory);
+      if (entry.isDirectory()) {
+        return sourceFiles(childUrl, pattern);
+      }
+      if (pattern.test(entry.name) && !entry.name.endsWith(".test.ts")) {
+        return [childUrl];
+      }
+      return [];
+    }),
+  );
+  return files.flat();
+}
+
+test("no dialog uses the unstyled `connection-dialog-footer` class", async () => {
+  const files = await sourceFiles(SRC_ROOT);
+  const offenders = [];
+  for (const file of files) {
+    const source = await readFile(file, "utf8");
+    if (source.includes("connection-dialog-footer")) {
+      offenders.push(file.pathname.replace(/.*\/src\//, "src/"));
+    }
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    `connection-dialog-footer is a dead class with no CSS — it renders a left-aligned, ` +
+      `gap-less, icon-less footer. Use the dialog-kit Actions/Sheet footer (or the styled ` +
+      `.dialog-actions row for legacy .connection-dialog surfaces) instead. Offending files: ` +
+      offenders.join(", "),
+  );
+});
+
+test("Delete Workspace confirmation uses the shared ConfirmSheet template", async () => {
+  const source = await readFile(
+    new URL("modules/workspace/WorkspaceRailDialogs.tsx", SRC_ROOT),
+    "utf8",
+  );
+  assert.match(
+    source,
+    /<ConfirmSheet[\s\S]*tone="danger"/,
+    "DeleteWorkspaceDialog must render through ConfirmSheet (tone=\"danger\"), not hand-rolled markup",
+  );
+});


### PR DESCRIPTION
## Summary
The **Delete Workspace** confirmation hand-rolled its markup with the `connection-dialog-footer` class — which **has no CSS rule at all**. As a result its footer rendered left-aligned, gap-less, and icon-less instead of the bottom-right, Windows-order action group every other delete in the app uses (`McpDeleteConfirmDialog`, `CredentialDeleteConfirmDialog`, etc.).

This routes it through the shared `ConfirmSheet` (`tone="danger"`), matching the app-wide delete convention: tinted red trash glyph, body copy, and a bottom-right footer with a red **Delete** 🗑 followed by **Cancel**.

> Note: `RenameWorkspaceDialog` was removed on `main` (commit `fd0babc8`), so only the Delete dialog remained to fix after rebasing.

### Before → After
| Before | After |
|---|---|
| Left-aligned dark **Delete**/Cancel, no icons, no danger glyph | Red trash glyph; bottom-right red **Delete** 🗑 → **Cancel** |

## Hardening (so it can't recur)
The guidelines already said "confirmations use ConfirmSheet; don't hand-roll" — yet this slipped through because the real trap is a **dead CSS class**. So this PR adds both clarity and enforcement:

- **`docs/DESIGN_LANGUAGE.md`** — new **"Footer & buttons"** section; explicitly bans `connection-dialog-footer`.
- **`tests/dialog-footer-policy.test.mjs`** — a build-failing guard (auto-discovered by `npm run check`) that rejects the dead class across `src/**` and locks the Delete Workspace dialog to `ConfirmSheet`.

## Testing
- `npx eslint` on touched files — clean
- `tsc --noEmit` — clean
- `node --test tests/dialog-footer-policy.test.mjs tests/dialog-portal-policy.test.mjs tests/connection-dialog-layout.test.mjs` — 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)