### PR TITLE
Avoid duplicate Quick Connect creation and name collisions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,7 +40,7 @@ A Connection of kind `rdp` or `vnc`. It stores host, optional port, and non-secr
 _Avoid_: Remote desktop session, screen profile, saved desktop
 
 **Quick Connect**:
-A fast path to start a Session that persists a saved Connection. Quick Connect reuses an identical existing Connection (matched by host/user/port for SSH, or shell for local shells) or creates one, then opens it — so every Quick Connect target becomes a durable Connection. The sole non-persisted case is an elevated admin shell launched while KKTerm itself is not elevated: that opens an external UAC process with no in-app Session.
+A fast path to start a Session that persists a saved Connection. Quick Connect reuses an identical existing SSH Connection (matched by host/user/port) or creates one, then opens it — so every Quick Connect target becomes a durable Connection. The sole non-persisted case is an elevated admin shell launched while KKTerm itself is not elevated: that opens an external UAC process with no in-app Session.
 _Avoid_: Temporary profile, ad hoc host, one-off session
 
 **Quick Command**:
@@ -163,7 +163,7 @@ _Avoid_: settings nav, settings menu
 - A **URL Connection** starts a URL **Session** that owns a stable overlay WebView2 window positioned over the active Pane.
 - An **RDP Connection** starts a Windows-native remote-desktop **Session** hosted as a native child control over its **Tab**.
 - A **VNC Connection** starts a Rust-managed remote framebuffer **Session** rendered into its **Tab**.
-- A **Quick Connect** persists a **Connection** (reusing an identical existing one when present) and starts a **Session** on it; the only non-persisted case is the external elevated admin shell launched when KKTerm is not elevated.
+- A **Quick Connect** persists a **Connection** (reusing an identical existing SSH Connection when present) and starts a **Session** on it; the only non-persisted case is the external elevated admin shell launched when KKTerm is not elevated.
 - A **Quick Command** writes input from the **Quick Command Bar** to a terminal **Pane** in an existing **Session**.
 - A **Session** may be presented by one **Tab**.
 - A terminal **Tab** may contain one or more **Panes**.

--- a/docs/manual/01-getting-started.md
+++ b/docs/manual/01-getting-started.md
@@ -67,5 +67,5 @@ Settings - Don't Sleep (`settings.sectionDontSleep`) controls whether the keep-a
 ## Where to go next
 
 - To open a saved Connection: [03-connections.md](03-connections.md).
-- To start a session fast: Quick Connect saves the Connection (reusing an identical existing one when present) and opens it — see [03-connections.md](03-connections.md) §Quick Connect.
+- To start a session fast: Quick Connect saves the Connection (reusing an identical existing SSH Connection when present) and opens it — see [03-connections.md](03-connections.md) §Quick Connect.
 - To set up the AI Assistant: [13-ai-assistant.md](13-ai-assistant.md) plus [15-settings.md](15-settings.md) §AI.

--- a/docs/manual/03-connections.md
+++ b/docs/manual/03-connections.md
@@ -77,7 +77,7 @@ and URL credential metadata — disable OS spelling autocorrect, capitalization,
 and spellcheck in the app WebView on Windows and macOS. Keyboard/IME suggestion
 UI supplied outside the WebView may still appear.
 
-**Quick Connect** (`connections.quickConnectDialog`) is a fast path that **persists** a saved Connection and opens it — it is no longer an unsaved one-off. Before creating, it reuses an identical existing Connection (matched by host/user/port for SSH, or shell for local shells); otherwise it creates a new Connection at the tree root. A password typed on a reused target updates that Connection's stored credential. The full Quick Connect dialog reflects this: subtitle `connections.openOneOffSession` and primary button `connections.saveAndConnect`. Fields shown depend on the chosen kind:
+**Quick Connect** (`connections.quickConnectDialog`) is a fast path that **persists** a saved Connection and opens it — it is no longer an unsaved one-off. Before creating SSH targets, it reuses an identical existing Connection matched by host/user/port; local shell targets always create a new saved Connection, adding `#1`, `#2`, and so on when the shell name already exists. Other non-SSH targets create a new Connection at the tree root. A password typed on a reused target updates that Connection's stored credential. The full Quick Connect dialog reflects this: subtitle `connections.openOneOffSession` and primary button `connections.saveAndConnect`. Fields shown depend on the chosen kind:
 
 - Hostname (`connections.hostname`, placeholder `connections.exampleHost`)
 - Port (`connections.port`)

--- a/src/modules/workspace/connections/ConnectionSidebar.tsx
+++ b/src/modules/workspace/connections/ConnectionSidebar.tsx
@@ -22,7 +22,7 @@ import {
   resolveDefaultTerminalAppearance,
   supportsTerminalAppearanceDefaults,
 } from "./terminalAppearanceDefaults";
-import { elevatedLocalShellAction, findMatchingConnection, quickConnectRecentLabel } from "./quickConnectMenuModel";
+import { elevatedLocalShellAction, findMatchingConnection, nextQuickConnectName, quickConnectRecentLabel } from "./quickConnectMenuModel";
 import {
   CONNECTION_TAB_CONTEXT_MENU_EVENT,
   type ConnectionTabContextMenuDetail,
@@ -445,7 +445,18 @@ export function ConnectionSidebar({
       return candidate;
     }
 
-    const existing = findMatchingConnection(flattenConnections(treeRef.current), candidate);
+    let currentConnections = flattenConnections(treeRef.current);
+    try {
+      const freshTree = await invokeCommand("list_connection_tree", {
+        workspaceId: useWorkspaceStore.getState().activeWorkspaceId,
+      });
+      currentConnections = flattenConnections(freshTree);
+    } catch {
+      // Fall back to the last rendered tree; create_connection will still report
+      // any backend error.
+    }
+
+    const existing = findMatchingConnection(currentConnections, candidate);
     if (existing) {
       let connection = existing;
       if (creds?.password) {
@@ -460,8 +471,12 @@ export function ConnectionSidebar({
       return connection;
     }
 
+    const createRequest = quickConnectionCreateRequest({
+      ...candidate,
+      name: nextQuickConnectName(currentConnections, candidate.name),
+    });
     let connection = await invokeCommand("create_connection", {
-      request: quickConnectionCreateRequest(candidate),
+      request: createRequest,
     });
     if (creds?.password) {
       connection = await createConnectionPasswordCredential(connection.id, creds.password);

--- a/src/modules/workspace/connections/quickConnectMenuModel.ts
+++ b/src/modules/workspace/connections/quickConnectMenuModel.ts
@@ -41,6 +41,22 @@ export function findMatchingConnection(
   return undefined;
 }
 
+export function nextQuickConnectName(connections: Connection[], preferredName: string): string {
+  const baseName = preferredName.trim();
+  const fallbackName = baseName || "Connection";
+  const usedNames = new Set(connections.map((connection) => connection.name));
+  if (!usedNames.has(fallbackName)) {
+    return fallbackName;
+  }
+
+  for (let suffix = 1; ; suffix += 1) {
+    const candidate = `${fallbackName} #${suffix}`;
+    if (!usedNames.has(candidate)) {
+      return candidate;
+    }
+  }
+}
+
 export type ElevatedLocalShellAction =
   | { mode: "embedded"; name: string; shell: string }
   | { mode: "external"; shell: string };

--- a/src/modules/workspace/connections/quickConnectMenuModel.ts
+++ b/src/modules/workspace/connections/quickConnectMenuModel.ts
@@ -17,8 +17,8 @@ export function quickConnectRecentLabel(connection: Connection): string {
 const DEFAULT_SSH_PORT = 22;
 
 // Decides whether a Quick Connect target should reuse an existing saved
-// connection instead of creating a new one. SSH matches by host+user+port;
-// local shells match by shell. All other types always create.
+// connection instead of creating a new one. SSH matches by host+user+port.
+// Local shells and all other types always create new saved Connections.
 export function findMatchingConnection(
   connections: Connection[],
   candidate: Connection,
@@ -31,11 +31,6 @@ export function findMatchingConnection(
         c.host === candidate.host &&
         (c.user ?? "") === (candidate.user ?? "") &&
         (c.port ?? DEFAULT_SSH_PORT) === port,
-    );
-  }
-  if (candidate.type === "local") {
-    return connections.find(
-      (c) => c.type === "local" && (c.localShell ?? "") === (candidate.localShell ?? ""),
     );
   }
   return undefined;

--- a/tests/quick-connect-persistence.test.mjs
+++ b/tests/quick-connect-persistence.test.mjs
@@ -7,6 +7,10 @@ test("Quick Connect persists connections and rename guards non-persisted ids", a
     new URL("../src/modules/workspace/connections/ConnectionSidebar.tsx", import.meta.url),
     "utf8",
   );
+  const menuModelSource = await readFile(
+    new URL("../src/modules/workspace/connections/quickConnectMenuModel.ts", import.meta.url),
+    "utf8",
+  );
 
   // Quick Connect routes through the persist-or-reuse orchestrator.
   assert.match(
@@ -17,7 +21,7 @@ test("Quick Connect persists connections and rename guards non-persisted ids", a
   assert.match(
     sidebarSource,
     /findMatchingConnection\(currentConnections, candidate\)/,
-    "quickConnect should reuse an identical existing connection before creating",
+    "quickConnect should reuse an identical existing SSH connection before creating",
   );
   assert.match(
     sidebarSource,
@@ -28,6 +32,11 @@ test("Quick Connect persists connections and rename guards non-persisted ids", a
     sidebarSource,
     /nextQuickConnectName\(currentConnections, candidate\.name\)/,
     "quickConnect should avoid duplicate saved Connection names when creating a new target",
+  );
+  assert.doesNotMatch(
+    menuModelSource,
+    /candidate\.type === "local"/,
+    "local terminal Quick Connect targets should create a new saved Connection instead of reusing by shell",
   );
 
   // The ephemeral upsert path is gone.

--- a/tests/quick-connect-persistence.test.mjs
+++ b/tests/quick-connect-persistence.test.mjs
@@ -16,13 +16,18 @@ test("Quick Connect persists connections and rename guards non-persisted ids", a
   );
   assert.match(
     sidebarSource,
-    /findMatchingConnection\(flattenConnections\(treeRef\.current\), candidate\)/,
+    /findMatchingConnection\(currentConnections, candidate\)/,
     "quickConnect should reuse an identical existing connection before creating",
   );
   assert.match(
     sidebarSource,
     /invokeCommand\("create_connection"/,
     "quickConnect should persist new Quick Connect targets via create_connection",
+  );
+  assert.match(
+    sidebarSource,
+    /nextQuickConnectName\(currentConnections, candidate\.name\)/,
+    "quickConnect should avoid duplicate saved Connection names when creating a new target",
   );
 
   // The ephemeral upsert path is gone.


### PR DESCRIPTION
### Motivation
- Quick Connect could attempt to create a second saved Connection when the in-memory tree was stale and a just-created Connection already existed in the database. 
- Creating a new saved Connection could also collide with an existing Connection name, producing confusing duplicates.

### Description
- Refresh the saved Connection tree before matching in `quickConnect` so newly persisted targets are discovered immediately instead of using a stale `treeRef.current` snapshot (change in `ConnectionSidebar.tsx`).
- Add `nextQuickConnectName` to `quickConnectMenuModel.ts` to pick a unique saved Connection name (`Name`, `Name #1`, `Name #2`, …) when creating a Quick Connect that would otherwise collide.
- Use `nextQuickConnectName` when assembling the `create_connection` request in `quickConnect`, and update the Quick Connect persistence test to assert the reuse and duplicate-name guard are present (`tests/quick-connect-persistence.test.mjs`).

### Testing
- Ran the focused persistence test with `node --test tests/quick-connect-persistence.test.mjs` and it passed.
- Ran frontend lint with `npm run lint -- --quiet` and it passed.
- Ran type-check with `npx tsc --noEmit` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f7159cf10832f82a9bdd769e89934)