### PR TITLE
fix(workspace): preserve original session and split panes in child-connection panorama (#430)

### DIFF
--- a/src/modules/workspace/connections/childConnections.test.ts
+++ b/src/modules/workspace/connections/childConnections.test.ts
@@ -1,8 +1,14 @@
 import {
+  collectPreservedParentPanes,
   focusedPaneIdForChildLayout,
   syncChildConnectionsFromTabs,
 } from "./childConnections.ts";
-import type { Connection, WorkspaceChildConnection, WorkspaceTab } from "../../../types";
+import type {
+  Connection,
+  WorkspaceChildConnection,
+  WorkspacePane,
+  WorkspaceTab,
+} from "../../../types";
 
 const parentConnection: Connection = {
   id: "parent-1",
@@ -75,4 +81,106 @@ if (fallbackFocusedPane !== undefined) {
 const initialFocusedPane = focusedPaneIdForChildLayout(undefined, tab.panes);
 if (initialFocusedPane !== undefined) {
   throw new Error("Opening a child panorama without prior focus should not invent a focused child Pane.");
+}
+
+// --- collectPreservedParentPanes (issue #430) ---
+
+function terminalPane(id: string, overrides: Partial<WorkspacePane> = {}): WorkspacePane {
+  return {
+    kind: "terminal",
+    id,
+    title: id,
+    toolbarTitle: id,
+    cwd: "~",
+    buffer: "",
+    connection: parentConnection,
+    ...overrides,
+  } as WorkspacePane;
+}
+
+function terminalTab(id: string, panes: WorkspacePane[], overrides: Partial<WorkspaceTab> = {}): WorkspaceTab {
+  return {
+    id,
+    title: id,
+    subtitle: "",
+    kind: "terminal",
+    panes,
+    connection: parentConnection,
+    ...overrides,
+  };
+}
+
+// Bug 1: the parent's original plain Tab (no childConnectionId) must be adopted
+// into the panorama instead of being left as an unreachable orphan.
+const orphanPlainTab = terminalTab("tab-parent-1", [terminalPane("pane-original")]);
+const newChildTab = terminalTab("tab-parent-1-new", [
+  terminalPane("pane-new-child", { childConnectionId: "child-2" }),
+]);
+const bug1 = collectPreservedParentPanes({
+  parentConnectionId: parentConnection.id,
+  activeWorkspaceId: "default",
+  defaultWorkspaceId: "default",
+  existingGroupTab: undefined,
+  tabs: [orphanPlainTab, newChildTab],
+});
+if (bug1.adoptedOrphanPanes.map((pane) => pane.id).join(",") !== "pane-original") {
+  throw new Error("Adding a child Tab must adopt the parent's original session, not orphan it (Bug 1).");
+}
+if (bug1.carriedGroupPanes.length !== 0) {
+  throw new Error("With no existing group Tab there are no carried Panes.");
+}
+
+// The named child Pane already being moved in must not be adopted a second time.
+const bug1Excluded = collectPreservedParentPanes({
+  parentConnectionId: parentConnection.id,
+  activeWorkspaceId: "default",
+  defaultWorkspaceId: "default",
+  existingGroupTab: undefined,
+  tabs: [orphanPlainTab, newChildTab],
+  excludedPaneIds: new Set(["pane-original"]),
+});
+if (bug1Excluded.adoptedOrphanPanes.length !== 0) {
+  throw new Error("Panes already claimed by the caller must not be adopted again.");
+}
+
+// Bug 2: a "split right" inside the panorama produces a childless Pane that must
+// survive a layout rebuild rather than being discarded.
+const groupTab = terminalTab(
+  "tab-parent-children",
+  [
+    terminalPane("pane-child-a", { childConnectionId: "child-1" }),
+    terminalPane("pane-split", { title: "Child 2" }),
+  ],
+  { childConnectionGroupParentId: parentConnection.id },
+);
+const bug2 = collectPreservedParentPanes({
+  parentConnectionId: parentConnection.id,
+  activeWorkspaceId: "default",
+  defaultWorkspaceId: "default",
+  existingGroupTab: groupTab,
+  tabs: [groupTab],
+});
+if (bug2.carriedGroupPanes.map((pane) => pane.id).join(",") !== "pane-split") {
+  throw new Error("An in-panorama split Pane must be carried forward on rebuild, not dropped (Bug 2).");
+}
+if (bug2.adoptedOrphanPanes.length !== 0) {
+  throw new Error("The group Tab itself must not be re-adopted as an orphan.");
+}
+
+// Panes from other Workspaces or other Connections must never be adopted.
+const foreignWorkspaceTab = terminalTab("tab-foreign-ws", [terminalPane("pane-foreign-ws")], {
+  workspaceId: "other",
+});
+const foreignConnectionTab = terminalTab("tab-foreign-conn", [terminalPane("pane-foreign-conn")], {
+  connection: { ...parentConnection, id: "parent-2" },
+});
+const scoped = collectPreservedParentPanes({
+  parentConnectionId: parentConnection.id,
+  activeWorkspaceId: "default",
+  defaultWorkspaceId: "default",
+  existingGroupTab: undefined,
+  tabs: [foreignWorkspaceTab, foreignConnectionTab],
+});
+if (scoped.adoptedOrphanPanes.length !== 0) {
+  throw new Error("Adoption must stay scoped to the active Workspace and the target Connection.");
 }

--- a/src/modules/workspace/connections/childConnections.test.ts
+++ b/src/modules/workspace/connections/childConnections.test.ts
@@ -184,3 +184,22 @@ const scoped = collectPreservedParentPanes({
 if (scoped.adoptedOrphanPanes.length !== 0) {
   throw new Error("Adoption must stay scoped to the active Workspace and the target Connection.");
 }
+
+// A plain parent Tab can temporarily contain Panes for other Connections after
+// drag-to-dock or split workflows. Only the parent's own childless Panes should
+// move into the child panorama.
+const otherConnection = { ...parentConnection, id: "other-connection" };
+const mixedParentTab = terminalTab("tab-mixed-parent", [
+  terminalPane("pane-parent"),
+  terminalPane("pane-other", { connection: otherConnection }),
+]);
+const mixed = collectPreservedParentPanes({
+  parentConnectionId: parentConnection.id,
+  activeWorkspaceId: "default",
+  defaultWorkspaceId: "default",
+  existingGroupTab: undefined,
+  tabs: [mixedParentTab],
+});
+if (mixed.adoptedOrphanPanes.map((pane) => pane.id).join(",") !== "pane-parent") {
+  throw new Error("Adoption must not pull unrelated split Panes into a parent's child panorama.");
+}

--- a/src/modules/workspace/connections/childConnections.ts
+++ b/src/modules/workspace/connections/childConnections.ts
@@ -101,6 +101,64 @@ export function syncChildConnectionsFromTabs(
   return changed ? next : children;
 }
 
+/**
+ * Gather the Panes that must survive when (re)building a parent Connection's
+ * child panorama Tab, beyond the named child Connections themselves (issue #430):
+ *
+ *  - `carriedGroupPanes`: Panes already inside the group Tab that never became
+ *    named children — e.g. a "split right" created within the panorama.
+ *    Rebuilding the layout strictly from the children list would drop them.
+ *  - `adoptedOrphanPanes`: the parent Connection's original session, opened as a
+ *    plain Tab with no `childConnectionId`. Without adoption it is left behind as
+ *    an unreachable orphan Tab once child Tabs take over the Connection.
+ *
+ * `excludedPaneIds` holds Panes the caller has already claimed (e.g. child Panes
+ * being moved in from other Tabs) so they are not adopted a second time.
+ */
+export function collectPreservedParentPanes(params: {
+  parentConnectionId: string;
+  activeWorkspaceId: string;
+  defaultWorkspaceId: string;
+  existingGroupTab: WorkspaceTab | undefined;
+  tabs: WorkspaceTab[];
+  excludedPaneIds?: ReadonlySet<string>;
+}): { carriedGroupPanes: WorkspacePane[]; adoptedOrphanPanes: WorkspacePane[] } {
+  const {
+    parentConnectionId,
+    activeWorkspaceId,
+    defaultWorkspaceId,
+    existingGroupTab,
+    tabs,
+    excludedPaneIds,
+  } = params;
+
+  const carriedGroupPanes = existingGroupTab
+    ? existingGroupTab.panes.filter((pane) => !pane.childConnectionId)
+    : [];
+
+  const claimed = new Set(excludedPaneIds ?? []);
+  const adoptedOrphanPanes: WorkspacePane[] = [];
+  for (const sourceTab of tabs) {
+    if (
+      sourceTab.kind !== "terminal" ||
+      sourceTab.childConnectionGroupParentId ||
+      sourceTab.connection?.id !== parentConnectionId ||
+      (sourceTab.workspaceId ?? defaultWorkspaceId) !== activeWorkspaceId
+    ) {
+      continue;
+    }
+    for (const pane of sourceTab.panes) {
+      if (pane.childConnectionId || claimed.has(pane.id)) {
+        continue;
+      }
+      claimed.add(pane.id);
+      adoptedOrphanPanes.push(pane);
+    }
+  }
+
+  return { carriedGroupPanes, adoptedOrphanPanes };
+}
+
 export function focusedPaneIdForChildLayout(
   existingTab: Pick<WorkspaceTab, "focusedPaneId"> | undefined,
   panes: WorkspacePane[],

--- a/src/modules/workspace/connections/childConnections.ts
+++ b/src/modules/workspace/connections/childConnections.ts
@@ -148,7 +148,11 @@ export function collectPreservedParentPanes(params: {
       continue;
     }
     for (const pane of sourceTab.panes) {
-      if (pane.childConnectionId || claimed.has(pane.id)) {
+      if (
+        pane.childConnectionId ||
+        claimed.has(pane.id) ||
+        pane.connection?.id !== parentConnectionId
+      ) {
         continue;
       }
       claimed.add(pane.id);

--- a/src/store.ts
+++ b/src/store.ts
@@ -58,7 +58,10 @@ import { resolveDefaultTerminalAppearance } from "./modules/workspace/connection
 import type { LocalShellOption } from "./modules/workspace/connections/utils";
 import type { GitBrowserTarget } from "./modules/git/gitTypes";
 import { markPanesForRuntimeMove } from "./modules/workspace/paneRegistry";
-import { focusedPaneIdForChildLayout } from "./modules/workspace/connections/childConnections";
+import {
+  collectPreservedParentPanes,
+  focusedPaneIdForChildLayout,
+} from "./modules/workspace/connections/childConnections";
 
 const LAYOUT_STORAGE_PREFIX = "kkterm.layout.";
 const TMUX_SESSION_STORAGE_PREFIX = "kkterm.tmuxSessions.";
@@ -1861,7 +1864,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
     const movedPaneIds = new Set<string>();
     const newPanes: WorkspacePane[] = [];
-    const childPanes = uniqueChildren
+    const namedChildPanes = uniqueChildren
       .map((child) => {
         const groupPane = groupPaneByChildId.get(child.id);
         if (groupPane) {
@@ -1903,6 +1906,20 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         return pane;
       })
       .filter((pane): pane is WorkspacePane => Boolean(pane));
+    // Preserve the parent's original session and any in-panorama split Panes so a
+    // layout rebuild from the children list never orphans them (issue #430).
+    const { carriedGroupPanes, adoptedOrphanPanes } = collectPreservedParentPanes({
+      parentConnectionId: connection.id,
+      activeWorkspaceId,
+      defaultWorkspaceId: DEFAULT_WORKSPACE_ID,
+      existingGroupTab,
+      tabs: state.tabs,
+      excludedPaneIds: movedPaneIds,
+    });
+    for (const pane of adoptedOrphanPanes) {
+      movedPaneIds.add(pane.id);
+    }
+    const childPanes = [...namedChildPanes, ...carriedGroupPanes, ...adoptedOrphanPanes];
     if (childPanes.length === 0) {
       get().openConnection(connection);
       return;

--- a/tests/workspace-connection-new-tab.test.mjs
+++ b/tests/workspace-connection-new-tab.test.mjs
@@ -177,3 +177,42 @@ test("Connection Tree supports forced new Tabs from Ctrl-click and Add to menu",
     "DOM fallback Add Tab should be disabled for non-terminal Child Connection Tab targets",
   );
 });
+
+test("Child Connection panorama preserves the parent's original session and split Panes (issue #430)", async () => {
+  const storeSource = await readFile(new URL("../src/store.ts", import.meta.url), "utf8");
+  const childConnectionsSource = await readFile(
+    new URL("../src/modules/workspace/connections/childConnections.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    childConnectionsSource,
+    /export function collectPreservedParentPanes/,
+    "child layout reconciliation should expose a testable helper for preserved Panes",
+  );
+  assert.match(
+    childConnectionsSource,
+    /existingGroupTab\s*\n?\s*\?\s*existingGroupTab\.panes\.filter\(\(pane\) => !pane\.childConnectionId\)/,
+    "in-panorama split Panes (no childConnectionId) must be carried forward on rebuild",
+  );
+  assert.match(
+    childConnectionsSource,
+    /sourceTab\.childConnectionGroupParentId \|\|\s*\n?\s*sourceTab\.connection\?\.id !== parentConnectionId/,
+    "orphan adoption must stay scoped to plain Tabs of the target parent Connection",
+  );
+  assert.match(
+    storeSource,
+    /const \{ carriedGroupPanes, adoptedOrphanPanes \} = collectPreservedParentPanes\(/,
+    "openChildConnectionLayout should fold preserved Panes into the panorama",
+  );
+  assert.match(
+    storeSource,
+    /for \(const pane of adoptedOrphanPanes\) \{\s*movedPaneIds\.add\(pane\.id\);/,
+    "adopted orphan Panes must be moved out of their original Tab so it is not left behind",
+  );
+  assert.match(
+    storeSource,
+    /const childPanes = \[\.\.\.namedChildPanes, \.\.\.carriedGroupPanes, \.\.\.adoptedOrphanPanes\];/,
+    "the rebuilt panorama must include named children plus carried and adopted Panes",
+  );
+});


### PR DESCRIPTION
## Summary

Fixes [#430](https://github.com/ryantsai/KKTerm/issues/430). When **child connection tabs** mode is enabled, adding a child tab (or splitting inside the panorama) was hiding/discarding the user's in-progress terminal session.

Root cause: [`openChildConnectionLayout`](https://github.com/ryantsai/KKTerm/blob/main/src/store.ts) rebuilt the parent's child panorama using *only* panes whose `childConnectionId` matched the current children list. Every other pane belonging to that parent was silently dropped or orphaned:

- **Bug 1** — the parent's original session (opened as a plain Tab with no `childConnectionId`) was never folded into the panorama, so it became an unreachable orphan Tab. On Windows with the top tab bar hidden, the user had to close every new tab to get it back.
- **Bug 2** (comment by JosephCLJ) — a "split right" inside the panorama created a childless pane that was discarded on the next layout rebuild.

The fix folds two extra pane sets into the rebuilt panorama via a new pure helper `collectPreservedParentPanes`:
- **carried** — childless panes already in the group Tab (in-panorama splits)
- **adopted** — the parent's original plain-Tab session, scoped to the active Workspace and Connection, moved in through the existing runtime-move path so the live session is preserved (not respawned)

The original session and the new child tab now coexist side-by-side in the panorama and both stay reachable.

Closes #430

## Type of change

- [x] Bug fix

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)

## Domain & docs

- [x] Uses the canonical vocabulary (Connection / Session / Tab / Workspace / Pane)
- [x] Source placement unchanged; logic extracted into existing `childConnections.ts` module

## i18n

- [x] No user-visible strings

## Checks

- [x] `npm run check` — 623 tests pass, lint clean on touched files, `tsc --noEmit` clean
- [ ] Validated in the real Tauri desktop runtime — **not yet** (see below)

## Notes for reviewers

- New behavioral coverage in `src/modules/workspace/connections/childConnections.test.ts` for both bugs plus workspace/connection scoping and the no-double-adopt guard. Added CI-gated source assertions in `tests/workspace-connection-new-tab.test.mjs` (the `src/**/*.test.ts` files are typechecked but not executed by `npm run check`).
- **Caveat — please verify the two flows manually in the desktop app before merge.** JosephCLJ's exact symptom ("split right → two brand-new terminals, original gone") implies a possible session-duplication path I couldn't fully confirm from static reading. This change addresses the confirmed root cause (pane discard on rebuild + orphaned original) for both scenarios; if a separate respawn path remains it needs a live repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)