### PR TITLE
fix(workspace): full-width toolbar for docked Document viewer

### DIFF
--- a/src/modules/workspace/connections/terminal/terminal.css
+++ b/src/modules/workspace/connections/terminal/terminal.css
@@ -148,13 +148,16 @@
   background: var(--chrome-strong);
 }
 
-/* File-browser sub-panes (SFTP / FTP / File Explorer) must fill the embedded
-   pane the same way the terminal surface does. `.sftp-workspace.active` is a
-   block-level flex column, so as a flex item in this row it would otherwise size
-   to its content width and leave the pane partially empty. Webview/remote-desktop
-   surfaces don't need this — their native overlay windows are positioned to the
-   pane bounds in JS, independent of the DOM box width. */
-.embedded-workspace-pane > .sftp-workspace {
+/* File-browser sub-panes (SFTP / FTP / File Explorer) and the Document viewer
+   must fill the embedded pane the same way the terminal surface does.
+   `.sftp-workspace.active` and `.file-viewer-workspace.active` are block-level
+   flex columns, so as a flex item in this row they would otherwise size to their
+   content width — leaving the pane partially empty and the toolbar narrower than
+   the pane. Webview/remote-desktop surfaces don't need this — their native
+   overlay windows are positioned to the pane bounds in JS, independent of the
+   DOM box width. */
+.embedded-workspace-pane > .sftp-workspace,
+.embedded-workspace-pane > .file-viewer-workspace {
   flex: 1 1 0;
   width: 100%;
   min-width: 0;


### PR DESCRIPTION
## Summary

A Document (file viewer) opened as a **docked pane** collapsed to its content width, so its toolbar (TXT / Text / Log / Hex) was narrower than the pane instead of spanning it. `.embedded-workspace-pane` is a flex **row** and `.file-viewer-workspace.active` is a block-level flex **column** with no `flex`/`width` rule, so it sized to content. The sibling `.sftp-workspace` already had this rule; the file viewer was the only embeddable surface missing it. Extended the existing rule in `terminal.css` to also target `.file-viewer-workspace`.

## Type of change

- [x] Bug fix

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)

## Domain & docs

- [x] Uses the canonical vocabulary (Connection / Session / Tab / Workspace / Module)
- [x] Source placement follows the Frontend Source Map (CSS lives beside its module)

## i18n

- [x] No user-visible strings

## UI / design language (if UI changed)

- [x] Colors read from tokens (no hard-coded hex); change is layout-only (flex/width)

## High-risk invariants

- [x] None violated — no close hooks, no Session state in the Connection model, no RDP/VNC/WebView2 surface changes

## Checks

- [x] CSS-only, cosmetic layout fix — full suite skipped per AGENTS.md cosmetic-change guidance

## Notes for reviewers

- No behavior change for **undocked** Document tabs — they sit in `.workspace-dockable-tab` (`display: block`), already full width.
- Verified SFTP / FTP / File Explorer (all `SftpWorkspace` → `.sftp-workspace`) were already correctly handled; no change needed there.
- Embedded-pane dispatch is an exhaustive `switch` with an `assertNeverPane` guard, so embeddable-surface coverage is now complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)