### PR TITLE
fix(lint): resolve all ESLint warnings

### DIFF
--- a/src/ai/AssistantPanel.tsx
+++ b/src/ai/AssistantPanel.tsx
@@ -547,6 +547,8 @@ export function AssistantPanel({
       disposed = true;
       unlisten?.();
     };
+    // Register the approval listener once on mount; handler deps are read via refs/stable callbacks.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -1001,7 +1003,7 @@ export function AssistantPanel({
       return;
     }
 
-    let text = "";
+    let text: string;
     if (pane.connection?.type === "ssh" && pane.tmuxSessionId) {
       try {
         text = await invokeCommand("capture_tmux_pane", {
@@ -1141,6 +1143,8 @@ export function AssistantPanel({
       true,
       assistantDirectSubmitRequest.snippet,
     );
+    // Fire only when a new direct-submit request arrives; the callbacks/state are read at run time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [assistantDirectSubmitRequest]);
 
   async function submitAssistantPrompt() {
@@ -1827,6 +1831,8 @@ export function AssistantPanel({
     node.style.left = `${screenshotRegionState.bounds.left}px`;
     node.style.top = `${screenshotRegionState.bounds.top}px`;
     node.style.width = `${screenshotRegionState.bounds.width}px`;
+    // Depend on the individual bounds fields, not the whole object, to avoid redundant DOM writes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     screenshotRegionState?.bounds.height,
     screenshotRegionState?.bounds.left,
@@ -1844,6 +1850,8 @@ export function AssistantPanel({
     node.style.left = `${screenshotSelectionRect.x}px`;
     node.style.top = `${screenshotSelectionRect.y}px`;
     node.style.width = `${screenshotSelectionRect.width}px`;
+    // Depend on the individual rect fields, not the whole object, to avoid redundant DOM writes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     screenshotSelectionRect?.height,
     screenshotSelectionRect?.width,

--- a/src/ai/AssistantWorkPanel.tsx
+++ b/src/ai/AssistantWorkPanel.tsx
@@ -35,8 +35,10 @@ export function AssistantWorkPanel({ message }: { message: AssistantChatMessage 
   const shouldShowThinkingStep = assistantWorkPanelShouldShowThinkingStep(message);
 
   useEffect(() => {
+    // Reset only when a new message arrives; isStreaming transitions are handled below.
     setExpanded(false);
     wasStreamingRef.current = Boolean(message.isStreaming);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [message.id]);
 
   useEffect(() => {

--- a/src/ai/providers.test.ts
+++ b/src/ai/providers.test.ts
@@ -26,7 +26,10 @@ try {
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
   if (!message.includes("Connect GitHub Copilot")) {
-    throw new Error(`GitHub Copilot should fail with the connection requirement, got: ${message}`);
+    throw Object.assign(
+      new Error(`GitHub Copilot should fail with the connection requirement, got: ${message}`),
+      { cause: error },
+    );
   }
 }
 

--- a/src/ai/streamMessage.ts
+++ b/src/ai/streamMessage.ts
@@ -39,7 +39,7 @@ export function applyAssistantStreamEventToMessage(
     case "contentDelta":
       msg.content += event.delta;
       break;
-    case "toolCallStart":
+    case "toolCallStart": {
       const startedToolId = streamEventString(event, "toolId", "tool_id");
       const startedToolName = streamEventString(event, "toolName", "tool_name");
       msg.workStartedAt = msg.workStartedAt ?? options.workStartedAt;
@@ -56,7 +56,8 @@ export function applyAssistantStreamEventToMessage(
         },
       ];
       break;
-    case "skillInvocation":
+    }
+    case "skillInvocation": {
       const skillName = streamEventString(event, "skillName", "skill_name");
       if (!skillName) {
         break;
@@ -64,7 +65,8 @@ export function applyAssistantStreamEventToMessage(
       msg.workStartedAt = msg.workStartedAt ?? options.workStartedAt;
       msg.skillNames = Array.from(new Set([...(msg.skillNames ?? []), skillName]));
       break;
-    case "toolCallEnd":
+    }
+    case "toolCallEnd": {
       const endedToolId = streamEventString(event, "toolId", "tool_id");
       const endedToolName = streamEventString(event, "toolName", "tool_name");
       if (!endedToolId) {
@@ -82,6 +84,7 @@ export function applyAssistantStreamEventToMessage(
           : tc,
       );
       break;
+    }
     case "planUpdate": {
       const steps: AssistantRunManifestStep[] = (Array.isArray(event.steps) ? event.steps : [])
         .filter((step) => step && typeof step.id === "string" && typeof step.label === "string")

--- a/src/app/AppUpdatePrompt.tsx
+++ b/src/app/AppUpdatePrompt.tsx
@@ -107,6 +107,8 @@ export function AppUpdatePrompt({
       }
       await runUpdateCheck("startup");
     })();
+    // runUpdateCheck is recreated each render; gate the startup check on settings readiness only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoUpdateChecksEnabled, settingsReady]);
 
   useEffect(() => {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -267,7 +267,7 @@ export interface SftpDirectoryListing {
   entries: SftpDirectoryEntry[];
 }
 
-export interface SftpSessionStarted extends SftpDirectoryListing {}
+export type SftpSessionStarted = SftpDirectoryListing;
 
 export interface LocalDirectoryEntry {
   name: string;
@@ -444,7 +444,7 @@ export interface SshTransportPlan {
   systemSshRole: string;
 }
 
-export interface SshConfigConnectionDraft extends CreateConnectionRequest {}
+export type SshConfigConnectionDraft = CreateConnectionRequest;
 
 export interface UnsupportedSshDirective {
   line: number;

--- a/src/modules/dashboard/registry/fujiBackground.tsx
+++ b/src/modules/dashboard/registry/fujiBackground.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- untyped canvas-art module; full typing is out of scope
 // @ts-nocheck
 import { useEffect, useRef } from "react";
 import { useDashboardAnimationActive } from "../view/animationGating";
@@ -213,7 +214,7 @@ export function FujiBg() {
       const grd=g.createLinearGradient(0,-r,0,r); grd.addColorStop(0,c1); grd.addColorStop(1,"#9a2410");
       g.fillStyle=grd; g.beginPath(); const pts=5;
       for(let i=0;i<pts*2;i++){ const ang=i/(pts*2)*6.2832-1.5708; const rad=i%2?r*0.42:r;
-        const px=Math.cos(ang)*rad, py=Math.sin(ang)*rad; i?g.lineTo(px,py):g.moveTo(px,py); }
+        const px=Math.cos(ang)*rad, py=Math.sin(ang)*rad; if(i){g.lineTo(px,py);}else{g.moveTo(px,py);} }
       g.closePath(); g.fill(); g.restore(); };
     const cluster = (bx,by,sc) => {
       const n = 2 + Math.floor(Math.random()*4);
@@ -612,7 +613,8 @@ export function FujiBg() {
     const TR=Math.min(SEASON*0.12, 7);
     const L=SEASON*4;
     const pos=(t % L)/SEASON;
-    let cur=Math.floor(pos)%4, nxt=(cur+1)%4, frac=pos-Math.floor(pos);
+    let cur=Math.floor(pos)%4, nxt=(cur+1)%4;
+    const frac=pos-Math.floor(pos);
     const trFrac=TR/SEASON;
     let mixk = frac>1-trFrac ? _fSmooth((frac-(1-trFrac))/trFrac) : 0;
     // preview hook: window.__fujiForceSeason = 0|1|2|3 pins a season (Spring..Winter)

--- a/src/modules/dashboard/script/ScriptWidgetHost.tsx
+++ b/src/modules/dashboard/script/ScriptWidgetHost.tsx
@@ -607,6 +607,7 @@ export function ScriptWidgetHost({
   }, []);
 
   useEffect(() => {
+    const activeSubscriptions = activeSubscriptionsRef.current;
     function allowBridgeMessage(type: RateLimitedBridgeMessage): boolean {
       const now = performance.now();
       const previous = bridgeLastAcceptedRef.current.get(type) ?? -Infinity;
@@ -652,7 +653,7 @@ export function ScriptWidgetHost({
       }
       if (isScriptWidgetSettingsMessage(data)) {
         if (!allowBridgeMessage("setSettings")) return;
-        let settingsJson = "{}";
+        let settingsJson: string;
         try {
           settingsJson = JSON.stringify(data.settings);
         } catch {
@@ -924,10 +925,10 @@ export function ScriptWidgetHost({
     window.addEventListener("message", onMessage);
     return () => {
       window.removeEventListener("message", onMessage);
-      for (const id of activeSubscriptionsRef.current) {
+      for (const id of activeSubscriptions) {
         void invokeCommand("network_stream_cancel", { subscriptionId: id });
       }
-      activeSubscriptionsRef.current.clear();
+      activeSubscriptions.clear();
     };
   }, [canUseNetworkTools, instance.id, onWidgetContextMenu, updateInstance, setWidgetHealth]);
 

--- a/src/modules/installer/InstallerToolDialog.tsx
+++ b/src/modules/installer/InstallerToolDialog.tsx
@@ -123,6 +123,7 @@ function InstalledInfoBody({ recipe }: { recipe: Recipe }) {
   const hasUpdate =
     supportsLatestVersion && isInstallerUpdateAvailable(latest, version);
   const webUi = webUiAffordanceForRecipe(recipe);
+  const hasWebUi = webUi !== null;
   const service = serviceAffordanceForRecipe(recipe);
   const terminalLaunch = terminalLaunchAffordanceForRecipe(recipe);
   const workspaceSpec = workspaceConnectionSpecForRecipe(recipe);
@@ -133,7 +134,7 @@ function InstalledInfoBody({ recipe }: { recipe: Recipe }) {
   const statusRefreshInFlight = useRef(false);
 
   useEffect(() => {
-    if (!webUi || !isTauriRuntime()) {
+    if (!hasWebUi || !isTauriRuntime()) {
       setWebUiStatus(null);
       return;
     }
@@ -158,7 +159,7 @@ function InstalledInfoBody({ recipe }: { recipe: Recipe }) {
       cancelled = true;
       window.clearInterval(timer);
     };
-  }, [recipe.id, !!webUi]);
+  }, [recipe.id, hasWebUi]);
 
   async function handleTogglePin() {
     if (!isTauriRuntime()) return;

--- a/src/modules/settings/AddMcpServerDialog.tsx
+++ b/src/modules/settings/AddMcpServerDialog.tsx
@@ -17,7 +17,7 @@ interface ParsedConfig {
 }
 
 const SECRET_HEADER_PATTERN = /^(authorization|x-api-key|x-auth-token|api-key)$/i;
-const SECRET_VALUE_HINT = /([A-Za-z0-9._\-]{20,})/;
+const SECRET_VALUE_HINT = /([A-Za-z0-9._-]{20,})/;
 
 interface DetectedSecret {
   headerName: string;

--- a/src/modules/settings/AiSettings.tsx
+++ b/src/modules/settings/AiSettings.tsx
@@ -591,6 +591,8 @@ function AiCliBackendControl({
 
   useEffect(() => {
     setStoredStatus(cli ? readStoredAiCliBackendStatus(cli.backend) : null);
+    // Only the backend identity matters here; depend on it rather than the whole cli object.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cli?.backend]);
 
   if (!cli) return null;
@@ -1368,8 +1370,7 @@ export function AiSettings() {
       disposed = true;
     };
   }, [
-    aiProviderDefinition.modelListStrategy,
-    aiProviderDefinition.strictModelList,
+    aiProviderDefinition,
     draft.allowInsecureTls,
     draft.baseUrl,
     draft.extraHeaders,

--- a/src/modules/settings/AppearanceSettings.tsx
+++ b/src/modules/settings/AppearanceSettings.tsx
@@ -101,6 +101,8 @@ export function AppearanceSettings({ onResetLayout }: { onResetLayout: () => voi
     return () => {
       disposed = true;
     };
+    // Resolve available fonts once on mount; setAppearanceSettings is a stable store action.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   async function handleOpenCustomFontsFolder() {

--- a/src/modules/settings/CredentialsSettings.tsx
+++ b/src/modules/settings/CredentialsSettings.tsx
@@ -127,7 +127,9 @@ export function CredentialsSettings() {
   }
 
   useEffect(() => {
+    // Load once on mount; `load` is recreated each render and must not retrigger the effect.
     void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/src/modules/settings/UrlSettings.tsx
+++ b/src/modules/settings/UrlSettings.tsx
@@ -99,7 +99,9 @@ export function UrlSettings() {
   }
 
   useEffect(() => {
+    // Load once on mount; `load` is recreated each render and must not retrigger the effect.
     void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   async function handleSave() {

--- a/src/modules/workspace/ScreenshotMenu.tsx
+++ b/src/modules/workspace/ScreenshotMenu.tsx
@@ -202,6 +202,8 @@ export function ScreenshotMenu({
     node.style.left = `${regionState.bounds.left}px`;
     node.style.top = `${regionState.bounds.top}px`;
     node.style.width = `${regionState.bounds.width}px`;
+    // Depend on the individual bounds fields, not the whole object, to avoid redundant DOM writes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     regionState?.bounds.height,
     regionState?.bounds.left,
@@ -219,6 +221,8 @@ export function ScreenshotMenu({
     node.style.left = `${selectionRect.x}px`;
     node.style.top = `${selectionRect.y}px`;
     node.style.width = `${selectionRect.width}px`;
+    // selectionRect is recomputed each render; depend on its fields, not the object identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectionRect?.height, selectionRect?.width, selectionRect?.x, selectionRect?.y]);
 
   return (

--- a/src/modules/workspace/connections/ConnectionSidebar.tsx
+++ b/src/modules/workspace/connections/ConnectionSidebar.tsx
@@ -603,10 +603,10 @@ export function ConnectionSidebar({
       const { iconDataUrl, ...request } = buildFileViewConnectionDraftFromPath(selectedPath, {
         workspaceId: useWorkspaceStore.getState().activeWorkspaceId,
       });
-      let connection = await invokeCommand("create_connection", {
+      const connection = await invokeCommand("create_connection", {
         request,
       });
-      connection = await saveConnectionIconPresentation(connection, iconDataUrl, null);
+      await saveConnectionIconPresentation(connection, iconDataUrl, null);
       await handleConnectionSaved();
     } catch (error) {
       setTreeError(error instanceof Error ? error.message : String(error));
@@ -1492,7 +1492,7 @@ export function ConnectionSidebar({
     iconDataUrl: string | null | undefined,
     iconBackgroundColor: string | null | undefined,
   ) {
-    let updatedConnection = await saveConnectionIconDataUrl(connection, iconDataUrl);
+    const updatedConnection = await saveConnectionIconDataUrl(connection, iconDataUrl);
     const normalizedIconBackgroundColor = iconBackgroundColor ?? null;
     if ((updatedConnection.iconBackgroundColor ?? null) === normalizedIconBackgroundColor) {
       return updatedConnection;
@@ -1636,6 +1636,8 @@ export function ConnectionSidebar({
   );
   const quickConnectShellOptions = useMemo(
     () => localShellOptionsForPlatform(terminalSettings.customShells),
+    // localShellOptionsForPlatform resolves labels via i18next.t, so recompute on language change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [i18n.language, terminalSettings.customShells],
   );
   const recentConnections = useMemo(() => {
@@ -2142,7 +2144,7 @@ export function ConnectionSidebar({
       return;
     }
 
-    let confirmed: boolean | null = null;
+    let confirmed: boolean | null;
     try {
       confirmed = await confirmNativeDialog(deleteConfirmationMessage(t, target), {
         kind: "warning",
@@ -4035,6 +4037,8 @@ function ConnectionDialog({
   }, [initialConnection?.iconDataUrl, tree]);
   const localShellOptions = useMemo(
     () => localShellOptionsForPlatform(terminalSettings.customShells),
+    // localShellOptionsForPlatform resolves labels via i18next.t, so recompute on language change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [i18n.language, terminalSettings.customShells],
   );
   const isEditMode = mode === "edit";

--- a/src/modules/workspace/connections/ImportDialog.tsx
+++ b/src/modules/workspace/connections/ImportDialog.tsx
@@ -560,6 +560,8 @@ function BookmarksPanel({
     return () => {
       cancelled = true;
     };
+    // Load bookmark sources once on mount; error callbacks are invoked at run time only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const selectedSource = sources.find((source) => source.id === selectedSourceId) ?? null;

--- a/src/modules/workspace/connections/remote-desktop/RdpCanvasView.tsx
+++ b/src/modules/workspace/connections/remote-desktop/RdpCanvasView.tsx
@@ -255,7 +255,6 @@ export function RdpCanvasView({
       return;
     }
     sendCtrlAltDelete();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cadSignal]);
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/modules/workspace/connections/remote-desktop/RemoteDesktopWorkspace.tsx
+++ b/src/modules/workspace/connections/remote-desktop/RemoteDesktopWorkspace.tsx
@@ -1258,6 +1258,8 @@ export function RemoteDesktopWorkspace({
     return () => {
       window.clearInterval(intervalId);
     };
+    // Re-arm the poll only when RDP eligibility changes; attemptRdpDisplaySync reads live refs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [canStartRdp]);
 
   useEffect(() => {
@@ -1315,6 +1317,8 @@ export function RemoteDesktopWorkspace({
     return () => {
       window.clearInterval(intervalId);
     };
+    // Re-arm the poll only when VNC eligibility changes; t/reportRemoteDesktopError are read at run time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [canStartVnc]);
 
   const handleVncSessionEvent = (event: VncSessionEvent) => {

--- a/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
+++ b/src/modules/workspace/connections/sftp/SftpWorkspace.tsx
@@ -266,6 +266,8 @@ export function SftpWorkspace({
     setPlainFtpFallbackActive(false);
     setFtpNoticeDialog(null);
     transientPasswordRef.current = null;
+    // Re-run only when the connection identity changes; reading the latest object inline is intended.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sourceConnection?.id]);
 
   function handleProtocolChange(protocol: SshFileBrowserProtocol) {
@@ -336,6 +338,8 @@ export function SftpWorkspace({
 
   useEffect(() => {
     void loadLocalDirectory(isLocalFilesBrowser ? connection?.localStartupDirectory : undefined);
+    // Reload when the startup directory or browser mode changes; loadLocalDirectory is recreated each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [connection?.localStartupDirectory, isLocalFilesBrowser]);
 
   useEffect(() => {
@@ -607,7 +611,7 @@ export function SftpWorkspace({
               return;
             }
             if (!enteredPassword) {
-              throw new Error(t("sftp.passwordPromptCanceled"));
+              throw Object.assign(new Error(t("sftp.passwordPromptCanceled")), { cause: error });
             }
             transientPasswordRef.current = enteredPassword;
             result = await commands.startSession({
@@ -681,6 +685,8 @@ export function SftpWorkspace({
         sessionIdRef.current = null;
       }
     };
+    // rememberRemotePath is an inline closure over stable refs; including it would restart the session every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeProtocolLabel, commands, connection, effectiveBrowserKind, isLocalFilesBrowser, markConnectionSessionEnded, markConnectionSessionStarted, showStatusBarNotice, sourceConnection, sshFileBrowserPort, sshFileBrowserProtocol, t]);
 
   const refreshRemoteDirectory = async () => {
@@ -970,6 +976,8 @@ export function SftpWorkspace({
 
     activeTransferIdRef.current = nextTransfer.id;
     void runQueuedTransfer(nextTransfer);
+    // Drain the queue when transfers change; runQueuedTransfer is recreated each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [transfers]);
 
   useEffect(() => {
@@ -1760,6 +1768,8 @@ export function SftpWorkspace({
     };
     registerFileBrowserController(tab.id, controller);
     return () => unregisterFileBrowserController(tab.id, controller);
+    // Re-register only on the listed inputs; refreshRemoteDirectory is recreated each render and read at call time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [commands, connection?.id, connection?.name, effectiveBrowserKind, isLocalFilesBrowser, remoteFiles, remotePath, selectedRemoteNames, status, t, tab.id]);
 
   return (
@@ -2504,7 +2514,7 @@ function writeRecentPaths(side: FilePaneSide, path: string, connectionId?: strin
     return readRecentPaths(side, connectionId);
   }
 
-  let state: RecentFileBrowserPaths = {};
+  let state: RecentFileBrowserPaths;
   try {
     state = JSON.parse(
       window.localStorage.getItem(FILE_BROWSER_RECENT_PATHS_STORAGE_KEY) || "{}",
@@ -2615,7 +2625,7 @@ function writeSidebarCollapsed(connectionKey: string, collapsed: boolean) {
   if (typeof window === "undefined") {
     return;
   }
-  let state: Record<string, boolean> = {};
+  let state: Record<string, boolean>;
   try {
     state = JSON.parse(
       window.localStorage.getItem(FILE_BROWSER_SIDEBAR_STORAGE_KEY) || "{}",

--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -179,6 +179,8 @@ export function TerminalWorkspace({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
+    // Bind Escape only while a dialog is open; closeSftpDialog is recreated each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sftpDialogConnection]);
 
   function focusTerminalPaneAfterDialogClose(paneId: string) {
@@ -338,6 +340,8 @@ export function TerminalWorkspace({
     const restore = () => restoreFocusedTerminalPane("workspace-activated");
     const frameId = window.requestAnimationFrame(restore);
     return () => window.cancelAnimationFrame(frameId);
+    // Re-arm on focus/active changes; restoreFocusedTerminalPane is recreated each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusedPaneId, isActive]);
 
   useEffect(() => {
@@ -425,6 +429,8 @@ export function TerminalWorkspace({
       document.removeEventListener("pointerdown", handleProbePointerdown, true);
       removeNativeFocusListener?.();
     };
+    // Re-bind activation listeners on focus/active changes; restoreFocusedTerminalPane is recreated each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusedPaneId, isActive]);
 
   function handleFontChange(delta: number | "reset") {
@@ -2189,6 +2195,7 @@ function TerminalPaneView({
   // A terminal Session belongs to the Pane id. Display metadata updates such
   // as Child Connection Tab rename/icon edits must not tear down and recreate
   // the live SSH/local process.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pane.id, tabId]);
 
   useEffect(() => {
@@ -2215,6 +2222,8 @@ function TerminalPaneView({
       Boolean(pane.tmuxSessionId && !tmuxMouseEnabled),
       handleTmuxWheelScroll,
     );
+    // Update the wheel override on tmux/mouse changes; handleTmuxWheelScroll is recreated each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pane.tmuxSessionId, tmuxMouseEnabled]);
 
   useEffect(() => {

--- a/src/modules/workspace/connections/webview/WebViewWorkspace.tsx
+++ b/src/modules/workspace/connections/webview/WebViewWorkspace.tsx
@@ -71,14 +71,13 @@ function acquireWebviewSession(sessionId: string, start: () => Promise<WebviewSe
     return current;
   }
 
-  let lease: WebviewSessionLease;
   const promise = Promise.resolve()
     .then(start)
     .then((started) => {
       lease.started = true;
       return started;
     });
-  lease = {
+  const lease: WebviewSessionLease = {
     promise,
     refCount: 1,
     closeTimer: null,
@@ -843,6 +842,8 @@ export function WebViewWorkspace({
       disposed = true;
       disposers.forEach((dispose) => dispose());
     };
+    // Re-subscribe only on the listed inputs; the credential/icon handlers are recreated each render and read at event time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [openUrlInNewTab, refreshOpenConnectionMetadata, tab.connection, tab.id, t, updateWebviewTabMetadata]);
 
   function handleNavigate(event: FormEvent<HTMLFormElement>) {


### PR DESCRIPTION
## Summary

Clears all **54** outstanding ESLint warnings so the lint gate stays meaningful — it can now block PRs on *new* problems rather than drowning in pre-existing noise. No runtime behavior changes intended.

## Mechanical fixes (21)
- `no-case-declarations` — wrapped `case` bodies in braces (`streamMessage.ts`)
- `no-useless-assignment` — dropped dead initializers across `AssistantPanel`, `ScriptWidgetHost`, `ConnectionSidebar`, `SftpWorkspace`
- `prefer-const` / `no-unused-vars` — `ConnectionSidebar`, `WebViewWorkspace`, `fujiBackground`
- `no-useless-escape` — removed redundant `\-` in a character class (`AddMcpServerDialog`)
- `preserve-caught-error` — attached `cause` via `Object.assign(new Error(...), { cause })` to stay ES2020-lib compatible (`providers.test.ts`, `SftpWorkspace`)
- `no-empty-object-type` — converted empty extending interfaces to type aliases (`tauri.ts`)
- `no-unused-expressions` / `ban-ts-comment` — `fujiBackground` (untyped canvas-art module; `@ts-nocheck` retained with a justified suppression)
- removed an unused `eslint-disable` directive (`RdpCanvasView`)

## react-hooks/exhaustive-deps (33)
Handled per hook:
- **Real fixes** where safe: `InstallerToolDialog` extracts `!!webUi` to a stable `hasWebUi` variable; `AiSettings` depends on the referentially-stable `aiProviderDefinition` (registry lookup) instead of two of its fields; `ScriptWidgetHost` captures the subscription Set inside the effect for cleanup.
- **Justified suppressions** where adding the dependency would change behavior (recreated-each-render callbacks that would cause reload loops, listener resubscription, or live SSH/terminal/SFTP session teardown). Each suppression has an inline comment explaining why.

## Verification
- `npm run lint` — clean (0 warnings)
- `tsc --noEmit` — clean
- `node tests/run-all.mjs` — 641/641 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)