### PR TITLE
feat(ai): add Ollama Cloud provider for direct cloud access

### DIFF
--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -1726,7 +1726,7 @@ fn model_list_strategy_for_provider(
         "github-copilot" | "github_copilot" | "github copilot" => {
             Ok(AiProviderModelListStrategy::GitHubCopilotSdk)
         }
-        "ollama" => Ok(AiProviderModelListStrategy::OllamaTags),
+        "ollama" | "ollama-cloud" => Ok(AiProviderModelListStrategy::OllamaTags),
         "openai" | "openrouter" | "deepseek" | "gemini" | "grok" | "litellm" | "nvidia"
         | "opencode" | "openai-compatible" | "openai_compatible" | "openai compatible" => {
             Ok(AiProviderModelListStrategy::OpenAiCompatible)
@@ -5700,7 +5700,7 @@ fn model_context_limit_tokens(provider_kind: &str, model: &str) -> (usize, bool)
     }
     if matches!(
         provider.as_str(),
-        "openai-compatible" | "litellm" | "openrouter" | "opencode" | "nvidia"
+        "openai-compatible" | "litellm" | "openrouter" | "opencode" | "nvidia" | "ollama-cloud"
     ) {
         return (32_000, true);
     }

--- a/src-tauri/src/ai/providers.rs
+++ b/src-tauri/src/ai/providers.rs
@@ -6,6 +6,7 @@ mod grok;
 mod litellm;
 mod nvidia;
 mod ollama;
+mod ollama_cloud;
 mod openai;
 mod openai_compatible;
 mod opencode;
@@ -23,6 +24,7 @@ pub(super) fn provider_for(kind: &str) -> Result<AgentProviderAdapter, String> {
         "openai" => Ok(AgentProviderAdapter::OpenAi(openai::provider())),
         "openrouter" => Ok(AgentProviderAdapter::OpenAi(openrouter::provider())),
         "ollama" => Ok(AgentProviderAdapter::OpenAi(ollama::provider())),
+        "ollama-cloud" => Ok(AgentProviderAdapter::OpenAi(ollama_cloud::provider())),
         "nvidia" => Ok(AgentProviderAdapter::OpenAi(nvidia::provider())),
         "opencode" => Ok(AgentProviderAdapter::OpenAi(opencode::provider())),
         "openai-compatible" => Ok(AgentProviderAdapter::OpenAi(openai_compatible::provider())),

--- a/src-tauri/src/ai/providers/ollama_cloud.rs
+++ b/src-tauri/src/ai/providers/ollama_cloud.rs
@@ -1,0 +1,18 @@
+use super::super::{
+    OpenAiApiStyle, OpenAiAuthStyle, OpenAiCompatibleProvider, OpenAiEndpointStyle,
+};
+
+pub(super) fn provider() -> OpenAiCompatibleProvider {
+    OpenAiCompatibleProvider {
+        provider_kind: "ollama-cloud",
+        label: "Ollama Cloud",
+        requires_api_key: true,
+        endpoint_style: OpenAiEndpointStyle::ChatCompletions,
+        auth_style: OpenAiAuthStyle::Bearer,
+        // ollama.com acts as a remote Ollama host reached over the
+        // OpenAI-compatible /v1 layer. The cloud host is not documented to
+        // implement the Responses API, so default to Chat Completions, which is
+        // the universally supported endpoint.
+        default_api: OpenAiApiStyle::ChatCompletions,
+    }
+}

--- a/src-tauri/src/ai/tests.rs
+++ b/src-tauri/src/ai/tests.rs
@@ -2682,6 +2682,7 @@ fn explicit_strict_tool_flags_are_only_sent_to_openai_family_providers() {
         "litellm",
         "nvidia",
         "ollama",
+        "ollama-cloud",
         "opencode",
         "openai-compatible",
         "openrouter",

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -1500,6 +1500,7 @@ const AI_PROVIDER_CREDENTIALS: &[(&str, &str, &str)] = &[
     ("litellm", "LiteLLM", "LiteLLM key"),
     ("github-copilot", "GitHub Copilot", "GitHub OAuth token"),
     ("ollama", "Ollama", "Ollama API key"),
+    ("ollama-cloud", "Ollama Cloud", "Ollama API key"),
     ("nvidia", "NVIDIA", "NVIDIA API key"),
     ("opencode", "OpenCode", "OpenCode API key"),
     ("openai-compatible", "OpenAI-compatible", "API key"),
@@ -5527,6 +5528,7 @@ fn validate_ai_provider_settings(
         "litellm" | "lite-llm" | "lite_llm" => "litellm".to_string(),
         "github-copilot" | "github_copilot" | "github copilot" => "github-copilot".to_string(),
         "ollama" => "ollama".to_string(),
+        "ollama-cloud" | "ollama_cloud" | "ollama cloud" => "ollama-cloud".to_string(),
         "nvidia" => "nvidia".to_string(),
         "opencode" | "open-code" | "open_code" | "open code" => "opencode".to_string(),
         "openai-compatible" | "openai_compatible" | "openai compatible" => {

--- a/src/ai/providerRegistry/index.ts
+++ b/src/ai/providerRegistry/index.ts
@@ -7,6 +7,7 @@ import { grokProvider } from "./grok";
 import { liteLlmProvider } from "./litellm";
 import { nvidiaProvider } from "./nvidia";
 import { ollamaProvider } from "./ollama";
+import { ollamaCloudProvider } from "./ollamaCloud";
 import { opencodeProvider } from "./opencode";
 import { openAiCompatibleProvider } from "./openAiCompatible";
 import { openAiProvider } from "./openai";
@@ -27,6 +28,7 @@ export const AI_PROVIDER_DEFINITIONS: AiProviderDefinition[] = [
   liteLlmProvider,
   githubCopilotProvider,
   ollamaProvider,
+  ollamaCloudProvider,
   nvidiaProvider,
   opencodeProvider,
   openAiCompatibleProvider,

--- a/src/ai/providerRegistry/modelCatalog.ts
+++ b/src/ai/providerRegistry/modelCatalog.ts
@@ -142,6 +142,27 @@ export const AI_PROVIDER_MODEL_CATALOG: AiProviderModelCatalog = {
       { id: "llama3.2-vision", label: "Llama 3.2 Vision", supportsImageInput: true },
       { id: "qwen3", label: "Qwen3", supportsImageInput: false },
       { id: "deepseek-r1", label: "DeepSeek-R1", supportsImageInput: false },
+      // Cloud models reached through a local signed-in Ollama (`ollama signin`
+      // then `ollama pull <model>-cloud`). The local daemon proxies these to the
+      // cloud; direct ollama.com access lives on the `ollama-cloud` provider.
+      { id: "gpt-oss:120b-cloud", label: "gpt-oss 120B (cloud)", supportsImageInput: false },
+      { id: "qwen3-coder:480b-cloud", label: "Qwen3 Coder 480B (cloud)", supportsImageInput: false },
+      { id: "qwen3.5:122b-cloud", label: "Qwen3.5 122B (cloud)", supportsImageInput: true },
+    ],
+  },
+  "ollama-cloud": {
+    defaultModel: "gpt-oss:120b",
+    defaultReasoningEffort: "default",
+    models: [
+      { id: "gpt-oss:120b", label: "gpt-oss 120B", recommended: true, supportsImageInput: false },
+      { id: "glm-5.2", label: "GLM-5.2", recommended: true, supportsImageInput: false },
+      { id: "deepseek-v4-pro", label: "DeepSeek V4 Pro", recommended: true, supportsImageInput: false },
+      { id: "qwen3-coder:480b", label: "Qwen3 Coder 480B", recommended: true, supportsImageInput: false },
+      { id: "kimi-k2.6", label: "Kimi K2.6", supportsImageInput: false },
+      { id: "minimax-m2.7", label: "MiniMax M2.7", supportsImageInput: false },
+      { id: "nemotron-3-super:120b", label: "Nemotron 3 Super 120B", supportsImageInput: false },
+      { id: "qwen3.5:122b", label: "Qwen3.5 122B", supportsImageInput: true },
+      { id: "gemma4", label: "Gemma 4", supportsImageInput: true },
     ],
   },
   nvidia: {

--- a/src/ai/providerRegistry/ollamaCloud.ts
+++ b/src/ai/providerRegistry/ollamaCloud.ts
@@ -1,0 +1,36 @@
+import { HOSTED_PROVIDER_SETTINGS_FIELDS, STANDARD_REASONING_EFFORTS } from "./shared";
+import type { AiProviderDefinition } from "./types";
+
+// Direct Ollama Cloud access: ollama.com acts as a remote Ollama host, reached
+// with a bearer API key. The OpenAI-compatible /v1 layer carries chat while the
+// native /api/tags endpoint lists the account's available cloud models. Local
+// Ollama and local signed-in cloud models stay on the separate `ollama`
+// provider (http://localhost:11434/v1).
+export const ollamaCloudProvider: AiProviderDefinition = {
+  kind: "ollama-cloud",
+  label: "Ollama Cloud",
+  baseUrl: "https://ollama.com/v1",
+  defaultModel: "gpt-oss:120b",
+  defaultReasoningEffort: "default",
+  reasoningEfforts: [...STANDARD_REASONING_EFFORTS],
+  requiresApiKey: true,
+  allowsCustomBaseUrl: false,
+  allowsCustomModel: true,
+  apiKeyLabel: "Ollama API key",
+  apiKeyUrl: "https://ollama.com/settings/keys",
+  modelListStrategy: "ollamaTags",
+  strictModelList: true,
+  modelOptions: [
+    { id: "gpt-oss:120b", label: "gpt-oss 120B", note: "Open-weight", supportsImageInput: false },
+    { id: "glm-5.2", label: "GLM-5.2", supportsImageInput: false },
+    { id: "deepseek-v4-pro", label: "DeepSeek V4 Pro", supportsImageInput: false },
+    { id: "qwen3-coder:480b", label: "Qwen3 Coder 480B", supportsImageInput: false },
+    { id: "kimi-k2.6", label: "Kimi K2.6", supportsImageInput: false },
+    { id: "minimax-m2.7", label: "MiniMax M2.7", supportsImageInput: false },
+    { id: "nemotron-3-super:120b", label: "Nemotron 3 Super 120B", supportsImageInput: false },
+    { id: "qwen3.5:122b", label: "Qwen3.5 122B", supportsImageInput: true },
+    { id: "gemma4", label: "Gemma 4", supportsImageInput: true },
+  ],
+  settingsFields: HOSTED_PROVIDER_SETTINGS_FIELDS,
+  capabilities: ["chat", "imageInput", "streaming", "toolCalling", "openAiCompatible"],
+};

--- a/src/ai/providers.test.ts
+++ b/src/ai/providers.test.ts
@@ -44,6 +44,20 @@ if (!ollamaDefinition.settingsFields.includes("apiKey") || ollamaDefinition.requ
 }
 validateAiProviderForChat(providerDefaultsFor("ollama"), false);
 
+const ollamaCloudDefinition = getAiProviderDefinition("ollama-cloud");
+if (ollamaCloudDefinition.modelListStrategy !== "ollamaTags") {
+  throw new Error("Ollama Cloud should refresh models from the native tags endpoint.");
+}
+if (ollamaCloudDefinition.baseUrl !== "https://ollama.com/v1") {
+  throw new Error(
+    `Ollama Cloud should target the direct cloud endpoint, got: ${ollamaCloudDefinition.baseUrl}`,
+  );
+}
+if (!ollamaCloudDefinition.requiresApiKey || ollamaCloudDefinition.allowsCustomBaseUrl) {
+  throw new Error("Ollama Cloud should require a bearer API key against the fixed cloud endpoint.");
+}
+validateAiProviderForChat(providerDefaultsFor("ollama-cloud"), true);
+
 const opencodeDefinition = getAiProviderDefinition("opencode");
 if (opencodeDefinition.baseUrl !== "https://opencode.ai/zen/go/v1") {
   throw new Error(`OpenCode should use the Go OpenAI-compatible base URL, got: ${opencodeDefinition.baseUrl}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -939,6 +939,7 @@ export type AiProviderKind =
   | "litellm"
   | "github-copilot"
   | "ollama"
+  | "ollama-cloud"
   | "nvidia"
   | "opencode"
   | "openai-compatible";


### PR DESCRIPTION
## Summary

Adds a new **Ollama Cloud** (`ollama-cloud`) AI provider for **direct cloud access** via `https://ollama.com/v1` with a bearer API key. The existing `ollama` provider is left as the runtime for **local Ollama** and **local signed-in cloud models** (`localhost:11434`).

Ollama Cloud documents two access methods, which map cleanly onto the provider split:

- **Local signed-in** (`ollama signin` → `ollama pull <model>-cloud`): served by the existing `ollama` provider, now seeded with a few `-cloud` presets so signed-in cloud models are pickable before a model refresh.
- **Direct cloud API key** (ollama.com acts as a remote Ollama host): the new `ollama-cloud` provider — required API key, fixed cloud endpoint, models listed via the documented native `/api/tags` endpoint (the bearer key authenticates the refresh).

## Type of change

- [x] Feature

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)
- [x] Backend (Rust/Tauri — `src-tauri/`)

## Implementation notes

- **Runtime:** runs on the existing OpenAI-compatible adapter (Chat Completions, bearer auth — mirroring `opencode`). The cloud docs only guarantee the native `/api/chat` flow and do **not** document `/v1/responses` on the cloud host, so Chat Completions is the safe, universally-supported transport. If the cloud `/v1` path ever proves unreliable, a native `/api/chat` adapter is the documented fallback — a follow-up, not a blocker.
- **Model seed:** reflects the current cloud lineup (`gpt-oss:120b`, `glm-5.2`, `deepseek-v4-pro`, `qwen3-coder:480b`, `kimi-k2.6`, `minimax-m2.7`, `nemotron-3-super:120b`, `qwen3.5:122b`, `gemma4`), aligned with the repo's existing model catalogs. The live `/api/tags` refresh is authoritative once a key is added; the seed is just the pre-refresh starting set.
- Settings UI and model refresh are fully data-driven from the provider registry — no per-provider UI code needed. Provider label/`apiKeyLabel` are English literals in the definition, consistent with every existing provider, so no new i18n keys.

### Files

- `src/ai/providerRegistry/ollamaCloud.ts` (new) — provider definition (hosted, bearer, `ollamaTags` refresh, `apiKeyUrl`)
- `src/ai/providerRegistry/{index,modelCatalog}.ts` — registration + model catalog (+ `-cloud` presets on `ollama`)
- `src/types.ts` — `"ollama-cloud"` added to `AiProviderKind`
- `src-tauri/src/ai/providers/ollama_cloud.rs` (new) — backend adapter
- `src-tauri/src/ai/providers.rs`, `src-tauri/src/ai.rs`, `src-tauri/src/storage.rs` — wiring (provider_for, model-list strategy, context default, credential registry, kind normalization)
- `src/ai/providers.test.ts`, `src-tauri/src/ai/tests.rs` — coverage

## Domain & docs

- [x] Uses canonical vocabulary
- [x] Source placement follows existing provider-registry layout
- No manual/MCP/Settings-safety text changed (the manual references the provider registry generically)

## i18n

- [x] No new user-visible strings (provider labels are English literals in the definition, matching all existing providers)

## Checks

- [x] `npx tsc --noEmit` (clean)
- [x] Frontend provider tests (`providers.test.ts`, `providerModelOptions.test.ts`) pass
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` (clean)
- [x] `cargo test --manifest-path src-tauri/Cargo.toml ai::` — 139 passed
- Change is < 500 LOC (additive registration); full suite optional per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)