### PR TITLE
fix(terminal): let powerline/Nerd Fonts work without a system install

### DIFF
--- a/docs/manual/15-settings.md
+++ b/docs/manual/15-settings.md
@@ -165,7 +165,7 @@ X11 forwarding is negotiated when a new native SSH Session starts. SSH Sessions 
 
 ## Terminal
 
-Section header `settings.sectionTerminal`. Font family + size, line height, cursor style, scrollback length, bell behaviour, default shell on Local. `settings.defaultTransparency` sets the starting local/Telnet/Serial terminal transparency for new terminal Connections and Child Connection Tabs; the default is 50. `settings.randomDynamicBackgroundOnCreate` assigns a random dynamic terminal background only when creating new local/Telnet/Serial Connections, new top-strip Tabs, or new Child Connection Tabs.
+Section header `settings.sectionTerminal`. Font family + size, line height, cursor style, scrollback length, bell behaviour, default shell on Local. The font family field (`settings.terminalFontFamily`) accepts any installed font name and also suggests custom fonts dropped into the app fonts folder (`settings.openCustomFontsFolder`, hint `settings.customFontsHint` / `settings.noCustomFonts`). Custom fonts — including powerline/Nerd Fonts — render without a system-wide install because KKTerm loads them into the WebView itself; this is the supported way to get powerline glyphs. `settings.defaultTransparency` sets the starting local/Telnet/Serial terminal transparency for new terminal Connections and Child Connection Tabs; the default is 50. `settings.randomDynamicBackgroundOnCreate` assigns a random dynamic terminal background only when creating new local/Telnet/Serial Connections, new top-strip Tabs, or new Child Connection Tabs.
 
 ## RDP and VNC
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,8 @@
       "assetProtocol": {
         "enable": true,
         "scope": [
-          "$EXE/backgrounds/**"
+          "$EXE/backgrounds/**",
+          "$EXE/fonts/**"
         ]
       }
     }

--- a/src/lib/customFonts.ts
+++ b/src/lib/customFonts.ts
@@ -1,3 +1,4 @@
+import { convertFileSrc } from "@tauri-apps/api/core";
 import { defaultAppearanceSettings } from "../app-defaults";
 import type { AppearanceSettings, CustomFont } from "../types";
 import { invokeCommand, isTauriRuntime } from "./tauri";
@@ -44,7 +45,7 @@ export async function loadCustomFontOptions(fonts: CustomFontOption[]) {
 
   await Promise.allSettled(
     fonts.map(async (font) => {
-      // Register each custom font under two families backed by the same bytes:
+      // Register each custom font under two families backed by the same file:
       // an internal synthetic family used by the app UI font picker, and the
       // font's human-readable file name. The terminal font field is free text,
       // so users reference dropped-in fonts (e.g. Nerd Fonts) by the name they
@@ -55,11 +56,14 @@ export async function loadCustomFontOptions(fonts: CustomFontOption[]) {
       if (families.length === 0) {
         return;
       }
-      const { dataBase64 } = await invokeCommand("load_custom_font_data", { path: font.path });
-      const buffer = base64ToArrayBuffer(dataBase64);
+      // Load through the asset protocol so the WebView fetches and decodes the
+      // font on its own (native, off-main-thread) resource pipeline. This keeps
+      // multi-megabyte fonts off the UI thread on startup: no base64 payload
+      // crosses the IPC boundary and no decode runs in JS.
+      const source = `url("${convertFileSrc(font.path)}")`;
       await Promise.allSettled(
         families.map(async (family) => {
-          const face = new FontFace(family, buffer.slice(0), { display: "swap" });
+          const face = new FontFace(family, source, { display: "swap" });
           await face.load();
           document.fonts.add(face);
           loadedFontFamilies.add(family);
@@ -99,13 +103,4 @@ function hashPath(path: string) {
     hash = Math.imul(hash, 16777619);
   }
   return (hash >>> 0).toString(36);
-}
-
-function base64ToArrayBuffer(value: string) {
-  const binary = window.atob(value);
-  const bytes = new Uint8Array(binary.length);
-  for (let index = 0; index < binary.length; index += 1) {
-    bytes[index] = binary.charCodeAt(index);
-  }
-  return bytes.buffer;
 }

--- a/src/lib/customFonts.ts
+++ b/src/lib/customFonts.ts
@@ -44,18 +44,27 @@ export async function loadCustomFontOptions(fonts: CustomFontOption[]) {
 
   await Promise.allSettled(
     fonts.map(async (font) => {
-      if (loadedFontFamilies.has(font.cssFamily)) {
+      // Register each custom font under two families backed by the same bytes:
+      // an internal synthetic family used by the app UI font picker, and the
+      // font's human-readable file name. The terminal font field is free text,
+      // so users reference dropped-in fonts (e.g. Nerd Fonts) by the name they
+      // see and type rather than an opaque synthetic id.
+      const families = [font.cssFamily, font.name].filter(
+        (family) => family.length > 0 && !loadedFontFamilies.has(family),
+      );
+      if (families.length === 0) {
         return;
       }
       const { dataBase64 } = await invokeCommand("load_custom_font_data", { path: font.path });
-      const face = new FontFace(
-        font.cssFamily,
-        base64ToArrayBuffer(dataBase64),
-        { display: "swap" },
+      const buffer = base64ToArrayBuffer(dataBase64);
+      await Promise.allSettled(
+        families.map(async (family) => {
+          const face = new FontFace(family, buffer.slice(0), { display: "swap" });
+          await face.load();
+          document.fonts.add(face);
+          loadedFontFamilies.add(family);
+        }),
       );
-      await face.load();
-      document.fonts.add(face);
-      loadedFontFamilies.add(font.cssFamily);
     }),
   );
 }

--- a/src/modules/settings/TerminalSettings.tsx
+++ b/src/modules/settings/TerminalSettings.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
-import { Terminal } from "lucide-react";
+import { FolderOpen, Terminal } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { invokeCommand, isTauriRuntime } from "../../lib/tauri";
+import { listCustomFontOptions, type CustomFontOption } from "../../lib/customFonts";
 import { isWindowsPlatform } from "../../lib/platform";
 import { useWorkspaceStore } from "../../store";
 import type { TerminalCursorStyle, TerminalSettings as TerminalSettingsType } from "../../types";
@@ -55,11 +56,42 @@ export function TerminalSettings() {
   const setTerminalSettings = useWorkspaceStore((state) => state.setTerminalSettings);
   const showStatusBarNotice = useWorkspaceStore((state) => state.showStatusBarNotice);
   const [draft, setDraft] = useState(terminalSettings);
+  const [customFonts, setCustomFonts] = useState<CustomFontOption[]>([]);
   const hasChanges = JSON.stringify(draft) !== JSON.stringify(terminalSettings);
 
   useEffect(() => {
     setDraft(terminalSettings);
   }, [terminalSettings]);
+
+  useEffect(() => {
+    let disposed = false;
+    if (!isTauriRuntime()) {
+      return () => {
+        disposed = true;
+      };
+    }
+    // Listing also registers each custom font with the WebView, so the family
+    // names suggested below resolve in the terminal once selected.
+    void listCustomFontOptions()
+      .then((fonts) => {
+        if (!disposed) setCustomFonts(fonts);
+      })
+      .catch(() => undefined);
+    return () => {
+      disposed = true;
+    };
+  }, []);
+
+  async function handleOpenCustomFontsFolder() {
+    if (!isTauriRuntime()) {
+      return;
+    }
+    try {
+      await invokeCommand("open_custom_fonts_folder");
+    } catch (err) {
+      showStatusBarNotice(err instanceof Error ? err.message : String(err), { tone: "error" });
+    }
+  }
 
   async function handleSave() {
     try {
@@ -93,16 +125,40 @@ export function TerminalSettings() {
         <div className="form-grid three-columns">
           <label data-tutorial-id="settings.terminalFontFamily">
             <span>{t("settings.fontFamily")}</span>
-            <input
-              onChange={(event) => {
-                const fontFamily = event.currentTarget.value;
-                setDraft((settings) => ({
-                  ...settings,
-                  fontFamily,
-                }));
-              }}
-              value={draft.fontFamily}
-            />
+            <div className="input-with-button">
+              <input
+                list="terminal-custom-fonts"
+                onChange={(event) => {
+                  const fontFamily = event.currentTarget.value;
+                  setDraft((settings) => ({
+                    ...settings,
+                    fontFamily,
+                  }));
+                }}
+                value={draft.fontFamily}
+              />
+              {isTauriRuntime() ? (
+                <button
+                  aria-label={t("settings.openCustomFontsFolder")}
+                  className="toolbar-button"
+                  onClick={() => void handleOpenCustomFontsFolder()}
+                  title={t("settings.openCustomFontsFolder")}
+                  type="button"
+                >
+                  <FolderOpen size={15} />
+                </button>
+              ) : null}
+            </div>
+            {customFonts.length > 0 ? (
+              <datalist id="terminal-custom-fonts">
+                {customFonts.map((font) => (
+                  <option key={font.path} value={font.name} />
+                ))}
+              </datalist>
+            ) : null}
+            <small className="field-hint">
+              {customFonts.length > 0 ? t("settings.customFontsHint") : t("settings.noCustomFonts")}
+            </small>
           </label>
           <label data-tutorial-id="settings.terminalFontSize">
             <span>{t("settings.fontSize")}</span>

--- a/src/modules/workspace/connections/terminal/renderer.ts
+++ b/src/modules/workspace/connections/terminal/renderer.ts
@@ -237,6 +237,26 @@ class XtermTerminalRenderer implements TerminalRenderer {
     this.applyHostBackground(this.backgroundOpacity);
     this.terminal.open(element);
     this.tryEnableWebglRenderer();
+    this.refreshAtlasWhenFontsReady();
+  }
+
+  private refreshAtlasWhenFontsReady() {
+    // Custom fonts (e.g. Nerd Fonts dropped into the app fonts folder) register
+    // asynchronously through the FontFace API. If a terminal opens before its
+    // configured font finishes loading, the glyph atlas caches fallback boxes.
+    // Rebuild the atlas once fonts settle so powerline/Nerd glyphs render
+    // without a reload.
+    if (typeof document === "undefined" || !document.fonts?.ready) {
+      return;
+    }
+    void document.fonts.ready.then(() => {
+      try {
+        this.terminal.clearTextureAtlas();
+      } catch {
+        // clearTextureAtlas may be unavailable or the terminal may already be
+        // disposed; the next render falls back to measuring fonts inline.
+      }
+    });
   }
 
   private applyHostBackground(opacity: number) {


### PR DESCRIPTION
Issue #349: powerline glyphs don't render in the terminal on macOS even
after installing a Nerd Font. Root cause is not a permission/CSP issue —
the terminal is xterm.js inside the WebView, which can only resolve a
font-family name against fonts the OS exposes. The terminal also passed
the configured family verbatim and had no link to the existing custom
fonts system, which only the app-UI font picker used.

- Register each custom font (from the app fonts folder) under both its
  internal synthetic family and its human-readable file name, so the
  terminal can reference dropped-in fonts by the name users see/type
  without a system-wide install.
- Settings > Terminal: suggest loaded custom fonts via a datalist on the
  font-family field, add an "open fonts folder" button, and show the
  loaded/none hint (reuses existing i18n keys).
- Rebuild the WebGL glyph atlas once document.fonts settles so a terminal
  that opens before its font finishes loading shows glyphs, not boxes.
- Document the supported powerline-font workflow in the settings manual.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014YZbKTUjseaC24B5onV2rs