### PR TITLE
feat(release): add increment_version option (default on)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
+      increment_version:
+        description: "Increment the patch version for this release (off reuses the current version)"
+        required: false
+        default: true
+        type: boolean
       draft:
         description: "Create the GitHub release as a draft"
         required: false
@@ -80,6 +85,7 @@ jobs:
           # generates notes, commits/tags, pushes main, creates the GitHub Release,
           # and uploads x64 + ARM64 installer assets.
           $releaseArgs = @("-File", "scripts/release-github-both-arch.ps1")
+          if ("${{ inputs.increment_version }}" -eq "false") { $releaseArgs += "-NoVersionIncrement" }
           if ("${{ inputs.draft }}" -eq "true") { $releaseArgs += "-Draft" }
           if ("${{ inputs.prerelease }}" -eq "true") { $releaseArgs += "-Prerelease" }
           if ("${{ inputs.skip_build }}" -eq "true") { $releaseArgs += "-SkipBuild" }

--- a/scripts/release-github-both-arch.ps1
+++ b/scripts/release-github-both-arch.ps1
@@ -8,7 +8,8 @@ param(
     [switch]$SkipBuild,
     [switch]$SkipSmoke,
     [switch]$SkipAiReleaseNotes,
-    [switch]$AllowDirty
+    [switch]$AllowDirty,
+    [switch]$NoVersionIncrement
 )
 
 $ErrorActionPreference = "Stop"
@@ -42,6 +43,9 @@ if ($SkipAiReleaseNotes) {
 }
 if ($AllowDirty) {
     $ForwardParams["AllowDirty"] = $true
+}
+if ($NoVersionIncrement) {
+    $ForwardParams["NoVersionIncrement"] = $true
 }
 
 & $ReleaseScript @ForwardParams

--- a/scripts/release-github.ps1
+++ b/scripts/release-github.ps1
@@ -9,7 +9,8 @@ param(
     [switch]$SkipSmoke,
     [switch]$SkipAiReleaseNotes,
     [switch]$AllowDirty,
-    [switch]$IncludeArm64
+    [switch]$IncludeArm64,
+    [switch]$NoVersionIncrement
 )
 
 $ErrorActionPreference = "Stop"
@@ -223,7 +224,14 @@ try {
     Assert-Version $CurrentVersion
 
     $VersionParts = $CurrentVersion.Split(".") | ForEach-Object { [int]$_ }
-    $NextVersion = "$($VersionParts[0]).$($VersionParts[1]).$($VersionParts[2] + 1)"
+    if ($NoVersionIncrement) {
+        # Reuse the current version instead of bumping the patch. The version
+        # files stay put; the release commit then carries only the regenerated
+        # release notes and changelog.
+        $NextVersion = $CurrentVersion
+    } else {
+        $NextVersion = "$($VersionParts[0]).$($VersionParts[1]).$($VersionParts[2] + 1)"
+    }
     $TagName = "v$NextVersion"
     $TargetTriple = "windows-x64"
     $InstallerExe = Join-Path $ResolvedOutputDir "kkterm-$NextVersion-$TargetTriple-setup.exe"


### PR DESCRIPTION
## What

Adds an `increment_version` `workflow_dispatch` input to the Release workflow, **defaulting to on**, controlling whether the patch version is bumped for a release.

## Why

Most releases bump the patch version (`1.2.3` → `1.2.4`), which stays the default. But sometimes you want to (re)publish a release at the *current* version — for example when a prior run bumped the version files but never tagged/published. This option makes that explicit instead of requiring a manual script invocation.

## How

- **`.github/workflows/release.yml`** — new `increment_version` boolean input (`default: true`). When the input is `false`, the publish step appends `-NoVersionIncrement` to the release script args.
- **`scripts/release-github-both-arch.ps1`** — new `-NoVersionIncrement` switch, forwarded to `release-github.ps1`.
- **`scripts/release-github.ps1`** — new `-NoVersionIncrement` switch; when set, `$NextVersion` reuses the current version instead of incrementing the patch.

## Behavior

- **On (default):** unchanged — patch is incremented; version files, notes, and changelog are all committed.
- **Off:** version files stay put; the release commit carries only the regenerated release notes/changelog, and the tag/release are cut at the current version.

## Reviewer note

With the option **off**, if the current version's tag or GitHub release already exists, the script's existing guards (`Tag already exists locally` / `GitHub release already exists`) abort the run — the intended safety behavior, since re-releasing an already-published version is almost always a mistake.