### PR TITLE
fix(settings): use fixed 80% height for settings dialog

### DIFF
--- a/src/modules/settings/settings.css
+++ b/src/modules/settings/settings.css
@@ -2024,8 +2024,8 @@
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
   width: min(1060px, calc(100vw - 96px));
-  height: calc(100vh - var(--app-titlebar-height, 0px) - 20px);
-  max-height: calc(100vh - var(--app-titlebar-height, 0px) - 20px);
+  height: 80vh;
+  max-height: 80vh;
   overflow: hidden;
   padding: 13px 2px 14px 17px;
   background: var(--surface);


### PR DESCRIPTION
## What changed

The settings dialog now uses a fixed `80vh` height instead of stretching to nearly fill the viewport.

```css
/* src/modules/settings/settings.css */
.settings-popup.settings-page {
  height: 80vh;       /* was: calc(100vh - var(--app-titlebar-height, 0px) - 20px) */
  max-height: 80vh;   /* was: calc(100vh - var(--app-titlebar-height, 0px) - 20px) */
}
```

## Why

On larger screens the dialog was overly tall, leaving very little margin around it. Pinning it to 80% of viewport height keeps it vertically centered (the backdrop already uses `place-items: center`) with comfortable breathing room.

## Reviewer notes

No layout regression: the popup's grid (`grid-template-rows: auto minmax(0, 1fr)` with `overflow: hidden`) keeps the header pinned and lets the content area scroll internally, so shrinking the overall panel just makes it shorter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)