### PR TITLE
fix(connections): make the whole tree row a click target for selection

### DIFF
--- a/src/modules/workspace/connections/connections.css
+++ b/src/modules/workspace/connections/connections.css
@@ -503,7 +503,10 @@
 .connection-row {
   gap: 5px;
   min-height: 28px;
-  padding: 2px 4px;
+  /* Vertical padding lives at 0 so the stretched .connection-open button covers
+     the full row height (border-box keeps the row at its min-height; content
+     stays centered). Horizontal padding is retained for inset. */
+  padding: 0 4px;
 }
 
 .connection-row:hover,
@@ -514,6 +517,11 @@
 .connection-open,
 .connection-child-tab-open {
   flex: 1 1 auto;
+  /* Stretch the select/open target to the full row height. Without this the
+     button is only as tall as its icon, leaving dead strips at the top and
+     bottom of each row where clicks land on the row div (drag handler only)
+     instead of selecting. Content stays centered via align-items on the row. */
+  align-self: stretch;
   gap: 6px;
   min-width: 0;
   padding: 0;
@@ -526,7 +534,8 @@
   gap: 5px;
   min-height: 26px;
   margin-left: 24px;
-  padding: 2px 4px 2px 10px;
+  /* Zero vertical padding so the stretched open button fills the row height. */
+  padding: 0 4px 0 10px;
   color: var(--text);
   background: transparent;
   border-left: 1px solid var(--border);


### PR DESCRIPTION
## Problem

Selecting a connection in the tree often required clicking right on/near the name. The real cause of the "missing clicks": the select/open `onClick` lives on the `.connection-open` button, which was only as tall as its **icon** (~18px). The row reserves `min-height: 28px` with `align-items: center`, so there were ~5px dead strips at the **top and bottom of every row**. Clicks landing there hit the row `<div>` (which only carries the drag/suppression handlers) instead of the select button — so nothing got selected.

## Fix (CSS only)

- Stretch `.connection-open` / `.connection-child-tab-open` to the full row height with `align-self: stretch`.
- Move the rows'' vertical padding to `0` (`.connection-row`, `.connection-child-tab-row`) so the button fills the row top-to-bottom.

Because `box-sizing: border-box` is global, the row keeps its `min-height` and the icon/text stay vertically centered — there is **no visual change**, only the previously-dead zones become clickable. The button already spans the full width via `flex: 1 1 auto`, so the hit target now covers essentially the entire row (only the small status dot on the far right is excluded).

## Safety

The folder **expand/collapse** control (`.tree-disclosure` inside `.tree-folder`, within `.tree-folder-row`) is a separate element with its own `onClick`/`onPointerDown` `stopPropagation`. None of the changed selectors touch it, so collapse/expand is unaffected.

## Testing

- CSS-only change; no type/logic impact.
- Suggested manual check: click the top and bottom edges of a connection row (not just the name) — it should now select; verify the folder chevron still expands/collapses normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)