### PR TITLE
Fix App Launcher launching explorer.exe on macOS

### DIFF
--- a/docs/manual/11-app-launcher.md
+++ b/docs/manual/11-app-launcher.md
@@ -54,7 +54,7 @@ Details values come from live local file metadata when available:
 
 App Launcher actions live in the right-click menu, not the default surface. Icon and list views show the icon and label; Details view also shows type, size, modified time, and the stored local path for comparison.
 
-- Launch: `appLauncher.launchApp`. Variants: `appLauncher.runNormal`, `appLauncher.runAdmin` (UAC elevation), `appLauncher.runAsUser` (run as a different user).
+- Launch: `appLauncher.launchApp`. Variants: `appLauncher.runNormal`, `appLauncher.runAdmin` (UAC elevation), `appLauncher.runAsUser` (run as a different user). `appLauncher.runAdmin` and `appLauncher.runAsUser` map to Windows shell verbs (`runas` / `runasuser`) and only appear on Windows; macOS and Linux show `appLauncher.runNormal` and `appLauncher.openFolder` only. A normal launch opens the entry through the host OS default handler (Windows `explorer.exe`, macOS/Linux the platform opener), so non-runnable files and folders never shell out to `explorer.exe` on macOS or Linux.
 - `appLauncher.openFolder` — open the containing local folder for files, shortcuts, scripts, and apps; for folder entries, open that folder.
 - `appLauncher.editApp` / `appLauncher.edit` — open the edit dialog.
 - `appLauncher.removeApp` / `appLauncher.remove` — delete. Status `appLauncher.removedStatus`.

--- a/src-tauri/src/app_launcher.rs
+++ b/src-tauri/src/app_launcher.rs
@@ -127,26 +127,36 @@ fn plan_launch_with_options(
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned);
 
-    if is_powershell_script(path) {
-        let parameters = Some(match arguments {
-            Some(arguments) => format!("-File \"{}\" {arguments}", path.replace('"', "\\\"")),
-            None => format!("-File \"{}\"", path.replace('"', "\\\"")),
-        });
-        return Ok(AppLauncherLaunchPlan {
-            target: "powershell.exe".to_string(),
-            parameters,
-            working_directory,
-            operation,
-        });
-    }
+    // Windows routes PowerShell scripts and shell-associated documents through
+    // native shims (powershell.exe / explorer.exe). macOS and Linux have no such
+    // executables: they open the path through the OS default handler in
+    // `launch_plan`, so they must not inject those Windows-only targets — doing so
+    // made the macOS launcher try to spawn explorer.exe (issue #466).
+    #[cfg(target_os = "windows")]
+    {
+        if is_powershell_script(path) {
+            let parameters = Some(match arguments {
+                Some(arguments) => {
+                    format!("-File \"{}\" {arguments}", path.replace('"', "\\\""))
+                }
+                None => format!("-File \"{}\"", path.replace('"', "\\\"")),
+            });
+            return Ok(AppLauncherLaunchPlan {
+                target: "powershell.exe".to_string(),
+                parameters,
+                working_directory,
+                operation,
+            });
+        }
 
-    if mode == AppLauncherLaunchMode::Normal && !runnable {
-        return Ok(AppLauncherLaunchPlan {
-            target: "explorer.exe".to_string(),
-            parameters: Some(path.to_string()),
-            working_directory,
-            operation,
-        });
+        if mode == AppLauncherLaunchMode::Normal && !runnable {
+            return Ok(AppLauncherLaunchPlan {
+                target: "explorer.exe".to_string(),
+                parameters: Some(path.to_string()),
+                working_directory,
+                operation,
+            });
+        }
     }
 
     Ok(AppLauncherLaunchPlan {
@@ -505,6 +515,7 @@ fn is_runnable_path(path: &str) -> bool {
     )
 }
 
+#[cfg(target_os = "windows")]
 fn is_powershell_script(path: &str) -> bool {
     path_extension(path).as_deref() == Some("ps1")
 }
@@ -605,34 +616,60 @@ mod tests {
         let plan = plan_launch("C:\\Docs\\notes.txt", AppLauncherLaunchMode::Normal)
             .expect("normal launches can open associated files");
 
-        assert_eq!(plan.target, "explorer.exe");
-        assert_eq!(plan.parameters.as_deref(), Some("C:\\Docs\\notes.txt"));
+        // Windows shells the document through explorer.exe; macOS and Linux open
+        // the path itself via the OS default handler.
+        #[cfg(target_os = "windows")]
+        {
+            assert_eq!(plan.target, "explorer.exe");
+            assert_eq!(plan.parameters.as_deref(), Some("C:\\Docs\\notes.txt"));
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            assert_eq!(plan.target, "C:\\Docs\\notes.txt");
+            assert_eq!(plan.parameters, None);
+        }
         assert_eq!(plan.operation, None);
     }
 
     #[test]
-    fn launch_plan_opens_office_documents_through_explorer() {
+    fn launch_plan_opens_office_documents_through_default_handler() {
         let plan = plan_launch("C:\\Docs\\budget.xlsx", AppLauncherLaunchMode::Normal)
             .expect("office documents open through their shell association");
 
-        assert_eq!(plan.target, "explorer.exe");
-        assert_eq!(plan.parameters.as_deref(), Some("C:\\Docs\\budget.xlsx"));
+        #[cfg(target_os = "windows")]
+        {
+            assert_eq!(plan.target, "explorer.exe");
+            assert_eq!(plan.parameters.as_deref(), Some("C:\\Docs\\budget.xlsx"));
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            assert_eq!(plan.target, "C:\\Docs\\budget.xlsx");
+            assert_eq!(plan.parameters, None);
+        }
         assert_eq!(plan.operation, None);
     }
 
     #[test]
-    fn launch_plan_opens_folders_through_explorer() {
+    fn launch_plan_opens_folders_through_default_handler() {
         let plan = plan_launch(
             "C:\\Users\\example\\Documents",
             AppLauncherLaunchMode::Normal,
         )
-        .expect("folders open in File Explorer");
+        .expect("folders open in the OS file manager");
 
-        assert_eq!(plan.target, "explorer.exe");
-        assert_eq!(
-            plan.parameters.as_deref(),
-            Some("C:\\Users\\example\\Documents")
-        );
+        #[cfg(target_os = "windows")]
+        {
+            assert_eq!(plan.target, "explorer.exe");
+            assert_eq!(
+                plan.parameters.as_deref(),
+                Some("C:\\Users\\example\\Documents")
+            );
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            assert_eq!(plan.target, "C:\\Users\\example\\Documents");
+            assert_eq!(plan.parameters, None);
+        }
         assert_eq!(plan.operation, None);
     }
 
@@ -641,7 +678,12 @@ mod tests {
         let plan = plan_launch("C:\\Tools\\script.ps1", AppLauncherLaunchMode::Admin)
             .expect("scripts can use admin launch");
 
+        // Only Windows wraps the script in powershell.exe; the admin verb itself
+        // is rejected later by `launch_plan` on other platforms.
+        #[cfg(target_os = "windows")]
         assert_eq!(plan.target, "powershell.exe");
+        #[cfg(not(target_os = "windows"))]
+        assert_eq!(plan.target, "C:\\Tools\\script.ps1");
         assert_eq!(plan.operation, Some("runas"));
 
         let error = plan_launch("C:\\Docs\\notes.txt", AppLauncherLaunchMode::Admin)

--- a/src-tauri/src/app_launcher.rs
+++ b/src-tauri/src/app_launcher.rs
@@ -159,6 +159,18 @@ fn plan_launch_with_options(
         }
     }
 
+    #[cfg(not(target_os = "windows"))]
+    {
+        if mode == AppLauncherLaunchMode::Normal && !runnable {
+            return Ok(AppLauncherLaunchPlan {
+                target: path.to_string(),
+                parameters: None,
+                working_directory: None,
+                operation,
+            });
+        }
+    }
+
     Ok(AppLauncherLaunchPlan {
         target: path.to_string(),
         parameters: arguments.map(ToOwned::to_owned),
@@ -646,6 +658,23 @@ mod tests {
             assert_eq!(plan.target, "C:\\Docs\\budget.xlsx");
             assert_eq!(plan.parameters, None);
         }
+        assert_eq!(plan.operation, None);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn launch_plan_opens_associated_files_through_default_handler_even_with_extra_fields() {
+        let plan = plan_launch_with_options(
+            "/Users/example/Documents/budget.xlsx",
+            Some("--ignored-by-default-handler"),
+            Some("/Users/example/Documents"),
+            AppLauncherLaunchMode::Normal,
+        )
+        .expect("associated files should still open through the OS default handler");
+
+        assert_eq!(plan.target, "/Users/example/Documents/budget.xlsx");
+        assert_eq!(plan.parameters, None);
+        assert_eq!(plan.working_directory, None);
         assert_eq!(plan.operation, None);
     }
 

--- a/src/modules/dashboard/widgets/builtin/app-launcher/AppLauncherWidget.tsx
+++ b/src/modules/dashboard/widgets/builtin/app-launcher/AppLauncherWidget.tsx
@@ -29,6 +29,7 @@ import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { LegacyDialogActions } from "../../../../../app/ui/dialog";
 import { selectAppLauncherFile, selectAppLauncherFolder, isTauriRuntime } from "../../../../../lib/tauri";
+import { isWindowsPlatform } from "../../../../../lib/platform";
 import { useWorkspaceStore } from "../../../../../store";
 import { useDashboardStore } from "../../../state/dashboardStore";
 import type { DashboardWidgetInstance } from "../../../types";
@@ -1104,6 +1105,10 @@ function AppLauncherMenu({
 }) {
   const { t } = useTranslation();
   const runnable = state.prepared?.runnable ?? isRunnablePath(state.entry.path);
+  // "Run as administrator" (UAC) and "Run as a different user" map to Windows
+  // shell verbs (runas / runasuser) that have no macOS/Linux equivalent, so the
+  // backend rejects them off Windows. Only surface them on Windows.
+  const supportsElevatedLaunch = isWindowsPlatform();
   return (
     <div
       ref={menuRef}
@@ -1122,24 +1127,28 @@ function AppLauncherMenu({
           void onLaunch(state.entry, "normal");
         }}
       />
-      <MenuButton
-        disabled={!runnable}
-        icon={<Shield size={14} />}
-        label={t("appLauncher.runAdmin")}
-        onClick={() => {
-          onClose();
-          void onLaunch(state.entry, "admin");
-        }}
-      />
-      <MenuButton
-        disabled={!runnable}
-        icon={<UserRound size={14} />}
-        label={t("appLauncher.runAsUser")}
-        onClick={() => {
-          onClose();
-          void onLaunch(state.entry, "differentUser");
-        }}
-      />
+      {supportsElevatedLaunch ? (
+        <>
+          <MenuButton
+            disabled={!runnable}
+            icon={<Shield size={14} />}
+            label={t("appLauncher.runAdmin")}
+            onClick={() => {
+              onClose();
+              void onLaunch(state.entry, "admin");
+            }}
+          />
+          <MenuButton
+            disabled={!runnable}
+            icon={<UserRound size={14} />}
+            label={t("appLauncher.runAsUser")}
+            onClick={() => {
+              onClose();
+              void onLaunch(state.entry, "differentUser");
+            }}
+          />
+        </>
+      ) : null}
       <MenuButton
         icon={<FolderOpen size={14} />}
         label={t("appLauncher.openFolder")}


### PR DESCRIPTION
The App Launcher built its launch plan with hard-coded Windows targets:
non-runnable files/folders were routed through `explorer.exe` and
PowerShell scripts through `powershell.exe`. On macOS and Linux those
executables do not exist, so a normal launch of a document or folder tried
to spawn `explorer.exe` and failed (issue #466).

Gate the Windows shell shims behind `#[cfg(target_os = "windows")]`. On
macOS and Linux the plan now targets the path itself, which `launch_plan`
opens through the OS default handler (the platform opener), and folders/
documents open natively instead of shelling out to explorer.exe.

Also hide the Windows-only "Run as administrator" and "Run as a different
user" launch entries on non-Windows platforms; they map to the `runas` /
`runasuser` shell verbs the backend already rejects off Windows.

Tests now assert the platform-specific launch plans, and the manual notes
the Windows-only launch variants.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015L58wLJaGWUQVdPHqzWU5r