### PR TITLE
fix(icons): keep icon-search input beside the magnifier instead of below it

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -666,6 +666,15 @@ h2 {
   min-width: 0;
 }
 
+/* Form-field labels above use a stacked grid, but a `.search-box` label is a
+   horizontal row (magnifier + input). Keep it flex so the input stays to the
+   right of the icon instead of dropping below it and overflowing the row. */
+.connection-dialog label.search-box,
+.settings-section label.search-box {
+  display: flex;
+  gap: 8px;
+}
+
 .connection-dialog label span,
 .settings-section label span {
   color: var(--text-muted);

--- a/tests/icon-search-row-layout.test.mjs
+++ b/tests/icon-search-row-layout.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+// Regression guard: dialog form-field labels use a stacked grid layout
+// (`.connection-dialog label { display: grid }`). The icon-picker search is a
+// `<label class="search-box icon-library-search">`, so without a more specific
+// override it inherits that grid and stacks the magnifier above the input,
+// which clips/overflows the typed text. A `label.search-box` override must keep
+// search boxes laid out as a horizontal flex row.
+test("search-box labels stay a horizontal flex row inside dialogs", async () => {
+  const baseCss = await readFile(
+    new URL("../src/styles/base.css", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    baseCss,
+    /\.connection-dialog label,\s*\.settings-section label\s*\{[^}]*display:\s*grid/,
+    "form-field labels are expected to use a stacked grid (the cause of the bug)",
+  );
+
+  const overrideMatch = baseCss.match(
+    /\.connection-dialog label\.search-box,\s*\.settings-section label\.search-box\s*\{([^}]*)\}/,
+  );
+  assert.ok(overrideMatch, "a label.search-box override should exist");
+  assert.match(
+    overrideMatch[1],
+    /display:\s*flex/,
+    "search boxes must be forced back to a horizontal flex row",
+  );
+});


### PR DESCRIPTION
## Bug
In the icon picker (e.g. the workspace edit dialog), the search text was rendering **below** the magnifying glass instead of to its right, overflowing the search row.

## Root cause
`base.css` styles dialog form-field labels as a stacked grid:

```css
.connection-dialog label,
.settings-section label { display: grid; }
```

The icon-picker search is a `<label class="search-box icon-library-search">`. That selector (specificity `0,1,1`) **outranks** the `.icon-library-search { display: flex }` rule (`0,1,0`), so inside the dialog the label became a single-column grid and stacked the magnifier above the input — clipping the typed text. The earlier input-reset fix removed the boxed pill but not this stacking.

## Fix
Add a higher-specificity override (`0,2,1`) co-located with the grid rule so a `.search-box` label stays a horizontal flex row:

```css
.connection-dialog label.search-box,
.settings-section label.search-box { display: flex; gap: 8px; }
```

This restores the icon + input row for the icon-picker search (and the new-workspace import search) in both the connection dialog and settings. The dashboard customize popover doesn't use a generic `label { display: grid }`, so it's unaffected.

## Notes
- CSS-only cosmetic change plus a regression guard test (`tests/icon-search-row-layout.test.mjs`) asserting the override exists.
- No i18n/manual changes (no user-visible strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)