### PR TITLE
fix: refresh PATH into psmux panes and right-align psmux toggle

### DIFF
--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -2376,6 +2376,21 @@ fn is_powershell_family_program(program: &str) -> bool {
     matches!(name, "powershell.exe" | "pwsh.exe" | "powershell" | "pwsh")
 }
 
+/// Builds the `new-session -e PATH=<value>` arguments that refresh PATH into a
+/// freshly created psmux pane. Returned empty when no PATH is available so the
+/// pane simply inherits the server environment. Kept separate (and taking PATH
+/// as an argument) so the wiring is unit-testable without psmux installed.
+fn psmux_pane_environment_args(path: Option<OsString>) -> Vec<OsString> {
+    let mut args = Vec::new();
+    if let Some(path) = path.filter(|value| !value.is_empty()) {
+        let mut entry = OsString::from("PATH=");
+        entry.push(path);
+        args.push(OsString::from("-e"));
+        args.push(entry);
+    }
+    args
+}
+
 fn psmux_session_id_for_launch(value: Option<&str>) -> Option<String> {
     let trimmed = value.map(str::trim).unwrap_or_default();
     if trimmed.is_empty() {
@@ -2482,6 +2497,16 @@ fn command_for(request: &StartTerminalSessionRequest) -> Result<CommandBuilder, 
                 command.arg("-A");
                 command.arg("-s");
                 command.arg(&session_id);
+                // Refresh PATH into the new pane. A psmux server is persistent and
+                // (like tmux) only refreshes its `update-environment` variables on
+                // attach — PATH is not among them — so a session created on an
+                // already-running server otherwise inherits the stale PATH the
+                // server captured at start and cannot find executables added to
+                // PATH afterwards (e.g. `claude`). `new-session -e` sets the
+                // pane's PATH explicitly from the current process environment.
+                for arg in psmux_pane_environment_args(std::env::var_os("PATH")) {
+                    command.arg(arg);
+                }
                 command.arg("--");
                 command.arg(&resolved_program);
                 for arg in &parsed.args {
@@ -3538,6 +3563,22 @@ mod tests {
         assert_eq!(psmux_session_id_for_launch(Some("   ")), None);
         // tmux/psmux target delimiters are rejected, matching the SSH path.
         assert_eq!(psmux_session_id_for_launch(Some("has:colon")), None);
+    }
+
+    #[test]
+    fn psmux_pane_environment_refreshes_current_path() {
+        // A stale psmux server would otherwise leave the pane with an outdated
+        // PATH; `new-session -e PATH=...` pins the current process PATH so tools
+        // like `claude` stay discoverable.
+        let args = psmux_pane_environment_args(Some(OsString::from("C:\\a;C:\\b")))
+            .iter()
+            .map(|value| value.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(args, vec!["-e".to_string(), "PATH=C:\\a;C:\\b".to_string()]);
+
+        // No PATH (or an empty one) means nothing to refresh.
+        assert!(psmux_pane_environment_args(None).is_empty());
+        assert!(psmux_pane_environment_args(Some(OsString::new())).is_empty());
     }
 
     #[test]

--- a/src/modules/workspace/connections/connections.css
+++ b/src/modules/workspace/connections/connections.css
@@ -1900,6 +1900,13 @@ fieldset.connection-specific-options > legend {
   grid-column: 3;
 }
 
+/* A popup <select> fills the control column, but a toggle's fixed-width switch
+   would otherwise sit at the column's left edge. Pin it to the right so the
+   switch lines up flush with the card edge like every other control. */
+.connection-option-fields > .connection-session-toggle:has(.option-glyph) > input[type="checkbox"] {
+  justify-self: end;
+}
+
 /* Dim the glyph alongside its disabled control (inherit-defaults state). */
 .connection-dialog label:has(:disabled) .option-glyph {
   opacity: 0.55;

--- a/tests/connection-dialog-layout.test.mjs
+++ b/tests/connection-dialog-layout.test.mjs
@@ -25,3 +25,13 @@ assert.match(
   /grid-template-columns:\s*auto\s+minmax\(0,\s*1fr\)\s+minmax\(120px,\s*168px\);/,
   "option panel toggle rows should use the same label start as select rows"
 );
+
+const optionToggleSwitchRule = connectionStyles.match(
+  /\.connection-option-fields\s*>\s*\.connection-session-toggle:has\(\.option-glyph\)\s*>\s*input\[type="checkbox"\]\s*\{(?<body>[^}]*)\}/s,
+);
+assert.ok(optionToggleSwitchRule, "option-field toggle switches should have a right-alignment rule");
+assert.match(
+  optionToggleSwitchRule.groups.body,
+  /justify-self:\s*end;/,
+  "the psmux toggle switch should sit flush with the right edge of its control column"
+);


### PR DESCRIPTION
## Summary

Two fixes around psmux session management on the local connection dialog.

### 1. Bug: `claude` (and other PATH tools) not found when psmux auto-management is enabled

psmux is a **persistent** multiplexer that follows tmux semantics: its server caches the environment from whenever it *first started*, and on attach only refreshes the variables named by `update-environment` — and **PATH is not on that list** (the tmux defaults are `DISPLAY`, `SSH_*`, etc.). So when a session is created on an already-running psmux server, the new pane inherits the server's **stale PATH** and can't find executables added to PATH after the server launched (e.g. `claude`). Shells launched directly work because they inherit KKTerm's current process environment.

**Fix:** psmux supports tmux 3.2's `new-session -e VAR=val`, which sets the new pane's environment explicitly. We now inject the current process `PATH`:

```
psmux new-session -A -s <name> -e PATH=<current PATH> -- pwsh …
```

so the pane always gets a fresh PATH regardless of the server's cache. Extracted into a testable `psmux_pane_environment_args()` helper.

*Inherent limitation:* if the named session already exists, attach reuses the already-running pane, whose env can't be changed — only newly created sessions get the refreshed PATH. This matches standard tmux/psmux behavior.

Refs: [psmux compatibility docs](https://github.com/psmux/psmux/blob/master/docs/compatibility.md), [psmux configuration docs](https://github.com/psmux/psmux/blob/master/docs/configuration.md)

### 2. Tweak: right-align the psmux toggle

The toggle is a glyph-bearing direct child of `.connection-option-fields`, so it matched the select-row grid rule (`grid-template-columns: auto minmax(0,1fr) minmax(120px,168px)`). A full-width `<select>` fills that control column, but the fixed-width 38px switch defaulted to the **left** of it, leaving a ~150px gap. Pinned the switch flush right with `justify-self: end`.

## Testing

- `cargo test --lib sessions::tests::psmux` — 4 tests pass (incl. new `psmux_pane_environment_refreshes_current_path`)
- `node --test tests/connection-dialog-layout.test.mjs` — passes (new right-alignment assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)