### PR TITLE
Simplify workspace icon section in edit dialog

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -725,6 +725,10 @@
 }
 
 .new-workspace-summary {
+  grid-template-columns: auto auto;
+  justify-content: start;
+  gap: 12px;
+  padding: 8px 10px;
   background: var(--surface);
 }
 

--- a/src/modules/workspace/NewWorkspaceDialog.tsx
+++ b/src/modules/workspace/NewWorkspaceDialog.tsx
@@ -226,10 +226,6 @@ export function NewWorkspaceDialog({
               name={name || workspace?.name || t("workspace.newWorkspace")}
               onChange={setIcon}
             />
-            <span>
-              <strong>{name.trim() || workspace?.name || t("workspace.newWorkspace")}</strong>
-              <small>{t("workspace.workspaceIcon")}</small>
-            </span>
             <ConnectionIconBackgroundPicker
               color={iconColor}
               onChange={setIconColor}


### PR DESCRIPTION
## What changed

In the new/edit workspace dialog, the icon section previously showed three things in a full-width row: the icon edit button, the workspace name title with an "Icon" caption beneath it, and the color palette.

This PR removes the name title and "Icon" caption, leaving just the icon edit button + color palette. The summary section is collapsed from a full-width three-column grid (`auto minmax(0,1fr) auto`) to a compact, left-aligned two-column layout (`auto auto`) with reduced padding (`8px 10px` vs `13px 14px`), shrinking its footprint by roughly half.

## Why

The name title was redundant (the name is already shown/edited in the field below), and the section took up more vertical and horizontal space than needed. This makes the icon-editing area a plain icon edit + palette control.

## Files

- `src/modules/workspace/NewWorkspaceDialog.tsx` — removed the `<span>` rendering the name (`<strong>`) and `workspace.workspaceIcon` caption (`<small>`).
- `src/app/app.css` — overrode `.new-workspace-summary` to the compact two-column layout.

## Reviewer notes

- The `workspace.workspaceIcon` i18n key is now only referenced by the icon edit button's aria-label (`editWorkspaceIcon` is separate); the `workspaceIcon` key itself is left in place as it's harmless and may be reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)