### PR TITLE
fix: launch CLI auth terminal with verbatim cmd.exe command line

### DIFF
--- a/src-tauri/src/ai/cli_backend.rs
+++ b/src-tauri/src/ai/cli_backend.rs
@@ -934,15 +934,14 @@ pub(crate) fn cli_process_invocation(command: &str, args: &[&str]) -> (String, V
 pub(crate) fn spawn_external_terminal(command: &str) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
+        use std::os::windows::process::CommandExt;
         let mut cmd = Command::new("cmd.exe");
-        cmd.args([
-            "/C",
-            "start",
-            "KKTerm AI CLI Auth",
-            "cmd.exe",
-            "/K",
-            command,
-        ]);
+        // `command` is already shell-quoted (the CLI path is wrapped in double
+        // quotes). Passing it through Rust's normal arg API escapes those quotes
+        // to `\"`, which cmd.exe's `/K` parser does not understand, so the launch
+        // fails with `'\"...claude.cmd\"' is not recognized`. `raw_arg` appends the
+        // command line verbatim instead, letting us control quoting exactly.
+        cmd.raw_arg(windows_external_terminal_command_line(command));
         cmd.spawn()
             .map_err(|error| format!("failed to open external terminal: {error}"))?;
         return Ok(());
@@ -956,6 +955,18 @@ pub(crate) fn spawn_external_terminal(command: &str) -> Result<(), String> {
             .map_err(|error| format!("failed to start CLI auth command: {error}"))?;
         Ok(())
     }
+}
+
+/// Builds the verbatim `cmd.exe` command line that opens a titled console window
+/// and runs `command` in it, keeping the window open afterwards (`/K`).
+///
+/// `command` arrives already shell-quoted. Wrapping it in an extra pair of quotes
+/// makes the inner `cmd /K` apply its quote-stripping rule (strip the outermost
+/// pair), reconstructing the original quoted command — and this stays correct even
+/// when the CLI path contains spaces.
+#[cfg(any(target_os = "windows", test))]
+pub(crate) fn windows_external_terminal_command_line(command: &str) -> String {
+    format!("/C start \"KKTerm AI CLI Auth\" cmd.exe /K \"{command}\"")
 }
 
 pub(crate) fn shell_quote(value: &str) -> String {

--- a/src-tauri/src/ai/tests.rs
+++ b/src-tauri/src/ai/tests.rs
@@ -304,6 +304,42 @@ fn windows_cli_process_args_run_cmd_shims_through_cmd_exe() {
 }
 
 #[test]
+fn windows_external_terminal_command_line_wraps_quoted_command() {
+    // A `.cmd` shim installed via nvm-for-windows: shell_quote wraps the path in
+    // double quotes, and the external-terminal command line must wrap that whole
+    // command in a second quote pair so the inner `cmd /K` strips exactly the
+    // outer pair and runs the original quoted command. Regression for the
+    // `'\"...claude.cmd\"' is not recognized` failure on quote-escaped launches.
+    let command = format!(
+        "{} auth login",
+        shell_quote("C:\\nvm4w\\nodejs\\claude.cmd")
+    );
+
+    let line = windows_external_terminal_command_line(&command);
+
+    assert_eq!(
+        line,
+        "/C start \"KKTerm AI CLI Auth\" cmd.exe /K \"\"C:\\nvm4w\\nodejs\\claude.cmd\" auth login\""
+    );
+    // The embedded quotes must stay raw (`"`), never escaped to `\"`, which is
+    // what broke cmd's parsing when the command went through Rust arg-escaping.
+    assert!(!line.contains("\\\""));
+}
+
+#[test]
+fn windows_external_terminal_command_line_handles_paths_with_spaces() {
+    let command = format!(
+        "{} auth login",
+        shell_quote("C:\\Program Files\\nodejs\\claude.cmd")
+    );
+
+    let line = windows_external_terminal_command_line(&command);
+
+    // Outer wrap keeps the space-containing path quoted after cmd strips one pair.
+    assert!(line.ends_with("/K \"\"C:\\Program Files\\nodejs\\claude.cmd\" auth login\""));
+}
+
+#[test]
 fn cli_backend_command_names_include_windows_npm_shims() {
     let codex_names = cli_backend_command_names(AiCliBackendKind::Codex);
     let claude_names = cli_backend_command_names(AiCliBackendKind::ClaudeCode);


### PR DESCRIPTION
## What

Fixes the **Authenticate** button in AI Assistant settings failing for the Claude Code (and Codex) CLI when the CLI is installed via Node/nvm-for-windows.

## Why

When `claude` resolves to a `.cmd` shim such as `C:\nvm4w\nodejs\claude.cmd`, the auth command was built as a pre-quoted string (`"C:\nvm4w\nodejs\claude.cmd" auth login`) and passed as a **single Rust `Command` arg** to `cmd.exe`. Rust's Windows arg escaper rewrote the embedded `"` to `\"`, so the inner `cmd /K` received `\"...claude.cmd\" auth login`. cmd's quote-stripping rule only triggers when the first char is a real `"` — here it's a backslash — so cmd tried to run the literal token and failed with:

```
'\"C:\nvm4w\nodejs\claude.cmd\"' is not recognized as an internal or external command
```

## How

- `spawn_external_terminal` (Windows branch) now builds the `cmd.exe` command line **verbatim** via `CommandExt::raw_arg`, bypassing Rust's arg escaping so the quotes stay raw.
- New pure helper `windows_external_terminal_command_line` wraps the already-quoted command in an extra quote pair, so the inner `cmd /K` strips exactly the outer pair and reconstructs the original command — correct even when the CLI path contains spaces.

## Notes for reviewers

- This only affected the **interactive auth launch**. The non-interactive status check (`run_cli_capture` → `cli_process_invocation`) already split `.cmd` shims into separate args correctly, which is why settings showed "CLI is installed and authenticated" while *Authenticate* failed.
- Added two regression tests: the nvm `.cmd` case (asserts quotes stay raw, never `\"`) and a spaces-in-path case. All 136 `ai::tests` pass on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)