### PR TITLE
feat(installer): house-style redesign of the Installer Helper page

### DIFF
--- a/docs/localization_todo/installer.empty.noMatches.md
+++ b/docs/localization_todo/installer.empty.noMatches.md
@@ -1,0 +1,16 @@
+# installer.empty.noMatches
+
+- **English value**: `No tools match your search.`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerPage.tsx`
+- **UI role**: `status`
+- **User flow**: Empty-state message shown in the content area when the search/filter returns no tools.
+- **Tone**: concise/neutral UI label
+- **Placeholders**: none
+- **Context/meaning**: Installer Helper Module (Windows AI tool installer) UI string.
+- **Domain notes**: "Installer Helper" is the KKTerm Module that installs/updates Windows developer and AI tools. Keep technical terms (winget, WSL, CLI) as-is.
+
+<!--
+Filename: installer.empty.noMatches.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/installer.footer.installed.md
+++ b/docs/localization_todo/installer.footer.installed.md
@@ -1,0 +1,16 @@
+# installer.footer.installed
+
+- **English value**: `{{count}} installed`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerPage.tsx`
+- **UI role**: `status`
+- **User flow**: Footer status line showing how many tools are installed.
+- **Tone**: concise/neutral UI label
+- **Placeholders**: {{count}} = number installed
+- **Context/meaning**: Installer Helper Module (Windows AI tool installer) UI string.
+- **Domain notes**: "Installer Helper" is the KKTerm Module that installs/updates Windows developer and AI tools. Keep technical terms (winget, WSL, CLI) as-is.
+
+<!--
+Filename: installer.footer.installed.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/installer.footer.tools.md
+++ b/docs/localization_todo/installer.footer.tools.md
@@ -1,0 +1,16 @@
+# installer.footer.tools
+
+- **English value**: `{{count}} tools`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerPage.tsx`
+- **UI role**: `status`
+- **User flow**: Footer status line showing the total number of tools currently listed.
+- **Tone**: concise/neutral UI label
+- **Placeholders**: {{count}} = number of tools
+- **Context/meaning**: Installer Helper Module (Windows AI tool installer) UI string.
+- **Domain notes**: "Installer Helper" is the KKTerm Module that installs/updates Windows developer and AI tools. Keep technical terms (winget, WSL, CLI) as-is.
+
+<!--
+Filename: installer.footer.tools.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/installer.footer.updates.md
+++ b/docs/localization_todo/installer.footer.updates.md
@@ -1,0 +1,16 @@
+# installer.footer.updates
+
+- **English value**: `{{count}} updates available`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerPage.tsx`
+- **UI role**: `status`
+- **User flow**: Footer status line showing how many installed tools have an update available.
+- **Tone**: concise/neutral UI label
+- **Placeholders**: {{count}} = number of available updates
+- **Context/meaning**: Installer Helper Module (Windows AI tool installer) UI string.
+- **Domain notes**: "Installer Helper" is the KKTerm Module that installs/updates Windows developer and AI tools. Keep technical terms (winget, WSL, CLI) as-is.
+
+<!--
+Filename: installer.footer.updates.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/installer.listColumn.action.md
+++ b/docs/localization_todo/installer.listColumn.action.md
@@ -1,0 +1,16 @@
+# installer.listColumn.action
+
+- **English value**: `Action`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerPage.tsx`
+- **UI role**: `heading`
+- **User flow**: Column header for the install/update action button in the Installer Helper List view.
+- **Tone**: concise/neutral UI label
+- **Placeholders**: none
+- **Context/meaning**: Installer Helper Module (Windows AI tool installer) UI string.
+- **Domain notes**: "Installer Helper" is the KKTerm Module that installs/updates Windows developer and AI tools. Keep technical terms (winget, WSL, CLI) as-is.
+
+<!--
+Filename: installer.listColumn.action.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/installer.listColumn.name.md
+++ b/docs/localization_todo/installer.listColumn.name.md
@@ -1,0 +1,16 @@
+# installer.listColumn.name
+
+- **English value**: `Name`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerPage.tsx`
+- **UI role**: `heading`
+- **User flow**: Column header for the tool name in the Installer Helper List view.
+- **Tone**: concise/neutral UI label
+- **Placeholders**: none
+- **Context/meaning**: Installer Helper Module (Windows AI tool installer) UI string.
+- **Domain notes**: "Installer Helper" is the KKTerm Module that installs/updates Windows developer and AI tools. Keep technical terms (winget, WSL, CLI) as-is.
+
+<!--
+Filename: installer.listColumn.name.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/installer.listColumn.status.md
+++ b/docs/localization_todo/installer.listColumn.status.md
@@ -1,0 +1,16 @@
+# installer.listColumn.status
+
+- **English value**: `Status`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerPage.tsx`
+- **UI role**: `heading`
+- **User flow**: Column header for the install-status pill in the Installer Helper List view.
+- **Tone**: concise/neutral UI label
+- **Placeholders**: none
+- **Context/meaning**: Installer Helper Module (Windows AI tool installer) UI string.
+- **Domain notes**: "Installer Helper" is the KKTerm Module that installs/updates Windows developer and AI tools. Keep technical terms (winget, WSL, CLI) as-is.
+
+<!--
+Filename: installer.listColumn.status.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/installer.search.md
+++ b/docs/localization_todo/installer.search.md
@@ -1,0 +1,16 @@
+# installer.search
+
+- **English value**: `Search tools`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerPage.tsx`
+- **UI role**: `placeholder`
+- **User flow**: Placeholder in the Installer Helper toolbar search field that filters the tool catalog.
+- **Tone**: concise/neutral UI label
+- **Placeholders**: none
+- **Context/meaning**: Installer Helper Module (Windows AI tool installer) UI string.
+- **Domain notes**: "Installer Helper" is the KKTerm Module that installs/updates Windows developer and AI tools. Keep technical terms (winget, WSL, CLI) as-is.
+
+<!--
+Filename: installer.search.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/installer.sidebar.allTools.md
+++ b/docs/localization_todo/installer.sidebar.allTools.md
@@ -1,0 +1,16 @@
+# installer.sidebar.allTools
+
+- **English value**: `All Tools`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerSidebar.tsx`
+- **UI role**: `label`
+- **User flow**: Rail filter row showing every tool in the Installer Helper catalog.
+- **Tone**: concise/neutral UI label
+- **Placeholders**: none
+- **Context/meaning**: Installer Helper Module (Windows AI tool installer) UI string.
+- **Domain notes**: "Installer Helper" is the KKTerm Module that installs/updates Windows developer and AI tools. Keep technical terms (winget, WSL, CLI) as-is.
+
+<!--
+Filename: installer.sidebar.allTools.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/installer.sidebar.categories.md
+++ b/docs/localization_todo/installer.sidebar.categories.md
@@ -1,0 +1,16 @@
+# installer.sidebar.categories
+
+- **English value**: `Categories`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerSidebar.tsx`
+- **UI role**: `heading`
+- **User flow**: Header above the tool-category filters in the Installer Helper category rail.
+- **Tone**: concise/neutral UI label
+- **Placeholders**: none
+- **Context/meaning**: Installer Helper Module (Windows AI tool installer) UI string.
+- **Domain notes**: "Installer Helper" is the KKTerm Module that installs/updates Windows developer and AI tools. Keep technical terms (winget, WSL, CLI) as-is.
+
+<!--
+Filename: installer.sidebar.categories.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/installer.sidebar.hide.md
+++ b/docs/localization_todo/installer.sidebar.hide.md
@@ -1,0 +1,16 @@
+# installer.sidebar.hide
+
+- **English value**: `Hide sidebar`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerPage.tsx`
+- **UI role**: `tooltip`
+- **User flow**: Tooltip on the toolbar toggle when the Installer Helper category rail is shown.
+- **Tone**: concise/neutral UI label
+- **Placeholders**: none
+- **Context/meaning**: Installer Helper Module (Windows AI tool installer) UI string.
+- **Domain notes**: "Installer Helper" is the KKTerm Module that installs/updates Windows developer and AI tools. Keep technical terms (winget, WSL, CLI) as-is.
+
+<!--
+Filename: installer.sidebar.hide.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/installer.sidebar.show.md
+++ b/docs/localization_todo/installer.sidebar.show.md
@@ -1,0 +1,16 @@
+# installer.sidebar.show
+
+- **English value**: `Show sidebar`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerPage.tsx`
+- **UI role**: `tooltip`
+- **User flow**: Tooltip on the toolbar toggle when the Installer Helper category rail is hidden.
+- **Tone**: concise/neutral UI label
+- **Placeholders**: none
+- **Context/meaning**: Installer Helper Module (Windows AI tool installer) UI string.
+- **Domain notes**: "Installer Helper" is the KKTerm Module that installs/updates Windows developer and AI tools. Keep technical terms (winget, WSL, CLI) as-is.
+
+<!--
+Filename: installer.sidebar.show.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/installer.sidebar.status.md
+++ b/docs/localization_todo/installer.sidebar.status.md
@@ -1,0 +1,16 @@
+# installer.sidebar.status
+
+- **English value**: `Status`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerSidebar.tsx`
+- **UI role**: `heading`
+- **User flow**: Header above the install-status filters (All/Installed/Updates/Not Installed) in the Installer Helper category rail.
+- **Tone**: concise/neutral UI label
+- **Placeholders**: none
+- **Context/meaning**: Installer Helper Module (Windows AI tool installer) UI string.
+- **Domain notes**: "Installer Helper" is the KKTerm Module that installs/updates Windows developer and AI tools. Keep technical terms (winget, WSL, CLI) as-is.
+
+<!--
+Filename: installer.sidebar.status.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/installer.sidebar.updates.md
+++ b/docs/localization_todo/installer.sidebar.updates.md
@@ -1,0 +1,16 @@
+# installer.sidebar.updates
+
+- **English value**: `Updates`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerSidebar.tsx`
+- **UI role**: `label`
+- **User flow**: Rail filter row showing only tools with an available update. Short noun, not the Update button verb.
+- **Tone**: concise/neutral UI label
+- **Placeholders**: none
+- **Context/meaning**: Installer Helper Module (Windows AI tool installer) UI string.
+- **Domain notes**: "Installer Helper" is the KKTerm Module that installs/updates Windows developer and AI tools. Keep technical terms (winget, WSL, CLI) as-is.
+
+<!--
+Filename: installer.sidebar.updates.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/installer.view.gallery.md
+++ b/docs/localization_todo/installer.view.gallery.md
@@ -1,0 +1,16 @@
+# installer.view.gallery
+
+- **English value**: `Gallery view`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerPage.tsx`
+- **UI role**: `tooltip`
+- **User flow**: Tooltip/label on the Gallery (icon grid) option of the Installer Helper view switch.
+- **Tone**: concise/neutral UI label
+- **Placeholders**: none
+- **Context/meaning**: Installer Helper Module (Windows AI tool installer) UI string.
+- **Domain notes**: "Installer Helper" is the KKTerm Module that installs/updates Windows developer and AI tools. Keep technical terms (winget, WSL, CLI) as-is.
+
+<!--
+Filename: installer.view.gallery.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/installer.view.list.md
+++ b/docs/localization_todo/installer.view.list.md
@@ -1,0 +1,16 @@
+# installer.view.list
+
+- **English value**: `List view`
+- **Namespace**: `installer`
+- **File/component**: `src/modules/installer/InstallerPage.tsx`
+- **UI role**: `tooltip`
+- **User flow**: Tooltip/label on the List option of the Installer Helper view switch.
+- **Tone**: concise/neutral UI label
+- **Placeholders**: none
+- **Context/meaning**: Installer Helper Module (Windows AI tool installer) UI string.
+- **Domain notes**: "Installer Helper" is the KKTerm Module that installs/updates Windows developer and AI tools. Keep technical terms (winget, WSL, CLI) as-is.
+
+<!--
+Filename: installer.view.list.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -710,6 +710,29 @@
     "checkUpdates": "Check for updates",
     "checkingForUpdates": "Checking for updates",
     "updateAll": "Update all",
+    "search": "Search tools",
+    "view": {
+      "list": "List view",
+      "gallery": "Gallery view"
+    },
+    "sidebar": {
+      "status": "Status",
+      "categories": "Categories",
+      "allTools": "All Tools",
+      "updates": "Updates",
+      "show": "Show sidebar",
+      "hide": "Hide sidebar"
+    },
+    "listColumn": {
+      "name": "Name",
+      "status": "Status",
+      "action": "Action"
+    },
+    "footer": {
+      "tools": "{{count}} tools",
+      "installed": "{{count}} installed",
+      "updates": "{{count}} updates available"
+    },
     "section": {
       "installed": "Installed",
       "available": "Available",
@@ -775,7 +798,8 @@
       "neverChecked": "Never"
     },
     "empty": {
-      "loading": "Loading catalog…"
+      "loading": "Loading catalog…",
+      "noMatches": "No tools match your search."
     },
     "confirm": {
       "installTitle": "Install {{name}}?",

--- a/src/modules/installer/InstallerListRow.tsx
+++ b/src/modules/installer/InstallerListRow.tsx
@@ -1,0 +1,190 @@
+// One row in the Installer Helper List view: icon + name + description, the
+// Installed and Latest version columns, a status pill, and a primary action.
+// Clicking the row opens the same app-owned InstallerToolDialog the Gallery
+// tiles use (info, or stepper while an install is in flight). Status/version
+// derivation is shared with the tile via useToolStatus.
+
+import { CircleArrowUp, CircleCheck, CircleX } from "lucide-react";
+import type { MouseEvent } from "react";
+import { useTranslation } from "react-i18next";
+import { isTauriRuntime, openExternalUrl } from "../../lib/tauri";
+import { iconUrlForRecipe, FALLBACK_ICON_URL } from "./icons";
+import { latestVersionWebUrlForRecipe } from "./latestSupport";
+import { useInstallerStore } from "./state";
+import { localizedDescription, type Recipe } from "./types";
+import { useToolStatus, type StatusTone } from "./useToolStatus";
+
+function StatusPill({ tone, label }: { tone: StatusTone; label: string }) {
+  const icon =
+    tone === "installed" ? (
+      <CircleCheck size={12} strokeWidth={2.2} aria-hidden="true" />
+    ) : tone === "update" ? (
+      <CircleArrowUp size={12} strokeWidth={2.2} aria-hidden="true" />
+    ) : tone === "failed" ? (
+      <CircleX size={12} strokeWidth={2.2} aria-hidden="true" />
+    ) : tone === "busy" ? (
+      <span className="installer-page__spinner" aria-hidden="true" />
+    ) : null;
+  return (
+    <span className="installer-pill" data-tone={tone}>
+      {icon}
+      {label}
+    </span>
+  );
+}
+
+export function InstallerListRow({ recipe }: { recipe: Recipe }) {
+  const { t, i18n } = useTranslation();
+  const openInfoDialog = useInstallerStore((s) => s.openInfoDialog);
+  const openStepperDialog = useInstallerStore((s) => s.openStepperDialog);
+
+  const {
+    isInstalled,
+    installedVersion,
+    partial,
+    latestSeen,
+    latestError,
+    supportsLatestVersion,
+    hasUpdate,
+    busy,
+    operation,
+    retrieving,
+    statusTone,
+  } = useToolStatus(recipe);
+  const latestWebUrl = latestVersionWebUrlForRecipe(recipe);
+
+  function handleOpen() {
+    if (busy) {
+      openStepperDialog(recipe.id);
+    } else {
+      openInfoDialog(recipe.id);
+    }
+  }
+
+  function handleActionClick(event: MouseEvent<HTMLButtonElement>) {
+    event.stopPropagation();
+    handleOpen();
+  }
+
+  function handleWebLatestClick(event: MouseEvent<HTMLAnchorElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!latestWebUrl) return;
+    if (!isTauriRuntime()) {
+      window.open(latestWebUrl, "_blank", "noopener,noreferrer");
+      return;
+    }
+    void openExternalUrl(latestWebUrl).catch(() => {
+      window.open(latestWebUrl, "_blank", "noopener,noreferrer");
+    });
+  }
+
+  const description = localizedDescription(recipe, i18n.language);
+
+  const installedText = retrieving
+    ? t("installer.status.retrieving")
+    : isInstalled
+      ? (installedVersion ?? t("installer.status.noVersion"))
+      : "—";
+
+  const latestText = retrieving
+    ? t("installer.status.retrieving")
+    : (latestError ?? latestSeen ?? t("installer.status.noVersion"));
+
+  const pillLabel = busy
+    ? operation === "uninstall"
+      ? t("installer.status.uninstalling")
+      : t("installer.status.installing")
+    : statusTone === "failed"
+      ? t("installer.stepper.failedBadge")
+      : statusTone === "update"
+        ? t("installer.actions.update")
+        : statusTone === "installed"
+          ? t("installer.section.installed")
+          : statusTone === "partial"
+            ? t("installer.status.partial", {
+                installed: partial?.[0] ?? 0,
+                total: partial?.[1] ?? 0,
+              })
+            : t("installer.status.notInstalled");
+
+  return (
+    <div
+      className="installer-listrow"
+      data-status={statusTone}
+      role="button"
+      tabIndex={0}
+      aria-label={recipe.name}
+      onClick={handleOpen}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          handleOpen();
+        }
+      }}
+    >
+      <div className="installer-listrow__name">
+        <img
+          className="installer-listrow__icon"
+          src={iconUrlForRecipe(recipe.id)}
+          alt=""
+          draggable={false}
+          onError={(event) => {
+            const img = event.currentTarget;
+            if (img.src !== FALLBACK_ICON_URL) {
+              img.src = FALLBACK_ICON_URL;
+            }
+          }}
+        />
+        <div className="installer-listrow__text">
+          <b title={recipe.name}>{recipe.name}</b>
+          <span title={description}>{description}</span>
+        </div>
+      </div>
+      <div className="installer-listrow__ver installer-listrow__ver--muted">
+        {installedText}
+      </div>
+      <div
+        className={`installer-listrow__ver${
+          !retrieving && latestError
+            ? " installer-listrow__ver--error"
+            : !retrieving && hasUpdate
+              ? " installer-listrow__ver--update"
+              : ""
+        }`}
+      >
+        {supportsLatestVersion || latestSeen ? (
+          latestText
+        ) : latestWebUrl ? (
+          <a
+            className="installer-tile__web-link"
+            href={latestWebUrl}
+            onClick={handleWebLatestClick}
+            rel="noopener noreferrer"
+          >
+            {t("installer.status.web")}
+          </a>
+        ) : (
+          "—"
+        )}
+      </div>
+      <div className="installer-listrow__status">
+        <StatusPill tone={statusTone} label={pillLabel} />
+      </div>
+      <div className="installer-listrow__action">
+        {!isInstalled || hasUpdate ? (
+          <button
+            type="button"
+            className="installer-act primary"
+            onClick={handleActionClick}
+            disabled={retrieving}
+          >
+            {hasUpdate
+              ? t("installer.actions.update")
+              : t("installer.actions.install")}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/installer/InstallerPage.tsx
+++ b/src/modules/installer/InstallerPage.tsx
@@ -1,4 +1,12 @@
-// Installer Helper Module page. Shell + section grouping + lifecycle.
+// Installer Helper Module page. Finder/SFTP-style shell + section grouping +
+// lifecycle.
+//
+// Shell (house style, mirrors the SFTP file browser): a slim top bar
+// (kind glyph + "Installer Helper" + a Checked/Checking status pill, no macOS
+// window chrome), a toolbar (sidebar toggle + current-filter crumb + search +
+// List/Gallery switch + Refresh + Update All), a left category rail
+// (InstallerSidebar) and a List or Gallery content view, with a footer status
+// line. The per-tool detail surface stays the app-owned InstallerToolDialog.
 //
 // Lifecycle:
 //   * Mount: load catalog (uses 1h disk cache), subscribe to progress events,
@@ -16,9 +24,24 @@
 //   * Unmount: keep the in-memory store; do NOT reset detected state (so
 //     visiting the Module again is instant).
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 import { listen } from "@tauri-apps/api/event";
+import {
+  Box,
+  CircleArrowUp,
+  CircleCheck,
+  CircleDashed,
+  Clock,
+  LayoutGrid,
+  Layers,
+  List as ListIcon,
+  PanelLeft,
+  RefreshCw,
+  Search,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { invokeCommand, isTauriRuntime } from "../../lib/tauri";
 import { useWorkspaceStore } from "../../store";
 import { useInstallerStore } from "./state";
@@ -27,20 +50,49 @@ import { InstallerConfirmDialog } from "./InstallerConfirmDialog";
 import { InstallerToolDialog } from "./InstallerToolDialog";
 import {
   PROGRESS_EVENT_NAME,
-  type DetectedState,
+  localizedDescription,
   type ProgressEvent,
   type Recipe,
-  type ToolState,
 } from "./types";
 import { installRecipeAndWait } from "./progress";
 import { ToolRow } from "./ToolRow";
-import { isInstallerUpdateAvailable } from "./versionCompare";
+import { InstallerListRow } from "./InstallerListRow";
+import {
+  InstallerSidebar,
+  type InstallerCounts,
+  type InstallerNav,
+} from "./InstallerSidebar";
+import { INSTALLER_CATEGORY_SECTIONS } from "./sections";
+import { deriveToolStatus } from "./useToolStatus";
 import { recipeSupportsLatestVersion } from "./latestSupport";
 import { resolveInstallerCheckIntervalSeconds } from "./checkInterval";
 import "./installer.css";
 
+type ViewMode = "list" | "gallery";
+
+const VIEW_MODE_STORAGE_KEY = "kkterm.installerViewMode.v1";
+const SIDEBAR_STORAGE_KEY = "kkterm.installerSidebarCollapsed.v1";
+
+function readViewMode(): ViewMode {
+  try {
+    return localStorage.getItem(VIEW_MODE_STORAGE_KEY) === "list"
+      ? "list"
+      : "gallery";
+  } catch {
+    return "gallery";
+  }
+}
+
+function readSidebarCollapsed(): boolean {
+  try {
+    return localStorage.getItem(SIDEBAR_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
 export function InstallerPage({ active }: { active: boolean }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const showStatusBarNotice = useWorkspaceStore(
     (state) => state.showStatusBarNotice,
   );
@@ -48,6 +100,9 @@ export function InstallerPage({ active }: { active: boolean }) {
   const catalog = useInstallerStore((s) => s.catalog);
   const detected = useInstallerStore((s) => s.detected);
   const toolState = useInstallerStore((s) => s.toolState);
+  const inFlight = useInstallerStore((s) => s.inFlight);
+  const lastStatus = useInstallerStore((s) => s.lastStatus);
+  const checkError = useInstallerStore((s) => s.checkError);
   const scanning = useInstallerStore((s) => s.scanning);
   const checking = useInstallerStore((s) => s.checking);
   const setCatalog = useInstallerStore((s) => s.setCatalog);
@@ -59,6 +114,11 @@ export function InstallerPage({ active }: { active: boolean }) {
   const applyProgress = useInstallerStore((s) => s.applyProgress);
   const beginInFlight = useInstallerStore((s) => s.beginInFlight);
   const openStepperDialog = useInstallerStore((s) => s.openStepperDialog);
+
+  const [nav, setNav] = useState<InstallerNav>("all");
+  const [query, setQuery] = useState("");
+  const [viewMode, setViewMode] = useState<ViewMode>(readViewMode);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(readSidebarCollapsed);
 
   const [updateAllConfirm, setUpdateAllConfirm] = useState<null | {
     items: string[];
@@ -187,7 +247,7 @@ export function InstallerPage({ active }: { active: boolean }) {
         return;
       }
       const toolIds = catalog.recipes
-        .filter(recipeSupportsLatestVersion)
+        .filter((recipe) => recipeSupportsLatestVersion(recipe))
         .map((r) => r.id);
       if (toolIds.length === 0) return;
       try {
@@ -217,7 +277,7 @@ export function InstallerPage({ active }: { active: boolean }) {
       const states = await invokeCommand("installer_get_state");
       setToolStates(states);
       const toolIds = catalog.recipes
-        .filter(recipeSupportsLatestVersion)
+        .filter((recipe) => recipeSupportsLatestVersion(recipe))
         .map((r) => r.id);
       if (toolIds.length > 0) {
         await invokeCommand("installer_check_latest_versions", {
@@ -233,10 +293,97 @@ export function InstallerPage({ active }: { active: boolean }) {
     }
   }
 
-  const sections = groupRecipes(catalog?.recipes ?? [], detected, toolState);
-  const updateAllRecipes = sections.updates.filter(
-    (recipe) => !(toolState[recipe.id]?.pinned ?? false),
+  // Catalog recipes, ordered and filtered to the visible Installer Helper set
+  // (section order, then per-section order). One ordered list drives counts,
+  // grouping, and the flat List/Gallery views.
+  const recipesById = useMemo(
+    () => new Map((catalog?.recipes ?? []).map((r) => [r.id, r])),
+    [catalog],
   );
+  const sectionOfId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const section of INSTALLER_CATEGORY_SECTIONS) {
+      for (const id of section.ids) map.set(id, section.id);
+    }
+    return map;
+  }, []);
+  const orderedRecipes = useMemo(
+    () =>
+      INSTALLER_CATEGORY_SECTIONS.flatMap((section) =>
+        section.ids
+          .map((id) => recipesById.get(id))
+          .filter((recipe): recipe is Recipe => !!recipe),
+      ),
+    [recipesById],
+  );
+
+  const statusFor = useMemo(() => {
+    return (recipe: Recipe) =>
+      deriveToolStatus(recipe, {
+        detected: detected[recipe.id],
+        toolState: toolState[recipe.id],
+        operation: inFlight[recipe.id]?.operation ?? null,
+        latestError: checkError[recipe.id],
+        lastFailed: lastStatus[recipe.id]?.kind === "failed",
+        scanning,
+        checking,
+      });
+  }, [detected, toolState, inFlight, lastStatus, checkError, scanning, checking]);
+
+  const counts = useMemo<InstallerCounts>(() => {
+    let installed = 0;
+    let updates = 0;
+    let none = 0;
+    const byCategory: Record<string, number> = {};
+    for (const section of INSTALLER_CATEGORY_SECTIONS) byCategory[section.id] = 0;
+    for (const recipe of orderedRecipes) {
+      const sectionId = sectionOfId.get(recipe.id);
+      if (sectionId) byCategory[sectionId] += 1;
+      const st = statusFor(recipe);
+      if (st.isInstalled) installed += 1;
+      else none += 1;
+      if (st.hasUpdate) updates += 1;
+    }
+    return { all: installed + none, installed, updates, none, byCategory };
+  }, [orderedRecipes, sectionOfId, statusFor]);
+
+  const updateAllRecipes = useMemo(
+    () =>
+      orderedRecipes.filter(
+        (recipe) =>
+          statusFor(recipe).hasUpdate &&
+          !(toolState[recipe.id]?.pinned ?? false),
+      ),
+    [orderedRecipes, statusFor, toolState],
+  );
+
+  const filteredRecipes = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const matches = (recipe: Recipe) =>
+      !q ||
+      recipe.name.toLowerCase().includes(q) ||
+      localizedDescription(recipe, i18n.language).toLowerCase().includes(q);
+    const navMatch = (recipe: Recipe) => {
+      if (nav.startsWith("sec:")) {
+        return sectionOfId.get(recipe.id) === nav.slice(4);
+      }
+      const st = statusFor(recipe);
+      if (nav === "installed") return st.isInstalled;
+      if (nav === "updates") return st.hasUpdate;
+      if (nav === "none") return !st.isInstalled;
+      return true;
+    };
+    return orderedRecipes.filter(
+      (recipe) => matches(recipe) && navMatch(recipe),
+    );
+  }, [orderedRecipes, query, nav, sectionOfId, statusFor, i18n.language]);
+
+  // Section-grouped headers only make sense across the whole catalog with no
+  // search; a status filter or a search reads better as a flat list.
+  const grouped =
+    !query.trim() &&
+    (nav === "all" || nav === "installed" || nav === "none");
+
   const lastCheckedAt = latestTimestamp([
     ...Object.values(detected).map((state) => state.lastCheckedAt ?? null),
     ...Object.values(toolState).map((state) => state.lastCheckAt),
@@ -247,6 +394,8 @@ export function InstallerPage({ active }: { active: boolean }) {
       : t("installer.status.neverChecked"),
   });
   const checkInProgress = scanning || checking;
+
+  const crumb = navCrumb(nav, t);
 
   function openUpdateAllConfirm() {
     if (!catalog || updateAllRecipes.length === 0) return;
@@ -299,67 +448,180 @@ export function InstallerPage({ active }: { active: boolean }) {
     }
   }
 
+  function changeViewMode(next: ViewMode) {
+    setViewMode(next);
+    try {
+      localStorage.setItem(VIEW_MODE_STORAGE_KEY, next);
+    } catch {
+      // Persisting the view preference is best-effort.
+    }
+  }
+
+  function toggleSidebar() {
+    setSidebarCollapsed((collapsed) => {
+      const next = !collapsed;
+      try {
+        localStorage.setItem(SIDEBAR_STORAGE_KEY, String(next));
+      } catch {
+        // Persisting the collapse preference is best-effort.
+      }
+      return next;
+    });
+  }
+
   return (
     <section
       className="installer-page"
       aria-label={t("installer.title")}
       data-active={active ? "true" : "false"}
     >
-      <header className="installer-page__header">
-        <div>
-          <h1>{t("installer.title")}</h1>
-          <p className="installer-page__subtitle">{t("installer.subtitle")}</p>
-        </div>
-        <div className="installer-page__actions">
-          <span
-            className={`installer-page__last-checked ${
-              checkInProgress ? "installer-page__last-checked--busy" : ""
-            }`}
-          >
-            {checkInProgress ? (
-              <>
-                <span className="installer-page__spinner" aria-hidden="true" />
-                {t("installer.checkingForUpdates")}
-              </>
-            ) : (
-              lastCheckedText
-            )}
-          </span>
-          <button
-            type="button"
-            className="installer-button"
-            onClick={() => void handleRefresh()}
-            disabled={scanning || checking || !catalog}
-          >
-            {checkInProgress
-              ? t("installer.checkingDots")
-              : t("installer.refresh")}
-          </button>
-          <button
-            type="button"
-            className="installer-button primary"
-            data-tutorial-id="installer.updateAll"
-            onClick={openUpdateAllConfirm}
-            disabled={scanning || !catalog || updateAllRecipes.length === 0}
-          >
-            {t("installer.updateAll")}
-          </button>
-        </div>
-      </header>
+      <div className="installer-topbar">
+        <span className="installer-topbar__kind">
+          <Box size={17} strokeWidth={1.9} aria-hidden="true" />
+          {t("installer.title")}
+        </span>
+        <span
+          className={`installer-conn-pill${
+            checkInProgress ? " installer-conn-pill--busy" : ""
+          }`}
+        >
+          {checkInProgress ? (
+            <>
+              <span className="installer-page__spinner" aria-hidden="true" />
+              {t("installer.checkingForUpdates")}
+            </>
+          ) : (
+            <>
+              <Clock size={12} strokeWidth={1.9} aria-hidden="true" />
+              {lastCheckedText}
+            </>
+          )}
+        </span>
+      </div>
 
-      {!catalog ? (
-        <div className="installer-empty">{t("installer.empty.loading")}</div>
-      ) : (
-        <div className="installer-page__sections">
-          {sections.categories.map((section) => (
-            <RecipeSection
-              key={section.titleKey}
-              titleKey={section.titleKey}
-              recipes={section.recipes}
-            />
-          ))}
+      <div className="installer-toolbar">
+        <button
+          type="button"
+          className={`installer-icon-btn${sidebarCollapsed ? "" : " active"}`}
+          onClick={toggleSidebar}
+          aria-pressed={!sidebarCollapsed}
+          title={
+            sidebarCollapsed
+              ? t("installer.sidebar.show")
+              : t("installer.sidebar.hide")
+          }
+          aria-label={
+            sidebarCollapsed
+              ? t("installer.sidebar.show")
+              : t("installer.sidebar.hide")
+          }
+        >
+          <PanelLeft size={16} strokeWidth={1.8} />
+        </button>
+        <span className="installer-toolbar__sep" />
+        <span className="installer-crumb" style={crumb.style}>
+          <crumb.Icon size={14} strokeWidth={1.9} aria-hidden="true" />
+          {crumb.label}
+        </span>
+        <span className="installer-toolbar__spacer" />
+        <label className="installer-search">
+          <Search size={14} strokeWidth={1.9} aria-hidden="true" />
+          <input
+            type="text"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={t("installer.search")}
+            spellCheck={false}
+            aria-label={t("installer.search")}
+          />
+        </label>
+        <div className="installer-segmented" role="tablist">
+          <button
+            type="button"
+            className={viewMode === "list" ? "active" : ""}
+            onClick={() => changeViewMode("list")}
+            title={t("installer.view.list")}
+            aria-label={t("installer.view.list")}
+            aria-selected={viewMode === "list"}
+          >
+            <ListIcon size={15} strokeWidth={1.9} />
+          </button>
+          <button
+            type="button"
+            className={viewMode === "gallery" ? "active" : ""}
+            onClick={() => changeViewMode("gallery")}
+            title={t("installer.view.gallery")}
+            aria-label={t("installer.view.gallery")}
+            aria-selected={viewMode === "gallery"}
+          >
+            <LayoutGrid size={15} strokeWidth={1.9} />
+          </button>
         </div>
-      )}
+        <button
+          type="button"
+          className="installer-button"
+          onClick={() => void handleRefresh()}
+          disabled={scanning || checking || !catalog}
+        >
+          <RefreshCw size={14} strokeWidth={1.9} aria-hidden="true" />
+          {checkInProgress
+            ? t("installer.checkingDots")
+            : t("installer.refresh")}
+        </button>
+        <button
+          type="button"
+          className="installer-button primary"
+          data-tutorial-id="installer.updateAll"
+          onClick={openUpdateAllConfirm}
+          disabled={scanning || !catalog || updateAllRecipes.length === 0}
+        >
+          <CircleArrowUp size={14} strokeWidth={2} aria-hidden="true" />
+          {t("installer.updateAll")}
+          {updateAllRecipes.length > 0 ? (
+            <span className="installer-button__count">
+              {updateAllRecipes.length}
+            </span>
+          ) : null}
+        </button>
+      </div>
+
+      <div className="installer-panes">
+        <InstallerSidebar
+          nav={nav}
+          onNavigate={setNav}
+          counts={counts}
+          collapsed={sidebarCollapsed}
+        />
+        <div className="installer-content">
+          {!catalog ? (
+            <div className="installer-empty">{t("installer.empty.loading")}</div>
+          ) : (
+            <InstallerContent
+              recipes={filteredRecipes}
+              grouped={grouped}
+              viewMode={viewMode}
+            />
+          )}
+          <div className="installer-foot">
+            <span>{t("installer.footer.tools", { count: counts.all })}</span>
+            <span className="installer-foot__dot" />
+            <span>
+              {t("installer.footer.installed", { count: counts.installed })}
+            </span>
+            {counts.updates > 0 ? (
+              <>
+                <span className="installer-foot__dot" />
+                <span className="installer-foot__updates">
+                  {t("installer.footer.updates", { count: counts.updates })}
+                </span>
+              </>
+            ) : null}
+            <span className="installer-foot__spacer" />
+            <span>{lastCheckedText}</span>
+          </div>
+        </div>
+      </div>
+
       <InstallerToolDialog />
       {updateAllConfirm ? (
         <InstallerConfirmDialog
@@ -384,117 +646,182 @@ export function InstallerPage({ active }: { active: boolean }) {
   );
 }
 
-function RecipeSection({
-  titleKey,
+function InstallerContent({
   recipes,
+  grouped,
+  viewMode,
 }: {
-  titleKey: string;
   recipes: Recipe[];
+  grouped: boolean;
+  viewMode: ViewMode;
 }) {
   const { t } = useTranslation();
-  if (recipes.length === 0) return null;
-  return (
-    <section className="installer-section">
-      <h2 className="installer-section__title">{t(titleKey)}</h2>
-      <div className="installer-section__grid">
-        {recipes.map((recipe) => (
-          <ToolRow key={recipe.id} recipe={recipe} />
-        ))}
+
+  if (recipes.length === 0) {
+    return (
+      <div className="installer-content__scroll">
+        <div className="installer-empty installer-empty--inline">
+          <Layers size={34} strokeWidth={1.5} aria-hidden="true" />
+          <span>{t("installer.empty.noMatches")}</span>
+        </div>
       </div>
-    </section>
+    );
+  }
+
+  if (!grouped) {
+    return (
+      <div className="installer-content__scroll">
+        {viewMode === "list" ? (
+          <ListView recipes={recipes} />
+        ) : (
+          <div className="installer-grid">
+            {recipes.map((recipe) => (
+              <ToolRow key={recipe.id} recipe={recipe} />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  const recipeIds = new Set(recipes.map((recipe) => recipe.id));
+  const groups = INSTALLER_CATEGORY_SECTIONS.map((section) => ({
+    section,
+    recipes: section.ids
+      .map((id) => recipes.find((recipe) => recipe.id === id))
+      .filter((recipe): recipe is Recipe => !!recipe && recipeIds.has(recipe.id)),
+  })).filter((group) => group.recipes.length > 0);
+
+  return (
+    <div className="installer-content__scroll">
+      {viewMode === "list" ? (
+        <ListView grouped groups={groups} />
+      ) : (
+        groups.map(({ section, recipes: sectionRecipes }) => (
+          <section className="installer-group" key={section.id}>
+            <h2
+              className="installer-group__title"
+              style={{ "--tint": `var(${section.tintVar})` } as CSSProperties}
+            >
+              <span className="installer-group__glyph">
+                <section.Icon size={14} strokeWidth={1.9} aria-hidden="true" />
+              </span>
+              {t(section.titleKey)}
+              <span className="installer-group__count">
+                {sectionRecipes.length}
+              </span>
+            </h2>
+            <div className="installer-grid">
+              {sectionRecipes.map((recipe) => (
+                <ToolRow key={recipe.id} recipe={recipe} />
+              ))}
+            </div>
+          </section>
+        ))
+      )}
+    </div>
   );
 }
 
-interface GroupedRecipes {
-  updates: Recipe[];
-  categories: Array<{ titleKey: string; recipes: Recipe[] }>;
+function ListView({
+  recipes,
+  grouped,
+  groups,
+}: {
+  recipes?: Recipe[];
+  grouped?: boolean;
+  groups?: Array<{
+    section: (typeof INSTALLER_CATEGORY_SECTIONS)[number];
+    recipes: Recipe[];
+  }>;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="installer-list">
+      <div className="installer-listhead">
+        <span>{t("installer.listColumn.name")}</span>
+        <span>{t("installer.section.installed")}</span>
+        <span>{t("installer.options.versionLatest")}</span>
+        <span>{t("installer.listColumn.status")}</span>
+        <span className="installer-listhead__action">
+          {t("installer.listColumn.action")}
+        </span>
+      </div>
+      {grouped && groups
+        ? groups.map(({ section, recipes: sectionRecipes }) => (
+            <div className="installer-list__group" key={section.id}>
+              <div
+                className="installer-list__grouphead"
+                style={
+                  { "--tint": `var(${section.tintVar})` } as CSSProperties
+                }
+              >
+                <span className="installer-group__glyph">
+                  <section.Icon
+                    size={13}
+                    strokeWidth={1.9}
+                    aria-hidden="true"
+                  />
+                </span>
+                {t(section.titleKey)}
+                <span className="installer-group__count">
+                  {sectionRecipes.length}
+                </span>
+              </div>
+              {sectionRecipes.map((recipe) => (
+                <InstallerListRow key={recipe.id} recipe={recipe} />
+              ))}
+            </div>
+          ))
+        : (recipes ?? []).map((recipe) => (
+            <InstallerListRow key={recipe.id} recipe={recipe} />
+          ))}
+    </div>
+  );
 }
 
-// Visibility allow-list for the Installer Helper. The UI renders by these
-// explicit per-section id lists, NOT by the catalog's `category` field, so a
-// recipe added to installer/catalog.v1.json stays invisible until its id is
-// listed here (groupRecipes filters on the union of these ids). See
-// docs/ADR/0008 "Adding a recipe (developer checklist)".
-const INSTALLER_CATEGORY_SECTIONS: Array<{
-  titleKey: string;
-  ids: string[];
-}> = [
-  {
-    titleKey: "installer.section.essentials",
-    ids: ["winget", "node-bundle", "python-bundle", "git"],
-  },
-  {
-    titleKey: "installer.section.aiAgents",
-    ids: [
-      "claude-code-cli",
-      "codex-cli",
-      "antigravity-cli",
-      "opencode",
-      "openclaw",
-      "codex-desktop",
-      "claude-desktop",
-      "hermes-agent",
-    ],
-  },
-  {
-    titleKey: "installer.section.aiPlatforms",
-    ids: ["ollama", "n8n", "open-webui", "flowise", "langflow"],
-  },
-  {
-    titleKey: "installer.section.development",
-    ids: [
-      "vscode",
-      "cursor",
-      "docker-desktop",
-      "bruno",
-      "wsl",
-      "rustup",
-    ],
-  },
-  {
-    titleKey: "installer.section.windowsPowerUser",
-    ids: ["powershell-7", "powertoys", "sysinternals-suite", "everything", "ditto"],
-  },
-  {
-    titleKey: "installer.section.remoteAccess",
-    ids: ["tailscale", "rustdesk"],
-  },
-  {
-    titleKey: "installer.section.utilities",
-    ids: ["notepadpp", "nssm", "vcxsrv", "ripgrep", "jq", "fzf", "coreutils", "7zip", "sharex", "ffmpeg", "excalidraw", "bentopdf"],
-  },
-];
-
-function groupRecipes(
-  recipes: Recipe[],
-  detected: Record<string, DetectedState>,
-  toolState: Record<string, ToolState>,
-): GroupedRecipes {
-  const updates: Recipe[] = [];
-  const visibleIds = new Set(
-    INSTALLER_CATEGORY_SECTIONS.flatMap((section) => section.ids),
-  );
-  for (const recipe of recipes) {
-    if (!visibleIds.has(recipe.id)) continue;
-    const det = detected[recipe.id];
-    if (!det) {
-      continue;
-    }
-    if (det.installed && recipeSupportsLatestVersion(recipe)) {
-      const latest = toolState[recipe.id]?.latestVersionSeen;
-      if (isInstallerUpdateAvailable(latest, det.installedVersion)) {
-        updates.push(recipe);
-      }
+function navCrumb(
+  nav: InstallerNav,
+  t: (key: string) => string,
+): { Icon: LucideIcon; label: string; style: CSSProperties } {
+  if (nav.startsWith("sec:")) {
+    const section = INSTALLER_CATEGORY_SECTIONS.find(
+      (s) => s.id === nav.slice(4),
+    );
+    if (section) {
+      return {
+        Icon: section.Icon,
+        label: t(section.titleKey),
+        style: { "--tint": `var(${section.tintVar})` } as CSSProperties,
+      };
     }
   }
-  const byId = new Map(recipes.map((recipe) => [recipe.id, recipe]));
-  const categories = INSTALLER_CATEGORY_SECTIONS.map((section) => ({
-    titleKey: section.titleKey,
-    recipes: section.ids
-      .map((id) => byId.get(id))
-      .filter((recipe): recipe is Recipe => !!recipe),
-  })).filter((section) => section.recipes.length > 0);
-  return { updates, categories };
+  if (nav === "installed") {
+    return {
+      Icon: CircleCheck,
+      label: t("installer.section.installed"),
+      style: { "--tint": "var(--green)" } as CSSProperties,
+    };
+  }
+  if (nav === "updates") {
+    return {
+      Icon: CircleArrowUp,
+      label: t("installer.sidebar.updates"),
+      style: { "--tint": "var(--accent)" } as CSSProperties,
+    };
+  }
+  if (nav === "none") {
+    return {
+      Icon: CircleDashed,
+      label: t("installer.status.notInstalled"),
+      style: { "--tint": "var(--text-faint)" } as CSSProperties,
+    };
+  }
+  return {
+    Icon: Layers,
+    label: t("installer.sidebar.allTools"),
+    style: { "--tint": "var(--accent)" } as CSSProperties,
+  };
 }
 
 function latestTimestamp(

--- a/src/modules/installer/InstallerSidebar.tsx
+++ b/src/modules/installer/InstallerSidebar.tsx
@@ -1,0 +1,148 @@
+// Installer Helper category rail — the Finder/SFTP-style left navigation.
+// STATUS filters (All / Installed / Updates / Not Installed) over the catalog,
+// then CATEGORIES (the visibility sections from sections.ts) with live counts.
+// Selecting a row drives the InstallerPage `nav` filter; counts are computed
+// once by the page and passed down so the rail and content always agree.
+
+import {
+  CircleArrowUp,
+  CircleCheck,
+  CircleDashed,
+  Layers,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { CSSProperties } from "react";
+import { useTranslation } from "react-i18next";
+import { INSTALLER_CATEGORY_SECTIONS } from "./sections";
+
+export type InstallerNav =
+  | "all"
+  | "installed"
+  | "updates"
+  | "none"
+  | `sec:${string}`;
+
+export interface InstallerCounts {
+  all: number;
+  installed: number;
+  updates: number;
+  none: number;
+  byCategory: Record<string, number>;
+}
+
+function SbRow({
+  Icon,
+  tint,
+  label,
+  count,
+  active,
+  dot,
+  onClick,
+}: {
+  Icon: LucideIcon;
+  tint: string;
+  label: string;
+  count: number;
+  active: boolean;
+  dot?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`installer-sb-row${active ? " active" : ""}`}
+      style={{ "--tint": tint } as CSSProperties}
+      onClick={onClick}
+      title={label}
+      aria-pressed={active}
+    >
+      <span className="installer-sb-row__ico">
+        <Icon size={17} strokeWidth={1.9} aria-hidden="true" />
+      </span>
+      <span className="installer-sb-row__nm">{label}</span>
+      {dot ? <span className="installer-sb-row__dot" aria-hidden="true" /> : null}
+      <span className="installer-sb-row__count">{count}</span>
+    </button>
+  );
+}
+
+export function InstallerSidebar({
+  nav,
+  onNavigate,
+  counts,
+  collapsed,
+}: {
+  nav: InstallerNav;
+  onNavigate: (nav: InstallerNav) => void;
+  counts: InstallerCounts;
+  collapsed: boolean;
+}) {
+  const { t } = useTranslation();
+  return (
+    <nav
+      className={`installer-rail${collapsed ? " collapsed" : ""}`}
+      aria-hidden={collapsed}
+      aria-label={t("installer.sidebar.categories")}
+    >
+      <div className="installer-rail__section">
+        <div className="installer-rail__head">
+          {t("installer.sidebar.status")}
+        </div>
+        <div className="installer-rail__list">
+          <SbRow
+            Icon={Layers}
+            tint="var(--accent)"
+            label={t("installer.sidebar.allTools")}
+            count={counts.all}
+            active={nav === "all"}
+            onClick={() => onNavigate("all")}
+          />
+          <SbRow
+            Icon={CircleCheck}
+            tint="var(--green)"
+            label={t("installer.section.installed")}
+            count={counts.installed}
+            active={nav === "installed"}
+            onClick={() => onNavigate("installed")}
+          />
+          <SbRow
+            Icon={CircleArrowUp}
+            tint="var(--accent)"
+            label={t("installer.sidebar.updates")}
+            count={counts.updates}
+            dot={counts.updates > 0}
+            active={nav === "updates"}
+            onClick={() => onNavigate("updates")}
+          />
+          <SbRow
+            Icon={CircleDashed}
+            tint="var(--text-faint)"
+            label={t("installer.status.notInstalled")}
+            count={counts.none}
+            active={nav === "none"}
+            onClick={() => onNavigate("none")}
+          />
+        </div>
+      </div>
+
+      <div className="installer-rail__section">
+        <div className="installer-rail__head">
+          {t("installer.sidebar.categories")}
+        </div>
+        <div className="installer-rail__list">
+          {INSTALLER_CATEGORY_SECTIONS.map((section) => (
+            <SbRow
+              key={section.id}
+              Icon={section.Icon}
+              tint={`var(${section.tintVar})`}
+              label={t(section.titleKey)}
+              count={counts.byCategory[section.id] ?? 0}
+              active={nav === `sec:${section.id}`}
+              onClick={() => onNavigate(`sec:${section.id}`)}
+            />
+          ))}
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/modules/installer/ToolRow.tsx
+++ b/src/modules/installer/ToolRow.tsx
@@ -9,55 +9,30 @@ import type { MouseEvent } from "react";
 import { isTauriRuntime, openExternalUrl } from "../../lib/tauri";
 import { iconUrlForRecipe, FALLBACK_ICON_URL } from "./icons";
 import { useInstallerStore } from "./state";
-import {
-  latestVersionWebUrlForRecipe,
-  recipeSupportsLatestVersion,
-} from "./latestSupport";
+import { latestVersionWebUrlForRecipe } from "./latestSupport";
+import { useToolStatus } from "./useToolStatus";
 import type { Recipe } from "./types";
-import { isInstallerUpdateAvailable } from "./versionCompare";
 
 export function ToolRow({ recipe }: { recipe: Recipe }) {
   const { t } = useTranslation();
-  const detected = useInstallerStore((s) => s.detected[recipe.id]);
-  const toolState = useInstallerStore((s) => s.toolState[recipe.id]);
-  const inFlight = useInstallerStore((s) => s.inFlight[recipe.id]);
-  const lastStatus = useInstallerStore((s) => s.lastStatus[recipe.id]);
-  const latestError = useInstallerStore((s) => s.checkError[recipe.id]);
-  const scanning = useInstallerStore((s) => s.scanning);
-  const checking = useInstallerStore((s) => s.checking);
   const openInfoDialog = useInstallerStore((s) => s.openInfoDialog);
   const openStepperDialog = useInstallerStore((s) => s.openStepperDialog);
 
-  const isInstalled = detected?.installed ?? false;
-  const installedVersion = detected?.installedVersion;
-  const partial = detected?.partialCount;
-  const latestSeen = toolState?.latestVersionSeen;
-  const supportsLatestVersion = recipeSupportsLatestVersion(recipe);
+  const {
+    isInstalled,
+    installedVersion,
+    partial,
+    latestSeen,
+    latestError,
+    runtimeVersion,
+    supportsLatestVersion,
+    hasUpdate,
+    busy,
+    operation,
+    retrieving,
+    statusTone,
+  } = useToolStatus(recipe);
   const latestWebUrl = latestVersionWebUrlForRecipe(recipe);
-  const hasUpdate =
-    supportsLatestVersion &&
-    isInstalled &&
-    isInstallerUpdateAvailable(latestSeen, installedVersion);
-  const busy = !!inFlight;
-  const retrieving = !busy && (scanning || checking);
-
-  const statusTone:
-    | "installed"
-    | "update"
-    | "busy"
-    | "failed"
-    | "partial"
-    | "none" = busy
-    ? "busy"
-    : lastStatus?.kind === "failed"
-      ? "failed"
-      : hasUpdate
-        ? "update"
-        : isInstalled
-          ? "installed"
-          : partial
-            ? "partial"
-            : "none";
 
   function handleOpen() {
     // While an install/uninstall is in flight (or its terminal state is the
@@ -105,7 +80,7 @@ export function ToolRow({ recipe }: { recipe: Recipe }) {
         : null;
   const runtimeVersionText = retrieving
     ? t("installer.status.retrieving")
-    : detected?.runtimeVersion ?? t("installer.status.noVersion");
+    : runtimeVersion ?? t("installer.status.noVersion");
 
   return (
     <article
@@ -149,7 +124,7 @@ export function ToolRow({ recipe }: { recipe: Recipe }) {
           </span>
           {busy ? (
             <span className="installer-tile__sub">
-              {inFlight.operation === "install"
+              {operation === "install"
                 ? t("installer.status.installing")
                 : t("installer.status.uninstalling")}
             </span>

--- a/src/modules/installer/installer.css
+++ b/src/modules/installer/installer.css
@@ -5,12 +5,10 @@
   z-index: 75;
   display: flex;
   flex-direction: column;
-  gap: 1.1rem;
-  padding: 1.35rem 1.75rem 1.75rem;
-  overflow-y: auto;
   height: 100%;
   min-height: 0;
   min-width: 0;
+  overflow: hidden;
   background: var(--app-bg);
   color: var(--text);
 }
@@ -72,6 +70,10 @@
 }
 
 .installer-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  white-space: nowrap;
   padding: 0.4rem 0.85rem;
   border-radius: 6px;
   border: 1px solid var(--border);
@@ -79,6 +81,21 @@
   color: inherit;
   font-size: 0.875rem;
   cursor: pointer;
+}
+
+.installer-button__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 17px;
+  height: 17px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.26);
+  font-size: 0.7rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  margin-left: 0.1rem;
 }
 
 .installer-button:hover:not(:disabled) {
@@ -300,12 +317,12 @@
 }
 
 @media (max-width: 980px) {
-  .installer-page {
-    padding: 1rem;
+  .installer-content__scroll {
+    padding: 12px;
   }
 
-  .installer-page__sections {
-    columns: 1;
+  .installer-rail {
+    width: 188px;
   }
 }
 
@@ -733,4 +750,578 @@
 
 .installer-confirm-footer {
   margin-top: 0.5rem;
+}
+
+/* ======================================================================
+   House-style shell — SFTP/Finder-flavoured top bar + toolbar + rail +
+   List/Gallery content + footer. Mirrors the file-browser pattern in
+   src/modules/workspace/connections/sftp; reads only design tokens.
+   ====================================================================== */
+
+/* ---- top bar (no macOS chrome; kind glyph + title + status pill) ---- */
+.installer-topbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 38px;
+  padding: 0 12px 0 14px;
+  background: var(--chrome);
+  border-bottom: 1px solid var(--hairline);
+}
+
+.installer-topbar__kind {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.installer-topbar__kind svg {
+  color: var(--accent);
+}
+
+.installer-conn-pill {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.installer-conn-pill svg {
+  color: var(--text-faint);
+}
+
+/* ---- toolbar ---- */
+.installer-toolbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 46px;
+  padding: 0 12px;
+  background: var(--chrome);
+  border-bottom: 1px solid var(--hairline);
+}
+
+.installer-toolbar__sep {
+  width: 1px;
+  height: 22px;
+  background: var(--border);
+  margin: 0 2px;
+}
+
+.installer-toolbar__spacer {
+  flex: 1 1 auto;
+}
+
+.installer-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  background: transparent;
+  border: 0;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+
+.installer-icon-btn:hover {
+  background: var(--hover);
+  color: var(--text);
+}
+
+.installer-icon-btn.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.installer-crumb {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 24px;
+  padding: 0 8px;
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+.installer-crumb svg {
+  color: var(--tint, var(--accent));
+}
+
+.installer-search {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 10px;
+  min-width: 168px;
+  border-radius: 8px;
+  background: var(--surface-muted);
+  color: var(--text-faint);
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.installer-search svg {
+  flex: 0 0 auto;
+}
+
+.installer-search input {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  outline: none;
+  color: var(--text);
+  font: inherit;
+}
+
+.installer-search input::placeholder {
+  color: var(--text-faint);
+}
+
+.installer-segmented {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 8px;
+  background: var(--chrome-strong);
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.installer-segmented button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 24px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+
+.installer-segmented button:hover {
+  color: var(--text);
+}
+
+.installer-segmented button.active {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+}
+
+/* ---- body: rail | content ---- */
+.installer-panes {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+}
+
+.installer-rail {
+  flex: 0 0 auto;
+  width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 12px 10px;
+  overflow-y: auto;
+  background: var(--surface-muted);
+  border-right: 1px solid var(--hairline);
+}
+
+.installer-rail.collapsed {
+  display: none;
+}
+
+.installer-rail__section {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.installer-rail__head {
+  padding: 0 8px 4px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.installer-rail__list {
+  display: grid;
+  gap: 1px;
+}
+
+.installer-sb-row {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  height: 30px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.installer-sb-row:hover {
+  background: var(--hover);
+}
+
+.installer-sb-row.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.installer-sb-row__ico {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: var(--tint, var(--accent));
+}
+
+.installer-sb-row.active .installer-sb-row__ico {
+  color: #fff;
+}
+
+.installer-sb-row__nm {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+.installer-sb-row__count {
+  flex: 0 0 auto;
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+.installer-sb-row.active .installer-sb-row__count {
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.installer-sb-row__dot {
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-left: auto;
+}
+
+.installer-sb-row__dot + .installer-sb-row__count {
+  margin-left: 7px;
+}
+
+.installer-sb-row.active .installer-sb-row__dot {
+  background: #fff;
+}
+
+.installer-content {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--app-bg);
+}
+
+.installer-content__scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 14px 16px 18px;
+}
+
+.installer-empty--inline {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 48px 16px;
+  color: var(--text-faint);
+}
+
+/* ---- gallery grid + group headers ---- */
+.installer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 0.7rem;
+  align-items: stretch;
+}
+
+.installer-group {
+  margin-bottom: 18px;
+}
+
+.installer-group__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 10px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.installer-group__glyph {
+  display: inline-flex;
+  color: var(--tint, var(--accent));
+}
+
+.installer-group__count {
+  color: var(--text-faint);
+  font-weight: 600;
+  font-size: 12px;
+}
+
+/* ---- list view ---- */
+.installer-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.installer-listhead {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 116px 116px 120px 92px;
+  gap: 10px;
+  align-items: center;
+  padding: 0 10px 8px;
+  background: var(--app-bg);
+  color: var(--text-faint);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.installer-listhead__action {
+  text-align: right;
+}
+
+.installer-list__grouphead {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 10px 0 4px;
+  padding: 0 10px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.installer-listrow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 116px 116px 120px 92px;
+  gap: 10px;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.installer-listrow:hover {
+  background: var(--hover);
+}
+
+.installer-listrow:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.installer-listrow__name {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.installer-listrow__icon {
+  width: 26px;
+  height: 26px;
+  object-fit: contain;
+  flex: 0 0 auto;
+}
+
+.installer-listrow__text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.installer-listrow__text b {
+  font-size: 13px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.installer-listrow__text span {
+  font-size: 11.5px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.installer-listrow__ver {
+  font-size: 12px;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.installer-listrow__ver--muted {
+  color: var(--text-muted);
+}
+
+.installer-listrow__ver--update {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.installer-listrow__ver--error {
+  color: var(--red);
+  font-weight: 600;
+}
+
+.installer-listrow__status {
+  min-width: 0;
+}
+
+.installer-listrow__action {
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* ---- shared status pill + compact action button ---- */
+.installer-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 21px;
+  padding: 0 9px;
+  border-radius: 999px;
+  background: var(--surface-muted);
+  color: var(--text-muted);
+  font-size: 11.5px;
+  font-weight: 600;
+  white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.installer-pill[data-tone="installed"] {
+  background: var(--green-soft);
+  color: var(--green);
+}
+
+.installer-pill[data-tone="update"] {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.installer-pill[data-tone="failed"] {
+  background: color-mix(in srgb, var(--red) 14%, transparent);
+  color: var(--red);
+}
+
+.installer-pill[data-tone="busy"],
+.installer-pill[data-tone="partial"] {
+  background: color-mix(in srgb, var(--amber) 16%, transparent);
+  color: var(--amber);
+}
+
+.installer-act {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 26px;
+  padding: 0 10px;
+  border-radius: 7px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.installer-act:hover {
+  background: var(--surface-muted);
+}
+
+.installer-act.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.installer-act:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ---- footer status line ---- */
+.installer-foot {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 30px;
+  padding: 0 16px;
+  background: var(--chrome);
+  border-top: 1px solid var(--hairline);
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.installer-foot__dot {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--text-faint);
+}
+
+.installer-foot__updates {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.installer-foot__spacer {
+  flex: 1 1 auto;
 }

--- a/src/modules/installer/sections.ts
+++ b/src/modules/installer/sections.ts
@@ -1,0 +1,106 @@
+// Visibility + presentation metadata for the Installer Helper category sidebar.
+//
+// The UI renders by these explicit per-section id lists, NOT by the catalog's
+// `category` field, so a recipe added to installer/catalog.v1.json stays
+// invisible until its id is listed here. See docs/ADR/0008 "Adding a recipe
+// (developer checklist)".
+//
+// Each section also carries a lucide glyph and a CSS tint variable (defined in
+// src/styles/colorSchemes.css) so the rail rows match the house-style mockup.
+
+import { Bot, Box, Code2, Cpu, Globe, Wrench, Zap } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+export interface InstallerSection {
+  /// Stable id; also the `sec:<id>` sidebar filter value.
+  id: string;
+  /// i18n key for the section / filter label.
+  titleKey: string;
+  /// Catalog recipe ids in this section, in display order.
+  ids: string[];
+  Icon: LucideIcon;
+  /// CSS custom property holding the section tint.
+  tintVar: string;
+}
+
+// NOTE: within each section, `ids` is declared immediately after `titleKey`.
+// Source-grep guards in tests/ assert `titleKey: "installer.section.X", ids:
+// [...]` adjacency, so keep these two fields together when editing.
+export const INSTALLER_CATEGORY_SECTIONS: InstallerSection[] = [
+  {
+    id: "essentials",
+    titleKey: "installer.section.essentials",
+    ids: ["winget", "node-bundle", "python-bundle", "git"],
+    Icon: Box,
+    tintVar: "--installer-tint-essentials",
+  },
+  {
+    id: "aiAgents",
+    titleKey: "installer.section.aiAgents",
+    ids: [
+      "claude-code-cli",
+      "codex-cli",
+      "antigravity-cli",
+      "opencode",
+      "openclaw",
+      "codex-desktop",
+      "claude-desktop",
+      "hermes-agent",
+    ],
+    Icon: Bot,
+    tintVar: "--installer-tint-ai-agents",
+  },
+  {
+    id: "aiPlatforms",
+    titleKey: "installer.section.aiPlatforms",
+    ids: ["ollama", "n8n", "open-webui", "flowise", "langflow"],
+    Icon: Cpu,
+    tintVar: "--installer-tint-ai-platforms",
+  },
+  {
+    id: "development",
+    titleKey: "installer.section.development",
+    ids: ["vscode", "cursor", "docker-desktop", "bruno", "wsl", "rustup"],
+    Icon: Code2,
+    tintVar: "--installer-tint-development",
+  },
+  {
+    id: "windowsPowerUser",
+    titleKey: "installer.section.windowsPowerUser",
+    ids: ["powershell-7", "powertoys", "sysinternals-suite", "everything", "ditto"],
+    Icon: Zap,
+    tintVar: "--installer-tint-power",
+  },
+  {
+    id: "remoteAccess",
+    titleKey: "installer.section.remoteAccess",
+    ids: ["tailscale", "rustdesk"],
+    Icon: Globe,
+    tintVar: "--installer-tint-remote",
+  },
+  {
+    id: "utilities",
+    titleKey: "installer.section.utilities",
+    ids: [
+      "notepadpp",
+      "nssm",
+      "vcxsrv",
+      "ripgrep",
+      "jq",
+      "fzf",
+      "coreutils",
+      "7zip",
+      "sharex",
+      "ffmpeg",
+      "excalidraw",
+      "bentopdf",
+    ],
+    Icon: Wrench,
+    tintVar: "--installer-tint-utilities",
+  },
+];
+
+/// All recipe ids visible in the Installer Helper, across every section.
+export const INSTALLER_VISIBLE_IDS = new Set(
+  INSTALLER_CATEGORY_SECTIONS.flatMap((section) => section.ids),
+);

--- a/src/modules/installer/useToolStatus.ts
+++ b/src/modules/installer/useToolStatus.ts
@@ -1,0 +1,110 @@
+// Shared status / version derivation for one Installer Helper tool. Extracted
+// from ToolRow so the Gallery tile, the List row, and the sidebar rail counts
+// all agree on a single source of truth.
+//
+// `deriveToolStatus` is a pure function over store slices so callers that need
+// the status of *many* recipes at once (the sidebar counts) can compute it in a
+// loop without violating the rules of hooks. `useToolStatus` is the per-recipe
+// hook that reads the store and forwards to it.
+
+import { useInstallerStore } from "./state";
+import { recipeSupportsLatestVersion } from "./latestSupport";
+import { isInstallerUpdateAvailable } from "./versionCompare";
+import type { DetectedState, Recipe, ToolState } from "./types";
+
+export type StatusTone =
+  | "installed"
+  | "update"
+  | "busy"
+  | "failed"
+  | "partial"
+  | "none";
+
+export interface ToolStatus {
+  isInstalled: boolean;
+  installedVersion: string | null | undefined;
+  partial: [number, number] | null | undefined;
+  latestSeen: string | null | undefined;
+  latestError: string | null | undefined;
+  runtimeVersion: string | null | undefined;
+  supportsLatestVersion: boolean;
+  hasUpdate: boolean;
+  busy: boolean;
+  operation: "install" | "uninstall" | null;
+  retrieving: boolean;
+  statusTone: StatusTone;
+}
+
+export interface ToolStatusInputs {
+  detected?: DetectedState;
+  toolState?: ToolState;
+  operation: "install" | "uninstall" | null;
+  latestError: string | null | undefined;
+  lastFailed: boolean;
+  scanning: boolean;
+  checking: boolean;
+}
+
+export function deriveToolStatus(
+  recipe: Recipe,
+  inputs: ToolStatusInputs,
+): ToolStatus {
+  const isInstalled = inputs.detected?.installed ?? false;
+  const installedVersion = inputs.detected?.installedVersion;
+  const partial = inputs.detected?.partialCount;
+  const latestSeen = inputs.toolState?.latestVersionSeen;
+  const supportsLatestVersion = recipeSupportsLatestVersion(recipe);
+  const hasUpdate =
+    supportsLatestVersion &&
+    isInstalled &&
+    isInstallerUpdateAvailable(latestSeen, installedVersion);
+  const busy = inputs.operation !== null;
+  const retrieving = !busy && (inputs.scanning || inputs.checking);
+
+  const statusTone: StatusTone = busy
+    ? "busy"
+    : inputs.lastFailed
+      ? "failed"
+      : hasUpdate
+        ? "update"
+        : isInstalled
+          ? "installed"
+          : partial
+            ? "partial"
+            : "none";
+
+  return {
+    isInstalled,
+    installedVersion,
+    partial,
+    latestSeen,
+    latestError: inputs.latestError,
+    runtimeVersion: inputs.detected?.runtimeVersion,
+    supportsLatestVersion,
+    hasUpdate,
+    busy,
+    operation: inputs.operation,
+    retrieving,
+    statusTone,
+  };
+}
+
+export function useToolStatus(recipe: Recipe): ToolStatus {
+  const detected = useInstallerStore((s) => s.detected[recipe.id]);
+  const toolState = useInstallerStore((s) => s.toolState[recipe.id]);
+  const inFlight = useInstallerStore((s) => s.inFlight[recipe.id]);
+  const lastStatus = useInstallerStore((s) => s.lastStatus[recipe.id]);
+  const latestError = useInstallerStore((s) => s.checkError[recipe.id]);
+  const scanning = useInstallerStore((s) => s.scanning);
+  const checking = useInstallerStore((s) => s.checking);
+
+  return deriveToolStatus(recipe, {
+    detected,
+    toolState,
+    operation: inFlight?.operation ?? null,
+    latestError,
+    lastFailed: lastStatus?.kind === "failed",
+    scanning,
+    checking,
+  });
+}

--- a/src/styles/colorSchemes.css
+++ b/src/styles/colorSchemes.css
@@ -38,6 +38,15 @@
   --border-strong: #c5c5cb;
   --accent: #0a84ff;
   --accent-soft: #e6f0ff;
+  /* Installer Helper category-rail tints (scheme-independent; defined once
+     here and inherited by every color scheme). */
+  --installer-tint-essentials: #0a84ff;
+  --installer-tint-ai-agents: #5e5ce6;
+  --installer-tint-ai-platforms: #af52de;
+  --installer-tint-development: #30c48d;
+  --installer-tint-power: #ff9f0a;
+  --installer-tint-remote: #30b0c7;
+  --installer-tint-utilities: #8e8e93;
   --green-soft: #ecfdf5;
   --amber-soft: #fff8e7;
   --green: #34c759;

--- a/tests/installer-managed-service-catalog.test.mjs
+++ b/tests/installer-managed-service-catalog.test.mjs
@@ -17,7 +17,7 @@ test("NSSM is a Utilities tool for managed Windows service helpers", () => {
 
 test("NSSM is visible in the Installer Helper Utilities section", async () => {
   const source = await readFile(
-    new URL("../src/modules/installer/InstallerPage.tsx", import.meta.url),
+    new URL("../src/modules/installer/sections.ts", import.meta.url),
     "utf8",
   );
 
@@ -38,7 +38,7 @@ test("VcXsrv is a Utilities tool for SSH X11 forwarding", () => {
 
 test("VcXsrv is visible in the Installer Helper Utilities section", async () => {
   const source = await readFile(
-    new URL("../src/modules/installer/InstallerPage.tsx", import.meta.url),
+    new URL("../src/modules/installer/sections.ts", import.meta.url),
     "utf8",
   );
 
@@ -65,7 +65,7 @@ test("Coreutils is a Utilities tool with winget and download providers", () => {
 
 test("Coreutils is visible in the Installer Helper Utilities section", async () => {
   const source = await readFile(
-    new URL("../src/modules/installer/InstallerPage.tsx", import.meta.url),
+    new URL("../src/modules/installer/sections.ts", import.meta.url),
     "utf8",
   );
 
@@ -78,7 +78,7 @@ test("Coreutils is visible in the Installer Helper Utilities section", async () 
 
 test("FFmpeg is visible in the Installer Helper Utilities section", async () => {
   const source = await readFile(
-    new URL("../src/modules/installer/InstallerPage.tsx", import.meta.url),
+    new URL("../src/modules/installer/sections.ts", import.meta.url),
     "utf8",
   );
 
@@ -107,7 +107,7 @@ test("BentoPDF is a Utilities managed web app with service support", () => {
 
 test("BentoPDF is visible in the Installer Helper Utilities section", async () => {
   const source = await readFile(
-    new URL("../src/modules/installer/InstallerPage.tsx", import.meta.url),
+    new URL("../src/modules/installer/sections.ts", import.meta.url),
     "utf8",
   );
 

--- a/tests/x-server-status-bar.test.mjs
+++ b/tests/x-server-status-bar.test.mjs
@@ -30,7 +30,7 @@ test("X server status indicator is settings-derived and renders before Don't Sle
 
 test("VcXsrv is listed as an Installer Helper utility", async () => {
   const installerSource = await readFile(
-    new URL("../src/modules/installer/InstallerPage.tsx", import.meta.url),
+    new URL("../src/modules/installer/sections.ts", import.meta.url),
     "utf8",
   );
   const manualSource = await readFile(new URL("../docs/manual/18-installer.md", import.meta.url), "utf8");


### PR DESCRIPTION
## What

Ports the Installer Helper house-style mockup into the real app. The Module now uses the Finder/SFTP file-browser shell, and the title row matches the **in-app SFTP browser bar** (kind glyph + "Installer Helper" + a status pill) rather than the mockup's macOS traffic lights.

- **Top bar** — Box glyph + "Installer Helper" + a Checked…/Checking pill (mirrors `sftp-toolbar` / `sftp-conn-pill`), no window chrome.
- **Toolbar** — sidebar toggle · current-filter crumb · search · List/Gallery switch · Refresh · Update All (count chip; `data-tutorial-id="installer.updateAll"` preserved).
- **Category rail** — STATUS filters (All / Installed / Updates [dot] / Not Installed) + the 7 CATEGORIES with lucide glyphs, per-category tints, and live counts. Collapsible, persisted in `localStorage`.
- **Content** — existing Gallery tiles **and** a new List view; grouped by section for All/Installed/Not-Installed, flat for filters/search, with an empty state.
- **Footer** — `{n} tools · {installed} installed · {updates} updates available · Checked …`.
- The per-tool detail surface stays the existing `InstallerToolDialog` (info + stepper).

## How

- New `useToolStatus.ts` centralises status/version derivation (consumed by the Gallery tile, the new `InstallerListRow`, and the rail counts).
- Section visibility/id lists moved to `sections.ts` with lucide glyphs + per-category tint vars; the source-grep guards were repointed there (path-only).
- 7 category tint tokens added to `colorSchemes.css` `:root` (inherited by every scheme — no hard-coded hex in components).
- `installer.*` i18n keys added (search, view, sidebar, listColumn, footer, empty.noMatches) with one `docs/localization_todo/` pending file each (en-only; i18next falls back to English).
- No backend / catalog / detection changes — presentation layer only; all existing effects and the install/update/Update-All flows are preserved.

## Verification

- `tsc --noEmit` clean; ESLint 0 errors (2 pre-existing warnings in the untouched `InstallerToolDialog.tsx`).
- Tests: 365/367 pass. The 2 failures (`bentopdf.needs` should include `nssm`) are **pre-existing and unrelated** — commit `77e18f0d` intentionally made BentoPDF's service on-demand; the stale tests aren't fixed here.
- **Not done:** live Default/Dark/+1-scheme visual pass in `npm run tauri dev` (can't drive the native window from CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
