### PR TITLE
fix: connection tree follows the active workspace when opening a connection from the rail

### DIFF
--- a/src/modules/workspace/connections/ConnectionSidebar.tsx
+++ b/src/modules/workspace/connections/ConnectionSidebar.tsx
@@ -347,7 +347,6 @@ export function ConnectionSidebar({
   const suppressTreeClickRef = useRef(false);
 
   useEffect(() => {
-    void reloadConnectionGroups();
     const handleTreeInvalidated = () => {
       void reloadConnectionGroups();
     };
@@ -360,6 +359,14 @@ export function ConnectionSidebar({
       void unlistenPromise.then((unlisten) => unlisten());
     };
   }, []);
+
+  // The tree always reflects the active Workspace. Reload whenever it changes
+  // (initial mount included) so activating a Tab from another Workspace in the
+  // activity rail — which switches Workspaces without touching the tree — still
+  // updates the tree, rather than relying solely on the invalidation event.
+  useEffect(() => {
+    void reloadConnectionGroups();
+  }, [activeWorkspaceId]);
 
   useEffect(() => {
     persistStoredChildConnections(childConnections);


### PR DESCRIPTION
## What

The connection tree (sidebar) now reloads reactively whenever `activeWorkspaceId` changes, instead of relying solely on the imperative `kkterm:connection-tree-invalidated` event.

## Why

Follow-up to #440. That PR fixed the canvas showing "No active session" when opening a connected connection from the activity rail that belongs to a different workspace — `activateTab` now switches `activeWorkspaceId` to the tab's parent workspace.

However, the connection tree did not follow the workspace switch. The canvas filters by `activeWorkspaceId` reactively, so it updated immediately; but the sidebar reloaded its tree **only** in response to the explicit `kkterm:connection-tree-invalidated` event. This couples correctness to every workspace-switching caller remembering to fire that event.

## How

`ConnectionSidebar` now reloads its tree in a `useEffect` keyed on `activeWorkspaceId` (which also covers the initial mount). The existing mount effect is reduced to just registering the invalidation/backend-change listeners. The tree now always reflects the active workspace regardless of how the switch happened.

## Notes for reviewers

- `tsc --noEmit` passes; lint shows only pre-existing warnings (none on the new effect).
- The `reloadConnectionGroups` reference in the new effect follows the same pattern as the existing mount effect (reads `useWorkspaceStore.getState().activeWorkspaceId` internally), so it is intentionally not listed as a dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)