### PR TITLE
Support interactive SSH password auth in native sessions

### DIFF
--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -799,7 +799,7 @@ impl SessionManager {
         }
 
         let auth_method = ssh_auth_method_for(&request, password.as_deref())?;
-        if uses_native_ssh(&request, password.as_deref(), &auth_method) {
+        if uses_native_ssh(&request, password.as_deref(), &auth_method, true) {
             let known_hosts_path = ssh::app_known_hosts_path(&app)?;
             let auth = native_ssh_auth_for(&request, password, &auth_method)?;
             match ssh::start_native_terminal(
@@ -1158,7 +1158,7 @@ impl SessionManager {
         let terminal_request = terminal_request_for_tmux(&request.connection);
         let password = connection_password_for(secrets, &terminal_request);
         let auth_method = ssh_auth_method_for(&terminal_request, password.as_deref())?;
-        if !uses_native_ssh(&terminal_request, password.as_deref(), &auth_method) {
+        if !uses_native_ssh(&terminal_request, password.as_deref(), &auth_method, false) {
             return Err(
                 "SSH port forwarding currently requires a native SSH Connection without ProxyJump"
                     .to_string(),
@@ -1395,15 +1395,20 @@ fn uses_native_ssh(
     request: &StartTerminalSessionRequest,
     password: Option<&str>,
     auth_method: &SshAuthMethod,
+    allow_interactive_password: bool,
 ) -> bool {
     // A SOCKS proxy no longer forces the system-ssh path: the native russh
     // transport dials through the proxy itself (see `ssh::connect_verified_client`).
     // ProxyJump still requires the system `ssh` client.
     request.connection_type.trim().eq_ignore_ascii_case("ssh")
         && ssh::can_start_native_terminal(
-            request.key_path.as_deref(),
+            match auth_method {
+                SshAuthMethod::KeyFile => request.key_path.as_deref(),
+                SshAuthMethod::Password | SshAuthMethod::Agent => None,
+            },
             password,
             matches!(auth_method, SshAuthMethod::Agent),
+            allow_interactive_password && matches!(auth_method, SshAuthMethod::Password),
             request.proxy_jump.as_deref(),
         )
 }
@@ -1472,10 +1477,7 @@ fn native_ssh_auth_for(
         SshAuthMethod::KeyFile => Ok(ssh::NativeSshAuth::KeyFile {
             key_path: request.key_path.clone().unwrap_or_default(),
         }),
-        SshAuthMethod::Password => Ok(ssh::NativeSshAuth::Password {
-            password: password
-                .ok_or_else(|| "password is required for native SSH sessions".to_string())?,
-        }),
+        SshAuthMethod::Password => Ok(ssh::NativeSshAuth::Password { password }),
         SshAuthMethod::Agent => Ok(ssh::NativeSshAuth::Agent),
     }
 }
@@ -1557,7 +1559,7 @@ fn run_ssh_command(
     let terminal_request = terminal_request_for_tmux(request);
     let password = connection_password_for(secrets, &terminal_request);
     let auth_method = ssh_auth_method_for(&terminal_request, password.as_deref())?;
-    if uses_native_ssh(&terminal_request, password.as_deref(), &auth_method) {
+    if uses_native_ssh(&terminal_request, password.as_deref(), &auth_method, false) {
         return ssh::run_remote_command(ssh::NativeSshCommandRequest {
             host: terminal_request.host.clone(),
             user: terminal_request.user.clone(),
@@ -2542,6 +2544,31 @@ mod tests {
 
         request.auth_method = Some("keyboardInteractive".to_string());
         assert!(ssh_auth_method_for(&request, None).is_err());
+    }
+
+    #[test]
+    fn password_auth_without_stored_secret_uses_native_interactive_auth_even_with_key_path() {
+        let mut request = ssh_request();
+        request.auth_method = Some("password".to_string());
+        request.key_path = Some("C:\\Users\\example\\.ssh\\id_ed25519".to_string());
+        let auth_method = ssh_auth_method_for(&request, None).expect("auth method resolves");
+
+        assert!(uses_native_ssh(&request, None, &auth_method, true));
+        assert!(!uses_native_ssh(&request, None, &auth_method, false));
+    }
+
+    #[test]
+    fn password_auth_ignores_stale_key_path_for_native_eligibility() {
+        let mut request = ssh_request();
+        request.auth_method = Some("password".to_string());
+        request.key_path = Some("C:\\Users\\example\\.ssh\\id_ed25519".to_string());
+        request.proxy_jump = Some("bastion".to_string());
+        let auth_method = ssh_auth_method_for(&request, None).expect("auth method resolves");
+
+        assert!(
+            !uses_native_ssh(&request, None, &auth_method, true),
+            "ProxyJump, not a stale key path, should be what disqualifies native SSH here"
+        );
     }
 
     #[test]

--- a/src-tauri/src/sftp.rs
+++ b/src-tauri/src/sftp.rs
@@ -1758,7 +1758,9 @@ fn auth_for(
                 .read_connection_password(owner_id)
                 .map_err(|error| format!("failed to read SFTP password: {error}"))?
                 .ok_or_else(|| "password auth requires a stored connection password".to_string())?;
-            Ok(ssh::NativeSshAuth::Password { password })
+            Ok(ssh::NativeSshAuth::Password {
+                password: Some(password),
+            })
         }
         SftpAuthMethod::Agent => Ok(ssh::NativeSshAuth::Agent),
     }

--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -128,7 +128,7 @@ pub(crate) struct NativeSshCommandRequest {
 #[derive(Clone)]
 pub enum NativeSshAuth {
     KeyFile { key_path: String },
-    Password { password: String },
+    Password { password: Option<String> },
     Agent,
 }
 
@@ -276,6 +276,7 @@ pub fn can_start_native_terminal(
     key_path: Option<&str>,
     password: Option<&str>,
     use_agent: bool,
+    interactive_password: bool,
     proxy_jump: Option<&str>,
 ) -> bool {
     let has_key_path = key_path
@@ -288,7 +289,7 @@ pub fn can_start_native_terminal(
         .map(str::trim)
         .is_some_and(|value| !value.is_empty());
 
-    (has_key_path || has_password || use_agent) && !has_proxy_jump
+    (has_key_path || has_password || use_agent || interactive_password) && !has_proxy_jump
 }
 
 pub fn start_native_terminal(
@@ -326,6 +327,7 @@ pub fn start_native_terminal(
     };
     let (control_tx, control_rx) = mpsc::unbounded_channel();
     let (ready_tx, ready_rx) = std_mpsc::sync_channel(1);
+    let returns_before_ready = matches!(request.auth, NativeSshAuth::Password { password: None });
     let worker = thread::spawn(move || {
         let result = run_native_terminal_thread(app.clone(), request.clone(), control_rx, ready_tx);
         if let Err(error) = result {
@@ -336,6 +338,15 @@ pub fn start_native_terminal(
             );
         }
     });
+
+    if returns_before_ready {
+        return Ok(NativeSshTerminal {
+            control: control_tx,
+            worker: Some(worker),
+            terminal_ready_ms: 0,
+            x11_forwarding_status: None,
+        });
+    }
 
     match ready_rx
         .recv_timeout(Duration::from_secs(15))
@@ -670,15 +681,23 @@ async fn run_native_terminal_once(
     startup_timeout: Duration,
 ) -> Result<TerminalRunOutcome, String> {
     let startup = async {
-        let session = connect_verified_client(NativeSshConnectionRequest {
-            host: request.host.clone(),
-            user: request.user.clone(),
-            port: request.port,
-            auth: request.auth.clone(),
-            known_hosts_path: request.known_hosts_path.clone(),
-            x11_forwarding: request.x11_forwarding.clone(),
-            socks_proxy: request.socks_proxy.clone(),
-        })
+        let mut prompt = TerminalAuthPrompt {
+            app,
+            session_id: &request.session_id,
+            control_rx,
+        };
+        let session = connect_verified_client_with_prompt(
+            NativeSshConnectionRequest {
+                host: request.host.clone(),
+                user: request.user.clone(),
+                port: request.port,
+                auth: request.auth.clone(),
+                known_hosts_path: request.known_hosts_path.clone(),
+                x11_forwarding: request.x11_forwarding.clone(),
+                socks_proxy: request.socks_proxy.clone(),
+            },
+            Some(&mut prompt),
+        )
         .await?;
 
         let ready_start = Instant::now();
@@ -738,10 +757,14 @@ async fn run_native_terminal_once(
         ))
     };
 
-    let (session, mut channel, terminal_ready_ms, x11_forwarding_status) =
+    let startup_result = if matches!(request.auth, NativeSshAuth::Password { password: None }) {
+        startup.await
+    } else {
         tokio::time::timeout(startup_timeout, startup)
             .await
-            .map_err(|_| "timed out while starting native SSH session".to_string())??;
+            .map_err(|_| "timed out while starting native SSH session".to_string())?
+    };
+    let (session, mut channel, terminal_ready_ms, x11_forwarding_status) = startup_result?;
 
     if let Some(ready_tx) = ready_tx {
         let _ = ready_tx.send(Ok((terminal_ready_ms, x11_forwarding_status)));
@@ -957,19 +980,31 @@ fn normalize_native_ssh_auth(auth: NativeSshAuth) -> Result<NativeSshAuth, Strin
                 Ok(NativeSshAuth::KeyFile { key_path })
             }
         }
-        NativeSshAuth::Password { password } => {
-            if password.is_empty() {
-                Err("password is required for SSH password authentication".to_string())
-            } else {
-                Ok(NativeSshAuth::Password { password })
-            }
-        }
+        NativeSshAuth::Password { password } => Ok(NativeSshAuth::Password {
+            password: password.and_then(|password| {
+                let password = password.trim().to_string();
+                (!password.is_empty()).then_some(password)
+            }),
+        }),
         NativeSshAuth::Agent => Ok(NativeSshAuth::Agent),
     }
 }
 
+struct TerminalAuthPrompt<'a> {
+    app: &'a AppHandle,
+    session_id: &'a str,
+    control_rx: &'a mut mpsc::UnboundedReceiver<SshTerminalControl>,
+}
+
 pub(crate) async fn connect_verified_client(
     request: NativeSshConnectionRequest,
+) -> Result<client::Handle<VerifyingClient>, String> {
+    connect_verified_client_with_prompt(request, None).await
+}
+
+async fn connect_verified_client_with_prompt(
+    request: NativeSshConnectionRequest,
+    mut prompt: Option<&mut TerminalAuthPrompt<'_>>,
 ) -> Result<client::Handle<VerifyingClient>, String> {
     let host = request.host.trim();
     if host.is_empty() {
@@ -990,37 +1025,33 @@ pub(crate) async fn connect_verified_client(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string);
-    with_ssh_startup_timeout("connecting to SSH server", async {
-        let verifying = VerifyingClient {
-            host: host.to_string(),
-            port: request.port,
-            known_hosts_path: request.known_hosts_path,
-            rejection: Arc::clone(&host_key_rejection),
-            x11_forwarding: request.x11_forwarding,
-        };
-        let connect = async {
-            match socks_proxy.as_deref() {
-                Some(proxy) => {
-                    let stream =
-                        crate::socks::connect_via_socks5(proxy, host, request.port).await?;
-                    client::connect_stream(config, stream, verifying)
-                        .await
-                        .map_err(|error| format!("failed to connect to SSH server: {error}"))
-                }
-                None => client::connect(config, (host, request.port), verifying)
+    let verifying = VerifyingClient {
+        host: host.to_string(),
+        port: request.port,
+        known_hosts_path: request.known_hosts_path,
+        rejection: Arc::clone(&host_key_rejection),
+        x11_forwarding: request.x11_forwarding,
+    };
+    let mut session = with_ssh_startup_timeout("connecting to SSH server", async {
+        match socks_proxy.as_deref() {
+            Some(proxy) => {
+                let stream = crate::socks::connect_via_socks5(proxy, host, request.port).await?;
+                client::connect_stream(config, stream, verifying)
                     .await
-                    .map_err(|error| {
-                        remembered_rejection(&host_key_rejection)
-                            .unwrap_or_else(|| format!("failed to connect to SSH server: {error}"))
-                    }),
+                    .map_err(|error| format!("failed to connect to SSH server: {error}"))
             }
-        };
-        let mut session = connect.await?;
-
-        authenticate_native_ssh(&mut session, user, &auth).await?;
-        Ok(session)
+            None => client::connect(config, (host, request.port), verifying)
+                .await
+                .map_err(|error| {
+                    remembered_rejection(&host_key_rejection)
+                        .unwrap_or_else(|| format!("failed to connect to SSH server: {error}"))
+                }),
+        }
     })
-    .await
+    .await?;
+
+    authenticate_native_ssh(&mut session, user, &auth, prompt.as_deref_mut()).await?;
+    Ok(session)
 }
 
 fn x11_port(display: u16) -> u16 {
@@ -1074,11 +1105,13 @@ where
         .map_err(|_| format!("timed out while {operation}"))?
 }
 
-pub(crate) async fn authenticate_native_ssh(
+async fn authenticate_native_ssh(
     session: &mut client::Handle<VerifyingClient>,
     user: &str,
     auth: &NativeSshAuth,
+    prompt: Option<&mut TerminalAuthPrompt<'_>>,
 ) -> Result<(), String> {
+    let mut prompt = prompt;
     let auth_result = match auth {
         NativeSshAuth::KeyFile { key_path } => {
             let key_pair = load_secret_key(key_path, None)
@@ -1100,10 +1133,27 @@ pub(crate) async fn authenticate_native_ssh(
                 .await
                 .map_err(|error| format!("SSH key-file authentication failed: {error}"))?
         }
-        NativeSshAuth::Password { password } => session
+        NativeSshAuth::Password {
+            password: Some(password),
+        } => session
             .authenticate_password(user.to_string(), password.clone())
             .await
             .map_err(|error| format!("SSH password authentication failed: {error}"))?,
+        NativeSshAuth::Password { password: None } => {
+            let prompt = prompt
+                .as_deref_mut()
+                .ok_or_else(|| "password is required for native SSH sessions".to_string())?;
+            match authenticate_keyboard_interactive_from_terminal(session, user, prompt).await? {
+                TerminalAuthOutcome::Success => return Ok(()),
+                TerminalAuthOutcome::Rejected => {
+                    let password = read_terminal_prompt(prompt, "Password: ", false).await?;
+                    session
+                        .authenticate_password(user.to_string(), password)
+                        .await
+                        .map_err(|error| format!("SSH password authentication failed: {error}"))?
+                }
+            }
+        }
         NativeSshAuth::Agent => {
             authenticate_with_agent(session, user).await?;
             return Ok(());
@@ -1120,6 +1170,116 @@ pub(crate) async fn authenticate_native_ssh(
     }
 
     Ok(())
+}
+
+enum TerminalAuthOutcome {
+    Success,
+    Rejected,
+}
+
+async fn authenticate_keyboard_interactive_from_terminal(
+    session: &mut client::Handle<VerifyingClient>,
+    user: &str,
+    prompt: &mut TerminalAuthPrompt<'_>,
+) -> Result<TerminalAuthOutcome, String> {
+    let mut response = session
+        .authenticate_keyboard_interactive_start(user.to_string(), None::<String>)
+        .await
+        .map_err(|error| format!("SSH keyboard-interactive authentication failed: {error}"))?;
+
+    loop {
+        match response {
+            client::KeyboardInteractiveAuthResponse::Success => {
+                return Ok(TerminalAuthOutcome::Success);
+            }
+            client::KeyboardInteractiveAuthResponse::Failure { .. } => {
+                return Ok(TerminalAuthOutcome::Rejected);
+            }
+            client::KeyboardInteractiveAuthResponse::InfoRequest {
+                name,
+                instructions,
+                prompts,
+            } => {
+                emit_auth_text(prompt, name);
+                emit_auth_text(prompt, instructions);
+                let mut responses = Vec::with_capacity(prompts.len());
+                for server_prompt in prompts {
+                    responses.push(
+                        read_terminal_prompt(prompt, &server_prompt.prompt, server_prompt.echo)
+                            .await?,
+                    );
+                }
+                response = session
+                    .authenticate_keyboard_interactive_respond(responses)
+                    .await
+                    .map_err(|error| {
+                        format!("SSH keyboard-interactive authentication failed: {error}")
+                    })?;
+            }
+        }
+    }
+}
+
+fn emit_auth_text(prompt: &TerminalAuthPrompt<'_>, text: String) {
+    let text = text.trim();
+    if !text.is_empty() {
+        emit_terminal_output(prompt.app, prompt.session_id, format!("{text}\r\n"));
+    }
+}
+
+async fn read_terminal_prompt(
+    prompt: &mut TerminalAuthPrompt<'_>,
+    label: &str,
+    echo: bool,
+) -> Result<String, String> {
+    emit_terminal_output(prompt.app, prompt.session_id, label.to_string());
+    let mut input = Vec::new();
+    while let Some(control) = prompt.control_rx.recv().await {
+        match control {
+            SshTerminalControl::Input(data) => {
+                for byte in data {
+                    match byte {
+                        b'\r' | b'\n' => {
+                            emit_terminal_output(prompt.app, prompt.session_id, "\r\n".to_string());
+                            return Ok(String::from_utf8_lossy(&input).into_owned());
+                        }
+                        0x03 => {
+                            emit_terminal_output(
+                                prompt.app,
+                                prompt.session_id,
+                                "^C\r\n".to_string(),
+                            );
+                            return Err("SSH password prompt was cancelled".to_string());
+                        }
+                        0x08 | 0x7f => {
+                            if input.pop().is_some() && echo {
+                                emit_terminal_output(
+                                    prompt.app,
+                                    prompt.session_id,
+                                    "\x08 \x08".to_string(),
+                                );
+                            }
+                        }
+                        _ => {
+                            input.push(byte);
+                            if echo {
+                                emit_terminal_output(
+                                    prompt.app,
+                                    prompt.session_id,
+                                    String::from_utf8_lossy(&[byte]).into_owned(),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            SshTerminalControl::Resize { .. } => {}
+            SshTerminalControl::Close => {
+                return Err("SSH password prompt was cancelled".to_string());
+            }
+        }
+    }
+    Err("SSH password prompt was cancelled".to_string())
 }
 
 async fn authenticate_with_agent(
@@ -1281,21 +1441,37 @@ mod tests {
             Some("C:\\Users\\example\\.ssh\\id_ed25519"),
             None,
             false,
+            false,
             None
         ));
         assert!(can_start_native_terminal(
             None,
             Some("not-for-sqlite"),
             false,
+            false,
             None
         ));
-        assert!(can_start_native_terminal(None, None, true, None));
-        assert!(!can_start_native_terminal(None, None, false, None));
-        assert!(!can_start_native_terminal(Some("  "), None, false, None));
-        assert!(!can_start_native_terminal(None, Some("  "), false, None));
+        assert!(can_start_native_terminal(None, None, true, false, None));
+        assert!(can_start_native_terminal(None, None, false, true, None));
+        assert!(!can_start_native_terminal(None, None, false, false, None));
+        assert!(!can_start_native_terminal(
+            Some("  "),
+            None,
+            false,
+            false,
+            None
+        ));
+        assert!(!can_start_native_terminal(
+            None,
+            Some("  "),
+            false,
+            false,
+            None
+        ));
         assert!(!can_start_native_terminal(
             Some("C:\\Users\\example\\.ssh\\id_ed25519"),
             None,
+            false,
             false,
             Some("bastion")
         ));
@@ -1735,7 +1911,7 @@ mod tests {
                 key_path: required_measurement_env("KKTERM_SSH_KEY_PATH")?,
             }),
             "password" => Ok(NativeSshAuth::Password {
-                password: required_measurement_env("KKTERM_SSH_PASSWORD")?,
+                password: Some(required_measurement_env("KKTERM_SSH_PASSWORD")?),
             }),
             _ => Err("KKTERM_SSH_AUTH must be agent, keyFile, or password".to_string()),
         }

--- a/src-tauri/src/ssh_keys.rs
+++ b/src-tauri/src/ssh_keys.rs
@@ -120,7 +120,9 @@ pub fn transfer_public_key(
         host,
         user: username,
         port: request.port.unwrap_or(22),
-        auth: ssh::NativeSshAuth::Password { password },
+        auth: ssh::NativeSshAuth::Password {
+            password: Some(password),
+        },
         known_hosts_path: ssh::app_known_hosts_path(&app)?,
         command: install_public_key_command(&public_key),
         timeout_seconds: Some(30),


### PR DESCRIPTION
## Summary
- Allow native SSH terminal startup to handle password auth without a stored secret by prompting in-terminal when needed.
- Treat stale key paths as irrelevant for password-auth native eligibility and keep ProxyJump as the actual disqualifier.
- Update SFTP and SSH auth plumbing to carry optional password secrets and add regression tests for the new eligibility rules.

## Testing
- Added unit coverage for native SSH eligibility with interactive password auth and stale key-path handling.
- Added unit coverage for optional password auth normalization and SFTP password auth wiring.