### PR TITLE
Restore terminal focus after assistant sends code

### DIFF
--- a/src/ai/AssistantPanel.tsx
+++ b/src/ai/AssistantPanel.tsx
@@ -59,6 +59,7 @@ import {
 import { useWorkspaceStore } from "../store";
 import { useDashboardStore } from "../modules/dashboard/state/dashboardStore";
 import {
+  focusPaneRenderer,
   getPaneRenderer,
   sendTextToRdpPane,
   writeInputToPane,
@@ -633,6 +634,7 @@ export function AssistantPanel({
     if (activeTerminalPaneId) {
       const data = prepareAssistantTerminalInput(code);
       writeInputToPane(activeTerminalPaneId, data);
+      focusPaneRenderer(activeTerminalPaneId);
       return;
     }
 

--- a/src/modules/workspace/paneRegistry.ts
+++ b/src/modules/workspace/paneRegistry.ts
@@ -45,6 +45,15 @@ export function getPaneRenderer(paneId: string): TerminalRenderer | undefined {
   return renderers.get(paneId);
 }
 
+export function focusPaneRenderer(paneId: string) {
+  const renderer = renderers.get(paneId);
+  if (!renderer) {
+    return false;
+  }
+  renderer.focus();
+  return true;
+}
+
 export function markPanesForRuntimeMove(paneIds: string[]) {
   for (const paneId of paneIds) {
     movingTerminalPaneIds.add(paneId);

--- a/tests/assistant-send-terminal-focus.test.mjs
+++ b/tests/assistant-send-terminal-focus.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const assistantPanelSource = await readFile(
+  new URL("../src/ai/AssistantPanel.tsx", import.meta.url),
+  "utf8",
+);
+const paneRegistrySource = await readFile(
+  new URL("../src/modules/workspace/paneRegistry.ts", import.meta.url),
+  "utf8",
+);
+
+test("assistant Send to terminal restores focus to the target terminal pane", () => {
+  assert.match(
+    paneRegistrySource,
+    /export function focusPaneRenderer\(paneId: string\)[\s\S]*?renderer\.focus\(\);/,
+    "the pane registry should expose a focused terminal renderer restore helper",
+  );
+  assert.match(
+    assistantPanelSource,
+    /writeInputToPane\(activeTerminalPaneId, data\);\s*focusPaneRenderer\(activeTerminalPaneId\);/,
+    "sending assistant code to a terminal should return text focus to that terminal pane",
+  );
+});


### PR DESCRIPTION
## Summary
- Restore focus to the active terminal pane after the assistant sends code there
- Add a pane registry helper to focus a terminal renderer by pane id
- Cover the focus handoff with a regression test

## Testing
- Added a unit test covering the focus restoration path