### PR TITLE
feat(sftp): per-pane view-options menu (item zoom + content-view background)

### DIFF
--- a/docs/localization_todo/sftp.background.md
+++ b/docs/localization_todo/sftp.background.md
@@ -1,0 +1,15 @@
+# sftp.background
+
+- **English value**: `Background…`
+- **Namespace**: `sftp`
+- **File/component**: `src/modules/workspace/connections/sftp/SftpFilePane.tsx`
+- **UI role**: `button`
+- **User flow**: Menu item in the file-pane view-options menu; opens the shared background picker that applies a background to the content view (the area with files and folders).
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Context/meaning**: "Background" = the visual backdrop behind the file/folder list. Keep the trailing ellipsis (…) to signal it opens a further picker, consistent with `dashboard.changeBackground`.
+- **Domain notes**: Reuses the Dashboard view background picker; mirror the wording used for Dashboard/terminal backgrounds in this locale.
+<!--
+Filename: sftp.background.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/sftp.backgroundDefaultHint.md
+++ b/docs/localization_todo/sftp.backgroundDefaultHint.md
@@ -1,0 +1,15 @@
+# sftp.backgroundDefaultHint
+
+- **English value**: `Use the default background for this view.`
+- **Namespace**: `sftp`
+- **File/component**: `src/modules/workspace/connections/sftp/SftpFilePane.tsx` (via `SharedBackgroundPopover` `defaultHintKey`)
+- **UI role**: `status`
+- **User flow**: Hint shown in the background picker's "Theme Default" mode, explaining that the content view will use no custom background.
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Context/meaning**: "view" = the file-browser content view (files/folders area); "default background" = no custom background, falls back to the theme. Parallels `terminal.backgroundDefaultHint`.
+- **Domain notes**: none
+<!--
+Filename: sftp.backgroundDefaultHint.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/sftp.viewOptions.md
+++ b/docs/localization_todo/sftp.viewOptions.md
@@ -1,0 +1,16 @@
+# sftp.viewOptions
+
+- **English value**: `View options`
+- **Namespace**: `sftp`
+- **File/component**: `src/modules/workspace/connections/sftp/SftpFilePane.tsx`
+- **UI role**: `tooltip`
+- **User flow**: Tooltip/aria-label for the hamburger button beside the file-pane search box that opens the zoom + background view-options menu.
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Context/meaning**: "View" here means the visual presentation of the file list (zoom level and background), not a database view or screen navigation.
+- **Domain notes**: Applies to both the local File Explorer and the SFTP/FTP dual-pane browser. SFTP/FTP stay English.
+
+<!--
+Filename: sftp.viewOptions.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/sftp.zoom.md
+++ b/docs/localization_todo/sftp.zoom.md
@@ -1,0 +1,15 @@
+# sftp.zoom
+
+- **English value**: `Zoom`
+- **Namespace**: `sftp`
+- **File/component**: `src/modules/workspace/connections/sftp/SftpFilePane.tsx`
+- **UI role**: `label`
+- **User flow**: Section label above the zoom slider in the file-pane view-options menu; the slider makes file/folder items smaller or bigger.
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Context/meaning**: Adjusts the on-screen size of file/folder items in the content view (a magnification level), not browser page zoom.
+- **Domain notes**: none
+<!--
+Filename: sftp.zoom.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/sftp.zoomAria.md
+++ b/docs/localization_todo/sftp.zoomAria.md
@@ -1,0 +1,15 @@
+# sftp.zoomAria
+
+- **English value**: `Adjust item size`
+- **Namespace**: `sftp`
+- **File/component**: `src/modules/workspace/connections/sftp/SftpFilePane.tsx`
+- **UI role**: `label`
+- **User flow**: Accessible (aria) label for the zoom range slider in the file-pane view-options menu.
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Context/meaning**: "item" = a file or folder entry shown in the content view; the slider scales their displayed size.
+- **Domain notes**: none
+<!--
+Filename: sftp.zoomAria.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/manual/07-sftp.md
+++ b/docs/manual/07-sftp.md
@@ -3,7 +3,7 @@
 ## AI grep hints
 
 - Keys: `sftp.*` (full namespace), `terminal.openSftp`, `terminal.sftp`
-- Topics: symmetric dual-pane browser, breadcrumb navigation, list/gallery view switch, upload, download, conflicts, cut/copy/paste, rename, delete, copy path, new folder, properties, chmod/chown, sort, collapsible transfer activity bar, tutorial targets `sftp.toolbar`, `sftp.upload`, `sftp.download`, `sftp.terminal`, `sftp.localPane`, `sftp.remotePane`, `sftp.transferQueue`
+- Topics: symmetric dual-pane browser, breadcrumb navigation, list/gallery view switch, per-pane view-options (hamburger) menu with item zoom + content-view background, upload, download, conflicts, cut/copy/paste, rename, delete, copy path, new folder, properties, chmod/chown, sort, collapsible transfer activity bar, tutorial targets `sftp.toolbar`, `sftp.upload`, `sftp.download`, `sftp.terminal`, `sftp.localPane`, `sftp.remotePane`, `sftp.transferQueue`
 - Synonyms: "file transfer", "scp", "upload to server", "download from server", "remote files"
 
 ## Opening an SFTP browser
@@ -54,6 +54,7 @@ Each pane header carries (with `Aria` siblings for accessibility):
 - New folder (remote): `sftp.createFolder` (`sftp.createFolderAria`). Remote new folder dialog `sftp.newRemoteFolder` — empty input warning `sftp.folderNameBlank`. Creation in-flight: `sftp.creatingFolder`.
 - Recent paths (`sftp.recentPathsAria`) and Refresh files: `sftp.refreshFiles` (`sftp.refreshFilesAria`)
 - View switch: list / gallery (`sftp.viewMode`).
+- View options (`sftp.viewOptions`) — a hamburger button to the right of the search box opens a per-pane menu with two controls: **Zoom** (`sftp.zoom`, slider aria `sftp.zoomAria`) scales the file/folder items in that pane's content view smaller or bigger, and **Background** (`sftp.background`) opens the shared background picker (same options as a Dashboard view background; default-mode hint `sftp.backgroundDefaultHint`) and applies the chosen preset / image / video / dynamic background within that pane's content view only. Both panes of an SFTP/FTP browser carry their own menu. These settings persist per Connection and per pane side, except in the ephemeral SSH-toolbar SFTP popup, where they are kept in memory only and forgotten when the popup closes.
 
 Cut, Copy, Paste, Rename, Copy Path, Delete, and Get Info are on the right-click context menu (see below). Pressing **Delete** or **Backspace** with a mutable local or remote selection starts the delete flow (remote confirm copy `sftp.deleteRemoteConfirm`, `sftp.deleteRemoteItemConfirm`, `sftp.deleteRemoteItemsMultiple`; local confirm copy reuses `sftp.deleteLabel` / `sftp.deleteSelected`; in-flight `sftp.deleting`). Rename in-flight `sftp.renaming` / empty warning `sftp.remoteNameBlank`; rename file aria `sftp.renameFileAria`.
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -538,6 +538,15 @@ fn update_connection_icon_background_color(
 }
 
 #[tauri::command]
+fn update_connection_file_browser_view_options(
+    storage: tauri::State<'_, storage::Storage>,
+    connection_id: String,
+    view_options: Option<storage::FileBrowserViewOptions>,
+) -> Result<Option<storage::SavedConnection>, String> {
+    storage.update_connection_file_browser_view_options(connection_id, view_options)
+}
+
+#[tauri::command]
 fn update_connection_terminal_appearance(
     storage: tauri::State<'_, storage::Storage>,
     connection_id: String,
@@ -3205,6 +3214,7 @@ pub fn run() {
             update_connection_icon_data_url,
             update_connection_icon_background_color,
             update_connection_terminal_appearance,
+            update_connection_file_browser_view_options,
             update_connection_tab_title,
             delete_connection,
             duplicate_connection,

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -72,6 +72,7 @@ CREATE TABLE IF NOT EXISTS connections (
     icon_background_color TEXT,
     terminal_opacity INTEGER,
     terminal_background_json TEXT,
+    file_browser_view_options_json TEXT,
     connection_type TEXT NOT NULL CHECK (connection_type IN ('local', 'ssh', 'telnet', 'serial', 'url', 'rdp', 'vnc', 'ftp', 'localFiles')),
     status TEXT NOT NULL CHECK (status IN ('connected', 'idle', 'offline')),
     sort_order INTEGER NOT NULL
@@ -1013,10 +1014,43 @@ pub struct SavedConnection {
     icon_background_color: Option<String>,
     terminal_opacity: Option<u8>,
     terminal_background: Option<crate::dashboard_storage::DashboardBackground>,
+    file_browser_view_options: Option<FileBrowserViewOptions>,
     #[serde(rename = "type")]
     connection_type: String,
     tags: Vec<String>,
     status: String,
+}
+
+/// Per-pane File Explorer / SFTP browser view options (item zoom + content-view
+/// background). Persisted per Connection so the durable browser surfaces keep
+/// their look; the ephemeral terminal-spawned SFTP popup never writes these.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct FileBrowserViewOptions {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    local: Option<FileBrowserPaneViewOptions>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    remote: Option<FileBrowserPaneViewOptions>,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct FileBrowserPaneViewOptions {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    zoom: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    background: Option<crate::dashboard_storage::DashboardBackground>,
+}
+
+impl FileBrowserViewOptions {
+    fn validate(&self) -> Result<(), String> {
+        for pane in [&self.local, &self.remote].into_iter().flatten() {
+            if let Some(background) = &pane.background {
+                background.validate().map_err(|error| format!("{error:?}"))?;
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Deserialize)]
@@ -1631,6 +1665,12 @@ impl Storage {
             &connection,
             "connections",
             "terminal_background_json",
+            "TEXT",
+        )?;
+        ensure_column(
+            &connection,
+            "connections",
+            "file_browser_view_options_json",
             "TEXT",
         )?;
         ensure_column(&connection, "connections", "tab_title", "TEXT")?;
@@ -2580,7 +2620,7 @@ fn list_root_connections_for_workspace(
     let mut statement = connection
         .prepare(
             "SELECT connections.id, name, tab_title, host, connections.username, port, key_path, proxy_jump, ssh_socks_proxy, ssh_socks_proxy_username, ssh_socks_proxy_inherit_defaults, auth_method, local_shell, local_startup_directory, local_startup_script, url, data_partition, use_tmux_sessions, tmux_connection_id, connection_type, serial_line, serial_speed, rdp_options, vnc_options, ftp_options, icon_data_url, icon_background_color, terminal_opacity, terminal_background_json, password_credential_id,
-                    url_credentials.username
+                    url_credentials.username, file_browser_view_options_json
              FROM connections
              LEFT JOIN url_credentials ON url_credentials.connection_id = connections.id
              WHERE folder_id IS NULL AND workspace_id = ?1
@@ -2643,7 +2683,7 @@ fn list_connections_for_folder(
     let mut statement = connection
         .prepare(&format!(
             "SELECT connections.id, name, tab_title, host, connections.username, port, key_path, proxy_jump, ssh_socks_proxy, ssh_socks_proxy_username, ssh_socks_proxy_inherit_defaults, auth_method, local_shell, local_startup_directory, local_startup_script, url, data_partition, use_tmux_sessions, tmux_connection_id, connection_type, serial_line, serial_speed, rdp_options, vnc_options, ftp_options, icon_data_url, icon_background_color, terminal_opacity, terminal_background_json, password_credential_id,
-                    url_credentials.username
+                    url_credentials.username, file_browser_view_options_json
              FROM connections
              LEFT JOIN url_credentials ON url_credentials.connection_id = connections.id
              WHERE {where_clause}
@@ -3019,7 +3059,7 @@ fn get_connection_by_id(
     let saved_connection = connection
         .query_row(
             "SELECT connections.id, name, tab_title, host, connections.username, port, key_path, proxy_jump, ssh_socks_proxy, ssh_socks_proxy_username, ssh_socks_proxy_inherit_defaults, auth_method, local_shell, local_startup_directory, local_startup_script, url, data_partition, use_tmux_sessions, tmux_connection_id, connection_type, serial_line, serial_speed, rdp_options, vnc_options, ftp_options, icon_data_url, icon_background_color, terminal_opacity, terminal_background_json, password_credential_id,
-                    url_credentials.username
+                    url_credentials.username, file_browser_view_options_json
              FROM connections
              LEFT JOIN url_credentials ON url_credentials.connection_id = connections.id
              WHERE connections.id = ?1",
@@ -3057,6 +3097,7 @@ fn get_connection_by_id(
                     icon_background_color: row.get(26)?,
                     terminal_opacity: normalize_loaded_terminal_opacity(row.get(27)?),
                     terminal_background: terminal_background_from_json(row.get(28)?),
+                    file_browser_view_options: file_browser_view_options_from_json(row.get(31)?),
                     password_credential_id,
                     url_credential_username: url_credential_username.clone(),
                     has_url_credential: url_credential_username.is_some(),
@@ -3109,6 +3150,7 @@ fn saved_connection_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SavedC
         icon_background_color: row.get(26)?,
         terminal_opacity: normalize_loaded_terminal_opacity(row.get(27)?),
         terminal_background: terminal_background_from_json(row.get(28)?),
+        file_browser_view_options: file_browser_view_options_from_json(row.get(31)?),
         url_credential_username: url_credential_username.clone(),
         has_url_credential: url_credential_username.is_some(),
         status: "idle".to_string(),
@@ -3690,6 +3732,24 @@ fn terminal_background_to_json(
             serde_json::to_string(background)
                 .map(Some)
                 .map_err(|_| "terminal background is invalid".to_string())
+        }
+    }
+}
+
+fn file_browser_view_options_from_json(value: Option<String>) -> Option<FileBrowserViewOptions> {
+    value.and_then(|json| serde_json::from_str::<FileBrowserViewOptions>(&json).ok())
+}
+
+fn file_browser_view_options_to_json(
+    options: &Option<FileBrowserViewOptions>,
+) -> Result<Option<String>, String> {
+    match options {
+        None => Ok(None),
+        Some(options) => {
+            options.validate()?;
+            serde_json::to_string(options)
+                .map(Some)
+                .map_err(|_| "file browser view options are invalid".to_string())
         }
     }
 }

--- a/src-tauri/src/storage/connections.rs
+++ b/src-tauri/src/storage/connections.rs
@@ -162,6 +162,7 @@ impl Storage {
             icon_background_color: None,
             terminal_opacity: Some(DEFAULT_TERMINAL_OPACITY),
             terminal_background: None,
+            file_browser_view_options: None,
             connection_type,
             tags,
             status: "idle".to_string(),
@@ -503,6 +504,35 @@ impl Storage {
             .execute(
                 "UPDATE connections SET terminal_opacity = ?1, terminal_background_json = ?2 WHERE id = ?3",
                 params![i64::from(terminal_opacity), terminal_background_json, &connection_id],
+            )
+            .map_err(to_storage_error)?;
+        get_connection_by_id(&connection, &connection_id).map(Some)
+    }
+
+    pub fn update_connection_file_browser_view_options(
+        &self,
+        connection_id: String,
+        view_options: Option<FileBrowserViewOptions>,
+    ) -> Result<Option<SavedConnection>, String> {
+        let connection_id = required_field("connection id", connection_id)?;
+        let view_options_json = file_browser_view_options_to_json(&view_options)?;
+        let connection = self.lock()?;
+        let current = connection
+            .query_row(
+                "SELECT file_browser_view_options_json FROM connections WHERE id = ?1",
+                params![&connection_id],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()
+            .map_err(to_storage_error)?
+            .ok_or_else(|| "connection was not found".to_string())?;
+        if current == view_options_json {
+            return Ok(None);
+        }
+        connection
+            .execute(
+                "UPDATE connections SET file_browser_view_options_json = ?1 WHERE id = ?2",
+                params![view_options_json, &connection_id],
             )
             .map_err(to_storage_error)?;
         get_connection_by_id(&connection, &connection_id).map(Some)
@@ -1140,7 +1170,7 @@ impl Storage {
 
         let source = transaction
             .query_row(
-                "SELECT folder_id, name, tab_title, host, username, port, key_path, proxy_jump, ssh_socks_proxy, ssh_socks_proxy_username, ssh_socks_proxy_inherit_defaults, auth_method, local_shell, local_startup_directory, local_startup_script, url, data_partition, use_tmux_sessions, serial_line, serial_speed, connection_type, icon_data_url, icon_background_color, terminal_opacity, terminal_background_json, workspace_id
+                "SELECT folder_id, name, tab_title, host, username, port, key_path, proxy_jump, ssh_socks_proxy, ssh_socks_proxy_username, ssh_socks_proxy_inherit_defaults, auth_method, local_shell, local_startup_directory, local_startup_script, url, data_partition, use_tmux_sessions, serial_line, serial_speed, connection_type, icon_data_url, icon_background_color, terminal_opacity, terminal_background_json, workspace_id, file_browser_view_options_json
                  FROM connections
                  WHERE id = ?1",
                 params![source_id],
@@ -1172,6 +1202,7 @@ impl Storage {
                         normalize_loaded_terminal_opacity(row.get::<_, Option<i64>>(23)?),
                         terminal_background_from_json(row.get::<_, Option<String>>(24)?),
                         row.get::<_, Option<String>>(25)?,
+                        file_browser_view_options_from_json(row.get::<_, Option<String>>(26)?),
                     ))
                 },
             )
@@ -1205,6 +1236,7 @@ impl Storage {
             terminal_opacity,
             terminal_background,
             workspace_id,
+            file_browser_view_options,
         ) = source;
         let workspace_id = normalize_workspace_id(workspace_id.unwrap_or_default());
         let duplicate_name = request
@@ -1226,8 +1258,8 @@ impl Storage {
         transaction
             .execute(
                 "INSERT INTO connections (
-                    id, folder_id, name, tab_title, host, username, port, key_path, proxy_jump, ssh_socks_proxy, ssh_socks_proxy_username, ssh_socks_proxy_inherit_defaults, auth_method, local_shell, local_startup_directory, local_startup_script, url, data_partition, use_tmux_sessions, tmux_connection_id, serial_line, serial_speed, connection_type, icon_data_url, icon_background_color, terminal_opacity, terminal_background_json, status, sort_order, workspace_id
-                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, 'idle', ?28, ?29)",
+                    id, folder_id, name, tab_title, host, username, port, key_path, proxy_jump, ssh_socks_proxy, ssh_socks_proxy_username, ssh_socks_proxy_inherit_defaults, auth_method, local_shell, local_startup_directory, local_startup_script, url, data_partition, use_tmux_sessions, tmux_connection_id, serial_line, serial_speed, connection_type, icon_data_url, icon_background_color, terminal_opacity, terminal_background_json, file_browser_view_options_json, status, sort_order, workspace_id
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, 'idle', ?29, ?30)",
                 params![
                     duplicate_id,
                     folder_id,
@@ -1256,6 +1288,7 @@ impl Storage {
                     icon_background_color,
                     terminal_opacity.map(i64::from),
                     terminal_background_to_json(&terminal_background)?,
+                    file_browser_view_options_to_json(&file_browser_view_options)?,
                     next_sort_order,
                     workspace_id
                 ],

--- a/src/app/ui/dialog/icons.tsx
+++ b/src/app/ui/dialog/icons.tsx
@@ -185,6 +185,7 @@ export const DIALOG_ICONS = {
   home: stroke(<path d="M4 11l8-7 8 7M6 9.5V20h12V9.5" />),
   back: stroke(<path d="M15 6l-6 6 6 6" />),
   forward: stroke(<path d="M9 6l6 6-6 6" />),
+  menu: stroke(<path d="M4 7h16M4 12h16M4 17h16" />),
   list: stroke(<path d="M9 6h11M9 12h11M9 18h11M4 6h.01M4 12h.01M4 18h.01" />),
   gallery: stroke(<path d="M4 5h6v6H4zM14 5h6v6h-6zM4 14h6v6H4zM14 14h6v6h-6z" />),
   drive: stroke(<path d="M5 5h14a1 1 0 011 1v12a1 1 0 01-1 1H5a1 1 0 01-1-1V6a1 1 0 011-1zM8 9.5h.01" />),

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2303,6 +2303,11 @@
     "searchAria": "Dateien in diesem Ordner suchen",
     "searchClear": "Suche löschen",
     "searchNoResults": "Keine Treffer für \"{{query}}\"",
+    "viewOptions": "Anzeigeoptionen",
+    "zoom": "Zoom",
+    "zoomAria": "Elementgröße anpassen",
+    "background": "Hintergrund…",
+    "backgroundDefaultHint": "Standardhintergrund für diese Ansicht verwenden.",
     "sidebar": {
       "title": "Seitenleiste",
       "show": "Seitenleiste anzeigen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2303,6 +2303,11 @@
     "searchAria": "Search files in this folder",
     "searchClear": "Clear search",
     "searchNoResults": "No matches for \"{{query}}\"",
+    "viewOptions": "View options",
+    "zoom": "Zoom",
+    "zoomAria": "Adjust item size",
+    "background": "Background…",
+    "backgroundDefaultHint": "Use the default background for this view.",
     "sidebar": {
       "title": "Sidebar",
       "show": "Show Sidebar",

--- a/src/i18n/locales/es-MX.json
+++ b/src/i18n/locales/es-MX.json
@@ -2303,6 +2303,11 @@
     "searchAria": "Buscar archivos en esta carpeta",
     "searchClear": "Borrar búsqueda",
     "searchNoResults": "Sin coincidencias para \"{{query}}\"",
+    "viewOptions": "Opciones de vista",
+    "zoom": "Zoom",
+    "zoomAria": "Ajustar el tamaño de los elementos",
+    "background": "Fondo…",
+    "backgroundDefaultHint": "Usa el fondo predeterminado de esta vista.",
     "sidebar": {
       "title": "Barra lateral",
       "show": "Mostrar barra lateral",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2303,6 +2303,11 @@
     "searchAria": "Buscar archivos en esta carpeta",
     "searchClear": "Borrar búsqueda",
     "searchNoResults": "Sin coincidencias para \"{{query}}\"",
+    "viewOptions": "Opciones de vista",
+    "zoom": "Zoom",
+    "zoomAria": "Ajustar el tamaño de los elementos",
+    "background": "Fondo…",
+    "backgroundDefaultHint": "Usar el fondo predeterminado para esta vista.",
     "sidebar": {
       "title": "Barra lateral",
       "show": "Mostrar barra lateral",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2303,6 +2303,11 @@
     "searchAria": "Rechercher des fichiers dans ce dossier",
     "searchClear": "Effacer la recherche",
     "searchNoResults": "Aucune correspondance pour \"{{query}}\"",
+    "viewOptions": "Options d'affichage",
+    "zoom": "Zoom",
+    "zoomAria": "Ajuster la taille des éléments",
+    "background": "Arrière-plan…",
+    "backgroundDefaultHint": "Utiliser l'arrière-plan par défaut pour cette vue.",
     "sidebar": {
       "title": "Barre latérale",
       "show": "Afficher la barre latérale",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -2303,6 +2303,11 @@
     "searchAria": "Cari file di folder ini",
     "searchClear": "Hapus pencarian",
     "searchNoResults": "Tidak ada kecocokan untuk \"{{query}}\"",
+    "viewOptions": "Opsi tampilan",
+    "zoom": "Zoom",
+    "zoomAria": "Sesuaikan ukuran item",
+    "background": "Latar belakang…",
+    "backgroundDefaultHint": "Gunakan latar belakang default untuk tampilan ini.",
     "sidebar": {
       "title": "Sidebar",
       "show": "Tampilkan Sidebar",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -2303,6 +2303,11 @@
     "searchAria": "Cerca file in questa cartella",
     "searchClear": "Cancella ricerca",
     "searchNoResults": "Nessuna corrispondenza per \"{{query}}\"",
+    "viewOptions": "Opzioni di visualizzazione",
+    "zoom": "Zoom",
+    "zoomAria": "Regola la dimensione degli elementi",
+    "background": "Sfondo…",
+    "backgroundDefaultHint": "Usa lo sfondo predefinito per questa vista.",
     "sidebar": {
       "title": "Barra laterale",
       "show": "Mostra barra laterale",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2303,6 +2303,11 @@
     "searchAria": "このフォルダー内のファイルを検索",
     "searchClear": "検索をクリア",
     "searchNoResults": "「{{query}}」に一致するものはありません",
+    "viewOptions": "表示オプション",
+    "zoom": "ズーム",
+    "zoomAria": "アイテムのサイズを調整",
+    "background": "背景…",
+    "backgroundDefaultHint": "このビューに既定の背景を使用します。",
     "sidebar": {
       "title": "サイドバー",
       "show": "サイドバーを表示",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -2303,6 +2303,11 @@
     "searchAria": "이 폴더에서 파일 검색",
     "searchClear": "검색 지우기",
     "searchNoResults": "\"{{query}}\"에 대한 일치 항목 없음",
+    "viewOptions": "보기 옵션",
+    "zoom": "확대/축소",
+    "zoomAria": "항목 크기 조정",
+    "background": "배경…",
+    "backgroundDefaultHint": "이 보기에 기본 배경을 사용합니다.",
     "sidebar": {
       "title": "사이드바",
       "show": "사이드바 표시",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2303,6 +2303,11 @@
     "searchAria": "Pesquisar arquivos nesta pasta",
     "searchClear": "Limpar pesquisa",
     "searchNoResults": "Nenhuma correspondência para \"{{query}}\"",
+    "viewOptions": "Opções de exibição",
+    "zoom": "Zoom",
+    "zoomAria": "Ajustar o tamanho dos itens",
+    "background": "Plano de fundo…",
+    "backgroundDefaultHint": "Usar o plano de fundo padrão para esta exibição.",
     "sidebar": {
       "title": "Barra lateral",
       "show": "Mostrar barra lateral",

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -2303,6 +2303,11 @@
     "searchAria": "ค้นหาไฟล์ในโฟลเดอร์นี้",
     "searchClear": "ล้างการค้นหา",
     "searchNoResults": "ไม่พบผลลัพธ์สำหรับ \"{{query}}\"",
+    "viewOptions": "ตัวเลือกมุมมอง",
+    "zoom": "ซูม",
+    "zoomAria": "ปรับขนาดรายการ",
+    "background": "พื้นหลัง…",
+    "backgroundDefaultHint": "ใช้พื้นหลังเริ่มต้นสำหรับมุมมองนี้",
     "sidebar": {
       "title": "แถบด้านข้าง",
       "show": "แสดงแถบด้านข้าง",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -2303,6 +2303,11 @@
     "searchAria": "Tìm tệp trong thư mục này",
     "searchClear": "Xóa tìm kiếm",
     "searchNoResults": "Không có kết quả cho \"{{query}}\"",
+    "viewOptions": "Tùy chọn xem",
+    "zoom": "Thu phóng",
+    "zoomAria": "Điều chỉnh kích thước mục",
+    "background": "Hình nền…",
+    "backgroundDefaultHint": "Dùng hình nền mặc định cho chế độ xem này.",
     "sidebar": {
       "title": "Thanh bên",
       "show": "Hiện thanh bên",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2303,6 +2303,11 @@
     "searchAria": "在此文件夹中搜索文件",
     "searchClear": "清除搜索",
     "searchNoResults": "没有匹配 \"{{query}}\" 的结果",
+    "viewOptions": "视图选项",
+    "zoom": "缩放",
+    "zoomAria": "调整项目大小",
+    "background": "背景…",
+    "backgroundDefaultHint": "为此视图使用默认背景。",
     "sidebar": {
       "title": "侧边栏",
       "show": "显示侧边栏",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2303,6 +2303,11 @@
     "searchAria": "在此資料夾中搜尋檔案",
     "searchClear": "清除搜尋",
     "searchNoResults": "沒有符合「{{query}}」的結果",
+    "viewOptions": "檢視選項",
+    "zoom": "縮放",
+    "zoomAria": "調整項目大小",
+    "background": "背景…",
+    "backgroundDefaultHint": "在此檢視使用預設背景。",
     "sidebar": {
       "title": "側邊欄",
       "show": "顯示側邊欄",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -27,6 +27,7 @@ import type {
   CustomFont,
   DashboardSettings,
   DatabaseBackupInfo,
+  FileBrowserViewOptions,
   FtpConnectionOptions,
   GeneralSettings,
   HostUsageSnapshot,
@@ -1012,6 +1013,10 @@ type CommandMap = {
   };
   update_connection_terminal_appearance: {
     args: { connectionId: string; terminalOpacity?: number | null; terminalBackground?: DashboardBackground | null };
+    result: Connection | null;
+  };
+  update_connection_file_browser_view_options: {
+    args: { connectionId: string; viewOptions?: FileBrowserViewOptions | null };
     result: Connection | null;
   };
   delete_connection: {

--- a/src/modules/workspace/connections/sftp/SftpBackgroundLayer.tsx
+++ b/src/modules/workspace/connections/sftp/SftpBackgroundLayer.tsx
@@ -1,0 +1,87 @@
+// Renders a DashboardBackground (preset / dynamic / image / video) as an
+// absolutely-positioned layer behind a file pane's content view. Mirrors the
+// terminal background layer but uses file-browser-scoped CSS classes so the SFTP
+// surface stays independent of terminal styling.
+import { useEffect, useState, type CSSProperties, type JSX } from "react";
+import { resolveBackgroundPreset } from "../../../dashboard/registry/backgroundPresets";
+import { DashboardDynamicBackground } from "../../../dashboard/registry/dynamicBackgrounds";
+import { loadBackgroundImage } from "../../../dashboard/state/persistence";
+import { type BackgroundFit, type DashboardBackground } from "../../../dashboard/types";
+
+function backgroundFitStyle(fit: BackgroundFit): CSSProperties {
+  switch (fit) {
+    case "fill":    return { backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center" };
+    case "fit":     return { backgroundSize: "contain", backgroundRepeat: "no-repeat", backgroundPosition: "center" };
+    case "stretch": return { backgroundSize: "100% 100%", backgroundRepeat: "no-repeat" };
+    case "tile":    return { backgroundSize: "auto", backgroundRepeat: "repeat" };
+    case "center":  return { backgroundSize: "auto", backgroundRepeat: "no-repeat", backgroundPosition: "center" };
+  }
+}
+
+function videoFitStyle(fit: BackgroundFit): CSSProperties {
+  switch (fit) {
+    case "fill":    return { objectFit: "cover" };
+    case "fit":     return { objectFit: "contain" };
+    case "stretch": return { objectFit: "fill" };
+    case "tile":    return { objectFit: "cover" };
+    case "center":  return { objectFit: "none" };
+  }
+}
+
+function dimColor(dim: number): string | undefined {
+  if (dim === 0) return undefined;
+  const alpha = Math.min(Math.abs(dim), 100) / 100;
+  return dim < 0
+    ? `rgba(0, 0, 0, ${alpha})`
+    : `rgba(255, 255, 255, ${alpha})`;
+}
+
+export function SftpBackgroundLayer({
+  active,
+  background,
+}: {
+  active: boolean;
+  background: DashboardBackground | null | undefined;
+}) {
+  const [mediaDataUrl, setMediaDataUrl] = useState("");
+  const mediaFile = background?.kind === "image" || background?.kind === "video" ? background.file : "";
+
+  useEffect(() => {
+    let cancelled = false;
+    setMediaDataUrl("");
+    if (!mediaFile) return;
+    void loadBackgroundImage(mediaFile).then((dataUrl) => {
+      if (!cancelled) setMediaDataUrl(dataUrl);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [mediaFile]);
+
+  if (!background) return null;
+
+  let layer: JSX.Element | null = null;
+  if (background.kind === "preset") {
+    layer = <div className="sftp-bg-fill" style={{ background: resolveBackgroundPreset(background.preset).css }} />;
+  } else if (background.kind === "dynamic") {
+    layer = <DashboardDynamicBackground active={active} id={background.dynamic} />;
+  } else if (background.kind === "image" && mediaDataUrl) {
+    const style: CSSProperties = {
+      backgroundImage: `url("${mediaDataUrl}")`,
+      ...backgroundFitStyle(background.fit),
+    };
+    const dim = dimColor(background.dim);
+    if (dim) (style as Record<string, string>)["--sftp-bg-dim-color"] = dim;
+    layer = <div className="sftp-bg-fill sftp-bg-media" style={style} />;
+  } else if (background.kind === "video" && mediaDataUrl) {
+    const dim = dimColor(background.dim);
+    const style = dim ? ({ "--sftp-bg-dim-color": dim } as CSSProperties) : undefined;
+    layer = (
+      <div className="sftp-bg-fill sftp-bg-media" style={style}>
+        <video aria-hidden="true" autoPlay loop muted playsInline src={mediaDataUrl} style={videoFitStyle(background.fit)} />
+      </div>
+    );
+  }
+
+  return layer ? <div className="sftp-bg-layer" aria-hidden="true">{layer}</div> : null;
+}

--- a/src/modules/workspace/connections/sftp/SftpFilePane.tsx
+++ b/src/modules/workspace/connections/sftp/SftpFilePane.tsx
@@ -3,13 +3,17 @@
 // editable path with recent-paths history, drag-to-transfer. All data flows in
 // through props; this file owns only local view/sort/edit UI state.
 import { useEffect, useId, useMemo, useRef, useState } from "react";
-import type { DragEvent as ReactDragEvent, KeyboardEvent, MouseEvent as ReactMouseEvent } from "react";
+import type { CSSProperties, DragEvent as ReactDragEvent, KeyboardEvent, MouseEvent as ReactMouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { DIcon } from "../../../../app/ui/dialog";
 import { technicalInputProps } from "../../../../lib/inputBehavior";
 import type { LocalPlacesListing } from "../../../../lib/tauri";
 import type { FileEntry } from "../../../../types";
+import { SharedBackgroundPopover } from "../../../dashboard/edit/SharedBackgroundPopover";
+import { loadBackgroundImage } from "../../../dashboard/state/persistence";
+import type { DashboardBackground } from "../../../dashboard/types";
 import { ExplorerSidebar } from "./ExplorerSidebar";
+import { SftpBackgroundLayer } from "./SftpBackgroundLayer";
 import { FileGlyph } from "./finderGlyphs";
 import { formatFileSize, joinLocalPath } from "./format";
 import type { FilePaneSide, LocalFavorite } from "./types";
@@ -19,6 +23,10 @@ type SortState = { key: SortKey; dir: "asc" | "desc" };
 type ViewMode = "list" | "gallery";
 
 const LIST_GRID = "minmax(0,1fr) 88px 128px";
+export const FILE_PANE_ZOOM_MIN = 0.8;
+export const FILE_PANE_ZOOM_MAX = 1.6;
+export const FILE_PANE_ZOOM_STEP = 0.1;
+export const FILE_PANE_ZOOM_DEFAULT = 1;
 
 export function FilePane({
   side,
@@ -54,6 +62,11 @@ export function FilePane({
   enableSearch = false,
   showFooter = false,
   availableBytes,
+  zoom = FILE_PANE_ZOOM_DEFAULT,
+  onZoomChange,
+  background = null,
+  onBackgroundChange,
+  backgroundActive = false,
 }: {
   side: FilePaneSide;
   title: string;
@@ -88,9 +101,18 @@ export function FilePane({
   enableSearch?: boolean;
   showFooter?: boolean;
   availableBytes?: number;
+  zoom?: number;
+  onZoomChange?: (zoom: number) => void;
+  background?: DashboardBackground | null;
+  onBackgroundChange?: (background: DashboardBackground | null) => void;
+  backgroundActive?: boolean;
 }) {
   const { t } = useTranslation();
   const pathSuggestionsId = useId();
+  const viewOptionsRef = useRef<HTMLDivElement | null>(null);
+  const [viewMenuOpen, setViewMenuOpen] = useState(false);
+  const [backgroundPopoverOpen, setBackgroundPopoverOpen] = useState(false);
+  const enableViewOptions = Boolean(onZoomChange || onBackgroundChange);
   const renameInputRef = useRef<HTMLInputElement | null>(null);
   const renameCanceledRef = useRef(false);
   const lastSelectedNameRef = useRef<string | null>(null);
@@ -121,6 +143,28 @@ export function FilePane({
     setEditingPath(false);
     setSearch("");
   }, [path]);
+
+  useEffect(() => {
+    if (!viewMenuOpen) {
+      return;
+    }
+    function onDoc(event: MouseEvent) {
+      if (viewOptionsRef.current && !viewOptionsRef.current.contains(event.target as Node)) {
+        setViewMenuOpen(false);
+      }
+    }
+    function onKey(event: globalThis.KeyboardEvent) {
+      if (event.key === "Escape") {
+        setViewMenuOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [viewMenuOpen]);
 
   useEffect(() => {
     if (!editingName) {
@@ -548,8 +592,69 @@ export function FilePane({
               ) : null}
             </div>
           ) : null}
+          {enableViewOptions ? (
+            <div className="sftp-viewopts-wrap" ref={viewOptionsRef}>
+              <button
+                aria-expanded={viewMenuOpen}
+                aria-label={t("sftp.viewOptions")}
+                className={`sftp-icon-btn${viewMenuOpen ? " active" : ""}`}
+                onClick={() => setViewMenuOpen((open) => !open)}
+                title={t("sftp.viewOptions")}
+                type="button"
+              >
+                <DIcon name="menu" size={16} />
+              </button>
+              {viewMenuOpen ? (
+                <div className="sftp-viewopts-menu" role="menu">
+                  {onZoomChange ? (
+                    <div className="sftp-viewopts-zoom">
+                      <span className="sftp-viewopts-label">{t("sftp.zoom")}</span>
+                      <div className="sftp-viewopts-zoom-row">
+                        <DIcon name="gallery" size={13} />
+                        <input
+                          aria-label={t("sftp.zoomAria")}
+                          max={FILE_PANE_ZOOM_MAX}
+                          min={FILE_PANE_ZOOM_MIN}
+                          onChange={(event) => onZoomChange(Number(event.currentTarget.value))}
+                          step={FILE_PANE_ZOOM_STEP}
+                          type="range"
+                          value={zoom}
+                        />
+                        <DIcon name="gallery" size={18} />
+                      </div>
+                    </div>
+                  ) : null}
+                  {onBackgroundChange ? (
+                    <button
+                      className="sftp-viewopts-item"
+                      onClick={() => {
+                        setViewMenuOpen(false);
+                        setBackgroundPopoverOpen(true);
+                      }}
+                      role="menuitem"
+                      type="button"
+                    >
+                      <DIcon name="palette" size={15} />
+                      <span>{t("sftp.background")}</span>
+                    </button>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
         </div>
       </div>
+      {backgroundPopoverOpen && onBackgroundChange ? (
+        <SharedBackgroundPopover
+          background={background}
+          className="sftp-bg-popover"
+          defaultHintKey="sftp.backgroundDefaultHint"
+          onBackgroundChange={onBackgroundChange}
+          onClose={() => setBackgroundPopoverOpen(false)}
+          onLoadBackgroundImage={async (file) => { await loadBackgroundImage(file); }}
+          titleKey="dashboard.changeBackground"
+        />
+      ) : null}
 
       <div className="sftp-pane-body">
         {enableSidebar ? (
@@ -586,12 +691,14 @@ export function FilePane({
           />
         ) : null}
         <div className="sftp-pane-content">
+          <SftpBackgroundLayer active={backgroundActive} background={background} />
           {view === "list" ? (
             <ListColumnHeader sort={sort} onSort={toggleSort} t={t} />
           ) : null}
 
           <div
             className={`sftp-file-body sftp-view-${view}${isDropTarget || forceDropTarget ? " drop-target" : ""}`}
+            style={{ "--sftp-zoom": zoom } as CSSProperties}
             onContextMenu={(event) => onContextMenuRequest?.(side, selectedNames, event)}
             onDragLeave={() => setIsDropTarget(false)}
             onDragOver={handleDragOver}

--- a/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
+++ b/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
@@ -20,7 +20,8 @@ import {
 } from "../../paneRegistry";
 import { useWorkspaceStore } from "../../../../store";
 import type { FileEntry, SftpSettings, WorkspaceTab } from "../../../../types";
-import { FilePane } from "./SftpFilePane";
+import type { DashboardBackground } from "../../../dashboard/types";
+import { FILE_PANE_ZOOM_DEFAULT, FilePane } from "./SftpFilePane";
 import { fileBrowserConnectionIconSrc } from "../fileBrowserConnectionIcons";
 import {
   ConfirmRemoteDeleteDialog,
@@ -47,7 +48,22 @@ const WINDOWS_DRIVES_PATH = "__KKTERM_WINDOWS_DRIVES__";
 const FILE_BROWSER_RECENT_PATHS_STORAGE_KEY = "kkterm.fileBrowserRecentPaths.v1";
 const FILE_BROWSER_FAVORITES_STORAGE_KEY = "kkterm.fileBrowserFavorites.v1";
 const FILE_BROWSER_SIDEBAR_STORAGE_KEY = "kkterm.fileBrowserSidebarCollapsed.v1";
+const FILE_BROWSER_VIEW_OPTIONS_STORAGE_KEY = "kkterm.fileBrowserViewOptions.v1";
 const RECENT_PATH_LIMIT = 5;
+
+// Per-pane zoom + content-view background. Persisted per Connection (keyed by
+// connection id, falling back to the tab id) and per pane side, except for the
+// ephemeral terminal-spawned SFTP browser (`inline`), which keeps these settings
+// in memory only so they are forgotten when the popup closes.
+type FileBrowserViewOptions = {
+  zoom: number;
+  background: DashboardBackground | null;
+};
+
+const DEFAULT_FILE_BROWSER_VIEW_OPTIONS: FileBrowserViewOptions = {
+  zoom: FILE_PANE_ZOOM_DEFAULT,
+  background: null,
+};
 
 type FileClipboard = {
   operation: LocalFileClipboardOperation;
@@ -60,12 +76,14 @@ export function SftpWorkspace({
   isActive,
   tab,
   commands: commandsProp,
+  inline = false,
   onClose,
 }: {
   isActive: boolean;
   tab: WorkspaceTab;
   commands?: FileBrowserCommands;
-  // Accepted for the terminal's inline SFTP dialog; no longer alters layout.
+  // The terminal's inline SFTP dialog. No longer alters layout, but marks the
+  // browser as ephemeral so per-pane view options are not persisted.
   inline?: boolean;
   onClose?: () => void;
 }) {
@@ -91,6 +109,12 @@ export function SftpWorkspace({
   const [favorites, setFavorites] = useState<LocalFavorite[]>(() => readFavorites());
   const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(() =>
     readSidebarCollapsed(sidebarConnectionKey, isLocalFilesBrowser),
+  );
+  const [localViewOptions, setLocalViewOptions] = useState<FileBrowserViewOptions>(() =>
+    readViewOptions(sidebarConnectionKey, "local", inline),
+  );
+  const [remoteViewOptions, setRemoteViewOptions] = useState<FileBrowserViewOptions>(() =>
+    readViewOptions(sidebarConnectionKey, "remote", inline),
   );
   const [status, setStatus] = useState(t("sftp.connecting"));
   const [remoteError, setRemoteError] = useState("");
@@ -211,10 +235,24 @@ export function SftpWorkspace({
     setSidebarCollapsed(readSidebarCollapsed(sidebarConnectionKey, isLocalFilesBrowser));
   }, [sidebarConnectionKey, isLocalFilesBrowser]);
 
+  useEffect(() => {
+    setLocalViewOptions(readViewOptions(sidebarConnectionKey, "local", inline));
+    setRemoteViewOptions(readViewOptions(sidebarConnectionKey, "remote", inline));
+  }, [sidebarConnectionKey, inline]);
+
   const toggleSidebar = () => {
     setSidebarCollapsed((collapsed) => {
       const next = !collapsed;
       writeSidebarCollapsed(sidebarConnectionKey, next);
+      return next;
+    });
+  };
+
+  const updateViewOptions = (side: FilePaneSide, patch: Partial<FileBrowserViewOptions>) => {
+    const setOptions = side === "local" ? setLocalViewOptions : setRemoteViewOptions;
+    setOptions((current) => {
+      const next = { ...current, ...patch };
+      writeViewOptions(sidebarConnectionKey, side, inline, next);
       return next;
     });
   };
@@ -1567,6 +1605,11 @@ export function SftpWorkspace({
           enableSearch
           showFooter
           availableBytes={isLocalDrivePicker ? undefined : localAvailableBytes}
+          zoom={localViewOptions.zoom}
+          onZoomChange={(zoom) => updateViewOptions("local", { zoom })}
+          background={localViewOptions.background}
+          onBackgroundChange={(background) => updateViewOptions("local", { background })}
+          backgroundActive={isActive}
         />
         {!isLocalFilesBrowser ? (
           <>
@@ -1618,6 +1661,11 @@ export function SftpWorkspace({
               renameRequest={renameRequest?.side === "remote" ? renameRequest : undefined}
               enableSearch
               showFooter
+              zoom={remoteViewOptions.zoom}
+              onZoomChange={(zoom) => updateViewOptions("remote", { zoom })}
+              background={remoteViewOptions.background}
+              onBackgroundChange={(background) => updateViewOptions("remote", { background })}
+              backgroundActive={isActive}
             />
           </>
         ) : null}
@@ -1979,6 +2027,67 @@ function writeSidebarCollapsed(connectionKey: string, collapsed: boolean) {
   }
   state[connectionKey] = collapsed;
   window.localStorage.setItem(FILE_BROWSER_SIDEBAR_STORAGE_KEY, JSON.stringify(state));
+}
+
+function viewOptionsKey(connectionKey: string, side: FilePaneSide) {
+  return `${connectionKey} ${side}`;
+}
+
+function normalizeViewOptions(value: unknown): FileBrowserViewOptions {
+  if (!value || typeof value !== "object") {
+    return { ...DEFAULT_FILE_BROWSER_VIEW_OPTIONS };
+  }
+  const record = value as { zoom?: unknown; background?: unknown };
+  const zoom =
+    typeof record.zoom === "number" && Number.isFinite(record.zoom)
+      ? record.zoom
+      : DEFAULT_FILE_BROWSER_VIEW_OPTIONS.zoom;
+  const background =
+    record.background && typeof record.background === "object"
+      ? (record.background as DashboardBackground)
+      : null;
+  return { zoom, background };
+}
+
+function readViewOptions(
+  connectionKey: string,
+  side: FilePaneSide,
+  ephemeral: boolean,
+): FileBrowserViewOptions {
+  // Ephemeral (terminal-spawned) browsers never read persisted options.
+  if (ephemeral || typeof window === "undefined") {
+    return { ...DEFAULT_FILE_BROWSER_VIEW_OPTIONS };
+  }
+  try {
+    const state = JSON.parse(
+      window.localStorage.getItem(FILE_BROWSER_VIEW_OPTIONS_STORAGE_KEY) || "{}",
+    ) as Record<string, unknown>;
+    return normalizeViewOptions(state[viewOptionsKey(connectionKey, side)]);
+  } catch {
+    return { ...DEFAULT_FILE_BROWSER_VIEW_OPTIONS };
+  }
+}
+
+function writeViewOptions(
+  connectionKey: string,
+  side: FilePaneSide,
+  ephemeral: boolean,
+  options: FileBrowserViewOptions,
+) {
+  // Ephemeral browsers keep view options in memory only.
+  if (ephemeral || typeof window === "undefined") {
+    return;
+  }
+  let state: Record<string, unknown> = {};
+  try {
+    state = JSON.parse(
+      window.localStorage.getItem(FILE_BROWSER_VIEW_OPTIONS_STORAGE_KEY) || "{}",
+    ) as Record<string, unknown>;
+  } catch {
+    state = {};
+  }
+  state[viewOptionsKey(connectionKey, side)] = options;
+  window.localStorage.setItem(FILE_BROWSER_VIEW_OPTIONS_STORAGE_KEY, JSON.stringify(state));
 }
 
 function normalizeRecentPaths(paths: unknown) {

--- a/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
+++ b/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
@@ -19,7 +19,7 @@ import {
   type FileBrowserController,
 } from "../../paneRegistry";
 import { useWorkspaceStore } from "../../../../store";
-import type { FileEntry, SftpSettings, WorkspaceTab } from "../../../../types";
+import type { FileBrowserViewOptions, FileEntry, SftpSettings, WorkspaceTab } from "../../../../types";
 import type { DashboardBackground } from "../../../dashboard/types";
 import { FILE_PANE_ZOOM_DEFAULT, FilePane } from "./SftpFilePane";
 import { fileBrowserConnectionIconSrc } from "../fileBrowserConnectionIcons";
@@ -48,22 +48,53 @@ const WINDOWS_DRIVES_PATH = "__KKTERM_WINDOWS_DRIVES__";
 const FILE_BROWSER_RECENT_PATHS_STORAGE_KEY = "kkterm.fileBrowserRecentPaths.v1";
 const FILE_BROWSER_FAVORITES_STORAGE_KEY = "kkterm.fileBrowserFavorites.v1";
 const FILE_BROWSER_SIDEBAR_STORAGE_KEY = "kkterm.fileBrowserSidebarCollapsed.v1";
-const FILE_BROWSER_VIEW_OPTIONS_STORAGE_KEY = "kkterm.fileBrowserViewOptions.v1";
 const RECENT_PATH_LIMIT = 5;
 
-// Per-pane zoom + content-view background. Persisted per Connection (keyed by
-// connection id, falling back to the tab id) and per pane side, except for the
+// Per-pane zoom + content-view background. Persisted durably on the Connection
+// (DB) so the look survives restarts and follows the Connection, except for the
 // ephemeral terminal-spawned SFTP browser (`inline`), which keeps these settings
 // in memory only so they are forgotten when the popup closes.
-type FileBrowserViewOptions = {
+type PaneViewOptions = {
   zoom: number;
   background: DashboardBackground | null;
 };
 
-const DEFAULT_FILE_BROWSER_VIEW_OPTIONS: FileBrowserViewOptions = {
+type PaneViewOptionsState = {
+  local: PaneViewOptions;
+  remote: PaneViewOptions;
+};
+
+const DEFAULT_PANE_VIEW_OPTIONS: PaneViewOptions = {
   zoom: FILE_PANE_ZOOM_DEFAULT,
   background: null,
 };
+
+function paneViewOptionsFromConnection(
+  side: FilePaneSide,
+  connection: WorkspaceTab["connection"],
+): PaneViewOptions {
+  const stored = connection?.fileBrowserViewOptions?.[side];
+  return {
+    zoom:
+      typeof stored?.zoom === "number" && Number.isFinite(stored.zoom)
+        ? stored.zoom
+        : FILE_PANE_ZOOM_DEFAULT,
+    background: stored?.background ?? null,
+  };
+}
+
+function initialViewOptionsState(
+  connection: WorkspaceTab["connection"],
+  ephemeral: boolean,
+): PaneViewOptionsState {
+  if (ephemeral) {
+    return { local: { ...DEFAULT_PANE_VIEW_OPTIONS }, remote: { ...DEFAULT_PANE_VIEW_OPTIONS } };
+  }
+  return {
+    local: paneViewOptionsFromConnection("local", connection),
+    remote: paneViewOptionsFromConnection("remote", connection),
+  };
+}
 
 type FileClipboard = {
   operation: LocalFileClipboardOperation;
@@ -110,12 +141,10 @@ export function SftpWorkspace({
   const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(() =>
     readSidebarCollapsed(sidebarConnectionKey, isLocalFilesBrowser),
   );
-  const [localViewOptions, setLocalViewOptions] = useState<FileBrowserViewOptions>(() =>
-    readViewOptions(sidebarConnectionKey, "local", inline),
+  const [viewOptions, setViewOptions] = useState<PaneViewOptionsState>(() =>
+    initialViewOptionsState(connection, inline),
   );
-  const [remoteViewOptions, setRemoteViewOptions] = useState<FileBrowserViewOptions>(() =>
-    readViewOptions(sidebarConnectionKey, "remote", inline),
-  );
+  const viewOptionsRef = useRef(viewOptions);
   const [status, setStatus] = useState(t("sftp.connecting"));
   const [remoteError, setRemoteError] = useState("");
   const [localStatus, setLocalStatus] = useState("");
@@ -151,6 +180,9 @@ export function SftpWorkspace({
   );
   const markConnectionSessionEnded = useWorkspaceStore(
     (state) => state.markConnectionSessionEnded,
+  );
+  const updateOpenConnectionFileBrowserViewOptions = useWorkspaceStore(
+    (state) => state.updateOpenConnectionFileBrowserViewOptions,
   );
 
   useEffect(() => {
@@ -235,10 +267,15 @@ export function SftpWorkspace({
     setSidebarCollapsed(readSidebarCollapsed(sidebarConnectionKey, isLocalFilesBrowser));
   }, [sidebarConnectionKey, isLocalFilesBrowser]);
 
+  // Re-seed the in-memory view options from the durable Connection only when the
+  // browser switches identity (not on our own round-tripped updates, which keep
+  // the same connection id).
   useEffect(() => {
-    setLocalViewOptions(readViewOptions(sidebarConnectionKey, "local", inline));
-    setRemoteViewOptions(readViewOptions(sidebarConnectionKey, "remote", inline));
-  }, [sidebarConnectionKey, inline]);
+    const next = initialViewOptionsState(connection, inline);
+    viewOptionsRef.current = next;
+    setViewOptions(next);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connection?.id, inline]);
 
   const toggleSidebar = () => {
     setSidebarCollapsed((collapsed) => {
@@ -248,13 +285,43 @@ export function SftpWorkspace({
     });
   };
 
-  const updateViewOptions = (side: FilePaneSide, patch: Partial<FileBrowserViewOptions>) => {
-    const setOptions = side === "local" ? setLocalViewOptions : setRemoteViewOptions;
-    setOptions((current) => {
-      const next = { ...current, ...patch };
-      writeViewOptions(sidebarConnectionKey, side, inline, next);
-      return next;
-    });
+  const persistViewOptions = (next: PaneViewOptionsState) => {
+    const connectionId = connection?.id;
+    // Ephemeral popup and transient (non-DB) connections stay in memory only.
+    if (inline || !connectionId || isTransientFileBrowserConnectionId(connectionId)) {
+      return;
+    }
+    const payload: FileBrowserViewOptions = {
+      local: { zoom: next.local.zoom, background: next.local.background },
+      remote: { zoom: next.remote.zoom, background: next.remote.background },
+    };
+    updateOpenConnectionFileBrowserViewOptions(connectionId, payload);
+    if (!isTauriRuntime()) {
+      return;
+    }
+    void invokeCommand("update_connection_file_browser_view_options", {
+      connectionId,
+      viewOptions: payload,
+    })
+      .then((updated) => {
+        if (updated) {
+          updateOpenConnectionFileBrowserViewOptions(
+            connectionId,
+            updated.fileBrowserViewOptions ?? payload,
+          );
+        }
+      })
+      .catch((error) => {
+        console.warn("file browser view options update failed.", error);
+      });
+  };
+
+  const updateViewOptions = (side: FilePaneSide, patch: Partial<PaneViewOptions>) => {
+    const prev = viewOptionsRef.current;
+    const next: PaneViewOptionsState = { ...prev, [side]: { ...prev[side], ...patch } };
+    viewOptionsRef.current = next;
+    setViewOptions(next);
+    persistViewOptions(next);
   };
 
   const addFavorite = (place: { label: string; path: string; icon: string; kind?: "file" | "folder" }) => {
@@ -1605,9 +1672,9 @@ export function SftpWorkspace({
           enableSearch
           showFooter
           availableBytes={isLocalDrivePicker ? undefined : localAvailableBytes}
-          zoom={localViewOptions.zoom}
+          zoom={viewOptions.local.zoom}
           onZoomChange={(zoom) => updateViewOptions("local", { zoom })}
-          background={localViewOptions.background}
+          background={viewOptions.local.background}
           onBackgroundChange={(background) => updateViewOptions("local", { background })}
           backgroundActive={isActive}
         />
@@ -1661,9 +1728,9 @@ export function SftpWorkspace({
               renameRequest={renameRequest?.side === "remote" ? renameRequest : undefined}
               enableSearch
               showFooter
-              zoom={remoteViewOptions.zoom}
+              zoom={viewOptions.remote.zoom}
               onZoomChange={(zoom) => updateViewOptions("remote", { zoom })}
-              background={remoteViewOptions.background}
+              background={viewOptions.remote.background}
               onBackgroundChange={(background) => updateViewOptions("remote", { background })}
               backgroundActive={isActive}
             />
@@ -2029,65 +2096,10 @@ function writeSidebarCollapsed(connectionKey: string, collapsed: boolean) {
   window.localStorage.setItem(FILE_BROWSER_SIDEBAR_STORAGE_KEY, JSON.stringify(state));
 }
 
-function viewOptionsKey(connectionKey: string, side: FilePaneSide) {
-  return `${connectionKey} ${side}`;
-}
-
-function normalizeViewOptions(value: unknown): FileBrowserViewOptions {
-  if (!value || typeof value !== "object") {
-    return { ...DEFAULT_FILE_BROWSER_VIEW_OPTIONS };
-  }
-  const record = value as { zoom?: unknown; background?: unknown };
-  const zoom =
-    typeof record.zoom === "number" && Number.isFinite(record.zoom)
-      ? record.zoom
-      : DEFAULT_FILE_BROWSER_VIEW_OPTIONS.zoom;
-  const background =
-    record.background && typeof record.background === "object"
-      ? (record.background as DashboardBackground)
-      : null;
-  return { zoom, background };
-}
-
-function readViewOptions(
-  connectionKey: string,
-  side: FilePaneSide,
-  ephemeral: boolean,
-): FileBrowserViewOptions {
-  // Ephemeral (terminal-spawned) browsers never read persisted options.
-  if (ephemeral || typeof window === "undefined") {
-    return { ...DEFAULT_FILE_BROWSER_VIEW_OPTIONS };
-  }
-  try {
-    const state = JSON.parse(
-      window.localStorage.getItem(FILE_BROWSER_VIEW_OPTIONS_STORAGE_KEY) || "{}",
-    ) as Record<string, unknown>;
-    return normalizeViewOptions(state[viewOptionsKey(connectionKey, side)]);
-  } catch {
-    return { ...DEFAULT_FILE_BROWSER_VIEW_OPTIONS };
-  }
-}
-
-function writeViewOptions(
-  connectionKey: string,
-  side: FilePaneSide,
-  ephemeral: boolean,
-  options: FileBrowserViewOptions,
-) {
-  // Ephemeral browsers keep view options in memory only.
-  if (ephemeral || typeof window === "undefined") {
-    return;
-  }
-  let state: Record<string, unknown> = {};
-  try {
-    state = JSON.parse(
-      window.localStorage.getItem(FILE_BROWSER_VIEW_OPTIONS_STORAGE_KEY) || "{}",
-    ) as Record<string, unknown>;
-  } catch {
-    state = {};
-  }
-  state[viewOptionsKey(connectionKey, side)] = options;
-  window.localStorage.setItem(FILE_BROWSER_VIEW_OPTIONS_STORAGE_KEY, JSON.stringify(state));
+// Transient terminal-local Connections (e.g. `local-123…`) are not durable DB
+// rows, so view-option writes for them are skipped.
+function isTransientFileBrowserConnectionId(connectionId: string) {
+  return /^local-\d+$/u.test(connectionId);
 }
 
 function normalizeRecentPaths(paths: unknown) {

--- a/src/modules/workspace/connections/sftp/sftp.css
+++ b/src/modules/workspace/connections/sftp/sftp.css
@@ -282,6 +282,68 @@
   background: var(--hover);
 }
 
+/* view options (hamburger) menu — zoom + content-view background */
+.sftp-viewopts-wrap {
+  position: relative;
+  display: inline-flex;
+}
+.sftp-viewopts-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 40;
+  display: grid;
+  gap: 8px;
+  width: 232px;
+  padding: 10px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: var(--shadow);
+}
+.sftp-viewopts-zoom {
+  display: grid;
+  gap: 6px;
+}
+.sftp-viewopts-label {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.sftp-viewopts-zoom-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+}
+.sftp-viewopts-zoom-row input[type="range"] {
+  flex: 1 1 auto;
+  margin: 0;
+  accent-color: var(--accent);
+}
+.sftp-viewopts-item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 8px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 12.5px;
+  text-align: left;
+  cursor: pointer;
+}
+.sftp-viewopts-item:hover {
+  background: var(--hover);
+}
+.sftp-bg-popover {
+  z-index: 260;
+}
+
 /* icon button */
 .sftp-icon-btn {
   display: inline-flex;
@@ -408,18 +470,22 @@
   border-radius: 10px;
 }
 
-/* list rows */
+/* list rows — `--sftp-zoom` (set on .sftp-file-body) scales item sizing. */
 .sftp-row {
   display: grid;
   align-items: center;
   gap: 10px;
-  height: 30px;
+  height: calc(30px * var(--sftp-zoom, 1));
   padding: 0 8px;
   border-radius: 6px;
   color: var(--text);
   user-select: none;
   cursor: default;
-  font-size: 13px;
+  font-size: calc(13px * var(--sftp-zoom, 1));
+}
+.sftp-row-glyph img {
+  width: calc(20px * var(--sftp-zoom, 1));
+  height: calc(20px * var(--sftp-zoom, 1));
 }
 .sftp-row .nm {
   display: flex;
@@ -442,7 +508,7 @@
   text-align: right;
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--sftp-zoom, 1));
 }
 .sftp-row:hover {
   background: var(--hover);
@@ -458,7 +524,7 @@
 /* gallery */
 .sftp-gallery-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(calc(96px * var(--sftp-zoom, 1)), 1fr));
   gap: 6px;
 }
 .sftp-tile {
@@ -481,13 +547,17 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 52px;
+  height: calc(52px * var(--sftp-zoom, 1));
+}
+.sftp-tile-ico img {
+  width: calc(52px * var(--sftp-zoom, 1));
+  height: calc(52px * var(--sftp-zoom, 1));
 }
 .sftp-tile-cap {
   max-width: 100%;
   padding: 1px 7px;
   border-radius: 6px;
-  font-size: 12px;
+  font-size: calc(12px * var(--sftp-zoom, 1));
   font-weight: 500;
   text-align: center;
   white-space: nowrap;
@@ -534,11 +604,42 @@
   min-height: 0;
 }
 .sftp-pane-content {
+  position: relative;
   display: flex;
   flex-direction: column;
   flex: 1 1 0;
   min-width: 0;
   min-height: 0;
+}
+/* Content-view background sits behind the column header + file list. */
+.sftp-pane-content > .sftp-col-head,
+.sftp-pane-content > .sftp-file-body {
+  position: relative;
+  z-index: 1;
+}
+
+/* ===================== content-view background ======================= */
+.sftp-bg-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+.sftp-bg-fill,
+.sftp-bg-fill video,
+.sftp-bg-layer .dw-dynamic-background {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+.sftp-bg-media::after {
+  position: absolute;
+  inset: 0;
+  display: block;
+  background: var(--sftp-bg-dim-color, transparent);
+  content: "";
 }
 
 .sftp-sidebar {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1157,6 +1157,7 @@ interface WorkspaceState {
   ) => void;
   refreshOpenConnectionMetadata: (connection: Connection) => void;
   updateOpenConnectionTerminalAppearance: (connectionId: string, appearance: Pick<Connection, "terminalOpacity" | "terminalBackground">) => void;
+  updateOpenConnectionFileBrowserViewOptions: (connectionId: string, fileBrowserViewOptions: Connection["fileBrowserViewOptions"]) => void;
   updateOpenTerminalPaneAppearance: (tabId: string, paneId: string, appearance: Pick<Connection, "terminalOpacity" | "terminalBackground">) => void;
   updateOpenTerminalPaneFontSize: (tabId: string, paneId: string, fontSize: number) => void;
   updateOpenTerminalPaneBackground: (tabId: string, paneId: string, terminalBackground: TerminalPane["terminalBackground"]) => void;
@@ -2731,6 +2732,15 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   updateOpenConnectionTerminalAppearance: (connectionId, appearance) => {
     set((state) => ({
       tabs: state.tabs.map((tab) => updateTabTerminalAppearance(tab, connectionId, appearance)),
+    }));
+  },
+  updateOpenConnectionFileBrowserViewOptions: (connectionId, fileBrowserViewOptions) => {
+    set((state) => ({
+      tabs: state.tabs.map((tab) =>
+        tab.connection?.id === connectionId
+          ? { ...tab, connection: { ...tab.connection, fileBrowserViewOptions } }
+          : tab,
+      ),
     }));
   },
   updateOpenTerminalPaneAppearance: (tabId, paneId, appearance) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,17 @@ export interface ReorderWorkspacesRequest {
 export type ConnectionStatus = "connected" | "idle" | "offline";
 export type SshAuthMethod = "keyFile" | "password" | "agent";
 
+/** Per-pane File Explorer / SFTP browser view options (item zoom + content-view
+ * background), persisted durably on the Connection. */
+export interface FileBrowserPaneViewOptions {
+  zoom?: number;
+  background?: DashboardBackground | null;
+}
+export interface FileBrowserViewOptions {
+  local?: FileBrowserPaneViewOptions;
+  remote?: FileBrowserPaneViewOptions;
+}
+
 export interface Connection {
   id: string;
   name: string;
@@ -76,6 +87,7 @@ export interface Connection {
   iconBackgroundColor?: string | null;
   terminalOpacity?: number | null;
   terminalBackground?: DashboardBackground | null;
+  fileBrowserViewOptions?: FileBrowserViewOptions | null;
   rdpOptions?: RdpConnectionOptions;
   vncOptions?: VncConnectionOptions;
   ftpOptions?: FtpConnectionOptions;


### PR DESCRIPTION
## Summary

Adds a per-pane **view-options menu** to the File Explorer and SFTP/FTP browser. A hamburger button to the right of each pane's search box opens a menu with two controls:

- **Zoom** — a slider that scales the file/folder items in that pane's content view via a `--sftp-zoom` CSS variable (list rows, icons, gallery tiles/captions).
- **Background** — opens the **same picker as a Dashboard view background** (`SharedBackgroundPopover`: theme-default / preset / image-video / dynamic) and renders the chosen background **within that pane's content view only** (behind the file list), via a new `SftpBackgroundLayer`.

Both panes of a dual-pane SFTP/FTP browser get their own menu, as does the single File Explorer pane.

Settings **persist per Connection and per pane side** in `localStorage`, consistent with the file browser's existing settings (sidebar state, favorites, recent paths). The **ephemeral SSH-toolbar SFTP popup** (`inline`) keeps them **in memory only**, so they are forgotten when the popup closes.

## Type of change

- [x] Feature
- [x] Docs / manual

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)
- [x] Docs (`docs/`, manual, ADR)

## Domain & docs

- [x] Uses the canonical vocabulary (Connection / Session / Tab)
- [x] Source placement follows the Frontend Source Map (new `SftpBackgroundLayer.tsx` lives in the sftp area; reuses the canonical Dashboard background registry/picker)
- [x] Manual updated — `docs/manual/07-sftp.md` (per-pane toolbar + grep hints)

## i18n

- [x] English keys added first in `src/i18n/locales/en.json` (`sftp.viewOptions`, `sftp.zoom`, `sftp.zoomAria`, `sftp.background`, `sftp.backgroundDefaultHint`), best-effort translations added to all 13 other locales, and pending review files added under `docs/localization_todo/`
- [x] One full sentence per key; no concatenated fragments

## UI / design language

- [x] Background uses the shared `SharedBackgroundPopover`; colors read from CSS tokens (no hard-coded hex)
- [x] Transient status unaffected; no `window.alert/confirm/prompt`
- Note: the hamburger/menu controls are not tutorial targets, so no `data-tutorial-id` was added.

## High-risk invariants

- [x] No frontend close hooks / close-confirmation flows added
- [x] No live Session state added to the durable Connection model (view options are stored in `localStorage`, not on the Connection record)

## Checks

- [x] `npm run check` — `i18n:check` ✓, `tsc --noEmit` ✓, eslint 0 errors (7 pre-existing warnings)
- [x] `npm run build` ✓
- [x] Frontend tests: 363/365 pass; the 2 failures are in `installer-managed-service-catalog.test.mjs` (BentoPDF/NSSM) and were confirmed to fail on the clean tree — pre-existing and unrelated
- [ ] Not yet validated in the real Tauri desktop runtime

## Notes for reviewers

- **Persistence choice:** view options use `localStorage` keyed by connection id + pane side, matching the existing file-browser settings rather than the durable Connection DB model used for `terminalBackground`. This avoids a Rust/schema change. If you'd prefer these stored on the Connection record (so they sync with backups/export), that's a larger follow-up.
- `SftpBackgroundLayer` mirrors `TerminalBackgroundLayer` but uses sftp-scoped CSS classes so the SFTP surface stays independent of terminal styling.
