### PR TITLE
fix: switch to a connection's parent workspace when opening it from the activity rail

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -1539,7 +1539,24 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     ),
   setDocumentStatusSlot: (slot) =>
     set((state) => (state.documentStatusSlot === slot ? {} : { documentStatusSlot: slot })),
-  activateTab: (tabId) => set({ activeTabId: tabId }),
+  activateTab: (tabId) => {
+    const state = get();
+    const tab = state.tabs.find((candidate) => candidate.id === tabId);
+    const targetWorkspaceId = tabWorkspaceId(tab);
+    // Activating a tab from another Workspace (e.g. a connected/pinned
+    // connection in the activity rail) must also switch to its parent
+    // Workspace; otherwise the canvas filters it out and shows "no active
+    // session" over the wrong Workspace.
+    if (tab && targetWorkspaceId !== state.activeWorkspaceId) {
+      persistActiveWorkspaceId(targetWorkspaceId);
+      set({ activeTabId: tabId, activeWorkspaceId: targetWorkspaceId });
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent("kkterm:connection-tree-invalidated"));
+      }
+      return;
+    }
+    set({ activeTabId: tabId });
+  },
   renameTab: async (tabId, title) => {
     const displayTitle = title.trim();
     if (!displayTitle) {


### PR DESCRIPTION
## What

Activating a tab now also switches the active workspace to that tab's parent workspace when they differ.

## Why

Clicking a connected or pinned connection in the activity rail routes through `activateTab`, which previously only set `activeTabId`. The workspace canvas filters tabs by `activeWorkspaceId` (`tabWorkspaceId(tab) === activeWorkspaceId`), so when the clicked connection's tab belonged to a different workspace than the active one, the tab was filtered out and the canvas rendered the "No active session" empty state over the wrong workspace.

## How

`activateTab` in `src/store.ts` now looks up the target tab, and if its parent workspace differs from the active one, switches `activeWorkspaceId` alongside `activeTabId`. It mirrors `setActiveWorkspace`'s side effects:
- persists the active workspace id
- dispatches `kkterm:connection-tree-invalidated` so the rail, sidebar, and connection tree re-read the new workspace's tree

Same-workspace callers (tab strip, connection sidebar, assistant tools) are unaffected since the workspace already matches — the early branch is a no-op for them.

## Notes for reviewers

- Pinned connections only surface in the rail when they belong to the active workspace's tree, so the `openConnection` (no existing tab) path always creates the tab in the correct workspace and didn't need changes. The cross-workspace case only arises for connected/pinned items backed by an existing tab, which always route through `activateTab`.
- `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)