### PR TITLE
fix(installer): fold Installer Helper footer into global status bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -391,6 +391,7 @@ function App() {
           key="status-bar"
           onOpenAssistant={openAssistantPanel}
           onOpenDashboardView={openDashboardView}
+          installerActive={visibleBasePage === "installer"}
         />
       ) : null}
       <AppUpdatePrompt key="app-update-prompt" settingsReady={generalSettingsReady} />

--- a/src/modules/installer/InstallerPage.tsx
+++ b/src/modules/installer/InstallerPage.tsx
@@ -114,6 +114,7 @@ export function InstallerPage({ active }: { active: boolean }) {
   const applyProgress = useInstallerStore((s) => s.applyProgress);
   const beginInFlight = useInstallerStore((s) => s.beginInFlight);
   const openStepperDialog = useInstallerStore((s) => s.openStepperDialog);
+  const setSummary = useInstallerStore((s) => s.setSummary);
 
   const [nav, setNav] = useState<InstallerNav>("all");
   const [query, setQuery] = useState("");
@@ -395,6 +396,17 @@ export function InstallerPage({ active }: { active: boolean }) {
   });
   const checkInProgress = scanning || checking;
 
+  // Mirror the footer roll-up into the store so the global app status bar can
+  // render it while this Module is the visible page.
+  useEffect(() => {
+    setSummary({
+      all: counts.all,
+      installed: counts.installed,
+      updates: counts.updates,
+      lastCheckedAt,
+    });
+  }, [setSummary, counts.all, counts.installed, counts.updates, lastCheckedAt]);
+
   const crumb = navCrumb(nav, t);
 
   function openUpdateAllConfirm() {
@@ -602,23 +614,6 @@ export function InstallerPage({ active }: { active: boolean }) {
               viewMode={viewMode}
             />
           )}
-          <div className="installer-foot">
-            <span>{t("installer.footer.tools", { count: counts.all })}</span>
-            <span className="installer-foot__dot" />
-            <span>
-              {t("installer.footer.installed", { count: counts.installed })}
-            </span>
-            {counts.updates > 0 ? (
-              <>
-                <span className="installer-foot__dot" />
-                <span className="installer-foot__updates">
-                  {t("installer.footer.updates", { count: counts.updates })}
-                </span>
-              </>
-            ) : null}
-            <span className="installer-foot__spacer" />
-            <span>{lastCheckedText}</span>
-          </div>
         </div>
       </div>
 

--- a/src/modules/installer/InstallerStatusSummary.tsx
+++ b/src/modules/installer/InstallerStatusSummary.tsx
@@ -1,0 +1,40 @@
+// Installer Helper roll-up rendered in the centre of the global app status
+// bar. It mirrors the counts the page used to show in its own footer status
+// line, and only renders while the Installer Helper Module is the visible
+// page so the global bar stays uncluttered everywhere else.
+
+import { useTranslation } from "react-i18next";
+import { useInstallerStore } from "./state";
+
+export function InstallerStatusSummary({ active }: { active: boolean }) {
+  const { t } = useTranslation();
+  const summary = useInstallerStore((s) => s.summary);
+
+  if (!active || !summary) {
+    return null;
+  }
+
+  const lastCheckedText = t("installer.lastChecked", {
+    time: summary.lastCheckedAt
+      ? new Date(summary.lastCheckedAt * 1000).toLocaleString()
+      : t("installer.status.neverChecked"),
+  });
+
+  return (
+    <div className="status-bar-installer" role="status">
+      <span>{t("installer.footer.tools", { count: summary.all })}</span>
+      <span className="status-bar-installer__dot" />
+      <span>{t("installer.footer.installed", { count: summary.installed })}</span>
+      {summary.updates > 0 ? (
+        <>
+          <span className="status-bar-installer__dot" />
+          <span className="status-bar-installer__updates">
+            {t("installer.footer.updates", { count: summary.updates })}
+          </span>
+        </>
+      ) : null}
+      <span className="status-bar-installer__dot" />
+      <span>{lastCheckedText}</span>
+    </div>
+  );
+}

--- a/src/modules/installer/installer.css
+++ b/src/modules/installer/installer.css
@@ -1296,32 +1296,3 @@
   cursor: not-allowed;
 }
 
-/* ---- footer status line ---- */
-.installer-foot {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  height: 30px;
-  padding: 0 16px;
-  background: var(--chrome);
-  border-top: 1px solid var(--hairline);
-  color: var(--text-muted);
-  font-size: 12px;
-}
-
-.installer-foot__dot {
-  width: 3px;
-  height: 3px;
-  border-radius: 50%;
-  background: var(--text-faint);
-}
-
-.installer-foot__updates {
-  color: var(--accent);
-  font-weight: 600;
-}
-
-.installer-foot__spacer {
-  flex: 1 1 auto;
-}

--- a/src/modules/installer/state.ts
+++ b/src/modules/installer/state.ts
@@ -58,6 +58,16 @@ interface OpenDialog {
   mode: "info" | "stepper";
 }
 
+/// Catalog roll-up published by the Installer Helper page so the global app
+/// status bar can mirror the per-page footer counts while the Module is the
+/// visible page. `null` until the page has computed counts at least once.
+interface InstallerSummary {
+  all: number;
+  installed: number;
+  updates: number;
+  lastCheckedAt: number | null;
+}
+
 interface InstallerStoreState {
   catalog: Catalog | null;
   detected: Record<string, DetectedState>;
@@ -92,6 +102,9 @@ interface InstallerStoreState {
   /// disabled with a reboot-required hint until the user restarts Windows.
   /// Reset only by restarting KKTerm — a real reboot kills the app anyway.
   wslJustEnabled: boolean;
+  /// Footer roll-up mirrored into the global status bar. Owned by the page;
+  /// `null` until the page first computes counts.
+  summary: InstallerSummary | null;
 
   setCatalog: (catalog: Catalog) => void;
   setDetected: (detected: Record<string, DetectedState>) => void;
@@ -104,6 +117,7 @@ interface InstallerStoreState {
   closeDialog: () => void;
   setScanning: (scanning: boolean) => void;
   setChecking: (checking: boolean) => void;
+  setSummary: (summary: InstallerSummary | null) => void;
   markInitialScanned: () => void;
   markWslJustEnabled: () => void;
   reset: () => void;
@@ -123,6 +137,7 @@ const initial: Pick<
   | "lastStatus"
   | "openDialog"
   | "wslJustEnabled"
+  | "summary"
 > = {
   catalog: null,
   detected: {},
@@ -136,6 +151,7 @@ const initial: Pick<
   lastStatus: {},
   openDialog: null,
   wslJustEnabled: false,
+  summary: null,
 };
 
 export const useInstallerStore = create<InstallerStoreState>((set) => ({
@@ -356,6 +372,7 @@ export const useInstallerStore = create<InstallerStoreState>((set) => ({
   closeDialog: () => set({ openDialog: null }),
   setScanning: (scanning) => set({ scanning }),
   setChecking: (checking) => set({ checking }),
+  setSummary: (summary) => set({ summary }),
   markInitialScanned: () => set({ hasInitialScanned: true }),
   markWslJustEnabled: () => set({ wslJustEnabled: true }),
   reset: () => set(initial),
@@ -393,4 +410,4 @@ function trimLog(lines: string[]): string[] {
 }
 
 export { GENERAL_STEP_BUCKET };
-export type { InstallerStoreState, StepperState, StepStatus };
+export type { InstallerStoreState, InstallerSummary, StepperState, StepStatus };

--- a/src/modules/workspace/StatusBar.tsx
+++ b/src/modules/workspace/StatusBar.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from "react-i18next";
 import { RailTooltip } from "../../app/RailTooltip";
 import { showNativeContextMenu } from "../../lib/nativeContextMenu";
 import { AiCodingUsageStatusBar } from "../dashboard/widgets/builtin/ai-coding-usage/AiCodingUsageStatusBar";
+import { InstallerStatusSummary } from "../installer/InstallerStatusSummary";
 import { invokeCommand, isTauriRuntime } from "../../lib/tauri";
 import { useWorkspaceStore } from "../../store";
 import type { StatusBarNotice } from "../../types";
@@ -27,9 +28,11 @@ const NOTIFICATION_FADE_MS = 220;
 export function StatusBar({
   onOpenAssistant,
   onOpenDashboardView,
+  installerActive,
 }: {
   onOpenAssistant: () => void;
   onOpenDashboardView: (viewId: string) => void;
+  installerActive: boolean;
 }) {
   const { t } = useTranslation();
   const notice = useWorkspaceStore((state) => state.statusBarNotice);
@@ -89,6 +92,7 @@ export function StatusBar({
         {statusBarMonitorEnabled ? <WorkspaceHostMetrics t={t} /> : null}
         <AiCodingUsageStatusBar onOpenDashboardView={onOpenDashboardView} />
       </div>
+      <InstallerStatusSummary active={installerActive} />
       <div className="status-bar-notice-area">
         {renderedNotice ? (
           <StatusNoticePopup

--- a/src/modules/workspace/workspace.css
+++ b/src/modules/workspace/workspace.css
@@ -288,6 +288,32 @@
   justify-content: flex-end;
 }
 
+/* Installer Helper roll-up, centre column, shown only while the Module is
+   the visible page (gated in React). */
+.status-bar-installer {
+  grid-column: 2;
+  grid-row: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.status-bar-installer__dot {
+  flex: 0 0 auto;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--text-faint);
+}
+
+.status-bar-installer__updates {
+  color: var(--accent);
+  font-weight: 600;
+}
+
 .status-bar-action {
   position: relative;
   display: inline-flex;


### PR DESCRIPTION
## Summary

The Installer Helper page rendered its own footer status line (`installer-foot`) beneath the page content. Because the global app status bar sits just below it, the two stacked and read as a duplicate status bar whenever the Module was open.

This moves the footer roll-up (tools / installed / updates / last-checked) into the **centre column of the global status bar** — the previously-unused `1fr` grid column — and shows it **only while the Installer Helper is the visible page**. The page's own footer is removed.

The Installer Helper's top bar (the "Checked / Checking…" pill) is untouched; only the redundant bottom footer was folded in.

## Type of change

- [x] Bug fix
- [x] Refactor / cleanup

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)

## What changed

- `state.ts`: added a `summary` slice + `setSummary` so the page publishes its already-computed counts rather than the status bar re-deriving them from the catalog.
- `InstallerStatusSummary.tsx` (new): centre-column component; returns `null` unless `active` and a `summary` exists.
- `InstallerPage.tsx`: publishes the summary via an effect; removed the `installer-foot` footer block.
- `StatusBar.tsx` / `App.tsx`: render the summary gated on `installerActive = visibleBasePage === "installer"`.
- CSS: dropped the dead `.installer-foot*` rules; added `.status-bar-installer*` (grid-column 2, centered).

## i18n

- [x] No new user-visible strings — reuses existing keys (`installer.footer.*`, `installer.lastChecked`, `installer.status.neverChecked`).

## UI / design language

- [x] Status content lives in the existing global status bar; colors read from tokens (`--text-faint`, `--accent`), no hard-coded hex.

## Checks

- [x] `npx tsc --noEmit` — clean
- [x] `eslint` on touched files — clean
- [ ] `npm run check` / `npm run build` — not run
- [ ] Validated in the real Tauri desktop runtime — not yet

## Notes for reviewers

Worth eyeballing in the real runtime: the summary should appear centered in the status bar only on the Installer Helper page and disappear when navigating to Workspace/Dashboard/Settings. The `summary` value persists in the store after leaving the page but is not displayed (gated by `installerActive`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)