### PR TITLE
fix: drop phantom "origin" branch from Git Browser remotes list

### DIFF
--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -399,23 +399,34 @@ fn parse_remotes(repo: &str) -> Result<Vec<GitRemote>, String> {
     let mut remotes = Vec::new();
     for name in names.lines().map(str::trim).filter(|n| !n.is_empty()) {
         let prefix = format!("refs/remotes/{name}/");
+        // `lstrip=3` drops the `refs/remotes/<remote>` prefix, leaving the bare
+        // branch name (including any nested path). The remote's symbolic HEAD
+        // (`refs/remotes/<remote>/HEAD`) becomes the literal `HEAD`, which
+        // `parse_remote_branches` filters out — using `%(refname:short)` instead
+        // would shorten it to the bare remote name and surface a phantom branch.
         let stdout = git_text(
             repo,
-            &["for-each-ref", "--format", "%(refname:short)", prefix.as_str()],
+            &["for-each-ref", "--format", "%(refname:lstrip=3)", prefix.as_str()],
         )
         .unwrap_or_default();
-        let branches = stdout
-            .lines()
-            .map(str::trim)
-            .filter(|b| !b.is_empty() && !b.ends_with("/HEAD"))
-            .map(|b| b.strip_prefix(&format!("{name}/")).unwrap_or(b).to_string())
-            .collect();
+        let branches = parse_remote_branches(&stdout);
         remotes.push(GitRemote {
             name: name.to_string(),
             branches,
         });
     }
     Ok(remotes)
+}
+
+/// Turn `for-each-ref --format %(refname:lstrip=3)` output for one remote into
+/// branch names, dropping blanks and the remote's symbolic `HEAD` pointer.
+fn parse_remote_branches(stdout: &str) -> Vec<String> {
+    stdout
+        .lines()
+        .map(str::trim)
+        .filter(|b| !b.is_empty() && *b != "HEAD")
+        .map(|b| b.to_string())
+        .collect()
 }
 
 fn parse_tags(repo: &str) -> Result<Vec<String>, String> {
@@ -1098,6 +1109,17 @@ mod tests {
         assert_eq!(parse_track("[behind 2]"), (0, 2));
         assert_eq!(parse_track("[ahead 3, behind 1]"), (3, 1));
         assert_eq!(parse_track(""), (0, 0));
+    }
+
+    #[test]
+    fn remote_branches_skip_symbolic_head() {
+        // `%(refname:lstrip=3)` yields bare branch names plus the literal HEAD
+        // for the remote's symbolic pointer, which must not become a branch.
+        let stdout = "HEAD\nmain\nfeature/login\nclaude/fix-x\n";
+        assert_eq!(
+            parse_remote_branches(stdout),
+            vec!["main", "feature/login", "claude/fix-x"],
+        );
     }
 
     #[test]

--- a/src-tauri/src/sftp.rs
+++ b/src-tauri/src/sftp.rs
@@ -2510,6 +2510,7 @@ mod tests {
             ssh_socks_proxy_secret_owner_id: None,
             auth_method: None,
             secret_owner_id: None,
+            password: None,
             passphrase_owner_id: None,
             path: None,
         }


### PR DESCRIPTION
## What

In the Git Browser sidebar, the **Remotes → origin** list showed an extra entry literally named **`origin`** above the real branches. This removes it.

## Why

The remote branches were read with `git for-each-ref --format %(refname:short) refs/remotes/<remote>/`. Git shortens the remote's **symbolic HEAD** ref `refs/remotes/origin/HEAD` to the bare remote name **`origin`** (not `origin/HEAD`), so:

- the `!b.ends_with("/HEAD")` filter didn't catch it, and
- `strip_prefix("origin/")` didn't match, leaving the value as `origin`.

Result: a phantom branch named after the remote.

## How

- Read with `%(refname:lstrip=3)` instead, which yields the clean branch name (including nested paths like `feature/login`) and turns the symbolic HEAD into the literal `HEAD`.
- Filter that `HEAD` out in a new pure helper `parse_remote_branches`, covered by a unit test (`remote_branches_skip_symbolic_head`).

## Incidental fix (unrelated, but required to run `cargo test`)

`src-tauri/src/sftp.rs`'s `sftp_request()` test fixture was missing the `password` field that had been added to `StartSftpSessionRequest`, which broke the entire lib **test** build on `main` (production `cargo check` was unaffected). Added `password: None` so the test target compiles and the git tests can run.

## Verification

- ✅ `cargo check --lib` (production)
- ✅ `cargo test --lib git::` — 7 passed, incl. the new remote-branch test

🤖 Generated with [Claude Code](https://claude.com/claude-code)