### PR TITLE
Persist terminal toolbar font size across launches

### DIFF
--- a/docs/manual/05-terminal.md
+++ b/docs/manual/05-terminal.md
@@ -49,6 +49,9 @@ In the Pane toolbar group `terminal.font` (Actions submenu `terminal.actions`):
 - `terminal.decreaseSize`
 - `terminal.resetSize`
 
+These controls apply the new size to every Pane in the current Tab and save it as
+the global terminal font size, so the change is preserved across app launches.
+
 Font family, default size, ligature settings, and cursor style are configured globally in Settings → Terminal (see [15-settings.md](15-settings.md) §Terminal).
 
 ## View submenu

--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -98,6 +98,8 @@ export function TerminalWorkspace({
     (state) => state.setQuickCommandBarVisible,
   );
   const sshSettings = useWorkspaceStore((state) => state.sshSettings);
+  const terminalSettings = useWorkspaceStore((state) => state.terminalSettings);
+  const setTerminalSettings = useWorkspaceStore((state) => state.setTerminalSettings);
   const generalSettings = useWorkspaceStore((state) => state.generalSettings);
   const setFocusedPane = useWorkspaceStore((state) => state.setFocusedPane);
   const showStatusBarNotice = useWorkspaceStore((state) => state.showStatusBarNotice);
@@ -390,6 +392,27 @@ export function TerminalWorkspace({
     const next = delta === "reset" ? defaultFontSize : currentFontSize() + delta;
     const clamped = Math.min(Math.max(Math.round(next), 6), 64);
     applyFontSizeToPanes(clamped);
+    void persistTerminalFontSize(clamped);
+  }
+
+  async function persistTerminalFontSize(fontSize: number) {
+    // The durable terminal font size is capped at the Settings range, while the
+    // live toolbar zoom range is wider. Clamp before persisting so the default
+    // reloaded on the next app launch always passes backend validation.
+    const persisted = Math.min(Math.max(fontSize, 8), 32);
+    if (persisted === terminalSettings.fontSize) {
+      return;
+    }
+    const nextSettings = { ...terminalSettings, fontSize: persisted };
+    try {
+      const saved = isTauriRuntime()
+        ? await invokeCommand("update_terminal_settings", { request: nextSettings })
+        : nextSettings;
+      setTerminalSettings(saved);
+    } catch {
+      // Best-effort: the live panes already reflect the new size even if saving
+      // the durable default fails.
+    }
   }
 
   return (

--- a/tests/terminal-font-size-persist.test.mjs
+++ b/tests/terminal-font-size-persist.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = await readFile("src/modules/workspace/connections/terminal/TerminalWorkspace.tsx", "utf8");
+
+test("toolbar font change persists the new size to the durable terminal settings", () => {
+  // The toolbar handler must both apply the live size and persist it so the
+  // change survives app launches.
+  assert.match(source, /applyFontSizeToPanes\(clamped\);\s*\n\s*void persistTerminalFontSize\(clamped\);/);
+  assert.match(source, /async function persistTerminalFontSize/);
+  assert.match(source, /invokeCommand\("update_terminal_settings", \{ request: nextSettings \}\)/);
+  assert.match(source, /setTerminalSettings\(saved\)/);
+});
+
+test("persisted toolbar font size is clamped to the Settings-valid range", () => {
+  // The backend rejects font sizes outside 8..=32, so the durable value must be
+  // clamped even though the live zoom range is wider.
+  assert.match(source, /Math\.min\(Math\.max\(fontSize, 8\), 32\)/);
+});


### PR DESCRIPTION
The Pane toolbar font controls only called renderer.setFontSize, which
updates xterm in-memory. New terminals (including after relaunch) read
their font size from the durable terminalSettings, so the change was
lost on the next app launch.

Persist the toolbar font size to terminalSettings via
update_terminal_settings, clamped to the backend-valid 8..32 range
(the live zoom range is wider).