### PR TITLE
fix(ssh): reuse live session for OS detection on blank-password connections

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2109,11 +2109,12 @@ async fn inspect_ssh_system_context(
 async fn detect_ssh_remote_os(
     app: tauri::AppHandle,
     request: sessions::TmuxConnectionRequest,
+    session_id: Option<String>,
 ) -> Result<sessions::DetectedRemoteOs, String> {
     run_blocking_command("SSH remote OS detection", move || {
         let sessions = app.state::<sessions::SessionManager>();
         let secrets = app.state::<secrets::Secrets>();
-        sessions.detect_ssh_remote_os(app.clone(), &secrets, request)
+        sessions.detect_ssh_remote_os(app.clone(), &secrets, request, session_id)
     })
     .await
 }

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -1102,6 +1102,7 @@ impl SessionManager {
         app: AppHandle,
         secrets: &secrets::Secrets,
         request: TmuxConnectionRequest,
+        session_id: Option<String>,
     ) -> Result<DetectedRemoteOs, String> {
         let cache_key = ssh_system_context_cache_key(&request);
         if let Some(cached) = self
@@ -1114,12 +1115,13 @@ impl SessionManager {
             return Ok(cached);
         }
 
-        let output = run_ssh_command(
+        let output = self.run_ssh_probe_command(
             app,
             secrets,
             &request,
+            session_id.as_deref(),
             remote_os_detect_command(),
-            Some(Duration::from_secs(3)),
+            Duration::from_secs(3),
         )?;
         let detected = parse_detected_remote_os(&output);
         self.os_detect_cache
@@ -1127,6 +1129,36 @@ impl SessionManager {
             .map_err(|_| "OS detection cache lock is poisoned".to_string())?
             .insert(cache_key, detected.clone());
         Ok(detected)
+    }
+
+    /// Runs a read-only probe command, preferring the live SSH Session named by
+    /// `session_id` so no second connection (and no system `ssh` console window)
+    /// is spawned. The live path also works for blank-password Connections that
+    /// authenticate interactively, where the system `ssh` fallback cannot. When
+    /// no live native Session is available it falls back to `run_ssh_command`.
+    fn run_ssh_probe_command(
+        &self,
+        app: AppHandle,
+        secrets: &secrets::Secrets,
+        request: &TmuxConnectionRequest,
+        session_id: Option<&str>,
+        command: String,
+        fallback_timeout: Duration,
+    ) -> Result<String, String> {
+        if let Some(handle) = session_id.and_then(|id| self.ssh_command_handle(id)) {
+            return handle.run(command, SSH_PROBE_LIVE_SESSION_TIMEOUT);
+        }
+        run_ssh_command(app, secrets, request, command, Some(fallback_timeout))
+    }
+
+    /// Clones a command handle out of a live native SSH Session without holding
+    /// the session lock while a probe runs.
+    fn ssh_command_handle(&self, session_id: &str) -> Option<ssh::NativeSshCommandHandle> {
+        let sessions = self.sessions.lock().ok()?;
+        match &sessions.get(session_id)?.transport {
+            TerminalTransport::NativeSsh(terminal) => Some(terminal.command_handle()),
+            _ => None,
+        }
     }
 
     pub fn list_remote_loopback_ports(
@@ -1659,7 +1691,7 @@ async fn run_ssh_port_forward(
 
     if let Ok(session) = std::sync::Arc::try_unwrap(ssh_session) {
         let session = session.into_inner();
-        let _ = ssh::disconnect_ssh_session(session, "port forward closed").await;
+        let _ = ssh::disconnect_ssh_session(&session, "port forward closed").await;
     }
     Ok(())
 }
@@ -1881,6 +1913,7 @@ fn run_system_ssh_command(
     };
     command.arg(target);
     command.arg(remote_command);
+    hide_console_window(&mut command);
 
     let output = if let Some(timeout) = timeout {
         run_command_with_timeout(command, timeout)?
@@ -1895,6 +1928,22 @@ fn run_system_ssh_command(
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
         Err(format!("system ssh command failed: {stderr}"))
+    }
+}
+
+/// Suppress the transient console window Windows shows when spawning the system
+/// `ssh` client from a GUI process. No-op on other platforms.
+fn hide_console_window(command: &mut ProcessCommand) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // CREATE_NO_WINDOW — see Windows process creation flags.
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = command;
     }
 }
 
@@ -1967,6 +2016,12 @@ fn tmux_rename_session_command(tmux_session_id: &str, new_tmux_session_id: &str)
         shell_single_quote(new_tmux_session_id)
     )
 }
+
+// A live-Session probe is queued behind authentication, so its wait spans an
+// interactive (blank-password) login plus the bounded command run. Keep it
+// generous enough for a person to type a password, but finite so an abandoned
+// login cannot tie up the probe forever.
+const SSH_PROBE_LIVE_SESSION_TIMEOUT: Duration = Duration::from_secs(25);
 
 const DEFAULT_SSH_BUFFER_LINES: u32 = 5_000;
 

--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     future::Future,
     path::PathBuf,
+    rc::Rc,
     sync::{Arc, mpsc as std_mpsc},
     thread::{self, JoinHandle},
     time::{Duration, Instant},
@@ -23,6 +24,10 @@ const SSH_TMUX_RESUME_TIMEOUT: Duration = Duration::from_secs(10);
 const SSH_TMUX_RESUME_DELAY: Duration = Duration::from_millis(750);
 const SSH_STARTUP_TIMEOUT: Duration = Duration::from_secs(15);
 const SSH_X11_REQUEST_WANT_REPLY: bool = true;
+// Upper bound for a one-off command run over a live SSH Session (remote-OS
+// detection, system context). It bounds only command execution: queue/auth wait
+// is bounded separately by the caller's `recv_timeout`.
+const SSH_COMMAND_TIMEOUT: Duration = Duration::from_secs(8);
 // Idle SSH sessions must keep sending SSH-level keepalives so NAT/firewall state
 // stays alive and a dead link is detected instead of silently freezing input
 // (russh equivalent of OpenSSH ServerAliveInterval/ServerAliveCountMax). An
@@ -53,6 +58,7 @@ pub fn transport_plan() -> SshTransportPlan {
 
 pub struct NativeSshTerminal {
     control: mpsc::UnboundedSender<SshTerminalControl>,
+    command_tx: mpsc::UnboundedSender<NativeSshCommandMsg>,
     worker: Option<JoinHandle<()>>,
     terminal_ready_ms: u128,
     x11_forwarding_status: Option<NativeSshX11ForwardingStatus>,
@@ -65,6 +71,46 @@ impl NativeSshTerminal {
 
     pub fn x11_forwarding_status(&self) -> Option<NativeSshX11ForwardingStatus> {
         self.x11_forwarding_status
+    }
+
+    /// A lightweight, cloneable handle that runs one-off commands on this live
+    /// SSH Session without holding the SessionManager lock. Reusing the already
+    /// authenticated Session means auxiliary probes (remote-OS detection, system
+    /// context) need no second connection and no system `ssh` fallback, so they
+    /// also work for blank-password Connections that authenticate interactively.
+    pub fn command_handle(&self) -> NativeSshCommandHandle {
+        NativeSshCommandHandle {
+            command_tx: self.command_tx.clone(),
+        }
+    }
+}
+
+/// A request to run a command on a live native SSH Session. The worker replies
+/// over the sync channel so a blocking caller can wait for the output.
+struct NativeSshCommandMsg {
+    command: String,
+    reply: std_mpsc::SyncSender<Result<String, String>>,
+}
+
+/// Cloneable handle to a live native SSH Session for running one-off remote
+/// commands over a fresh exec channel on the existing authenticated transport.
+#[derive(Clone)]
+pub struct NativeSshCommandHandle {
+    command_tx: mpsc::UnboundedSender<NativeSshCommandMsg>,
+}
+
+impl NativeSshCommandHandle {
+    /// Runs `command` on the live Session and returns its combined output. The
+    /// command is queued until the Session finishes authenticating, so for a
+    /// blank-password Connection the caller waits for the interactive login to
+    /// complete (bounded by `timeout`) before the probe runs.
+    pub fn run(&self, command: String, timeout: Duration) -> Result<String, String> {
+        let (reply, rx) = std_mpsc::sync_channel(1);
+        self.command_tx
+            .send(NativeSshCommandMsg { command, reply })
+            .map_err(|_| "native SSH session is closed".to_string())?;
+        rx.recv_timeout(timeout)
+            .map_err(|_| format!("SSH command timed out after {} seconds", timeout.as_secs()))?
     }
 }
 
@@ -330,10 +376,17 @@ pub fn start_native_terminal(
         socks_proxy: request.socks_proxy,
     };
     let (control_tx, control_rx) = mpsc::unbounded_channel();
+    let (command_tx, command_rx) = mpsc::unbounded_channel();
     let (ready_tx, ready_rx) = std_mpsc::sync_channel(1);
     let returns_before_ready = matches!(request.auth, NativeSshAuth::Password { password: None });
     let worker = thread::spawn(move || {
-        let result = run_native_terminal_thread(app.clone(), request.clone(), control_rx, ready_tx);
+        let result = run_native_terminal_thread(
+            app.clone(),
+            request.clone(),
+            control_rx,
+            command_rx,
+            ready_tx,
+        );
         if let Err(error) = result {
             emit_terminal_output(
                 &app,
@@ -346,6 +399,7 @@ pub fn start_native_terminal(
     if returns_before_ready {
         return Ok(NativeSshTerminal {
             control: control_tx,
+            command_tx,
             worker: Some(worker),
             terminal_ready_ms: 0,
             x11_forwarding_status: None,
@@ -358,6 +412,7 @@ pub fn start_native_terminal(
     {
         Ok((terminal_ready_ms, x11_forwarding_status)) => Ok(NativeSshTerminal {
             control: control_tx,
+            command_tx,
             worker: Some(worker),
             terminal_ready_ms,
             x11_forwarding_status,
@@ -541,12 +596,24 @@ async fn run_remote_command_async(request: NativeSshCommandRequest) -> Result<St
     })
     .await?;
 
+    let result = exec_collect_on_session(&session, request.command).await;
+    disconnect_ssh_session(&session, "command completed").await?;
+    result
+}
+
+/// Opens a fresh exec channel on an already-connected Session, runs `command`,
+/// and returns its combined stdout/stderr. The Session is left connected so a
+/// live terminal Session can be reused for background probes.
+async fn exec_collect_on_session(
+    session: &client::Handle<VerifyingClient>,
+    command: String,
+) -> Result<String, String> {
     let mut channel = session
         .channel_open_session()
         .await
         .map_err(|error| format!("failed to open SSH command channel: {error}"))?;
     channel
-        .exec(false, request.command.into_bytes())
+        .exec(false, command.into_bytes())
         .await
         .map_err(|error| format!("failed to run SSH command: {error}"))?;
 
@@ -569,7 +636,6 @@ async fn run_remote_command_async(request: NativeSshCommandRequest) -> Result<St
 
     let _ = channel.eof().await;
     let _ = channel.close().await;
-    disconnect_ssh_session(session, "command completed").await?;
     if exit_status == 0 {
         Ok(output)
     } else {
@@ -615,6 +681,7 @@ fn run_native_terminal_thread(
     app: AppHandle,
     request: NativeSshTerminalRequest,
     control_rx: mpsc::UnboundedReceiver<SshTerminalControl>,
+    command_rx: mpsc::UnboundedReceiver<NativeSshCommandMsg>,
     ready_tx: std_mpsc::SyncSender<Result<NativeSshReadyResult, String>>,
 ) -> Result<(), String> {
     let runtime = tokio::runtime::Builder::new_current_thread()
@@ -623,7 +690,13 @@ fn run_native_terminal_thread(
         .map_err(|error| format!("failed to create native SSH runtime: {error}"))?;
 
     let startup_error_tx = ready_tx.clone();
-    let result = runtime.block_on(run_native_terminal(app, request, control_rx, ready_tx));
+    // A LocalSet lets background command probes run as `!Send` local tasks
+    // (russh's `client::Handle` is not `Sync`, so it cannot cross `tokio::spawn`).
+    let local = tokio::task::LocalSet::new();
+    let result = local.block_on(
+        &runtime,
+        run_native_terminal(app, request, control_rx, command_rx, ready_tx),
+    );
     if let Err(error) = &result {
         let _ = startup_error_tx.send(Err(error.clone()));
     }
@@ -634,6 +707,7 @@ async fn run_native_terminal(
     app: AppHandle,
     request: NativeSshTerminalRequest,
     mut control_rx: mpsc::UnboundedReceiver<SshTerminalControl>,
+    mut command_rx: mpsc::UnboundedReceiver<NativeSshCommandMsg>,
     ready_tx: std_mpsc::SyncSender<Result<NativeSshReadyResult, String>>,
 ) -> Result<(), String> {
     let current_request = request;
@@ -651,6 +725,7 @@ async fn run_native_terminal(
             &app,
             &current_request,
             &mut control_rx,
+            &mut command_rx,
             ready_tx.take(),
             timeout,
         )
@@ -681,6 +756,7 @@ async fn run_native_terminal_once(
     app: &AppHandle,
     request: &NativeSshTerminalRequest,
     control_rx: &mut mpsc::UnboundedReceiver<SshTerminalControl>,
+    command_rx: &mut mpsc::UnboundedReceiver<NativeSshCommandMsg>,
     ready_tx: Option<std_mpsc::SyncSender<Result<NativeSshReadyResult, String>>>,
     startup_timeout: Duration,
 ) -> Result<TerminalRunOutcome, String> {
@@ -769,6 +845,10 @@ async fn run_native_terminal_once(
             .map_err(|_| "timed out while starting native SSH session".to_string())?
     };
     let (session, mut channel, terminal_ready_ms, x11_forwarding_status) = startup_result?;
+    // Share the authenticated Session so background probes can open their own
+    // exec channels without a second connection. `client::Handle` is not Clone,
+    // so an Rc provides the shared, read-only access the local probe tasks need.
+    let session = Rc::new(session);
 
     if let Some(ready_tx) = ready_tx {
         let _ = ready_tx.send(Ok((terminal_ready_ms, x11_forwarding_status)));
@@ -803,9 +883,30 @@ async fn run_native_terminal_once(
                     Some(SshTerminalControl::Close) | None => {
                         let _ = channel.eof().await;
                         let _ = channel.close().await;
-                        let _ = disconnect_ssh_session(session, "").await;
+                        let _ = disconnect_ssh_session(&session, "").await;
                         return Ok(TerminalRunOutcome::Closed);
                     }
+                }
+            }
+            command = command_rx.recv() => {
+                if let Some(NativeSshCommandMsg { command, reply }) = command {
+                    // Run the probe on its own exec channel concurrently with the
+                    // shell so terminal I/O is never blocked. The shared Session
+                    // handle reuses the authenticated transport, so no second
+                    // connection (and no system `ssh` window) is needed.
+                    let session = Rc::clone(&session);
+                    tokio::task::spawn_local(async move {
+                        let result = match tokio::time::timeout(
+                            SSH_COMMAND_TIMEOUT,
+                            exec_collect_on_session(&session, command),
+                        )
+                        .await
+                        {
+                            Ok(result) => result,
+                            Err(_) => Err("SSH command timed out".to_string()),
+                        };
+                        let _ = reply.send(result);
+                    });
                 }
             }
             message = channel.wait() => {
@@ -818,7 +919,7 @@ async fn run_native_terminal_once(
                         );
                     }
                     Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => {
-                        let _ = disconnect_ssh_session(session, "").await;
+                        let _ = disconnect_ssh_session(&session, "").await;
                         return Ok(TerminalRunOutcome::Disconnected);
                     }
                     _ => {}
@@ -838,7 +939,7 @@ fn can_resume_tmux_terminal(request: &NativeSshTerminalRequest) -> bool {
 }
 
 pub(crate) async fn disconnect_ssh_session(
-    session: client::Handle<VerifyingClient>,
+    session: &client::Handle<VerifyingClient>,
     reason: &str,
 ) -> Result<(), String> {
     match session
@@ -1894,7 +1995,7 @@ mod tests {
 
         let _ = channel.eof().await;
         let _ = channel.close().await;
-        disconnect_ssh_session(session, "readiness measured").await?;
+        disconnect_ssh_session(&session, "readiness measured").await?;
         Ok(terminal_ready_ms)
     }
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1756,6 +1756,7 @@ type CommandMap = {
         authMethod?: "keyFile" | "password" | "agent";
         secretOwnerId?: string;
       };
+      sessionId?: string;
     };
     result: DetectedRemoteOs;
   };

--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -1380,7 +1380,7 @@ const osDetectInFlight = new Set<string>();
 // "done" flag stops it, so the host is probed only once for performance) and is
 // skipped when the user has chosen an icon, so a hand-picked icon is never
 // overridden.
-async function maybeAutoDetectOsIcon(connection: Connection) {
+async function maybeAutoDetectOsIcon(connection: Connection, sessionId?: string) {
   if (!shouldAutoDetectOsIcon(connection) || osDetectInFlight.has(connection.id)) {
     return;
   }
@@ -1388,6 +1388,7 @@ async function maybeAutoDetectOsIcon(connection: Connection) {
   try {
     const detected = await invokeCommand("detect_ssh_remote_os", {
       request: tmuxConnectionRequest(connection),
+      sessionId,
     });
     const iconId = osIconIdForDetection(detected);
     if (!iconId) {
@@ -2022,7 +2023,7 @@ function TerminalPaneView({
           writeInputToSession(startupInput);
         }
         markConnectionSessionStarted(connection.id);
-        void maybeAutoDetectOsIcon(connection);
+        void maybeAutoDetectOsIcon(connection, result.sessionId);
       } catch (error) {
         terminal.writeln("");
         terminal.writeln(t("terminal.failedToStartDetail", { message: String(error) }));


### PR DESCRIPTION
Blank-password SSH Connections authenticate interactively in the terminal,
so a separate non-interactive probe connection could not authenticate. OS
icon detection therefore fell back to the system `ssh` client with
BatchMode=yes, which (1) flashed a transient console window on Windows and
(2) failed to authenticate, leaving the default icon even after the user
typed the password correctly.

Run the remote-OS probe over the already-authenticated live SSH Session via
a fresh exec channel instead of opening a second connection. The probe is
queued on the session worker and runs once interactive auth completes, so it
needs no external `ssh` process and works for blank-password Connections.
The system `ssh` fallback (still used for ProxyJump) now also suppresses its
console window with CREATE_NO_WINDOW.