### PR TITLE
fix: anchor assistant working spinner to right of status bar

### DIFF
--- a/src/modules/workspace/workspace.css
+++ b/src/modules/workspace/workspace.css
@@ -284,6 +284,7 @@
 }
 
 .status-bar-actions {
+  grid-column: 3;
   justify-content: flex-end;
 }
 


### PR DESCRIPTION
The status bar is a 3-column grid, but its middle child
(.status-bar-notice-area) uses position: fixed, taking it out of the
grid's auto-placement flow. This caused .status-bar-actions to be
auto-placed into the middle 1fr column instead of the rightmost column,
so the assistant working spinner rendered near the center. Pin the
actions to column 3 so it sits flush against the right edge.