### PR TITLE
fix(connections): stop browser-bookmark import dialog hanging forever

### DIFF
--- a/src/modules/workspace/connections/ImportDialog.tsx
+++ b/src/modules/workspace/connections/ImportDialog.tsx
@@ -115,6 +115,7 @@ export function ImportDialog({ sshSettings, onClose, onImported }: ImportDialogP
   const [bookmarksLoaded, setBookmarksLoaded] = useState(false);
   const [bookmarksLoading, setBookmarksLoading] = useState(false);
   const [bookmarksPreviewing, setBookmarksPreviewing] = useState(false);
+  const bookmarkDiscoveryRef = useRef(false);
   const [search, setSearch] = useState("");
   const [typeFilter, setTypeFilter] = useState<ConnectionType | "all">("all");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
@@ -210,10 +211,17 @@ export function ImportDialog({ sshSettings, onClose, onImported }: ImportDialogP
   }, [activeWorkspaceId, destinationWorkspaceId, workspaceOptions]);
 
   useEffect(() => {
-    if (source !== "bookmarks" || bookmarksLoaded || bookmarksLoading) {
+    // Guard re-entrancy with a ref, NOT with `bookmarksLoading`. Listing the
+    // loading flag in the dependency array (and writing it below) made the
+    // effect re-run the moment discovery started, whose cleanup cancelled the
+    // in-flight request before it could resolve — so the dialog hung on
+    // "Looking for browser bookmark sources…" forever regardless of which (or
+    // whether any) browsers were installed.
+    if (source !== "bookmarks" || bookmarksLoaded || bookmarkDiscoveryRef.current) {
       return;
     }
     let cancelled = false;
+    bookmarkDiscoveryRef.current = true;
     setBookmarksLoading(true);
     invokeCommand("list_browser_bookmark_sources", undefined)
       .then((response) => {
@@ -227,23 +235,23 @@ export function ImportDialog({ sshSettings, onClose, onImported }: ImportDialogP
         if (first) {
           setBookmarkSourceId(first.id);
         }
-        setBookmarksLoaded(true);
       })
       .catch((failure) => {
         if (!cancelled) {
           setError(failure instanceof Error ? failure.message : String(failure));
-          setBookmarksLoaded(true);
         }
       })
       .finally(() => {
+        bookmarkDiscoveryRef.current = false;
         if (!cancelled) {
+          setBookmarksLoaded(true);
           setBookmarksLoading(false);
         }
       });
     return () => {
       cancelled = true;
     };
-  }, [bookmarksLoaded, bookmarksLoading, source]);
+  }, [bookmarksLoaded, source]);
 
   async function handleBrowse() {
     setError("");
@@ -324,6 +332,7 @@ export function ImportDialog({ sshSettings, onClose, onImported }: ImportDialogP
     setBookmarkSources([]);
     setBookmarkSourceId("");
     setSelectedNodeIds(new Set());
+    bookmarkDiscoveryRef.current = false;
     setBookmarksLoaded(false);
     clearPreview();
   }

--- a/tests/connection-import-bookmark-loading.test.mjs
+++ b/tests/connection-import-bookmark-loading.test.mjs
@@ -7,25 +7,30 @@ const source = await readFile(
   "utf8",
 );
 
-test("bookmark import source discovery settles when no sources are found", () => {
+test("bookmark discovery does not cancel its own in-flight request", () => {
+  // Regression: the discovery effect wrote `setBookmarksLoading(true)` while
+  // `bookmarksLoading` was in its dependency array. That re-ran the effect,
+  // whose cleanup flipped `cancelled = true`, so the resolved request bailed
+  // out and the dialog hung on "Looking for browser bookmark sources…"
+  // forever — even on machines with no Firefox / no matching browser at all.
   assert.match(
     source,
-    /const \[bookmarksLoaded, setBookmarksLoaded\] = useState\(false\)/,
-    "bookmark discovery needs an explicit loaded flag so an empty source list is stable",
+    /const bookmarkDiscoveryRef = useRef\(false\)/,
+    "discovery must be de-duplicated with a ref, not by re-triggering on its own loading state",
   );
   assert.match(
     source,
-    /source !== "bookmarks" \|\| bookmarksLoaded \|\| bookmarksLoading/,
-    "bookmark discovery should be gated by loaded/loading state, not by source count",
+    /source !== "bookmarks" \|\| bookmarksLoaded \|\| bookmarkDiscoveryRef\.current/,
+    "discovery should be gated by the ref + loaded flag, never by the loading flag it writes",
   );
   assert.doesNotMatch(
     source,
-    /source !== "bookmarks" \|\| bookmarkSources\.length > 0 \|\| bookmarksLoading/,
-    "an empty bookmark source list must not retrigger discovery forever",
+    /\}, \[[^\]]*bookmarksLoading[^\]]*\]\);/,
+    "the loading flag must not be a dependency of the discovery effect — that is what cancelled the in-flight request",
   );
   assert.match(
     source,
     /setBookmarksLoaded\(true\);/,
-    "bookmark discovery should mark both success and failure paths as settled",
+    "bookmark discovery should mark the request as settled when it resolves",
   );
 });


### PR DESCRIPTION
## What

The **Import browser bookmarks** tab in the connection import dialog got stuck on *"Looking for browser bookmark sources…"* forever and never completed — independent of which (or whether any) browsers were installed.

## Root cause

A React effect re-entrancy regression introduced by the import-dialog redesign (`b9892ac1`), not a browser/SQLite issue.

The discovery effect wrote `setBookmarksLoading(true)` while `bookmarksLoading` was in its **own dependency array** (`[bookmarksLoaded, bookmarksLoading, source]`):

1. Tab opens → effect runs → `setBookmarksLoading(true)` fires the IPC request and registers cleanup.
2. That state write re-renders → because `bookmarksLoading` is a dependency, React runs the effect **cleanup** (`cancelled = true`) and re-runs the effect (which bails on the loading guard).
3. The IPC request resolves a moment later → `.then`/`.finally` see `cancelled === true` and **bail out** → `setBookmarksLoaded(true)` / `setBookmarksLoading(false)` never run → loading sticks on `true` forever.

Before the redesign, the bookmark UI was a separate child component with an empty (`[]`) dependency array, so writing the loading flag could not re-trigger discovery. The later `bookmarksLoaded` patch (`5b2d59ed`) didn't address the `cancelled`-flag interaction, so it kept hanging. This is the classic React footgun of writing a state value that is also in the effect's dependency list alongside a `cancelled` cleanup guard.

## Fix

- De-dupe discovery with a `bookmarkDiscoveryRef` instead of the loading flag, and drop `bookmarksLoading` from the effect dependency array — the effect no longer cancels its own in-flight request.
- Reset the ref in `handleBookmarkRefresh` so the Refresh button re-fetches.
- Rewrite the regression test, which previously locked in the broken approach (it asserted `bookmarksLoading` belonged in the gate), to guard the real invariant: the loading flag must **not** be a dependency of the discovery effect.

## Notes for reviewers

- Frontend-only change — no Rust rebuild needed; a frontend reload picks it up.
- Verified: regression test passes, ESLint clean, `tsc --noEmit` clean for the file.
- Out of scope (optional follow-up): the bookmark file/SQLite reads still run synchronously on the main thread. Moving them to the existing `run_blocking_command` pattern would prevent UI freezes on very large bookmark files, but it is not the cause of this hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)