### PR TITLE
feat: detect serial ports and make Line field an editable dropdown

### DIFF
--- a/docs/localization_todo/connections.serialLinePlaceholder.md
+++ b/docs/localization_todo/connections.serialLinePlaceholder.md
@@ -1,0 +1,16 @@
+# connections.serialLinePlaceholder
+
+- **English value**: `e.g. COM3 or /dev/cu.usbserial-1410`
+- **Namespace**: `connections`
+- **File/component**: `src/modules/workspace/connections/connection-dialog/SerialConnectionFields.tsx`
+- **UI role**: `placeholder`
+- **User flow**: Shown in the empty Serial connection "Line" field of the add/edit connection dialog, hinting at the device-path format the user may type or pick from the detected-port dropdown.
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Context/meaning**: Example of a serial device identifier. Was previously the Windows-only literal `COM1`, which misled macOS/Linux users (issue #429); now gives a cross-platform example. The `e.g.` is an abbreviation for "for example" and the device strings are technical examples — translate the `e.g.` lead-in but keep `COM3` and `/dev/cu.usbserial-1410` verbatim as literal device names.
+- **Domain notes**: `COM3` (Windows) and `/dev/cu.usbserial-1410` (macOS) are literal OS serial-port path examples and must stay unchanged in every locale.
+
+<!--
+Filename: connections.serialLinePlaceholder.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/manual/03-connections.md
+++ b/docs/manual/03-connections.md
@@ -16,7 +16,7 @@
 | Local terminal | `connections.localShell` | Local PTY (ConPTY/`portable_pty`). |
 | SSH terminal | `connections.secureShell`, type label `connections.ssh` | Backed by the `NativeSsh` transport. May persist tmux launch prefs. |
 | Telnet | `connections.telnetShell`, type label `connections.telnet` | Password terminal. |
-| Serial | `connections.serialLine`, type label `connections.serial` | Serial line. |
+| Serial | `connections.serialLine`, type label `connections.serial` | Serial line. The `connections.line` field is an editable dropdown (`list_serial_ports`): it scans OS-detected ports (macOS `/dev/cu.*`, Linux `/dev/tty*`, Windows `COM*`) as pick-or-type suggestions and defaults to the first detected port, falling back to a platform-appropriate example when none are found. |
 | URL | `connections.embeddedWebApp` | Embedded WebView2 overlay window. See [08-url-webview.md](08-url-webview.md). |
 | RDP | `connections.windowsRdp` | Windows native via mstscax. See [09-remote-desktop.md](09-remote-desktop.md). |
 | VNC | `connections.screenControl` | RFB through `vnc-rs`. |

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -689,6 +689,11 @@ fn delete_url_credential(
 }
 
 #[tauri::command]
+fn list_serial_ports() -> Vec<String> {
+    serial::available_serial_ports()
+}
+
+#[tauri::command]
 fn list_url_data_partitions(
     storage: tauri::State<'_, storage::Storage>,
 ) -> Result<Vec<storage::UrlDataPartitionSummary>, String> {
@@ -3396,6 +3401,7 @@ pub fn run() {
             duplicate_connection,
             move_connection_folder,
             move_connection,
+            list_serial_ports,
             // ── URL connections & credentials
             update_url_connection_icon_from_page,
             upsert_url_credential,

--- a/src-tauri/src/serial.rs
+++ b/src-tauri/src/serial.rs
@@ -36,6 +36,23 @@ impl NativeSerialTerminal {
     }
 }
 
+/// Enumerate serial ports the OS currently exposes.
+///
+/// Backed by `serial2`, which scans IOKit on macOS (`/dev/cu.*`), `/sys/class/tty`
+/// on Linux (`/dev/ttyUSB*`, `/dev/ttyACM*`, …) and the `SERIALCOMM` registry on
+/// Windows (`COM*`). Enumeration is best-effort: on any error we return an empty
+/// list so callers can still fall back to manual entry.
+pub fn available_serial_ports() -> Vec<String> {
+    let mut ports: Vec<String> = SerialPort::available_ports()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect();
+    ports.sort();
+    ports.dedup();
+    ports
+}
+
 pub fn start_native_terminal(
     app: AppHandle,
     request: NativeSerialTerminalRequest,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2045,7 +2045,7 @@
     "cliAccountApply": "Set account profile",
     "line": "Line",
     "speed": "Speed",
-    "serialLinePlaceholder": "COM1",
+    "serialLinePlaceholder": "e.g. COM3 or /dev/cu.usbserial-1410",
     "url": "URL",
     "urlPlaceholder": "https://example.com",
     "dataPartition": "Data partition",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1243,6 +1243,10 @@ type CommandMap = {
     args: undefined;
     result: UrlDataPartitionSummary[];
   };
+  list_serial_ports: {
+    args: undefined;
+    result: string[];
+  };
   clear_url_data_partition: {
     args: { name: string };
     result: null;

--- a/src/modules/workspace/connections/connection-dialog/SerialConnectionFields.tsx
+++ b/src/modules/workspace/connections/connection-dialog/SerialConnectionFields.tsx
@@ -1,9 +1,42 @@
+import { useEffect, useId, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { technicalInputProps } from "../../../../lib/inputBehavior";
+import { isMacPlatform, isWindowsPlatform } from "../../../../lib/platform";
+import { invokeCommand } from "../../../../lib/tauri";
 import type { Connection } from "../../../../types";
+
+function platformDefaultLine(): string {
+  if (isWindowsPlatform()) return "COM1";
+  if (isMacPlatform()) return "/dev/cu.";
+  return "/dev/ttyUSB0";
+}
 
 export function SerialConnectionFields({ initialConnection }: { initialConnection?: Connection }) {
   const { t } = useTranslation();
+  const datalistId = useId();
+  const [ports, setPorts] = useState<string[]>([]);
+  const initialLine = initialConnection?.serialLine ?? initialConnection?.host ?? platformDefaultLine();
+  const [line, setLine] = useState(initialLine);
+
+  useEffect(() => {
+    let cancelled = false;
+    invokeCommand("list_serial_ports")
+      .then((detected) => {
+        if (cancelled) return;
+        setPorts(detected);
+        // Pre-fill the first detected port only when the user hasn't already
+        // provided a line (new connection still showing the platform default).
+        if (detected[0] && initialLine === platformDefaultLine()) {
+          setLine((current) => (current === platformDefaultLine() ? detected[0] : current));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setPorts([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [initialLine]);
 
   return (
     <>
@@ -17,10 +50,19 @@ export function SerialConnectionFields({ initialConnection }: { initialConnectio
           <input
             name="serialLine"
             {...technicalInputProps}
-            defaultValue={initialConnection?.serialLine ?? initialConnection?.host ?? "COM1"}
+            list={ports.length > 0 ? datalistId : undefined}
+            value={line}
+            onChange={(event) => setLine(event.currentTarget.value)}
             placeholder={t("connections.serialLinePlaceholder")}
             required
           />
+          {ports.length > 0 && (
+            <datalist id={datalistId}>
+              {ports.map((port) => (
+                <option key={port} value={port} />
+              ))}
+            </datalist>
+          )}
         </label>
         <label className="endpoint-port-input">
           <span>{t("connections.speed")}*</span>


### PR DESCRIPTION
## Summary

The Serial connection dialog hardcoded the **Line** field default to `COM1`, a Windows-only device name that misled macOS (`/dev/cu.*`) and Linux (`/dev/tty*`) users. The field was also plain free text with no way to discover which ports actually exist. This adds cross-platform port detection and turns the Line field into an editable (type-or-pick) dropdown.

Closes #429.

## Type of change

- [x] Feature
- [x] Bug fix
- [x] Docs / manual

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)
- [x] Backend (Rust/Tauri — `src-tauri/`)
- [x] Docs (`docs/`, manual, ADR)

## What changed

- **Backend:** `serial::available_serial_ports()` enumerates ports via the existing `serial2` dependency (no new crate) and is exposed as the `list_serial_ports` Tauri command. Cross-platform out of the box — macOS `/dev/cu.*` (IOKit), Linux `/dev/ttyUSB*`/`ttyACM*` (`/sys/class/tty`), Windows `COM*` (registry). Best-effort: sorted/deduped, returns empty on error so manual entry still works.
- **Frontend:** the Line field is now a native `<input list>` + `<datalist>` (the same pick-or-type pattern already used in AiSettings/TerminalSettings/SftpFilePane). It queries `list_serial_ports` on mount, pre-fills the first detected port, and fixes the `COM1`-on-every-OS default with a platform-aware fallback (`COM1` / `/dev/cu.` / `/dev/ttyUSB0`). The input is controlled so the async-detected default lands reliably.

## Domain & docs

- [x] Uses canonical vocabulary (Connection / Session / Tab)
- [x] Reused the typed `invokeCommand` wrapper / `CommandMap` in `src/lib/tauri.ts`
- [x] Updated the relevant manual chapter (`docs/manual/03-connections.md`)

## i18n

- [x] Changed `connections.serialLinePlaceholder` (was the Windows-only `COM1`) in `en.json` first, with a matching pending file under `docs/localization_todo/`
- [x] One full sentence per key, no placeholders needed

## Checks

- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` (serial suite, 11 passed)
- [x] `tsc --noEmit` clean; `npm run i18n:check` passes (all 14 locales match)
- [ ] Not yet validated in the real Tauri desktop runtime

## Notes for reviewers

- Deliberately scoped out (per the simplicity rule, and confirmed with the requester): no live hot-plug events and no manual "rescan" button — ports are re-queried each time the dialog opens. Easy to add a refresh affordance later.
- macOS callout devices (`cu.*`, what `serial2` returns) are the correct choice for a terminal vs. the `tty.*` dial-in devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
