### PR TITLE
fix(ui): soften over-the-top drop shadows that bleed on light backgrounds

### DIFF
--- a/src/modules/settings/settings.css
+++ b/src/modules/settings/settings.css
@@ -2366,7 +2366,7 @@
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 22px;
-  box-shadow: var(--shadow), 0 12px 36px rgba(0, 0, 0, 0.14);
+  box-shadow: var(--shadow);
 }
 
 .settings-popup .settings-page-header {

--- a/src/modules/workspace/connections/sftp/sftp.css
+++ b/src/modules/workspace/connections/sftp/sftp.css
@@ -1286,7 +1286,7 @@
   backdrop-filter: saturate(180%) blur(20px);
   border: 0.5px solid var(--border);
   border-radius: 10px;
-  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.28), 0 2px 8px rgba(0, 0, 0, 0.16);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12), 0 2px 6px rgba(0, 0, 0, 0.08);
 }
 .sftp-ctx-menu button {
   display: flex;

--- a/src/modules/workspace/connections/terminal/terminal.css
+++ b/src/modules/workspace/connections/terminal/terminal.css
@@ -487,7 +487,8 @@
   border: 1px solid #7f90a7;
   border-radius: 8px;
   box-shadow:
-    0 22px 60px rgba(0, 0, 0, 0.5),
+    0 8px 24px rgba(0, 0, 0, 0.18),
+    0 2px 8px rgba(0, 0, 0, 0.1),
     0 0 0 1px rgba(255, 255, 255, 0.04) inset;
 }
 

--- a/src/modules/workspace/workspace.css
+++ b/src/modules/workspace/workspace.css
@@ -628,8 +628,8 @@
   --status-popup-glass-bg: rgba(252 252 253 / 88%);
   --status-popup-glass-hi: rgba(255 255 255 / 80%);
   --status-popup-glass-shadow:
-    0 24px 60px rgba(15 23 42 / 30%),
-    0 4px 14px rgba(15 23 42 / 16%);
+    0 8px 24px rgba(15 23 42 / 10%),
+    0 2px 8px rgba(15 23 42 / 7%);
   will-change: opacity, transform;
 }
 
@@ -647,8 +647,8 @@
   --status-popup-glass-bg: rgba(255 255 255 / 86%);
   --status-popup-glass-hi: rgba(255 255 255 / 82%);
   --status-popup-glass-shadow:
-    0 24px 56px rgba(44 104 18 / 26%),
-    0 4px 14px rgba(8 45 104 / 14%);
+    0 8px 22px rgba(44 104 18 / 12%),
+    0 2px 8px rgba(8 45 104 / 7%);
 }
 
 .status-popup.success {

--- a/src/styles/colorSchemes.css
+++ b/src/styles/colorSchemes.css
@@ -202,7 +202,7 @@
   --nav-toolbar-tooltip-bg: #111827;
   --nav-toolbar-tooltip-text: #f8fafc;
   --nav-toolbar-tooltip-border: rgba(255, 255, 255, 0.14);
-  --shadow: 0 12px 40px rgba(0, 8, 32, 0.1);
+  --shadow: 0 8px 24px rgba(0, 8, 32, 0.1), 0 2px 6px rgba(0, 8, 32, 0.06);
 }
 
 [data-color-scheme="mac"] {
@@ -268,7 +268,7 @@
   --nav-toolbar-tooltip-bg: #12306b;
   --nav-toolbar-tooltip-text: #ffffff;
   --nav-toolbar-tooltip-border: rgba(255, 255, 255, 0.28);
-  --shadow: 0 14px 42px rgba(255, 111, 0, 0.18);
+  --shadow: 0 8px 24px rgba(255, 111, 0, 0.1), 0 2px 6px rgba(255, 111, 0, 0.06);
 }
 
 [data-color-scheme="purple"] {
@@ -334,7 +334,7 @@
   --nav-toolbar-tooltip-bg: #3b1430;
   --nav-toolbar-tooltip-text: #fff0f7;
   --nav-toolbar-tooltip-border: rgba(255, 190, 220, 0.25);
-  --shadow: 0 12px 40px rgba(80, 20, 60, 0.1);
+  --shadow: 0 8px 24px rgba(80, 20, 60, 0.1), 0 2px 6px rgba(80, 20, 60, 0.06);
 }
 
 [data-color-scheme="green-kuai-kuai"] {
@@ -368,7 +368,7 @@
   --nav-toolbar-tooltip-bg: #082d68;
   --nav-toolbar-tooltip-text: #ffffff;
   --nav-toolbar-tooltip-border: rgba(255, 255, 255, 0.2);
-  --shadow: 0 18px 46px rgba(44, 104, 18, 0.2);
+  --shadow: 0 8px 24px rgba(44, 104, 18, 0.1), 0 2px 6px rgba(44, 104, 18, 0.06);
 }
 
 [data-color-scheme="blue-see"] {
@@ -437,7 +437,7 @@
   --nav-toolbar-tooltip-bg: #07151c;
   --nav-toolbar-tooltip-text: #ffffff;
   --nav-toolbar-tooltip-border: rgba(255, 255, 255, 0.24);
-  --shadow: 0 16px 44px rgba(31, 160, 203, 0.16);
+  --shadow: 0 8px 24px rgba(31, 160, 203, 0.1), 0 2px 6px rgba(31, 160, 203, 0.06);
 }
 
 [data-color-scheme="confetti"] {
@@ -470,7 +470,7 @@
   --nav-toolbar-tooltip-bg: #221435;
   --nav-toolbar-tooltip-text: #fff0f8;
   --nav-toolbar-tooltip-border: rgba(240, 152, 208, 0.25);
-  --shadow: 0 12px 40px rgba(60, 20, 70, 0.08);
+  --shadow: 0 8px 24px rgba(60, 20, 70, 0.1), 0 2px 6px rgba(60, 20, 70, 0.06);
 }
 
 [data-color-scheme="bubble-tea"] {
@@ -503,7 +503,7 @@
   --nav-toolbar-tooltip-bg: #2a1710;
   --nav-toolbar-tooltip-text: #fff4e8;
   --nav-toolbar-tooltip-border: rgba(224, 176, 128, 0.25);
-  --shadow: 0 12px 40px rgba(60, 30, 10, 0.1);
+  --shadow: 0 8px 24px rgba(60, 30, 10, 0.1), 0 2px 6px rgba(60, 30, 10, 0.06);
 }
 
 [data-color-scheme="semiconductor"] {
@@ -539,7 +539,7 @@
   --nav-toolbar-tooltip-bg: #050505;
   --nav-toolbar-tooltip-text: #ffffff;
   --nav-toolbar-tooltip-border: rgba(255, 255, 255, 0.18);
-  --shadow: 0 16px 44px rgba(0, 0, 0, 0.18);
+  --shadow: 0 8px 24px rgba(0, 0, 0, 0.1), 0 2px 6px rgba(0, 0, 0, 0.06);
 }
 
 [data-color-scheme="canarinho"] {
@@ -576,7 +576,7 @@
   --titlebar-text: #193375;
   --titlebar-hover-bg: rgba(25, 51, 117, 0.12);
   --titlebar-border: rgba(25, 51, 117, 0.2);
-  --shadow: 0 16px 44px rgba(25, 174, 71, 0.16);
+  --shadow: 0 8px 24px rgba(25, 174, 71, 0.1), 0 2px 6px rgba(25, 174, 71, 0.06);
 }
 
 [data-color-scheme="la-albiceleste"] {
@@ -613,7 +613,7 @@
   --titlebar-text: #173e69;
   --titlebar-hover-bg: rgba(23, 62, 105, 0.14);
   --titlebar-border: rgba(23, 62, 105, 0.2);
-  --shadow: 0 16px 44px rgba(67, 161, 213, 0.16);
+  --shadow: 0 8px 24px rgba(67, 161, 213, 0.1), 0 2px 6px rgba(67, 161, 213, 0.06);
 }
 
 [data-color-scheme="les-bleus"] {
@@ -687,7 +687,7 @@
   --titlebar-text: #2a1a10;
   --titlebar-hover-bg: rgba(42, 26, 16, 0.12);
   --titlebar-border: rgba(42, 26, 16, 0.16);
-  --shadow: 0 16px 44px rgba(243, 108, 33, 0.18);
+  --shadow: 0 8px 24px rgba(243, 108, 33, 0.1), 0 2px 6px rgba(243, 108, 33, 0.06);
 }
 
 [data-color-scheme="die-mannschaft"] {
@@ -724,7 +724,7 @@
   --titlebar-text: #161413;
   --titlebar-hover-bg: rgba(22, 20, 19, 0.08);
   --titlebar-border: rgba(22, 20, 19, 0.12);
-  --shadow: 0 16px 44px rgba(0, 0, 0, 0.14);
+  --shadow: 0 8px 24px rgba(0, 0, 0, 0.09), 0 2px 6px rgba(0, 0, 0, 0.05);
 }
 
 [data-color-scheme="la-roja"] {
@@ -761,7 +761,7 @@
   --titlebar-text: #ffffff;
   --titlebar-hover-bg: rgba(255, 255, 255, 0.16);
   --titlebar-border: rgba(255, 255, 255, 0.2);
-  --shadow: 0 16px 44px rgba(227, 6, 19, 0.16);
+  --shadow: 0 8px 24px rgba(227, 6, 19, 0.1), 0 2px 6px rgba(227, 6, 19, 0.06);
 }
 
 [data-color-scheme="os-navegadores"] {
@@ -835,7 +835,7 @@
   --titlebar-text: #ffffff;
   --titlebar-hover-bg: rgba(255, 255, 255, 0.16);
   --titlebar-border: rgba(255, 255, 255, 0.2);
-  --shadow: 0 16px 44px rgba(237, 28, 36, 0.16);
+  --shadow: 0 8px 24px rgba(237, 28, 36, 0.1), 0 2px 6px rgba(237, 28, 36, 0.06);
 }
 
 [data-color-scheme="el-tri"] {
@@ -872,7 +872,7 @@
   --titlebar-text: #ffffff;
   --titlebar-hover-bg: rgba(255, 255, 255, 0.14);
   --titlebar-border: rgba(255, 255, 255, 0.18);
-  --shadow: 0 16px 44px rgba(0, 104, 71, 0.16);
+  --shadow: 0 8px 24px rgba(0, 104, 71, 0.1), 0 2px 6px rgba(0, 104, 71, 0.06);
 }
 
 [data-color-scheme="three-lions"] {
@@ -909,7 +909,7 @@
   --titlebar-text: #00216a;
   --titlebar-hover-bg: rgba(0, 33, 106, 0.08);
   --titlebar-border: rgba(0, 33, 106, 0.12);
-  --shadow: 0 16px 44px rgba(0, 33, 106, 0.14);
+  --shadow: 0 8px 24px rgba(0, 33, 106, 0.1), 0 2px 6px rgba(0, 33, 106, 0.06);
 }
 
 [data-color-scheme="samurai-blue"] {
@@ -983,5 +983,5 @@
   --titlebar-text: #ffffff;
   --titlebar-hover-bg: rgba(255, 255, 255, 0.14);
   --titlebar-border: rgba(255, 255, 255, 0.18);
-  --shadow: 0 16px 44px rgba(191, 10, 48, 0.16);
+  --shadow: 0 8px 24px rgba(191, 10, 48, 0.1), 0 2px 6px rgba(191, 10, 48, 0.06);
 }


### PR DESCRIPTION
## What

Tones down drop shadows that were heavy enough to visibly bleed on white/light backgrounds, starting from the reported status-bar popup and extending to every other surface with the same issue.

## Why

The status-bar popup shadow bled against white surfaces. An audit of the rest of the UI found the same over-the-top treatment on the shared theme `--shadow` token (consumed by dialogs, dropdowns, and popovers across the app) and on a couple of standalone menus/popups — large blur radii (40–60px) and high opacity.

## Changes

- **`src/modules/workspace/workspace.css`** — lighten `.status-popup` glass shadow for the default light theme and the `green-kuai-kuai` theme.
- **`src/styles/colorSchemes.css`** — harmonize every light-theme (`--surface: #fff`) `--shadow` to a consistent, subtle two-layer recipe `0 8px 24px <tint>/0.1, 0 2px 6px <tint>/0.06`, preserving each theme's tint hue. Covers `light`, `orange`, `pink`, `green-kuai-kuai`, `blue-green-white`, `confetti`, `bubble-tea`, `semiconductor`, `canarinho`, `la-albiceleste`, `oranje`, `die-mannschaft`, `la-roja`, `vatreni`, `el-tri`, `three-lions`, `stars-and-stripes`. **Dark themes and the `mac`/`:root` baselines are intentionally left unchanged** — heavy shadows read fine on dark backgrounds and `mac` was already subtle.
- **`src/modules/workspace/connections/sftp/sftp.css`** — lighten `.sftp-ctx-menu` shadow.
- **`src/modules/workspace/connections/terminal/terminal.css`** — lighten `.tmux-session-menu` shadow (kept the inset hairline).
- **`src/modules/settings/settings.css`** — drop the redundant extra shadow layer stacked on top of `var(--shadow)` for the settings page.

## Reviewer notes

- These are visual values reasoned about, not yet screenshot-verified across all 17 themes. Worth a quick spot-check on a couple of saturated light themes (e.g. `la-roja`, `stars-and-stripes`) against a white surface.
- `die-mannschaft` uses a marginally lower opacity (`0.09/0.05`) to stay faithful to its already-lower original value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)