### PR TITLE
feat(file-browser): remote search, status bar, connected explorer, icon fixes

### DIFF
--- a/docs/localization_todo/sftp.availableSpace.md
+++ b/docs/localization_todo/sftp.availableSpace.md
@@ -1,0 +1,16 @@
+# sftp.availableSpace
+
+- **English value**: `{{size}} available`
+- **Namespace**: `sftp`
+- **File/component**: `src/modules/workspace/connections/sftp/SftpFilePane.tsx`
+- **UI role**: `status`
+- **User flow**: Status-bar free-space readout for the local drive holding the current folder.
+- **Tone**: concise/neutral
+- **Placeholders**: {{size}} is a formatted size such as 120 GB; keep the token unchanged.
+- **Context/meaning**: Remaining free space on the drive (local pane only).
+- **Domain notes**: Local File Explorer / SFTP browser pane status bar. Terms like SFTP/FTP stay English.
+
+<!--
+Filename: sftp.availableSpace.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/sftp.foldersCount.md
+++ b/docs/localization_todo/sftp.foldersCount.md
@@ -1,0 +1,16 @@
+# sftp.foldersCount
+
+- **English value**: `{{count}} folders`
+- **Namespace**: `sftp`
+- **File/component**: `src/modules/workspace/connections/sftp/SftpFilePane.tsx`
+- **UI role**: `status`
+- **User flow**: Status-bar count of folders in the current file-browser folder.
+- **Tone**: concise/neutral
+- **Placeholders**: {{count}} is the number of folders; keep the token unchanged.
+- **Context/meaning**: How many of the current folder's entries are folders.
+- **Domain notes**: Local File Explorer / SFTP browser pane status bar. Terms like SFTP/FTP stay English.
+
+<!--
+Filename: sftp.foldersCount.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/sftp.itemsCount.md
+++ b/docs/localization_todo/sftp.itemsCount.md
@@ -1,0 +1,16 @@
+# sftp.itemsCount
+
+- **English value**: `{{count}} items`
+- **Namespace**: `sftp`
+- **File/component**: `src/modules/workspace/connections/sftp/SftpFilePane.tsx`
+- **UI role**: `status`
+- **User flow**: Status-bar count of entries in the current file-browser folder.
+- **Tone**: concise/neutral
+- **Placeholders**: {{count}} is the number of items; keep the token unchanged.
+- **Context/meaning**: Total entries (files + folders) shown in the current folder.
+- **Domain notes**: Local File Explorer / SFTP browser pane status bar. Terms like SFTP/FTP stay English.
+
+<!--
+Filename: sftp.itemsCount.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -3526,7 +3526,12 @@ fn normalize_connection_icon_data_url(value: Option<String>) -> Result<Option<St
         if value.len() > 512 * 1024 {
             return Err("connection icon data URL is too large".to_string());
         }
-        if !value.starts_with("data:image/") {
+        // Accept an inline image data URL or one of the app's icon-catalog refs
+        // ("lucide:Name" / "material:id"), which the icon picker offers and the
+        // ConnectionIcon renderer resolves. Catalog refs are short identifiers.
+        let is_image_data_url = value.starts_with("data:image/");
+        let is_icon_ref = value.starts_with("lucide:") || value.starts_with("material:");
+        if !is_image_data_url && !is_icon_ref {
             return Err("connection icon must be an image data URL".to_string());
         }
     }

--- a/src/app/tutorialNavigationModel.test.ts
+++ b/src/app/tutorialNavigationModel.test.ts
@@ -66,7 +66,6 @@ const workspaceTargets = [
   "sftp.toolbar",
   "sftp.upload",
   "sftp.download",
-  "sftp.terminal",
   "sftp.localPane",
   "sftp.remotePane",
   "sftp.transferQueue",

--- a/src/app/tutorialNavigationModel.ts
+++ b/src/app/tutorialNavigationModel.ts
@@ -95,7 +95,6 @@ const WORKSPACE_TUTORIAL_TARGET_IDS = [
   "sftp.toolbar",
   "sftp.upload",
   "sftp.download",
-  "sftp.terminal",
   "sftp.localPane",
   "sftp.remotePane",
   "sftp.transferQueue",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2170,6 +2170,9 @@
       "inFavorites": "In Favorites",
       "driveFree": "{{free}} free of {{total}}"
     },
+    "itemsCount": "{{count}} items",
+    "foldersCount": "{{count}} folders",
+    "availableSpace": "{{size}} available",
     "transferringStatus": "{{count}} transferring · {{percent}}%",
     "transfersIdleStatus": "{{count}} completed · idle",
     "transferHint": "Drag files between panes, or use the transfer arrows to start a transfer.",

--- a/src/modules/workspace/connections/sftp/SftpFilePane.tsx
+++ b/src/modules/workspace/connections/sftp/SftpFilePane.tsx
@@ -11,7 +11,7 @@ import type { LocalPlacesListing } from "../../../../lib/tauri";
 import type { FileEntry } from "../../../../types";
 import { ExplorerSidebar } from "./ExplorerSidebar";
 import { FileGlyph } from "./finderGlyphs";
-import { joinLocalPath } from "./format";
+import { formatFileSize, joinLocalPath } from "./format";
 import type { FilePaneSide, LocalFavorite } from "./types";
 
 type SortKey = "name" | "size" | "date";
@@ -52,6 +52,8 @@ export function FilePane({
   onReorderFavorites,
   onOpenFavoriteFile,
   enableSearch = false,
+  showFooter = false,
+  availableBytes,
 }: {
   side: FilePaneSide;
   title: string;
@@ -84,6 +86,8 @@ export function FilePane({
   onReorderFavorites?: (next: LocalFavorite[]) => void;
   onOpenFavoriteFile?: (path: string) => void;
   enableSearch?: boolean;
+  showFooter?: boolean;
+  availableBytes?: number;
 }) {
   const { t } = useTranslation();
   const pathSuggestionsId = useId();
@@ -334,6 +338,7 @@ export function FilePane({
 
   const isEmpty = !isLoading && !status && sortedFiles.length === 0;
   const isNoResults = !isLoading && !status && sortedFiles.length > 0 && visibleFiles.length === 0;
+  const folderCount = useMemo(() => files.filter((file) => file.kind === "folder").length, [files]);
 
   return (
     <section
@@ -659,6 +664,24 @@ export function FilePane({
           </div>
         </div>
       </div>
+
+      {showFooter ? (
+        <div className="sftp-pane-foot">
+          <span>{t("sftp.itemsCount", { count: files.length })}</span>
+          {folderCount > 0 ? (
+            <>
+              <span className="dot" />
+              <span>{t("sftp.foldersCount", { count: folderCount })}</span>
+            </>
+          ) : null}
+          {availableBytes !== undefined ? (
+            <>
+              <span className="sftp-pane-foot-spacer" />
+              <span>{t("sftp.availableSpace", { size: formatFileSize(availableBytes) })}</span>
+            </>
+          ) : null}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
+++ b/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
@@ -1,6 +1,6 @@
 import { confirmTrustedSshHostKey, connectionToolbarTitle, uniqueRuntimeId, usesNativeSshHostKeyVerification } from "../utils";
 
-import { Terminal, X } from "lucide-react";
+import { X } from "lucide-react";
 import { DIcon } from "../../../../app/ui/dialog";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
@@ -60,18 +60,17 @@ export function SftpWorkspace({
   isActive,
   tab,
   commands: commandsProp,
-  inline = false,
   onClose,
 }: {
   isActive: boolean;
   tab: WorkspaceTab;
   commands?: FileBrowserCommands;
+  // Accepted for the terminal's inline SFTP dialog; no longer alters layout.
   inline?: boolean;
   onClose?: () => void;
 }) {
   const { t } = useTranslation();
   const appearanceSettings = useWorkspaceStore((state) => state.appearanceSettings);
-  const openTerminalHere = useWorkspaceStore((state) => state.openTerminalHere);
   const connection = tab.connection;
   const isLocalFilesBrowser = tab.kind === "localFiles";
   const commands = useMemo<FileBrowserCommands | null>(
@@ -195,6 +194,18 @@ export function SftpWorkspace({
       disposed = true;
     };
   }, []);
+
+  // The File Explorer has no network session, but it should still register as a
+  // live connection (green dot in the rail / connection tree) the moment it
+  // opens, and release it when the tab closes.
+  useEffect(() => {
+    const connectionId = connection?.id;
+    if (!isLocalFilesBrowser || !connectionId) {
+      return;
+    }
+    markConnectionSessionStarted(connectionId);
+    return () => markConnectionSessionEnded(connectionId);
+  }, [connection?.id, isLocalFilesBrowser, markConnectionSessionEnded, markConnectionSessionStarted]);
 
   useEffect(() => {
     setSidebarCollapsed(readSidebarCollapsed(sidebarConnectionKey, isLocalFilesBrowser));
@@ -396,6 +407,19 @@ export function SftpWorkspace({
   };
 
   const isLocalDrivePicker = localPath === WINDOWS_DRIVES_PATH;
+
+  // Free space of the drive that holds the current local folder, for the status
+  // bar. Picks the longest matching mount point (e.g. C:\ for C:\Users\...).
+  const localAvailableBytes = useMemo(() => {
+    if (!localPlaces || !localPath || isLocalDrivePicker) {
+      return undefined;
+    }
+    const normalizedPath = localPath.toLowerCase();
+    const drive = localPlaces.drives
+      .filter((entry) => normalizedPath.startsWith(entry.path.toLowerCase()))
+      .sort((left, right) => right.path.length - left.path.length)[0];
+    return drive?.freeBytes;
+  }, [isLocalDrivePicker, localPath, localPlaces]);
 
   const refreshLocalDirectory = async () => {
     await loadLocalDirectory(localPath || undefined);
@@ -1146,14 +1170,6 @@ export function SftpWorkspace({
     }
   };
 
-  const handleOpenTerminalHere = () => {
-    if (!connection || !isConnected || !commands?.capabilities.openTerminalHere) {
-      return;
-    }
-
-    openTerminalHere(connection, remotePath);
-  };
-
   const selectedLocalFiles = localFiles.filter((file) => selectedLocalNames.includes(file.name));
   const selectedRemoteFiles = remoteFiles.filter((file) => selectedRemoteNames.includes(file.name));
 
@@ -1499,18 +1515,6 @@ export function SftpWorkspace({
           {hasRemoteHost ? hostLabel : null}
         </span>
         <span className="sftp-bar-right">
-          {!inline && commands?.capabilities.openTerminalHere ? (
-            <button
-              className="toolbar-button"
-              data-tutorial-id="sftp.terminal"
-              disabled={!isConnected}
-              onClick={handleOpenTerminalHere}
-              type="button"
-            >
-              <Terminal size={15} />
-              {t("sftp.terminal")}
-            </button>
-          ) : null}
           {onClose ? (
             <button
               className="sftp-bar-close"
@@ -1557,6 +1561,8 @@ export function SftpWorkspace({
           onReorderFavorites={reorderFavorites}
           onOpenFavoriteFile={(path) => void openFilesystemPath(path)}
           enableSearch
+          showFooter
+          availableBytes={isLocalDrivePicker ? undefined : localAvailableBytes}
         />
         {!isLocalFilesBrowser ? (
           <>
@@ -1606,6 +1612,8 @@ export function SftpWorkspace({
               onDropTransfer={isConnected && !isTransferring ? handleDropTransfer : undefined}
               forceDropTarget={isRemoteDropTarget}
               renameRequest={renameRequest?.side === "remote" ? renameRequest : undefined}
+              enableSearch
+              showFooter
             />
           </>
         ) : null}

--- a/src/modules/workspace/connections/sftp/sftp.css
+++ b/src/modules/workspace/connections/sftp/sftp.css
@@ -27,8 +27,9 @@
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
   gap: 12px;
-  min-height: 22px;
-  padding: 1px 6px 1px 14px;
+  min-height: 34px;
+  /* Even top/bottom padding keeps the kind glyph + title vertically centered. */
+  padding: 5px 6px 5px 14px;
 }
 /* Slim the action controls so they don't force the half-height titlebar taller. */
 .sftp-toolbar .toolbar-button {
@@ -776,6 +777,30 @@
   border-color: var(--accent);
   color: var(--accent);
   background: var(--sel-soft);
+}
+
+/* pane status bar (items / folders + free space) */
+.sftp-pane-foot {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 26px;
+  padding: 0 12px;
+  border-top: 1px solid var(--hairline);
+  color: var(--text-faint);
+  font-size: 11.5px;
+  font-weight: 500;
+  user-select: none;
+}
+.sftp-pane-foot .dot {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--text-faint);
+}
+.sftp-pane-foot-spacer {
+  flex: 1 1 auto;
 }
 
 /* search box (local pane, right of the view switcher) */

--- a/src/store.ts
+++ b/src/store.ts
@@ -1304,6 +1304,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
           keyPath: undefined,
           proxyJump: undefined,
           ftpOptions: undefined,
+          // Keep the file-browser identity for the rail/tab glyph instead of the
+          // default SSH terminal icon (this connection opens a file browser). Use
+          // a catalog icon ref (not an imported asset) so non-Vite consumers of
+          // the store, like the test runner, don't choke on a .svg import.
+          iconDataUrl: connection.iconDataUrl ?? "material:folder-server",
         };
         get().openSftpBrowserInNewTab(sshConnection);
         return;
@@ -1839,6 +1844,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         keyPath: undefined,
         proxyJump: undefined,
         ftpOptions: undefined,
+        // Keep the file-browser identity for the rail/tab glyph instead of the
+        // default SSH terminal icon (this connection opens a file browser). Use
+        // a catalog icon ref (not an imported asset) so non-Vite consumers of
+        // the store, like the test runner, don't choke on a .svg import.
+        iconDataUrl: connection.iconDataUrl ?? "material:folder-server",
       };
       get().openSftpBrowser(sshConnection);
       return;


### PR DESCRIPTION
A batch of File Explorer / SFTP browser follow-ups.

> **Stacked on #327** — base branch is `claude/explorer-sidebar-tweaks`, so this PR's diff shows only the new commit. Merge #327 first (GitHub will retarget this to `main`), or rebase if #327 lands squashed.

## Changes

1. **Search on the remote pane.** The current-folder name filter (case-insensitive, non-recursive) now also appears on the SFTP/FTP remote pane, not just local.

2. **Pane status bar.** Each pane gets a footer showing item and folder counts (e.g. `16 items • 13 folders`). The local pane also shows free space for the drive holding the current folder (e.g. `189 GB available`), matching the redesign.

3. **File Explorer counts as connected on open.** The local File Explorer now registers a live connection session as soon as it opens (green dot in the activity rail / connection tree) and releases it when the tab closes. Previously it never reached connected status.

4. **Activity rail icon for FTP-over-SFTP.** An FTP-type connection using the SFTP sub-protocol is opened through a synthesized SSH connection, which made the rail/tab show the **SSH terminal** glyph. It now keeps a file-browser glyph (`material:folder-server`) unless the user set a custom icon.

5. **Fix "connection icon must be an image data URL".** The icon picker offers lucide/material catalog icons and `ConnectionIcon` renders them, but the backend rejected anything that wasn't a `data:image/` URL — so picking a library icon failed to save. `normalize_connection_icon_data_url` now also accepts `lucide:` / `material:` refs.

6. **Remove the SFTP toolbar Terminal button.** No longer auto-offered in the browser (also removed its onboarding tour step); users can open a terminal manually.

7. **Center the toolbar title.** Even top/bottom padding so the kind glyph + title are vertically centered instead of leaning to the top.

## Notes for reviewers
- New i18n keys (`sftp.itemsCount`, `sftp.foldersCount`, `sftp.availableSpace`) added to `en.json` with matching `docs/localization_todo` records (`fallbackLng: "en"`).
- The synthesized FTP-over-SFTP connection is in-memory only (never persisted), and uses a catalog icon ref rather than an imported asset so the non-Vite test runner doesn't choke on a `.svg` import.

## Verification
- `tsc --noEmit`: clean
- `eslint`: 0 errors
- `cargo check`: clean (pre-existing warnings only)
- `vite build`: succeeds
- JS test suite: 311/312 — the single failure (`macOS release script`) is pre-existing and unrelated (fails identically on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
