### PR TITLE
fix(rdp): stop status notice popup from permanently parking the RDP ActiveX surface

### DIFF
--- a/src/modules/workspace/nativeOverlay.ts
+++ b/src/modules/workspace/nativeOverlay.ts
@@ -8,7 +8,7 @@ const NATIVE_BLOCKING_OVERLAY_SELECTOR = [
   ".app-launcher-dialog-backdrop",
   ".settings-backdrop",
   ".settings-page",
-  ".status-bar-notice-area",
+  ".status-popup",
   ".tutorial-overlay",
   ".dw-catalog-backdrop",
   ".dw-customize",

--- a/src/modules/workspace/workspace.css
+++ b/src/modules/workspace/workspace.css
@@ -275,10 +275,10 @@
 .status-bar-notice-area {
   position: fixed;
   right: 0;
-  bottom: 28px;
+  top: var(--app-titlebar-height, 23px);
   left: 0;
   z-index: 9999;
-  padding-bottom: 16px;
+  padding-top: 12px;
   justify-content: center;
   pointer-events: none;
 }
@@ -712,7 +712,7 @@
 
 .status-popup.is-exiting {
   opacity: 0;
-  transform: translateY(16px) scale(0.97);
+  transform: translateY(-16px) scale(0.97);
   transition:
     opacity 200ms ease,
     transform 200ms ease;
@@ -721,7 +721,7 @@
 @keyframes status-popup-enter-pulse {
   from {
     opacity: 0;
-    transform: translateY(12px) scale(0.78);
+    transform: translateY(-12px) scale(0.78);
   }
 
   to {

--- a/tests/dont-sleep-settings.test.mjs
+++ b/tests/dont-sleep-settings.test.mjs
@@ -60,9 +60,17 @@ test("Don't Sleep rail uses state-specific tooltip copy and shared Pulse status 
   assert.match(workspaceCss, /--status-popup-glass-bg:\s*rgba\(252 252 253 \/ 88%\)/);
   assert.match(workspaceCss, /--status-popup-glass-bg:\s*rgba\(44 44 46 \/ 62%\)/);
   assert.match(workspaceCss, /\.status-popup-pulse[\s\S]*background:\s*var\(--status-popup-glass-bg\);[\s\S]*var\(--status-popup-glass-shadow\)/);
-  assert.match(workspaceCss, /@keyframes status-popup-enter-pulse[\s\S]*translateY\(12px\) scale\(0\.78\)/);
-  assert.match(workspaceCss, /\.status-bar-notice-area[\s\S]*bottom:\s*28px;[\s\S]*z-index:\s*9999;/);
-  assert.match(nativeOverlaySource, /"\.status-bar-notice-area"/);
+  assert.match(workspaceCss, /@keyframes status-popup-enter-pulse[\s\S]*translateY\(-12px\) scale\(0\.78\)/);
+  // The notice popup is anchored to the top title-bar band so it never overlaps
+  // (and parks) the RDP ActiveX surface, which extends to the bottom status bar.
+  assert.match(
+    workspaceCss,
+    /\.status-bar-notice-area[\s\S]*top:\s*var\(--app-titlebar-height, 23px\);[\s\S]*z-index:\s*9999;/,
+  );
+  // RDP suppression must key off the visible popup, not the always-rendered
+  // (and therefore permanently blocking) notice-area container.
+  assert.match(nativeOverlaySource, /"\.status-popup"/);
+  assert.doesNotMatch(nativeOverlaySource, /"\.status-bar-notice-area"/);
 });
 
 test("Don't Sleep has its own foreground-only Settings section", () => {


### PR DESCRIPTION
The status notice popup redesign turned `.status-bar-notice-area` into a
fixed, full-width overlay anchored at `bottom: 28px` with `padding-bottom`.
That container is always rendered (only the popup inside it is conditional),
so even when empty it kept a full-width strip overlapping the bottom edge of
the RDP host surface. Since the container was listed as an RDP blocking
overlay, `documentHasRdpBlockingOverlay()` returned true permanently and the
ActiveX control stayed parked off-screen, so the remote desktop never showed
again.

Move the notice popup to the top title-bar band so it renders above the RDP
ActiveX HWND (in the webview layer) without parking the live session, flip the
enter/exit animation to slide from the top, and key RDP suppression off the
visible `.status-popup` rather than the always-present notice-area container.

https://claude.ai/code/session_01MrkDA3KfFCchurBQENu6Yw