### PR TITLE
Fix emoji column misalignment in the terminal (Unicode 11 widths)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@tauri-apps/plugin-updater": "^2.10.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
+        "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
@@ -3524,6 +3525,12 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.16.0.tgz",
       "integrity": "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-unicode11": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.9.0.tgz",
+      "integrity": "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==",
       "license": "MIT"
     },
     "node_modules/@xterm/addon-web-links": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@tauri-apps/plugin-updater": "^2.10.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
+    "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",

--- a/src/modules/workspace/connections/terminal/renderer.ts
+++ b/src/modules/workspace/connections/terminal/renderer.ts
@@ -4,6 +4,7 @@ import {
   type ISearchOptions,
   type ISearchResultChangeEvent,
 } from "@xterm/addon-search";
+import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import {
@@ -151,6 +152,13 @@ class XtermTerminalRenderer implements TerminalRenderer, TerminalFontAtlasRefres
     this.backgroundOpacity = backgroundOpacity;
     this.terminal = new XtermTerminal(terminalOptionsFor(settings, backgroundOpacity));
     this.terminal.attachCustomWheelEventHandler((event) => this.handleWheelEvent(event));
+    // xterm defaults to its built-in Unicode v6 width tables, where emoji are
+    // still 1 cell wide. Modern shells emit emoji that fonts paint two cells
+    // wide, so the v6 model under-counts the cursor advance and every column
+    // after an emoji drifts (issue #454). Activate Unicode 11 widths so wide
+    // codepoints reserve two cells and stay aligned.
+    this.terminal.loadAddon(new Unicode11Addon());
+    this.terminal.unicode.activeVersion = "11";
     this.terminal.loadAddon(this.fitAddon);
     this.terminal.loadAddon(this.searchAddon);
     this.terminal.loadAddon(new WebLinksAddon(handleTerminalLink));


### PR DESCRIPTION
## Summary

Fixes #454 — emoji caused column misalignment in the terminal on Windows (and any platform), while Windows Terminal rendered the same output correctly.

## Root cause

This is **not** a monospaced-font problem. The terminal was running on xterm.js's built-in **Unicode v6** width tables, where most emoji (e.g. `U+1F300`–`U+1F64F`) are still classified as **1 cell wide** — they only became East Asian *Wide* in Unicode 9.0+.

Modern shells emit emoji that the font paints **two cells** wide, so the v6 model under-counts the cursor advance by one cell per emoji and every column after it drifts. This happens regardless of the chosen font, including the default monospaced stack (`"Cascadia Mono", "SF Mono", "JetBrains Mono", Consolas, monospace`), because the mismatch is in cell-width accounting, not the typeface. On Windows the emoji glyphs themselves come from the `Segoe UI Emoji` fallback, which also paints wider than one cell — but the alignment defect is upstream of rendering.

The renderer (`src/modules/workspace/connections/terminal/renderer.ts`) loaded the fit, search, web-links and webgl addons but never loaded a Unicode addon or set `terminal.unicode.activeVersion`, so xterm defaulted to v6.

## Change

- Add `@xterm/addon-unicode11` (`^0.9.0`, the release aligned with `@xterm/xterm@^6`).
- Load the addon and set `terminal.unicode.activeVersion = "11"` in the renderer constructor, before the terminal is opened, so wide codepoints reserve two cells.

## Known limitation

xterm.js computes width per-codepoint, so multi-codepoint **ZWJ sequences** (family emoji 👨‍👩‍👧, some flags, skin-tone modifiers) can still misalign — a known xterm.js grapheme-cluster limitation that Windows Terminal does not share. This PR fixes single-codepoint wide emoji, which is the common case.

## Testing

- `npx tsc --noEmit` passes.
- Manual verification of emoji alignment should be done in the real Tauri desktop runtime on Windows per the repo's terminal-validation guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhLfbcM3AY7cQyqNMPwYSZ)_