### PR TITLE
Fix Gemini AI provider settings validation

### DIFF
--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -1244,12 +1244,14 @@ const AI_PROVIDER_CREDENTIALS: &[(&str, &str, &str)] = &[
     ("anthropic", "Anthropic", "Anthropic API key"),
     ("openrouter", "OpenRouter", "OpenRouter API key"),
     ("deepseek", "DeepSeek", "DeepSeek API key"),
+    ("gemini", "Google Gemini", "Google AI Studio API key"),
     ("grok", "xAI Grok", "xAI API key"),
     ("azure-openai", "Azure OpenAI", "Azure OpenAI API key"),
     ("litellm", "LiteLLM", "LiteLLM key"),
     ("github-copilot", "GitHub Copilot", "GitHub OAuth token"),
     ("ollama", "Ollama", "Ollama API key"),
     ("nvidia", "NVIDIA", "NVIDIA API key"),
+    ("opencode", "OpenCode", "OpenCode API key"),
     ("openai-compatible", "OpenAI-compatible", "API key"),
 ];
 
@@ -4518,6 +4520,7 @@ fn validate_ai_provider_settings(
         "anthropic" => "anthropic".to_string(),
         "openrouter" => "openrouter".to_string(),
         "deepseek" => "deepseek".to_string(),
+        "gemini" | "google-gemini" | "google_gemini" | "google gemini" => "gemini".to_string(),
         "grok" | "xai" => "grok".to_string(),
         "azure-openai" | "azure_openai" | "azure openai" => "azure-openai".to_string(),
         "litellm" | "lite-llm" | "lite_llm" => "litellm".to_string(),

--- a/src-tauri/src/storage/tests.rs
+++ b/src-tauri/src/storage/tests.rs
@@ -2401,17 +2401,62 @@
             .filter(|candidate| candidate.kind == "aiApiKey")
             .collect::<Vec<_>>();
 
-        assert!(
-            ai_candidates
-                .iter()
-                .any(|candidate| candidate.owner_id == "ai-provider:openai")
-        );
-        assert!(
-            ai_candidates
-                .iter()
-                .any(|candidate| candidate.owner_id == "ai-provider:openrouter")
-        );
-        assert!(ai_candidates.len() > 1);
+        for provider_kind in [
+            "openai",
+            "anthropic",
+            "openrouter",
+            "deepseek",
+            "gemini",
+            "grok",
+            "azure-openai",
+            "litellm",
+            "github-copilot",
+            "ollama",
+            "nvidia",
+            "opencode",
+            "openai-compatible",
+        ] {
+            let owner_id = format!("ai-provider:{provider_kind}");
+            assert!(
+                ai_candidates
+                    .iter()
+                    .any(|candidate| candidate.owner_id == owner_id),
+                "{provider_kind} should expose a stored credential candidate"
+            );
+        }
+    }
+
+    #[test]
+    fn ai_provider_settings_accept_every_registered_provider() {
+        let storage =
+            Storage::open(temp_db_path("ai-provider-all-registered")).expect("storage opens");
+
+        for provider_kind in [
+            "openai",
+            "anthropic",
+            "openrouter",
+            "deepseek",
+            "gemini",
+            "grok",
+            "azure-openai",
+            "litellm",
+            "github-copilot",
+            "ollama",
+            "nvidia",
+            "opencode",
+            "openai-compatible",
+        ] {
+            let mut settings = storage
+                .ai_provider_settings()
+                .expect("default AI provider settings load");
+            settings.provider_kind = provider_kind.to_string();
+            settings.base_url = format!("https://{provider_kind}.example.com/v1");
+
+            let updated = storage
+                .update_ai_provider_settings(settings)
+                .unwrap_or_else(|error| panic!("{provider_kind} should validate: {error}"));
+            assert_eq!(updated.provider_kind, provider_kind);
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Saving Google Gemini provider settings failed because backend storage validation did not recognize the `gemini` provider or common Gemini spelling aliases, causing "AI provider is not supported" errors.
- The AI credential owner candidates list omitted `gemini` and `opencode`, so stored-key management did not expose owners for those registered providers.
- Add regression coverage so the storage layer accepts every registered provider and exposes credential candidates for each provider kind.

### Description
- Accept Google Gemini (and common aliases) in backend validation by updating `validate_ai_provider_settings` in `src-tauri/src/storage.rs` to map Gemini variants to `gemini`.
- Add `gemini` and `opencode` entries to the `AI_PROVIDER_CREDENTIALS` table in `src-tauri/src/storage.rs` so stored credential candidates include those providers.
- Add storage tests in `src-tauri/src/storage/tests.rs` that validate every registered AI provider kind can be saved and that `list_stored_credential_candidates` exposes an `ai-provider:<kind>` owner for each provider.
- Apply `rustfmt` to the touched Rust sources for minimal formatting of the edited scope.

### Testing
- Ran `git diff --check` and local formatting with `rustfmt --edition 2024` which both succeeded.
- Attempted to run the focused Rust tests via `cargo test --manifest-path src-tauri/Cargo.toml ai_provider -- --nocapture`, but the build failed in this environment due to a missing system dependency: `glib-2.0` (pkg-config cannot find `glib-2.0.pc`).
- The new unit tests are included in the repo and are expected to pass in CI or a developer environment with the required system libs installed (CI provides the `glib-2.0` dependency).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fafe23de0832fb70aa12a442c4487)