### PR TITLE
Explain outdated Copilot CLI instead of raw serde error

### DIFF
--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -1961,6 +1961,21 @@ fn format_copilot_sdk_error(stage: &str, error: CopilotSdkError) -> String {
                  COPILOT_CLI_PATH environment variable to its full path, then try again."
             )
         }
+        // A JSON deserialization failure means the Copilot CLI's responses no
+        // longer match the wire schema the SDK understands — almost always an
+        // outdated or mismatched externally-installed CLI. A legacy CLI that
+        // predates the SDK's `connect` handshake falls back to `ping`, whose
+        // numeric timestamp the SDK expects as a string, producing a raw serde
+        // "invalid type: integer ..., expected a string" error. Surface
+        // actionable guidance instead of that confusing text.
+        CopilotSdkErrorKind::Json => {
+            format!(
+                "GitHub Copilot CLI returned a response KKTerm could not understand. \
+                 The installed Copilot CLI is likely outdated or incompatible with this \
+                 version of KKTerm. Update it (for example, \
+                 `npm install -g @github/copilot@latest`), then try again. (Details: {error})"
+            )
+        }
         _ => format!("GitHub Copilot SDK failed to {stage}: {error}"),
     }
 }

--- a/src-tauri/src/ai/tests.rs
+++ b/src-tauri/src/ai/tests.rs
@@ -3638,6 +3638,44 @@ fn resolve_copilot_cli_honors_explicit_path_override() {
     });
 }
 
+#[test]
+fn format_copilot_sdk_error_maps_json_failure_to_cli_update_guidance() {
+    // A legacy Copilot CLI that predates the SDK `connect` handshake falls back
+    // to `ping` and returns a numeric timestamp where the SDK expects a string,
+    // surfacing a raw serde error. KKTerm must translate that into actionable
+    // guidance instead of the confusing "invalid type" text (issue #456).
+    let error = CopilotSdkError::with_message(
+        CopilotSdkErrorKind::Json,
+        "invalid type: integer `1782380691690`, expected a string",
+    );
+    let message = format_copilot_sdk_error("start", error);
+
+    assert!(
+        message.contains("outdated or incompatible"),
+        "expected CLI-update guidance, got: {message}"
+    );
+    assert!(
+        message.contains("npm install -g @github/copilot@latest"),
+        "expected an update command, got: {message}"
+    );
+    // The underlying detail stays available for bug reports.
+    assert!(message.contains("1782380691690"), "expected detail, got: {message}");
+}
+
+#[test]
+fn format_copilot_sdk_error_keeps_stage_context_for_other_failures() {
+    let error = CopilotSdkError::with_message(
+        CopilotSdkErrorKind::InvalidConfig,
+        "bad config",
+    );
+    let message = format_copilot_sdk_error("create session", error);
+
+    assert!(
+        message.contains("failed to create session"),
+        "expected stage-based message, got: {message}"
+    );
+}
+
 /// Set (or clear) an env var for the duration of `body`, restoring the previous
 /// value afterward. Copilot CLI resolution reads process env directly.
 fn temp_env_var(key: &str, value: Option<&str>, body: impl FnOnce()) {


### PR DESCRIPTION
When the GitHub Copilot SDK fails to start because the externally-installed
Copilot CLI is too old to support the `connect` handshake, the SDK falls back
to the legacy `ping` RPC. Newer/legacy CLIs return `ping.timestamp` as an
epoch-ms integer, which the SDK deserializes into a `String`, so KKTerm
surfaced a confusing raw serde error:

    GitHub Copilot SDK failed to start: invalid type: integer
    `1782380691690`, expected a string

Map the SDK's JSON (wire-schema-mismatch) error to actionable guidance telling
the user to update their Copilot CLI, while preserving the underlying detail
for bug reports.

Fixes #456

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01K7pEaY5Ts3eAKST54S4UXZ