### PR TITLE
fix(url): stop the native browser from clipping status notice popups

### DIFF
--- a/src/modules/workspace/nativeOverlay.ts
+++ b/src/modules/workspace/nativeOverlay.ts
@@ -19,6 +19,10 @@ const WEBVIEW_BLOCKING_OVERLAY_SELECTOR = [
   ".settings-backdrop",
   ".dw-catalog-backdrop",
   ".screenshot-region-overlay",
+  // The status notice popup is anchored to the top title-bar band and overlaps the
+  // top of the URL Connection's native browser surface. Suppress the live WebView with
+  // a snapshot while the popup is visible so the popup is not clipped behind the browser.
+  ".status-popup",
 ].join(", ");
 
 export function documentHasRdpBlockingOverlay(surface: Element | null) {

--- a/tests/webview-visibility-lifecycle.test.mjs
+++ b/tests/webview-visibility-lifecycle.test.mjs
@@ -61,6 +61,20 @@ test("Dashboard catalog dialog suppresses embedded URL Connection WebViews", asy
   assert.match(webviewSelector, /\.dw-catalog-backdrop/);
 });
 
+test("status notice popup suppresses embedded URL Connection WebViews", async () => {
+  const source = await readFile(
+    new URL("../src/modules/workspace/nativeOverlay.ts", import.meta.url),
+    "utf8",
+  );
+
+  const webviewSelector = source.match(/const WEBVIEW_BLOCKING_OVERLAY_SELECTOR = \[[\s\S]*?\]\.join/)?.[0];
+
+  assert.ok(webviewSelector, "WebView blocking overlay selector should exist");
+  // The native browser surface otherwise clips the top-anchored status popup, so the
+  // visible popup must suppress the live WebView the same way the RDP host surface does.
+  assert.match(webviewSelector, /\.status-popup/);
+});
+
 test("backend hides overlay URL WebViews instead of using unstable child APIs", async () => {
   const source = await readFile(new URL("../src-tauri/src/webview.rs", import.meta.url), "utf8");
 


### PR DESCRIPTION
The URL Connection pane embeds a native browser WebView that renders above
the React DOM. The status notice popup is anchored to the top title-bar band
and overlaps the top of that native surface, so info/error popups were drawn
behind the live browser and clipped from view.

Add `.status-popup` to WEBVIEW_BLOCKING_OVERLAY_SELECTOR so a visible notice
suppresses the live WebView with a snapshot (mirroring the RDP host-surface
behavior), letting the popup render on top. The popup is only rendered while a
notice is active, so the WebView is never permanently parked.