### PR TITLE
fix: sync-input mouse garble + toolbar toggle + native tooltip clamp

### DIFF
--- a/docs/localization_todo/workspace.syncInput.md
+++ b/docs/localization_todo/workspace.syncInput.md
@@ -2,9 +2,9 @@
 
 - **English value**: `Sync input to all terminals`
 - **Namespace**: `workspace`
-- **File/component**: `src/modules/workspace/StatusBar.tsx`
+- **File/component**: `src/modules/workspace/connections/terminal/TerminalWorkspace.tsx`
 - **UI role**: `tooltip`
-- **User flow**: Tooltip/aria-label for the Status Bar toggle button that mirrors keystrokes typed in the focused terminal pane to every other open terminal pane. The button appears when two or more terminal panes are open.
+- **User flow**: Tooltip/aria-label for the terminal Pane toolbar toggle (left of the Quick Command Bar toggle) that mirrors keystrokes typed in the focused terminal pane to every other open terminal pane.
 - **Tone**: concise/neutral
 - **Placeholders**: none
 - **Context/meaning**: "input" = keyboard input/keystrokes; "sync" = broadcast/mirror the same input to multiple terminals at once.

--- a/docs/localization_todo/workspace.syncInputEnabledNotice.md
+++ b/docs/localization_todo/workspace.syncInputEnabledNotice.md
@@ -2,9 +2,9 @@
 
 - **English value**: `Input is now mirrored to every open terminal.`
 - **Namespace**: `workspace`
-- **File/component**: `src/modules/workspace/StatusBar.tsx`
+- **File/component**: `src/modules/workspace/connections/terminal/TerminalWorkspace.tsx`
 - **UI role**: `status`
-- **User flow**: Status Bar warning notice shown the moment the user turns on "Sync input to all terminals", warning that keystrokes will now go to all open terminal panes at once.
+- **User flow**: Status Bar warning notice shown the moment the user turns on "Sync input to all terminals" from the terminal Pane toolbar toggle, warning that keystrokes will now go to all open terminal panes at once.
 - **Tone**: short warning, neutral phrasing
 - **Placeholders**: none
 - **Context/meaning**: "Input" = keyboard input; "mirrored" = the same keystrokes are broadcast/duplicated to every open terminal.

--- a/docs/manual/02-app-layout.md
+++ b/docs/manual/02-app-layout.md
@@ -69,9 +69,10 @@ Owned by `src/modules/workspace/StatusBar.tsx`. Three roles:
 3. **Watchdog state** — when one or more watchdogs exist, the right side shows an animated watchdog icon with `watchdog.statusBarLabel`. Activating it opens a list of running or terminal-undismissed watchdogs. Selecting a watchdog opens its detail panel with state, elapsed time, watch summary, next check, exit condition, notification method, action mode, recent values, trigger events, AI interventions, and report actions.
 4. **Encrypted credential database state** — when Settings → Credentials uses encrypted database storage, the right side shows a lock or unlock icon. `app.credentialStoreLocked` means saved secrets cannot be read until the master password is entered; activating `app.credentialStoreUnlockAction` opens only the encrypted database unlock dialog. `app.credentialStoreUnlocked` means the store is available for saved-password reads; activating `app.credentialStoreLockAction` locks it again for the current app run.
 5. **Don't Sleep state** — when Don't Sleep mode is enabled, the right side shows a coffee icon with tooltip `app.dontSleepStatusEnabled`. If `settings.dontSleepForegroundOnly` is on, this indicates the user-facing mode is enabled; the OS power assertion is active only while KKTerm is focused and not minimized.
-6. **Sync input state** (`workspace.syncInput`) — a toggle that appears while two or more terminal Panes are open (and stays visible while enabled so it can be turned off). When on, keystrokes typed into the focused terminal Pane are mirrored to every other open terminal Pane; enabling it shows the warning popup `workspace.syncInputEnabledNotice` and every synced terminal Pane gains a warning outline. The mode is runtime-only and resets to off on app relaunch.
 
 Tutorial targets: `workspace.statusBar`, `workspace.hostUsage`.
+
+Right-side status icons use the shared `RailTooltip`, which prefers a native OS tooltip and clamps it into the monitor work area so a maximized window's bottom-right icons are not truncated at the screen edge.
 
 ## Workspace chrome resize behaviour
 

--- a/docs/manual/05-terminal.md
+++ b/docs/manual/05-terminal.md
@@ -38,7 +38,7 @@ Do not use `window.prompt` / `window.confirm` for paste confirmation; the implem
 
 ## Sync input to all terminals
 
-The Status Bar `workspace.syncInput` toggle (see [02-app-layout.md](02-app-layout.md)) mirrors keystrokes from the focused terminal Pane to every other open terminal Pane, for running the same command across many Sessions at once. Mirrored input goes straight to each target Pane's PTY, so multi-line paste confirmation still applies once on the Pane the user types in. Synced terminal Panes show a warning outline while the mode is on. The toggle is runtime-only and off by default after launch.
+Each terminal Pane toolbar has a `workspace.syncInput` toggle, immediately left of the Quick Command Bar toggle. When on, keystrokes typed into the focused terminal Pane are mirrored to every other open terminal Pane, for running the same command across many Sessions at once. Only real keyboard, IME, and paste text is mirrored — mouse and focus control sequences (clicks, drags, scroll, focus reports) are filtered out so they do not arrive as garbled coordinates in other Panes or in shells that never enabled mouse mode. Mirrored input goes straight to each target Pane's PTY, so multi-line paste confirmation still applies once on the Pane the user types in. Because input also reaches terminal Panes on Tabs that are not currently visible, enabling the toggle shows the warning popup `workspace.syncInputEnabledNotice`, the toggle pulses green on every terminal Pane, and each receiving Pane shows a pulsing green outline. The mode is runtime-only and off by default after launch.
 
 ## Find in scrollback
 

--- a/src-tauri/src/native_tooltip.rs
+++ b/src-tauri/src/native_tooltip.rs
@@ -11,14 +11,17 @@ mod platform {
     use super::NativeTooltipRequest;
     use std::sync::Mutex;
     use tauri::Manager;
-    use windows::Win32::Foundation::{HWND, LPARAM, RECT, WPARAM};
+    use windows::Win32::Foundation::{HWND, LPARAM, POINT, RECT, WPARAM};
+    use windows::Win32::Graphics::Gdi::{
+        GetMonitorInfoW, MONITOR_DEFAULTTONEAREST, MONITORINFO, MonitorFromPoint,
+    };
     use windows::Win32::UI::Controls::{
         TOOLTIPS_CLASSW, TTF_ABSOLUTE, TTF_TRACK, TTM_ADDTOOLW, TTM_SETMAXTIPWIDTH,
         TTM_TRACKACTIVATE, TTM_TRACKPOSITION, TTS_ALWAYSTIP, TTS_NOPREFIX, TTTOOLINFOW,
     };
     use windows::Win32::UI::WindowsAndMessaging::{
-        CW_USEDEFAULT, CreateWindowExW, DestroyWindow, SendMessageW, WINDOW_STYLE, WS_EX_TOPMOST,
-        WS_POPUP,
+        CW_USEDEFAULT, CreateWindowExW, DestroyWindow, GetWindowRect, SendMessageW, WINDOW_STYLE,
+        WS_EX_TOPMOST, WS_POPUP,
     };
     use windows::core::PWSTR;
 
@@ -121,6 +124,41 @@ mod platform {
                 Some(WPARAM(1)),
                 Some(LPARAM((&mut tool_info as *mut TTTOOLINFOW) as isize)),
             );
+
+            // With TTF_ABSOLUTE the tooltip is anchored by its top-left corner,
+            // so an icon near a screen edge (e.g. a maximized window's
+            // bottom-right status bar) pushes the tip off-screen and it renders
+            // truncated. Measure the activated tip and clamp it into the
+            // monitor work area, repositioning only when it would overflow.
+            let mut tip_rect = RECT::default();
+            if GetWindowRect(tooltip_hwnd, &mut tip_rect).is_ok() {
+                let tip_width = tip_rect.right - tip_rect.left;
+                let tip_height = tip_rect.bottom - tip_rect.top;
+                let monitor =
+                    MonitorFromPoint(POINT { x: screen_x, y: screen_y }, MONITOR_DEFAULTTONEAREST);
+                let mut monitor_info = MONITORINFO {
+                    cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+                    ..Default::default()
+                };
+                if GetMonitorInfoW(monitor, &mut monitor_info).as_bool() {
+                    let work = monitor_info.rcWork;
+                    let margin = (8.0 * scale_factor).round() as i32;
+                    let clamped_x = screen_x
+                        .min((work.right - tip_width - margin).max(work.left + margin))
+                        .max(work.left + margin);
+                    let clamped_y = screen_y
+                        .min((work.bottom - tip_height - margin).max(work.top + margin))
+                        .max(work.top + margin);
+                    if clamped_x != screen_x || clamped_y != screen_y {
+                        SendMessageW(
+                            tooltip_hwnd,
+                            TTM_TRACKPOSITION,
+                            Some(WPARAM(0)),
+                            Some(LPARAM(make_lparam(clamped_x, clamped_y))),
+                        );
+                    }
+                }
+            }
 
             state.tooltip_hwnd = Some(tooltip_hwnd.0 as isize);
         }

--- a/src/modules/workspace/StatusBar.tsx
+++ b/src/modules/workspace/StatusBar.tsx
@@ -10,7 +10,6 @@ import {
   Lock,
   LoaderCircle,
   MemoryStick,
-  Radio,
   TriangleAlert,
   Unlock,
   X,
@@ -113,7 +112,6 @@ export function StatusBar({
         ) : null}
       </div>
       <div className="status-bar-actions">
-        <SyncInputStatusButton />
         <WatchdogStatusBar />
         <AssistantWorkingStatusButton onOpenAssistant={onOpenAssistant} />
         <CredentialStoreStatusButton />
@@ -316,46 +314,6 @@ function CredentialStoreStatusButton() {
         />
       ) : null}
     </>
-  );
-}
-
-function SyncInputStatusButton() {
-  const { t } = useTranslation();
-  const syncInputEnabled = useWorkspaceStore((state) => state.syncInputEnabled);
-  const setSyncInputEnabled = useWorkspaceStore((state) => state.setSyncInputEnabled);
-  const showStatusBarNotice = useWorkspaceStore((state) => state.showStatusBarNotice);
-  const terminalPaneCount = useWorkspaceStore((state) =>
-    state.tabs.reduce(
-      (total, tab) => (tab.kind === "terminal" ? total + tab.panes.length : total),
-      0,
-    ),
-  );
-
-  // Only useful once two or more terminal panes are open; keep it visible while
-  // enabled so it can always be turned back off.
-  if (!syncInputEnabled && terminalPaneCount < 2) {
-    return null;
-  }
-
-  function toggle() {
-    const next = !syncInputEnabled;
-    setSyncInputEnabled(next);
-    if (next) {
-      showStatusBarNotice(t("workspace.syncInputEnabledNotice"), { tone: "warning" });
-    }
-  }
-
-  return (
-    <button
-      className={`status-bar-action sync-input-status${syncInputEnabled ? " is-active" : ""}`}
-      aria-label={t("workspace.syncInput")}
-      aria-pressed={syncInputEnabled}
-      onClick={toggle}
-      type="button"
-    >
-      <Radio size={14} />
-      <RailTooltip label={t("workspace.syncInput")} />
-    </button>
   );
 }
 

--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -10,7 +10,7 @@ import { SftpWorkspace } from "../sftp/SftpWorkspace";
 import { FileViewerWorkspace } from "../file-viewer/FileViewerWorkspace";
 import { WebViewWorkspace } from "../webview/WebViewWorkspace";
 import { ConnectionGlyph } from "../ConnectionGlyph";
-import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Bot, Check, FileText, Folder, FolderOpen, Mouse, ChevronRight, Circle, ClipboardPaste, Copy, Menu, Monitor, Network, PanelBottom, Pencil, RefreshCw, Save, Search, SplitSquareHorizontal, Square, Type, X } from "lucide-react";
+import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Bot, Check, FileText, Folder, FolderOpen, Mouse, ChevronRight, Circle, ClipboardPaste, Copy, Menu, Monitor, Network, PanelBottom, Pencil, Radio, RefreshCw, Save, Search, SplitSquareHorizontal, Square, Type, X } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
@@ -671,6 +671,18 @@ function layoutContainsPane(layout: LayoutNode, paneId: string): boolean {
 
 function isTerminalPane(pane: WorkspacePane): pane is TerminalPane {
   return pane.kind === undefined || pane.kind === "terminal";
+}
+
+// Matches the control sequences xterm emits for pointer/focus activity rather
+// than typed text, so the sync-input broadcast can skip them. Covers SGR (1006)
+// `CSI < … M/m`, X10 (1000) `CSI M …`, URXVT (1015) `CSI … M`, and focus
+// tracking (1004) `CSI I` / `CSI O`. Keyboard sequences (arrows, function keys,
+// modifyOtherKeys, IME text) never match these, so they still broadcast.
+// eslint-disable-next-line no-control-regex -- ESC (\x1b) is the literal CSI introducer we must match.
+const TERMINAL_POINTER_SEQUENCE = /^\x1b\[(M|<[0-9;]*[Mm]|[0-9;]+M|[IO])/;
+
+function isTerminalPointerSequence(data: string): boolean {
+  return TERMINAL_POINTER_SEQUENCE.test(data);
 }
 
 function EmbeddedConnectionPane({
@@ -1516,6 +1528,7 @@ function TerminalPaneView({
   const sshSettings = useWorkspaceStore((state) => state.sshSettings);
   const generalSettings = useWorkspaceStore((state) => state.generalSettings);
   const syncInputEnabled = useWorkspaceStore((state) => state.syncInputEnabled);
+  const setSyncInputEnabled = useWorkspaceStore((state) => state.setSyncInputEnabled);
   const x11ForwardingStatus = pane.x11ForwardingStatus ?? (
     pane.connection?.type === "ssh" && sshSettings.managedXServerEnabled ? "enabled" : "disabled"
   );
@@ -1798,7 +1811,11 @@ function TerminalPaneView({
       // mirrored to every other open terminal pane.
       void writeWithPasteConfirmation(data, (input) => {
         writeInputToSession(input);
-        if (useWorkspaceStore.getState().syncInputEnabled) {
+        // Only mirror real keyboard/IME/paste text. xterm routes mouse and
+        // focus activity through onData as control sequences too; broadcasting
+        // those would dump garbled coordinates into the other panes (and into
+        // shells that never enabled mouse mode), so they are filtered out.
+        if (useWorkspaceStore.getState().syncInputEnabled && !isTerminalPointerSequence(input)) {
           broadcastInputToOtherPanes(pane.id, input);
         }
       });
@@ -2518,6 +2535,23 @@ function TerminalPaneView({
               <Folder size={13} />
             </button>
           ) : null}
+          <button
+            className={`terminal-pane-action terminal-sync-toggle${syncInputEnabled ? " active" : ""}`}
+            aria-label={t("workspace.syncInput")}
+            aria-pressed={syncInputEnabled}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => {
+              const next = !syncInputEnabled;
+              setSyncInputEnabled(next);
+              if (next) {
+                showStatusBarNotice(t("workspace.syncInputEnabledNotice"), { tone: "warning" });
+              }
+            }}
+            title={t("workspace.syncInput")}
+            type="button"
+          >
+            <Radio size={13} />
+          </button>
           <button
             className={`terminal-pane-action quick-command-toggle${quickCommandBarVisible ? " active" : ""}`}
             aria-label={quickCommandBarVisible ? t("terminal.quickCommandsHide") : t("terminal.quickCommandsShow")}

--- a/src/modules/workspace/connections/terminal/terminal.css
+++ b/src/modules/workspace/connections/terminal/terminal.css
@@ -262,9 +262,40 @@
 }
 
 /* Input is mirrored to this pane; warn before typing into many sessions. */
+/* Input is mirrored to every open terminal Pane while sync is on, including
+   Panes on Tabs that are not currently visible, so the cue must be loud: a
+   pulsing green outline on each receiving Pane and a pulsing green toolbar
+   toggle. */
 .terminal-pane-sync-active {
-  outline: 2px solid var(--notice-warning);
+  outline: 2px solid var(--green);
   outline-offset: -2px;
+  animation: terminal-sync-pulse 1.6s ease-in-out infinite;
+}
+
+.terminal-pane-action.terminal-sync-toggle.active {
+  color: var(--green);
+  background: color-mix(in srgb, var(--green) 18%, transparent);
+  animation: terminal-sync-toggle-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes terminal-sync-pulse {
+  0%,
+  100% {
+    outline-color: color-mix(in srgb, var(--green) 55%, transparent);
+  }
+  50% {
+    outline-color: var(--green);
+  }
+}
+
+@keyframes terminal-sync-toggle-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--green) 60%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--green) 28%, transparent);
+  }
 }
 
 .terminal-pane-search-open {

--- a/src/modules/workspace/workspace.css
+++ b/src/modules/workspace/workspace.css
@@ -372,10 +372,6 @@
   color: var(--accent);
 }
 
-.sync-input-status.is-active {
-  color: var(--notice-warning);
-  background: color-mix(in srgb, var(--notice-warning) 16%, transparent);
-}
 
 .status-bar-x-server-glyph {
   display: inline-grid;


### PR DESCRIPTION
## Summary

Fixes three bugs, two in the sync-input feature and one unrelated tooltip bug.

### 1. Sync input garbled other terminals on mouse clicks/scroll
When sync was on, clicking or scrolling in the commander terminal injected garbled coordinates (e.g. `0;64;18M…`, `/bin/sh: 64: not found`) into the other terminals. xterm routes pointer and focus activity through `onData` as control sequences, and those were being broadcast alongside real input. The broadcast now forwards **only real keyboard/IME/paste text** — SGR (1006), X10 (1000), URXVT (1015) mouse reports and focus tracking (1004) are filtered out. The source pane still receives its own mouse events, so mouse mode keeps working where you type. Keyboard sequences (arrows, function keys, modifyOtherKeys, IME) never match the filter, so they still mirror.

### 2. Sync toggle moved to the terminal toolbar with a loud green cue
Per request, the toggle moved from the Status Bar to each terminal Pane toolbar, immediately left of the Quick Command Bar toggle. Because input can reach terminal Panes on Tabs that are not visible, when enabled the toggle **pulses green** and every receiving Pane shows a **pulsing green outline**, plus the existing warning popup on enable. The state is still runtime-only and off after relaunch.

### 3. Native tooltip truncated at the right edge when maximized
Bottom-right Status Bar icons (Don't Sleep, etc.) showed their tooltip clipped past the screen edge on a maximized window. `RailTooltip` uses a native Win32 tooltip anchored by its top-left corner; it is now measured after activation and **clamped into the monitor work area**, repositioning only when it would overflow.

## Type of change

- [x] Bug fix

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)
- [x] Backend (Rust/Tauri — `src-tauri/native_tooltip.rs`)
- [x] Docs (manual + localization_todo notes)

## Implementation notes

- [TerminalWorkspace.tsx](src/modules/workspace/connections/terminal/TerminalWorkspace.tsx) — `isTerminalPointerSequence` guard on the broadcast path; new toolbar toggle button; `Radio` icon import.
- [StatusBar.tsx](src/modules/workspace/StatusBar.tsx) — removed the old status-bar toggle.
- [terminal.css](src/modules/workspace/connections/terminal/terminal.css) — green pulsing toggle + Pane outline animations; [workspace.css](src/modules/workspace/workspace.css) — removed the obsolete status-bar rule.
- [native_tooltip.rs](src-tauri/src/native_tooltip.rs) — `GetWindowRect` + `MonitorFromPoint`/`GetMonitorInfoW` clamp into `rcWork`.

No new i18n keys (reused `workspace.syncInput` / `workspace.syncInputEnabledNotice`); their localization_todo notes were updated to point at the new toolbar location.

## Checks

- [x] ESLint (0 errors), `tsc --noEmit` (clean), frontend tests (554/554)
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` (clean, no warnings)
- [ ] Validated in the real Tauri desktop runtime — not yet done

## Notes for reviewers

Worth a real-runtime pass (the Win32 tooltip and terminal input can't be exercised in Vite/CI):
1. Split a Tab into ≥2 terminal Panes, enable sync from the toolbar, **click/scroll** in a tmux pane with mouse mode on — the other panes must stay clean; then type a command and confirm it mirrors.
2. Confirm the toggle and receiving panes pulse green.
3. Maximize the window and hover the bottom-right Don't Sleep icon — the tooltip should be fully visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
