### PR TITLE
fix(connections): respect double-click-to-open for child connections

### DIFF
--- a/src/modules/workspace/connections/ConnectionSidebar.tsx
+++ b/src/modules/workspace/connections/ConnectionSidebar.tsx
@@ -4662,6 +4662,9 @@ function ConnectionChildTabRow({
   onRename: () => void;
 }) {
   const { t } = useTranslation();
+  const doubleClickOpensConnection = useWorkspaceStore(
+    (state) => state.generalSettings.doubleClickOpensConnection,
+  );
   const title = child.name;
   const clickTimerRef = useRef<number | null>(null);
 
@@ -4688,6 +4691,13 @@ function ConnectionChildTabRow({
       <button
         className="connection-child-tab-open"
         onClick={() => {
+          // In double-click-to-open mode a single click must not open the
+          // child Connection, matching the parent ConnectionRow. Opening
+          // happens from onDoubleClick below; rename moves to the context menu.
+          if (doubleClickOpensConnection) {
+            clearClickTimer();
+            return;
+          }
           clearClickTimer();
           clickTimerRef.current = window.setTimeout(() => {
             clickTimerRef.current = null;
@@ -4698,6 +4708,10 @@ function ConnectionChildTabRow({
           event.preventDefault();
           event.stopPropagation();
           clearClickTimer();
+          if (doubleClickOpensConnection) {
+            onActivate();
+            return;
+          }
           onRename();
         }}
         type="button"


### PR DESCRIPTION
## Problem

Follow-up to #352. With **"double-click to open connection"** enabled, parent Connection rows correctly require a double-click to open — but **child Connection rows** (the per-tab rows shown in the tree when the top tab strip is hidden, i.e. `hideTopTabButtons`) still opened on a **single click**. Inconsistent behaviour between parent and child connections.

## Fix

`ConnectionChildTabRow` now reads the `doubleClickOpensConnection` setting and mirrors the parent `ConnectionRow`:

- **Double-click-to-open mode ON:** a single click no longer opens the child; a double-click activates it. Rename (previously bound to double-click) remains available via the context menu — consistent with how parent rows behave in this mode.
- **Default (single-click) mode:** unchanged — single click opens (with the existing 180ms debounce), double-click renames.

## Testing

- `npx tsc --noEmit` — clean.
- Suggested manual check, with the tab strip hidden and double-click-to-open enabled: single-clicking a child row should no longer open it; double-clicking should. With the setting off, behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)