### PR TITLE
feat: add GLM-5.2 as curated OpenCode model

### DIFF
--- a/src/ai/providerRegistry/modelCatalog.ts
+++ b/src/ai/providerRegistry/modelCatalog.ts
@@ -162,6 +162,7 @@ export const AI_PROVIDER_MODEL_CATALOG: AiProviderModelCatalog = {
       { id: "kimi-k2.6", label: "Kimi K2.6", recommended: true, supportsImageInput: false },
       { id: "deepseek-v4-flash", label: "DeepSeek V4 Flash", recommended: true, supportsImageInput: false },
       { id: "deepseek-v4-pro", label: "DeepSeek V4 Pro", recommended: true, supportsImageInput: false },
+      { id: "glm-5.2", label: "GLM-5.2", recommended: true, supportsImageInput: false },
       { id: "glm-5.1", label: "GLM-5.1", supportsImageInput: false },
       { id: "qwen3.6-plus", label: "Qwen3.6 Plus", supportsImageInput: false },
       { id: "mimo-v2.5", label: "MiMo-V2.5", supportsImageInput: false },

--- a/src/ai/providerRegistry/opencode.ts
+++ b/src/ai/providerRegistry/opencode.ts
@@ -19,6 +19,7 @@ export const opencodeProvider: AiProviderDefinition = {
     { id: "kimi-k2.5", label: "Kimi K2.5", supportsImageInput: false },
     { id: "deepseek-v4-pro", label: "DeepSeek V4 Pro", supportsImageInput: false },
     { id: "deepseek-v4-flash", label: "DeepSeek V4 Flash", supportsImageInput: false },
+    { id: "glm-5.2", label: "GLM-5.2", supportsImageInput: false },
     { id: "glm-5.1", label: "GLM-5.1", supportsImageInput: false },
     { id: "glm-5", label: "GLM-5", supportsImageInput: false },
     { id: "qwen3.6-plus", label: "Qwen3.6 Plus", supportsImageInput: false },


### PR DESCRIPTION
## What

Adds **GLM-5.2** to the OpenCode Zen provider as a curated model.

- `src/ai/providerRegistry/modelCatalog.ts` — adds `glm-5.2` to the curated OpenCode catalog (the list surfaced via `applyModelCatalog`), marked `recommended: true`, placed above `glm-5.1`.
- `src/ai/providerRegistry/opencode.ts` — adds `glm-5.2` to the base provider definition's `modelOptions` for consistency.

## Why

GLM-5.2 was released 2026-06-13 as Z.ai's new flagship coding/agentic model (1M-token context window, high/max reasoning efforts). OpenCode Zen exposes it under the model id `glm-5.2`, confirmed against the [OpenCode Zen docs](https://opencode.ai/docs/zen/).

## Notes for reviewer

- `supportsImageInput: false` matches the other GLM/text entries; the multimodal `glm-5v` line is separate.
- No Rust changes needed — `src-tauri/src/ai/providers/opencode.rs` only defines the provider transport, not the model list.
- No tests assert specific OpenCode model ids, so nothing else was affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)