### PR TITLE
fix(ui): refine recents list and soften popover shadows

### DIFF
--- a/src/modules/settings/settings.css
+++ b/src/modules/settings/settings.css
@@ -2035,7 +2035,7 @@
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 22px;
-  box-shadow: var(--shadow), 0 24px 72px rgba(0, 0, 0, 0.24);
+  box-shadow: var(--shadow), 0 12px 36px rgba(0, 0, 0, 0.14);
 }
 
 .settings-popup .settings-page-header {

--- a/src/modules/workspace/connections/sftp/SftpFilePane.tsx
+++ b/src/modules/workspace/connections/sftp/SftpFilePane.tsx
@@ -498,9 +498,10 @@ export function FilePane({
                     onMouseDown={(event) => event.preventDefault()}
                     onClick={() => void commitPathDraft(recentPath)}
                     role="menuitem"
+                    title={recentPath}
                     type="button"
                   >
-                    {recentPath}
+                    <bdi dir="ltr">{recentPath}</bdi>
                   </button>
                 ))}
               </div>

--- a/src/modules/workspace/connections/sftp/sftp.css
+++ b/src/modules/workspace/connections/sftp/sftp.css
@@ -249,24 +249,29 @@
 }
 .sftp-recent-menu {
   position: absolute;
-  top: calc(100% + 5px);
+  top: calc(100% + 6px);
   right: 0;
   z-index: 40;
   display: grid;
-  width: min(360px, 80vw);
-  padding: 4px;
+  width: min(340px, 80vw);
+  padding: 5px;
   background: var(--surface);
-  border: 1px solid var(--border-strong);
-  border-radius: 8px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
   box-shadow: var(--shadow);
 }
 .sftp-recent-menu button {
   min-width: 0;
-  padding: 6px 8px;
+  padding: 5px 9px;
   border: 0;
   border-radius: 6px;
   background: transparent;
   color: var(--text);
+  font-size: 12px;
+  line-height: 1.45;
+  /* Truncate from the start so the trailing folder — the part that tells you
+     where the path leads — stays visible instead of being clipped. */
+  direction: rtl;
   text-align: left;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/styles/colorSchemes.css
+++ b/src/styles/colorSchemes.css
@@ -67,7 +67,7 @@
   --nav-toolbar-tooltip-bg: #111827;
   --nav-toolbar-tooltip-text: #f8fafc;
   --nav-toolbar-tooltip-border: rgba(255, 255, 255, 0.14);
-  --shadow: 0 32px 80px rgba(0, 0, 0, 0.26), 0 8px 24px rgba(0, 0, 0, 0.14);
+  --shadow: 0 8px 28px rgba(0, 0, 0, 0.12), 0 2px 6px rgba(0, 0, 0, 0.06);
   /* Platform-aware default: SF Pro on macOS, bundled Inter on Windows. */
   --app-ui-font-family:
     -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display",
@@ -134,7 +134,7 @@
   --nav-toolbar-tooltip-bg: #111827;
   --nav-toolbar-tooltip-text: #f8fafc;
   --nav-toolbar-tooltip-border: rgba(255, 255, 255, 0.14);
-  --shadow: 0 36px 96px rgba(0, 0, 0, 0.62), 0 10px 30px rgba(0, 0, 0, 0.5);
+  --shadow: 0 10px 32px rgba(0, 0, 0, 0.5), 0 3px 8px rgba(0, 0, 0, 0.35);
 }
 
 [data-color-scheme="light"] {


### PR DESCRIPTION
## What changed

**SFTP recents menu redesign** ([`SftpFilePane.tsx`](src/modules/workspace/connections/sftp/SftpFilePane.tsx), [`sftp.css`](src/modules/workspace/connections/sftp/sftp.css))
- Dropped the list to a compact `12px` Apple/Finder-style density (tighter padding + line-height).
- Truncation now happens at the **start** of the path instead of the end, so the trailing folder — the part that tells you where each path actually leads — stays visible (`…\Desktop\KKTerm` instead of `C:\Users\ryan.RYAN5080\Desktop\KKTerm…`).
  - Implemented with the `direction: rtl; text-align: left` ellipsis trick, with the path wrapped in `<bdi dir="ltr">` so reading order and leading separators (`/`, `C:\`) are never reordered.
- Added a `title` tooltip exposing the full path on hover.
- Softer corner radius and lighter border to match other surfaces.

**Shadow bleed cleanup** ([`colorSchemes.css`](src/styles/colorSchemes.css), [`settings.css`](src/modules/settings/settings.css))
- The recents menu, AI assistant chatbox, and connection browser all share one `var(--shadow)` token. Only the **default light** and **dark** schemes defined an oversized shadow (32–36px offset, 80–96px blur); every other theme was already subtle. Brought those two in line:

  | Scheme | Before | After |
  |---|---|---|
  | Default light | `0 32px 80px /.26`, `0 8px 24px /.14` | `0 8px 28px /.12`, `0 2px 6px /.06` |
  | Dark | `0 36px 96px /.62`, `0 10px 30px /.5` | `0 10px 32px /.5`, `0 3px 8px /.35` |

- Softened the extra hardcoded layer stacked on the settings modal (`0 24px 72px /.24` → `0 12px 36px /.14`).

## Why
Reported: the recents dropdown looked un-polished (oversized font, clipped subfolder names) and the drop shadow bled too heavily across popover surfaces sharing the same token.

## Notes for reviewers
- Because the change targets the shared `--shadow` token, the softer shadow propagates to all consumers (menus, chatbox, connection browser, dialogs, dashboard, tooltips) automatically.
- Left the tutorial spotlight's `0 0 0 9999px` backdrop untouched — that's the screen-dimming overlay, not a bleed.
- This is a visual change; worth a quick look at the recents dropdown on a deep path plus the dark theme. `tsc --noEmit` and `eslint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
