### PR TITLE
fix(ai): use Chat Completions for Gemini and NVIDIA providers

### DIFF
--- a/src-tauri/src/ai/providers/gemini.rs
+++ b/src-tauri/src/ai/providers/gemini.rs
@@ -9,6 +9,9 @@ pub(super) fn provider() -> OpenAiCompatibleProvider {
         requires_api_key: true,
         endpoint_style: OpenAiEndpointStyle::ChatCompletions,
         auth_style: OpenAiAuthStyle::Bearer,
-        default_api: OpenAiApiStyle::Responses,
+        // Gemini's OpenAI-compatibility layer implements /chat/completions but
+        // not the OpenAI Responses API (/responses returns HTTP 404), so it must
+        // default to Chat Completions.
+        default_api: OpenAiApiStyle::ChatCompletions,
     }
 }

--- a/src-tauri/src/ai/providers/nvidia.rs
+++ b/src-tauri/src/ai/providers/nvidia.rs
@@ -9,6 +9,9 @@ pub(super) fn provider() -> OpenAiCompatibleProvider {
         requires_api_key: true,
         endpoint_style: OpenAiEndpointStyle::ChatCompletions,
         auth_style: OpenAiAuthStyle::Bearer,
-        default_api: OpenAiApiStyle::Responses,
+        // NVIDIA NIM exposes only the OpenAI /chat/completions endpoint, not the
+        // Responses API (/responses returns HTTP 404), so it must default to
+        // Chat Completions.
+        default_api: OpenAiApiStyle::ChatCompletions,
     }
 }

--- a/src-tauri/src/ai/tests.rs
+++ b/src-tauri/src/ai/tests.rs
@@ -2338,6 +2338,25 @@
     }
 
     #[test]
+    fn chat_completions_only_providers_never_use_responses_api() {
+        // These providers' OpenAI-compatibility layers do not implement the
+        // Responses API (/responses returns HTTP 404), so they must resolve to
+        // Chat Completions regardless of the requested api mode.
+        for provider_kind in ["gemini", "nvidia"] {
+            let provider = openai_provider(provider_kind);
+            for api_mode in ["chatCompletions", "responses", ""] {
+                assert!(
+                    matches!(
+                        provider.api_style_for_settings(api_mode),
+                        OpenAiApiStyle::ChatCompletions
+                    ),
+                    "{provider_kind} should use Chat Completions for api_mode {api_mode:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn tool_definitions_include_performance_counters_tool() {
         let settings: AiAssistantToolSettings = serde_json::from_value(json!({
             "performanceCounters": true


### PR DESCRIPTION
### Motivation
- Selecting **Google Gemini** as the AI provider failed at runtime with `Google Gemini returned HTTP 404`. The request was being sent to `https://generativelanguage.googleapis.com/v1beta/openai/responses`.
- Gemini's OpenAI-compatibility layer implements `/chat/completions`, `/embeddings`, `/models`, `/images/generations`, and `/videos` — but **not** the OpenAI Responses API. Hitting `/responses` returns 404. (Confirmed against Google's docs as of June 2026.)
- The provider was hardcoded to `default_api: OpenAiApiStyle::Responses`, and `api_style_for_settings` only honors the user's `apiMode` setting for the generic `openai-compatible` provider — every named provider uses its `default_api`.

### Audit
While fixing Gemini, I audited every provider currently defaulting to `Responses` against its real API surface:

| Provider | Supports `/responses`? | Action |
|---|---|---|
| openai | ✅ native | unchanged |
| azure-openai | ✅ | unchanged |
| openrouter | ✅ Beta (`POST /v1/responses`) | unchanged |
| litellm | ✅ proxy exposes `/v1/responses` | unchanged |
| ollama | ✅ since v0.13.3 (experimental, non-stateful) | unchanged |
| **nvidia** | ❌ NIM only `/chat/completions` | **fixed → ChatCompletions** |
| **gemini** | ❌ | **fixed → ChatCompletions** |

NVIDIA NIM would 404 on `/responses` identically to Gemini, so it gets the same fix.

### Changes
- `src-tauri/src/ai/providers/gemini.rs`: `default_api` → `ChatCompletions`.
- `src-tauri/src/ai/providers/nvidia.rs`: `default_api` → `ChatCompletions`.
- `src-tauri/src/ai/tests.rs`: regression test asserting `gemini` and `nvidia` resolve to Chat Completions for any requested api mode.

### Testing
- `cargo test chat_completions_only_providers_never_use_responses_api` — passes.

### Notes for reviewer
- The resulting endpoint is `.../v1beta/openai/chat/completions` (base URL unchanged); only the API style was wrong.
- **Ollama** caveat: Responses support requires Ollama v0.13.3+. Users on older versions will still 404. Left as `Responses` for now since recent Ollama supports it, but happy to flip it to ChatCompletions if we want to be conservative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)