### PR TITLE
fix: move File Explorer Git icon into the pane toolbar

### DIFF
--- a/src/modules/workspace/connections/sftp/SftpFilePane.tsx
+++ b/src/modules/workspace/connections/sftp/SftpFilePane.tsx
@@ -6,6 +6,7 @@ import { useEffect, useId, useMemo, useRef, useState } from "react";
 import type { CSSProperties, DragEvent as ReactDragEvent, KeyboardEvent, MouseEvent as ReactMouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { DIcon } from "../../../../app/ui/dialog";
+import { GitIcon } from "../../../git/GitIcon";
 import { technicalInputProps } from "../../../../lib/inputBehavior";
 import type { LocalPlacesListing } from "../../../../lib/tauri";
 import type { FileEntry } from "../../../../types";
@@ -45,6 +46,7 @@ export function FilePane({
   onOpenFolder,
   onOpenFile,
   onOpenTerminalHere,
+  onOpenGit,
   onPathSubmit,
   recentPaths = [],
   onSelectionChange,
@@ -84,6 +86,9 @@ export function FilePane({
   onOpenFolder?: (folderName: string) => void;
   onOpenFile?: (fileName: string) => void;
   onOpenTerminalHere?: () => void;
+  /** Open the Git Browser for this pane's directory; shown only when the
+   * directory is inside a git repository (File Explorer local pane). */
+  onOpenGit?: () => void;
   onPathSubmit?: (path: string) => void | Promise<void>;
   recentPaths?: string[];
   onSelectionChange?: (fileNames: string[]) => void;
@@ -511,6 +516,18 @@ export function FilePane({
           </div>
         )}
         <div className="sftp-pane-head-actions">
+          {onOpenGit ? (
+            <button
+              className="sftp-icon-btn"
+              aria-label={t("git.openBrowser")}
+              disabled={isLoading}
+              onClick={onOpenGit}
+              title={t("git.openBrowser")}
+              type="button"
+            >
+              <GitIcon name="branch" size={16} />
+            </button>
+          ) : null}
           {onOpenTerminalHere ? (
             <button
               className="sftp-icon-btn"

--- a/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
+++ b/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
@@ -18,7 +18,6 @@ import {
   type FileBrowserController,
 } from "../../paneRegistry";
 import { useWorkspaceStore } from "../../../../store";
-import { GitIcon } from "../../../git/GitIcon";
 import { useGitRepoDetection } from "../../../git/useGitRepoDetection";
 import type { Connection, FileBrowserViewOptions, FileEntry, FtpConnectionOptions, SftpSettings, WorkspaceTab } from "../../../../types";
 import type { DashboardBackground } from "../../../dashboard/types";
@@ -1832,17 +1831,6 @@ export function SftpWorkspace({
           {hasRemoteHost ? hostLabel : null}
         </span>
         <span className="sftp-bar-right">
-          {gitRepo ? (
-            <button
-              className="sftp-bar-git"
-              aria-label={t("git.openBrowser")}
-              title={t("git.openBrowser")}
-              onClick={() => openGitBrowser(gitRepo.repoRoot, gitRepo.label)}
-              type="button"
-            >
-              <GitIcon name="branch" size={15} />
-            </button>
-          ) : null}
           {showPlainFtpWarning ? (
             <span
               className="sftp-title-warning"
@@ -1887,6 +1875,7 @@ export function SftpWorkspace({
           onOpenFolder={openLocalFolder}
           onOpenFile={(fileName) => void handleOpenLocalFile(fileName)}
           onOpenTerminalHere={() => void handleOpenLocalTerminalHere()}
+          onOpenGit={gitRepo ? () => openGitBrowser(gitRepo.repoRoot, gitRepo.label) : undefined}
           onPathSubmit={(path) => void loadLocalDirectory(path)}
           recentPaths={recentLocalPaths}
           onSelectionChange={setSelectedLocalNames}

--- a/src/modules/workspace/connections/sftp/sftp.css
+++ b/src/modules/workspace/connections/sftp/sftp.css
@@ -177,8 +177,7 @@
 .sftp-title-warning svg {
   flex: 0 0 auto;
 }
-.sftp-bar-close,
-.sftp-bar-git {
+.sftp-bar-close {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -191,8 +190,7 @@
   cursor: pointer;
   transition: background 0.12s, color 0.12s;
 }
-.sftp-bar-close:hover,
-.sftp-bar-git:hover {
+.sftp-bar-close:hover {
   background: var(--hover);
   color: var(--text);
 }


### PR DESCRIPTION
## What

Moves the File Explorer **Git Browser icon** out of the titlebar's top-right group and into the **file pane action toolbar**, immediately to the **left of the "open terminal here" button** — alongside the other directory actions (terminal / up / new folder / recent).

| Before | After |
|--------|-------|
| Branch icon in the titlebar top-right, away from the directory controls | Branch icon as the first item in the toolbar row, left of the terminal icon |

## Why

The icon's previous placement (titlebar top-right) was disconnected from the directory it acts on. The terminal icon and the other navigation actions live in the pane toolbar, so the Git icon belongs there too.

## How

- Added an `onOpenGit?` prop to `SftpFilePane`; when provided, it renders a `sftp-icon-btn` Git button as the first child of `sftp-pane-head-actions`, before the terminal button (shared toolbar-icon styling for visual parity).
- `SftpWorkspace` now passes `onOpenGit` to the local pane instead of rendering a button in `sftp-bar-right`, and the dead `.sftp-bar-git` titlebar CSS is removed.
- The button is still driven by the reactive `useGitRepoDetection(localPath, isLocalFilesBrowser)` result, so it **appears/disappears as the user navigates between directories**, not just for the initial directory. Only the File Explorer (`localFiles`) local pane receives it; dual-pane SFTP/FTP is unaffected.

## Verification

- ✅ `tsc --noEmit`
- ✅ ESLint (0 errors on changed files)
- ✅ `vite build`
- ✅ 624 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)