### PR TITLE
Close open tabs and refresh UI when deleting a workspace

### DIFF
--- a/src/app/ActivityRail.tsx
+++ b/src/app/ActivityRail.tsx
@@ -103,6 +103,7 @@ export function ActivityRail({
   const workspaces = useWorkspaceStore((state) => state.workspaces);
   const setWorkspaces = useWorkspaceStore((state) => state.setWorkspaces);
   const setActiveWorkspace = useWorkspaceStore((state) => state.setActiveWorkspace);
+  const closeWorkspaceTabs = useWorkspaceStore((state) => state.closeWorkspaceTabs);
   const activeTabId = useWorkspaceStore((state) => state.activeTabId);
   const activeSessionCounts = useWorkspaceStore((state) => state.activeSessionCounts);
   const tabs = useWorkspaceStore((state) => state.tabs);
@@ -908,8 +909,10 @@ export function ActivityRail({
         <DeleteWorkspaceDialog
           workspace={workspaceToDelete}
           onClose={() => setWorkspaceToDelete(null)}
-          onDeleted={() => {
+          onDeleted={(deletedWorkspace) => {
+            closeWorkspaceTabs(deletedWorkspace.id);
             setWorkspaceToDelete(null);
+            onNavigate("workspace");
             void reloadWorkspaces();
           }}
         />

--- a/src/store.ts
+++ b/src/store.ts
@@ -1006,6 +1006,7 @@ interface WorkspaceState {
   setQuery: (query: string) => void;
   setWorkspaces: (workspaces: Workspace[]) => void;
   setActiveWorkspace: (workspaceId: string) => void;
+  closeWorkspaceTabs: (workspaceId: string, fallbackWorkspaceId?: string) => void;
   setGeneralSettings: (settings: GeneralSettings) => void;
   setCredentialSettings: (settings: CredentialSettings) => void;
   setDashboardSettings: (settings: DashboardSettings) => void;
@@ -1176,7 +1177,14 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         workspaces.find((workspace) => workspace.isDefault)?.id ??
         workspaces[0].id;
       persistActiveWorkspaceId(fallbackId);
-      set({ workspaces, activeWorkspaceId: fallbackId });
+      set({
+        workspaces,
+        activeWorkspaceId: fallbackId,
+        activeTabId: firstTabIdForWorkspace(get().tabs, fallbackId),
+      });
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent("kkterm:connection-tree-invalidated"));
+      }
       return;
     }
     set({ workspaces });
@@ -1195,6 +1203,43 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     });
     // The Connection Tree, rail, and sidebar all re-read the active Workspace's
     // tree off this shared invalidation event.
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent("kkterm:connection-tree-invalidated"));
+    }
+  },
+  closeWorkspaceTabs: (workspaceId, fallbackWorkspaceId = DEFAULT_WORKSPACE_ID) => {
+    const closingTabs = get().tabs.filter(
+      (tab) => tabWorkspaceId(tab) === workspaceId,
+    );
+    if (closingTabs.length === 0 && get().activeWorkspaceId !== workspaceId) {
+      return;
+    }
+    const remainingTabs = get().tabs.filter(
+      (tab) => tabWorkspaceId(tab) !== workspaceId,
+    );
+    const nextActiveWorkspaceId =
+      get().activeWorkspaceId === workspaceId
+        ? fallbackWorkspaceId
+        : get().activeWorkspaceId;
+    const activeTabStillOpen = remainingTabs.some(
+      (tab) => tab.id === get().activeTabId,
+    );
+    const nextActiveTabId = activeTabStillOpen
+      ? get().activeTabId
+      : firstTabIdForWorkspace(remainingTabs, nextActiveWorkspaceId);
+
+    if (nextActiveWorkspaceId !== get().activeWorkspaceId) {
+      persistActiveWorkspaceId(nextActiveWorkspaceId);
+    }
+    set((state) => ({
+      tabs: remainingTabs,
+      activeWorkspaceId: nextActiveWorkspaceId,
+      activeTabId: nextActiveTabId,
+      activeSessionCounts: decrementActiveSessionCounts(
+        state.activeSessionCounts,
+        closingTabs.flatMap(urlConnectionIdsForTab),
+      ),
+    }));
     if (typeof window !== "undefined") {
       window.dispatchEvent(new CustomEvent("kkterm:connection-tree-invalidated"));
     }

--- a/tests/workspace-delete-cleanup.test.mjs
+++ b/tests/workspace-delete-cleanup.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const storeSource = readFileSync("src/store.ts", "utf8");
+const activityRailSource = readFileSync("src/app/ActivityRail.tsx", "utf8");
+
+assert.match(
+  storeSource,
+  /closeWorkspaceTabs: \(workspaceId: string, fallbackWorkspaceId\?: string\) => void;/,
+  "workspace store exposes a targeted cleanup action for deleted Workspace tabs",
+);
+
+assert.match(
+  storeSource,
+  /closeWorkspaceTabs: \(workspaceId, fallbackWorkspaceId = DEFAULT_WORKSPACE_ID\) => \{[\s\S]*?tabs: remainingTabs,[\s\S]*?activeWorkspaceId: nextActiveWorkspaceId,[\s\S]*?window\.dispatchEvent\(new CustomEvent\("kkterm:connection-tree-invalidated"\)\);[\s\S]*?\n  \},\n  setGeneralSettings:/,
+  "deleted Workspace cleanup closes its open tabs, falls back to Default Workspace, and invalidates the Connection Tree",
+);
+
+assert.match(
+  storeSource,
+  /set\(\{[\s\S]*?workspaces,[\s\S]*?activeWorkspaceId: fallbackId,[\s\S]*?activeTabId: firstTabIdForWorkspace\(get\(\)\.tabs, fallbackId\),[\s\S]*?\}\);[\s\S]*?window\.dispatchEvent\(new CustomEvent\("kkterm:connection-tree-invalidated"\)\);/,
+  "workspace list refresh also invalidates the tree when the active Workspace disappears",
+);
+
+assert.match(
+  activityRailSource,
+  /const closeWorkspaceTabs = useWorkspaceStore\(\(state\) => state\.closeWorkspaceTabs\);/,
+  "Activity Rail reads the deleted Workspace cleanup action",
+);
+
+assert.match(
+  activityRailSource,
+  /onDeleted=\{\(deletedWorkspace\) => \{[\s\S]*?closeWorkspaceTabs\(deletedWorkspace\.id\);[\s\S]*?onNavigate\("workspace"\);[\s\S]*?void reloadWorkspaces\(\);[\s\S]*?\}\}/,
+  "Activity Rail cleans up deleted Workspace sessions and returns to Workspace before refreshing lists",
+);


### PR DESCRIPTION
### Motivation
- Deleting a non-default Workspace left its open tabs and connections visible in the UI while the rail title reverted to the Default Workspace, causing stale/incorrect workspace state in the Connection Tree and tab strip. The change ensures deleted Workspace sessions are closed and the UI refreshes to a consistent Default Workspace view.

### Description
- Added `closeWorkspaceTabs(workspaceId, fallbackWorkspaceId?)` to the shared workspace store to close tabs scoped to a deleted Workspace, decrement URL session counts, update `activeWorkspaceId`/`activeTabId`, and dispatch `kkterm:connection-tree-invalidated` for a refresh. 
- Updated `setWorkspaces` fallback path to recalculate `activeTabId` for the fallback Workspace and invalidate the Connection Tree when the active Workspace disappears. 
- Wired the Activity Rail delete flow to call `closeWorkspaceTabs` when a Workspace is deleted, navigate back to the Workspace module, and then reload Workspace list state. 
- Added a regression test `tests/workspace-delete-cleanup.test.mjs` that asserts the new store action exists and that Activity Rail is wired to call it on Workspace deletion.

### Testing
- Ran `npm run check` (lint + frontend tests) and the full frontend test suite passed (337 tests), and the new regression test was included in that run; note: the `check` invocation was accidentally run with an extra `--help` flag which printed `tsc` help instead of performing the final compile step. 
- Ran `npx tsc --noEmit` to perform a proper type-check and it completed successfully. 
- Ran `git diff --check` to confirm no whitespace/overlap issues and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f826cf998832fb9cca1ff84dec367)