### PR TITLE
fix: stretch embedded file-browser sub-panes to full width

### DIFF
--- a/src/modules/workspace/connections/terminal/terminal.css
+++ b/src/modules/workspace/connections/terminal/terminal.css
@@ -148,6 +148,18 @@
   background: var(--chrome-strong);
 }
 
+/* File-browser sub-panes (SFTP / FTP / File Explorer) must fill the embedded
+   pane the same way the terminal surface does. `.sftp-workspace.active` is a
+   block-level flex column, so as a flex item in this row it would otherwise size
+   to its content width and leave the pane partially empty. Webview/remote-desktop
+   surfaces don't need this — their native overlay windows are positioned to the
+   pane bounds in JS, independent of the DOM box width. */
+.embedded-workspace-pane > .sftp-workspace {
+  flex: 1 1 0;
+  width: 100%;
+  min-width: 0;
+}
+
 .embedded-workspace-pane:has(> .embedded-pane-close) > .webview-workspace .webview-pane > header {
   padding-right: 40px;
 }

--- a/tests/embedded-file-browser-width.test.mjs
+++ b/tests/embedded-file-browser-width.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+// Regression: an SFTP / FTP / File Explorer browser docked as a sub-pane did not
+// expand to the full width of its split cell, because .embedded-workspace-pane is
+// a flex row and only `.terminal-workspace` had a stretch rule. `.sftp-workspace`
+// (the file-browser surface) needs the same flex/width or it sizes to content.
+test("embedded file-browser sub-panes stretch to fill the pane width", async () => {
+  const css = await readFile(
+    new URL("../src/modules/workspace/connections/terminal/terminal.css", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    css,
+    /\.embedded-workspace-pane\s*>\s*\.sftp-workspace\s*\{[^}]*flex:\s*1 1 0;[^}]*width:\s*100%;[^}]*\}/,
+    ".embedded-workspace-pane > .sftp-workspace must set flex: 1 1 0 and width: 100%",
+  );
+});


### PR DESCRIPTION
@
## Problem

A docked **SFTP / FTP / File Explorer** browser did not expand to the full width of its split cell when rendered as a sub-pane (see screenshot — file browser leaves empty space in its pane).

## Root cause

`.embedded-workspace-pane` is a flex row. Only `.terminal-workspace` had a stretch rule (`flex: 1 1 0; width: 100%`). The file-browser surface `.sftp-workspace.active` is a block-level flex **column**, so as a flex item in the row it sized to its content width and left the pane partially empty.

Webview / remote-desktop surfaces are not affected: their native overlay windows are positioned to the pane bounds in JS, independent of the DOM box width — only the pure-DOM file browser depends on CSS width.

## Fix

Add a stretch rule for `.embedded-workspace-pane > .sftp-workspace` (`flex: 1 1 0; width: 100%; min-width: 0`), mirroring the terminal surface.

## Notes

- CSS-only change plus a regression assertion. `npm run check` passes — lint, **336 tests** (1 new), `tsc`.
- Confirm in the real Tauri runtime: dock two File Explorer/SFTP browsers side by side; each should fill its pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@