### PR TITLE
Create Connections by dropping OS files/folders onto the Connection Tree

### DIFF
--- a/docs/manual/03-connections.md
+++ b/docs/manual/03-connections.md
@@ -128,6 +128,8 @@ Auto-detection runs at most once per Connection: after the first established SSH
 
 Drag a Connection onto a folder to move it; drag onto another Connection to reorder. Folders can be nested: when dragging a folder over another folder, drop on the center of the row to make it a subfolder, or drop near the row edge to reorder it beside that folder. While a tree drag is active, a temporary `connections.root` drop target appears so Connections or folders can be moved back to the root even when the visible tree has no blank space. Order is persisted.
 
+Dropping files or folders from the OS onto the Connection Tree creates Connections immediately with default settings, the same as Add Connection: a dropped file becomes a Document Connection (`connections.fileView`, named after the file), and a dropped folder becomes a File Explorer Connection (`connections.localFiles`, named after the folder's last path segment). The tree highlights while a file is dragged over it. Multiple items can be dropped at once.
+
 ## Status badges
 
 Each Connection in the tree shows a live status dot when it has one or more Sessions open. The dot is derived from `withLiveConnectionStatuses` in `src/modules/workspace/connections/treeUtils.ts` and is **display-only**. Do not pass the live-status Connection to workspace components that own Session lifecycle (TerminalWorkspace, WebViewWorkspace, RemoteDesktopWorkspace, SftpWorkspace) — they look up the stable Connection by id from the raw tree. See `src/modules/dashboard/widgets/ConnectionWidgetBody.tsx` for the safe pattern.

--- a/src/modules/workspace/connections/ConnectionSidebar.tsx
+++ b/src/modules/workspace/connections/ConnectionSidebar.tsx
@@ -29,12 +29,14 @@ import {
   type ConnectionTabContextMenuDetail,
 } from "./connectionTabContextMenu";
 import { buildFileViewConnectionDraftFromPath } from "./fileViewConnectionDraft";
+import { buildLocalFilesConnectionDraftFromPath } from "./localFilesConnectionDraft";
 import { confirmTrustedSshHostKey, connectionPasswordOwnerId, connectionSshSocksProxyPasswordOwnerId, defaultPortForConnectionType, connectionTypeLabel, ftpPortForProtocolSelection, isRemoteDesktopConnectionType, localShellOptionsForPlatform, resolveSshSocksProxyRequest, uniqueRuntimeId, type LocalShellOption } from "./utils";
 import { RECENT_CONNECTION_LIMIT, loadCollapsedFolderIds, loadRecentConnectionIds, notifyConnectionTreeInvalidated, saveCollapsedFolderIds, saveRecentConnectionIds } from "./connectionSidebarState";
 import { collectConnectionFolderIds, countConnections, countFolders, filterConnectedConnections, filterConnectionTree, findConnectionInTree, flattenConnections, flattenFolders, visibleFlatConnections as flattenVisibleConnections, withLiveConnectionStatuses } from "./treeUtils";
 import { WorkspaceIcon } from "../workspaceIcons";
 import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Check, ChevronDown, ChevronRight, CircleDot, Folder, FolderPlus, KeyRound, LayoutDashboard, List, Maximize2, Minimize2, PanelRight, Pencil, Pin, PinOff, Play, Plus, RotateCcw, Save, Search, Settings, SquarePlus, Trash2, X } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { FormEvent, MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from "react";
 import type { TFunction } from "i18next";
@@ -272,6 +274,9 @@ export function ConnectionSidebar({
   const [quickConnectMenuOpen, setQuickConnectMenuOpen] = useState(false);
   const [recentConnectionIds, setRecentConnectionIds] = useState(loadRecentConnectionIds);
   const [dropTarget, setDropTarget] = useState("");
+  // Highlight shown while an OS file/folder is dragged over the tree, before it
+  // is dropped to create a Document/File Explorer Connection.
+  const [externalFileDropActive, setExternalFileDropActive] = useState(false);
   const [dragPreview, setDragPreview] = useState<TreeDragPreview | null>(null);
   const [draggedSourceId, setDraggedSourceId] = useState("");
   const [canvasDropZone, setCanvasDropZone] = useState<CanvasDropZone | null>(null);
@@ -316,6 +321,7 @@ export function ConnectionSidebar({
   }, [childConnections, tree]);
   const addConnectionRef = useRef<HTMLDivElement | null>(null);
   const quickConnectRef = useRef<HTMLDivElement | null>(null);
+  const treeListRef = useRef<HTMLDivElement | null>(null);
   const draggedItemRef = useRef<DraggedTreeItem | null>(null);
   const pointerDragTargetRef = useRef<TreeDropTarget | null>(null);
   const canvasDropTargetRef = useRef<CanvasDropZone | null>(null);
@@ -429,6 +435,48 @@ export function ConnectionSidebar({
     },
     [],
   );
+
+  // Drop OS files/folders onto the Connection Tree to create Connections: files
+  // become Document Connections, folders become File Explorer Connections.
+  useEffect(() => {
+    if (!isTauriRuntime()) {
+      return;
+    }
+
+    let disposed = false;
+    let unlisten: (() => void) | null = null;
+    void getCurrentWebview()
+      .onDragDropEvent((event) => {
+        if (disposed) {
+          return;
+        }
+        if (event.payload.type === "over") {
+          setExternalFileDropActive(
+            isPositionInsideTree(event.payload.position.x, event.payload.position.y),
+          );
+        } else if (event.payload.type === "drop") {
+          const inside = isPositionInsideTree(event.payload.position.x, event.payload.position.y);
+          setExternalFileDropActive(false);
+          if (inside) {
+            void handleExternalPathsDroppedRef.current(event.payload.paths);
+          }
+        } else {
+          setExternalFileDropActive(false);
+        }
+      })
+      .then((dispose) => {
+        if (disposed) {
+          dispose();
+        } else {
+          unlisten = dispose;
+        }
+      });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
 
   async function reloadConnectionGroups() {
     try {
@@ -574,6 +622,63 @@ export function ConnectionSidebar({
       await handleConnectionSaved();
     } catch (error) {
       setTreeError(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  // True when an OS drag-drop position (physical pixels) lands inside the tree
+  // list. Mirrors the App Launcher's dual raw/scaled check so it works across
+  // the WebView2 device-pixel-ratio differences seen on Windows.
+  function isPositionInsideTree(x: number, y: number) {
+    const bounds = treeListRef.current?.getBoundingClientRect();
+    if (!bounds) {
+      return false;
+    }
+    const scale = window.devicePixelRatio || 1;
+    const inside = (px: number, py: number) =>
+      px >= bounds.left && px <= bounds.right && py >= bounds.top && py <= bounds.bottom;
+    return inside(x, y) || inside(x / scale, y / scale);
+  }
+
+  // Create a Connection per OS-dropped path: folders become File Explorer
+  // Connections with default settings (named after the last folder segment),
+  // files become Document Connections — matching the Add Connection flows.
+  async function handleExternalPathsDropped(paths: string[]) {
+    if (!isTauriRuntime()) {
+      return;
+    }
+    const uniquePaths = Array.from(new Set(paths.map((path) => path.trim()).filter(Boolean)));
+    if (uniquePaths.length === 0) {
+      return;
+    }
+
+    const workspaceId = useWorkspaceStore.getState().activeWorkspaceId;
+    let created = 0;
+    for (const path of uniquePaths) {
+      try {
+        const prepared = await invokeCommand("prepare_app_launcher_entry", { request: { path } });
+        if (prepared.fileKind === "missing") {
+          continue;
+        }
+        if (prepared.fileKind === "folder") {
+          await invokeCommand("create_connection", {
+            request: buildLocalFilesConnectionDraftFromPath(prepared.path, { workspaceId }),
+          });
+        } else {
+          const { iconDataUrl, ...request } = buildFileViewConnectionDraftFromPath(prepared.path, {
+            workspaceId,
+          });
+          const connection = await invokeCommand("create_connection", { request });
+          await saveConnectionIconPresentation(connection, iconDataUrl, null);
+        }
+        created += 1;
+      } catch (error) {
+        setTreeError(error instanceof Error ? error.message : String(error));
+      }
+    }
+
+    if (created > 0) {
+      await reloadConnectionGroups();
+      notifyConnectionTreeInvalidated();
     }
   }
 
@@ -1459,6 +1564,8 @@ export function ConnectionSidebar({
   treeRef.current = treeWithLiveStatuses;
   const handleOpenConnectionRef = useRef(handleOpenConnection);
   handleOpenConnectionRef.current = handleOpenConnection;
+  const handleExternalPathsDroppedRef = useRef(handleExternalPathsDropped);
+  handleExternalPathsDroppedRef.current = handleExternalPathsDropped;
   const onExternalOpenConnectionRef = useRef(onExternalOpenConnection);
   onExternalOpenConnectionRef.current = onExternalOpenConnection;
 
@@ -2498,7 +2605,8 @@ export function ConnectionSidebar({
       {treeError ? <p className="form-error tree-error">{treeError}</p> : null}
 
       <div
-        className={`tree-list ${dropTarget === "root" ? "drop-target" : ""}`}
+        ref={treeListRef}
+        className={`tree-list ${dropTarget === "root" ? "drop-target" : ""}${externalFileDropActive ? " external-drop-target" : ""}`}
         aria-label={t("connections.connectionTree")}
         data-tutorial-id="connections.tree"
         data-connection-count={displayTree.connections.length}

--- a/src/modules/workspace/connections/connections.css
+++ b/src/modules/workspace/connections/connections.css
@@ -304,6 +304,7 @@
 }
 
 .tree-list.drop-target,
+.tree-list.external-drop-target,
 .tree-folder-row.drop-target,
 .connection-row.drop-target,
 .tree-root-drop-target.drop-target {

--- a/src/modules/workspace/connections/localFilesConnectionDraft.ts
+++ b/src/modules/workspace/connections/localFilesConnectionDraft.ts
@@ -1,0 +1,30 @@
+import type { CreateConnectionRequest } from "../../../types";
+
+function folderNameFromPath(path: string) {
+  const parts = path.trim().replace(/[\\/]+$/g, "").split(/[\\/]+/).filter(Boolean);
+  return parts[parts.length - 1] ?? "";
+}
+
+// Build a File Explorer (localFiles) Connection draft for a dropped folder. It
+// uses the default File Explorer settings (no custom icon) and names the
+// Connection after the dropped folder's last path segment.
+export function buildLocalFilesConnectionDraftFromPath(
+  directoryPath: string,
+  options: { workspaceId?: string; folderId?: string } = {},
+): CreateConnectionRequest {
+  const name = folderNameFromPath(directoryPath) || directoryPath;
+  const draft: CreateConnectionRequest = {
+    name,
+    host: "localhost",
+    user: "local",
+    type: "localFiles",
+    localStartupDirectory: directoryPath,
+  };
+  if (options.workspaceId) {
+    draft.workspaceId = options.workspaceId;
+  }
+  if (options.folderId) {
+    draft.folderId = options.folderId;
+  }
+  return draft;
+}

--- a/tests/local-files-connection-drop.test.ts
+++ b/tests/local-files-connection-drop.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { buildLocalFilesConnectionDraftFromPath } from "../src/modules/workspace/connections/localFilesConnectionDraft.ts";
+
+test("File Explorer drop drafts name the Connection after the last folder segment with default settings", () => {
+  const draft = buildLocalFilesConnectionDraftFromPath("C:\\Users\\ryan\\Projects\\kkterm\\", {
+    workspaceId: "workspace-1",
+  });
+
+  assert.deepEqual(draft, {
+    name: "kkterm",
+    host: "localhost",
+    user: "local",
+    type: "localFiles",
+    workspaceId: "workspace-1",
+    localStartupDirectory: "C:\\Users\\ryan\\Projects\\kkterm\\",
+  });
+});
+
+test("File Explorer drop drafts do not attach a custom icon (default File Explorer glyph)", () => {
+  const draft = buildLocalFilesConnectionDraftFromPath("/home/ryan/notes");
+  assert.equal("iconDataUrl" in draft, false);
+});
+
+test("Dropping onto the Connection Tree routes folders to File Explorer and files to Document", async () => {
+  const sidebarSource = await readFile(
+    new URL("../src/modules/workspace/connections/ConnectionSidebar.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    sidebarSource,
+    /prepared\.fileKind === "folder"[\s\S]*buildLocalFilesConnectionDraftFromPath/,
+    "Dropped folders should create File Explorer (localFiles) Connections.",
+  );
+  assert.match(
+    sidebarSource,
+    /buildFileViewConnectionDraftFromPath\(prepared\.path/,
+    "Dropped files should create Document (fileView) Connections.",
+  );
+  assert.match(
+    sidebarSource,
+    /getCurrentWebview\(\)\s*\.onDragDropEvent/,
+    "The tree should subscribe to OS drag-drop events.",
+  );
+});


### PR DESCRIPTION
## Summary

Dragging files or folders from the OS onto the Connection Tree now creates Connections immediately with default settings, mirroring the Add Connection flows:

- **File → Document Connection** (`fileView`), named after the file, with the Material file icon — identical to the existing Add Connection → Document path.
- **Folder → File Explorer Connection** (`localFiles`), named after the folder's last path segment, with default File Explorer settings (default glyph, no custom icon).

The tree highlights while a file is dragged over it, and multiple items can be dropped at once.

## Type of change

- [x] Feature
- [x] Docs / manual

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)
- [x] Docs (`docs/`, manual, ADR)

## Domain & docs

- [x] Uses the canonical vocabulary (Document Connection / File Explorer Connection / Connection Tree)
- [x] Reused the existing `prepare_app_launcher_entry` typed wrapper for file-vs-folder detection and the `onDragDropEvent` pattern from `AppLauncherWidget`; new `localFilesConnectionDraft.ts` is a sibling of the existing `fileViewConnectionDraft.ts`
- [x] Updated the manual: `docs/manual/03-connections.md` Drag and drop section

## i18n

- [x] No new user-visible strings — the created Connection appearing in the tree is the feedback, matching Add Connection (which shows no toast). Reused the existing `drop-target` highlight styling.

## UI / design language

- [x] No dialogs added; `external-drop-target` reuses the existing tree drop highlight (token-based, no hard-coded hex). Tree's `data-tutorial-id` left intact.

## High-risk invariants

- [x] No close hooks added; no live Session state added to the durable Connection model; no RDP/VNC/WebView2 surface rules touched.

## Checks

- [x] `tsc --noEmit` — clean
- [x] ESLint on touched files — 0 errors (pre-existing warnings only, none at changed lines)
- [x] Frontend test suite via `tests/run-all.mjs` — 391 pass, 0 fail (incl. 3 new tests in `tests/local-files-connection-drop.test.ts`)
- [ ] Validated in the real Tauri desktop runtime — OS drag-drop is Tauri-only and no-ops in Vite/browser; the live drop was not exercised here, but the file/folder routing is unit-tested. **Recommend a manual drag-drop smoke test in the desktop build.**

## Notes for reviewers

- File-vs-folder detection reuses `prepare_app_launcher_entry`, which does incidental OS-icon extraction per path — negligible for a handful of dropped items, and the returned icon is ignored.
- The OS drag-drop listener registers once per sidebar mount via a handler ref (same pattern as the existing tree listeners); other surfaces' `onDragDropEvent` listeners are position-gated, so dropping on the tree vs. an SFTP pane never double-fires.