### PR TITLE
fix: align drag-to-dock overlay with panes

### DIFF
--- a/src/modules/workspace/connections/ConnectionSidebar.tsx
+++ b/src/modules/workspace/connections/ConnectionSidebar.tsx
@@ -4318,27 +4318,33 @@ function DockOverlay({ zone }: { zone: CanvasDropZone | null }) {
     zone.kind === "split"
       ? `dock-overlay-highlight dock-overlay-${zone.direction}`
       : "dock-overlay-highlight dock-overlay-empty";
+  // Portal to <body>: the host `.connection-sidebar` declares `contain: layout`,
+  // which makes it the containing block for `position: fixed` descendants. Left
+  // inline, the overlay would resolve its viewport coordinates against the
+  // sidebar box and render misaligned with the panes it points at.
   return (
-    <div className="dock-overlay" aria-hidden="true">
-      <div
-        className="dock-overlay-outline"
-        style={{
-          left: `${rect.left}px`,
-          top: `${rect.top}px`,
-          width: `${rect.width}px`,
-          height: `${rect.height}px`,
-        }}
-      />
-      <div
-        className={highlightClass}
-        style={{
-          left: `${highlight.left}px`,
-          top: `${highlight.top}px`,
-          width: `${highlight.width}px`,
-          height: `${highlight.height}px`,
-        }}
-      />
-    </div>
+    <DialogPortal>
+      <div className="dock-overlay" aria-hidden="true">
+        <div
+          className="dock-overlay-outline"
+          style={{
+            left: `${rect.left}px`,
+            top: `${rect.top}px`,
+            width: `${rect.width}px`,
+            height: `${rect.height}px`,
+          }}
+        />
+        <div
+          className={highlightClass}
+          style={{
+            left: `${highlight.left}px`,
+            top: `${highlight.top}px`,
+            width: `${highlight.width}px`,
+            height: `${highlight.height}px`,
+          }}
+        />
+      </div>
+    </DialogPortal>
   );
 }
 

--- a/tests/connection-tree-canvas-dock.test.ts
+++ b/tests/connection-tree-canvas-dock.test.ts
@@ -83,4 +83,13 @@ test("the Connection Tree drag wires Connections onto Workspace Canvas dock targ
   assert.match(sidebarSource, /addConnectionToTerminalPane\(zone\.tabId, connection, zone\.direction, zone\.paneId\)/);
   assert.match(sidebarSource, /completeCanvasDrop\(dragged\.connectionId, canvasZone\)/);
   assert.match(sidebarSource, /<DockOverlay zone=\{canvasDropZone\} \/>/);
+
+  // The overlay must portal to <body> so its fixed coordinates align with the
+  // panes; the host `.connection-sidebar` is a `contain: layout` block that
+  // would otherwise offset `position: fixed` children.
+  assert.match(
+    sidebarSource,
+    /function DockOverlay[\s\S]*?<DialogPortal>\s*<div className="dock-overlay"/,
+    "DockOverlay should render through DialogPortal (document.body)",
+  );
 });


### PR DESCRIPTION
@
## Problem

The Visual Studio–style drag-to-dock overlay (added in #329) rendered its highlight **offset from the pane under the cursor** — the hint did not line up with the actual drop target (see report screenshot, where the highlight floats below/right of the pane).

## Root cause

`DockOverlay` was rendered inline inside the Connection Tree, whose host element `.connection-sidebar` declares `contain: layout style` ([src/app/app.css:397](../blob/main/src/app/app.css#L397)). **Layout containment makes that element the containing block for `position: fixed` descendants.** So the overlay — which positions itself with viewport coordinates from `getBoundingClientRect()` / `elementFromPoint()` — resolved those coordinates against the sidebar box instead of the viewport, drawing it in the wrong place.

## Fix

Render `DockOverlay` through `DialogPortal` (`createPortal` to `document.body`), escaping the contained ancestor. `position: fixed` now resolves against the viewport, so the highlight aligns exactly with the target pane. No coordinate math changed — only where the element is mounted.

## Notes

- The pre-existing tree drag-preview chip technically shares the same containing-block quirk, but it predates this feature and was not part of the report, so it is left untouched to keep the fix surgical.
- Added a regression assertion that `DockOverlay` renders through `DialogPortal`.
- `npm run check` passes — lint, 333 tests (0 fail), `tsc`. Frontend-only.
- The overlay alignment should be confirmed in the real Tauri runtime (not a browser preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@