### PR TITLE
Fix fleets nav resize lag, remove transport from new fleet, add icon pickers, better icons

### DIFF
--- a/src-tauri/src/itops/commands.rs
+++ b/src-tauri/src/itops/commands.rs
@@ -20,7 +20,7 @@ use super::run_storage;
 use super::storage as ito;
 use super::types::{
     BatchTask, Fleet, FleetFilter, Rack, RackItem, RackItemKind, RackItemMetadata, ResolvedHost,
-    RunEvent, RunEventHost, RunHistoryEntry, RunScope, Transport,
+    RoomIcon, RunEvent, RunEventHost, RunHistoryEntry, RunScope, Transport,
 };
 
 fn storage(app: &AppHandle) -> State<'_, crate::storage::Storage> {
@@ -40,10 +40,12 @@ pub fn itops_create_fleet(
     member_ids: Vec<String>,
     filter: Option<FleetFilter>,
     transport: Transport,
+    icon_data_url: Option<String>,
+    icon_background_color: Option<String>,
 ) -> Result<Fleet, String> {
     let id = new_itops_id("hg");
     storage(&app).with_connection_infallible(|conn| {
-        ito::create_fleet(conn, &id, &name, member_ids, filter, transport)
+        ito::create_fleet(conn, &id, &name, member_ids, filter, transport, icon_data_url.as_deref(), icon_background_color.as_deref())
             .map_err(|error| error.to_string())
     })
 }
@@ -56,9 +58,11 @@ pub fn itops_update_fleet(
     member_ids: Vec<String>,
     filter: Option<FleetFilter>,
     transport: Transport,
+    icon_data_url: Option<String>,
+    icon_background_color: Option<String>,
 ) -> Result<Fleet, String> {
     storage(&app).with_connection_infallible(|conn| {
-        ito::update_fleet(conn, &id, &name, member_ids, filter, transport)
+        ito::update_fleet(conn, &id, &name, member_ids, filter, transport, icon_data_url.as_deref(), icon_background_color.as_deref())
             .map_err(|error| error.to_string())
     })
 }
@@ -364,6 +368,20 @@ pub fn itops_set_server_room_background(
 ) -> Result<Fleet, String> {
     storage(&app).with_connection_infallible(|conn| {
         ito::set_server_room_background(conn, &fleet_id, &server_room, background)
+            .map_err(|error| error.to_string())
+    })
+}
+
+/// Set (or clear) a server room's icon within a Fleet.
+#[tauri::command]
+pub fn itops_set_room_icon(
+    app: AppHandle,
+    fleet_id: String,
+    server_room: String,
+    icon: Option<RoomIcon>,
+) -> Result<Fleet, String> {
+    storage(&app).with_connection_infallible(|conn| {
+        ito::set_room_icon(conn, &fleet_id, &server_room, icon)
             .map_err(|error| error.to_string())
     })
 }

--- a/src-tauri/src/itops/storage.rs
+++ b/src-tauri/src/itops/storage.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use rusqlite::{Connection as SqliteConnection, OptionalExtension, params, params_from_iter};
 
 use crate::dashboard_storage::DashboardBackground;
-use super::types::{Fleet, FleetFilter, RackItemKind, ResolvedHost, RunScope, Transport};
+use super::types::{Fleet, FleetFilter, RackItemKind, ResolvedHost, RoomIcon, RunScope, Transport};
 
 #[derive(Debug)]
 pub enum ItopsStorageError {
@@ -103,6 +103,15 @@ fn room_backgrounds_to_json(map: &HashMap<String, DashboardBackground>) -> Resul
     serde_json::to_string(map).map_err(|error| ItopsStorageError::Validation(error.to_string()))
 }
 
+fn parse_room_icons(raw: Option<String>) -> HashMap<String, RoomIcon> {
+    raw.and_then(|json| serde_json::from_str(&json).ok())
+        .unwrap_or_default()
+}
+
+fn room_icons_to_json(map: &HashMap<String, RoomIcon>) -> Result<String> {
+    serde_json::to_string(map).map_err(|error| ItopsStorageError::Validation(error.to_string()))
+}
+
 fn row_to_group(row: &rusqlite::Row<'_>) -> rusqlite::Result<Fleet> {
     let member_ids: String = row.get(3)?;
     let filter_json: Option<String> = row.get(4)?;
@@ -116,11 +125,15 @@ fn row_to_group(row: &rusqlite::Row<'_>) -> rusqlite::Result<Fleet> {
         transport: Transport::from_db_str(&transport).unwrap_or(Transport::Auto),
         background: parse_background(row.get(6)?),
         room_backgrounds: parse_room_backgrounds(row.get(7)?),
+        icon_data_url: row.get(8)?,
+        icon_background_color: row.get(9)?,
+        room_icons: parse_room_icons(row.get(10)?),
     })
 }
 
 const SELECT_GROUP_COLUMNS: &str = "id, name, sort_order, member_ids_json, filter_json, transport, \
-     background_json, room_backgrounds_json FROM itops_fleets";
+     background_json, room_backgrounds_json, icon_data_url, icon_background_color, \
+     room_icons_json FROM itops_fleets";
 
 /// Re-read one Fleet by id (used after a mutation to return preserved fields
 /// such as backgrounds that the mutation does not touch).
@@ -163,6 +176,8 @@ pub fn create_fleet(
     member_ids: Vec<String>,
     filter: Option<FleetFilter>,
     transport: Transport,
+    icon_data_url: Option<&str>,
+    icon_background_color: Option<&str>,
 ) -> Result<Fleet> {
     let name = validate_name(name)?;
     let next_sort: i64 = conn.query_row(
@@ -173,9 +188,9 @@ pub fn create_fleet(
     let member_json = member_ids_to_json(&member_ids)?;
     let filter_json = filter_to_json(&filter)?;
     conn.execute(
-        "INSERT INTO itops_fleets (id, name, sort_order, member_ids_json, filter_json, transport)
-         VALUES (?, ?, ?, ?, ?, ?)",
-        params![id, name, next_sort, member_json, filter_json, transport.as_db_str()],
+        "INSERT INTO itops_fleets (id, name, sort_order, member_ids_json, filter_json, transport, icon_data_url, icon_background_color)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        params![id, name, next_sort, member_json, filter_json, transport.as_db_str(), icon_data_url, icon_background_color],
     )?;
     Ok(Fleet {
         id: id.to_string(),
@@ -186,6 +201,9 @@ pub fn create_fleet(
         transport,
         background: None,
         room_backgrounds: HashMap::new(),
+        icon_data_url: icon_data_url.map(|s| s.to_string()),
+        icon_background_color: icon_background_color.map(|s| s.to_string()),
+        room_icons: HashMap::new(),
     })
 }
 
@@ -196,6 +214,8 @@ pub fn update_fleet(
     member_ids: Vec<String>,
     filter: Option<FleetFilter>,
     transport: Transport,
+    icon_data_url: Option<&str>,
+    icon_background_color: Option<&str>,
 ) -> Result<Fleet> {
     let name = validate_name(name)?;
     // Existence check (returns NotFound before the UPDATE).
@@ -211,11 +231,11 @@ pub fn update_fleet(
     let filter_json = filter_to_json(&filter)?;
     conn.execute(
         "UPDATE itops_fleets
-         SET name = ?, member_ids_json = ?, filter_json = ?, transport = ?, updated_at = CURRENT_TIMESTAMP
+         SET name = ?, member_ids_json = ?, filter_json = ?, transport = ?, icon_data_url = ?, icon_background_color = ?, updated_at = CURRENT_TIMESTAMP
          WHERE id = ?",
-        params![name, member_json, filter_json, transport.as_db_str(), id],
+        params![name, member_json, filter_json, transport.as_db_str(), icon_data_url, icon_background_color, id],
     )?;
-    // Re-read so preserved fields (backgrounds) round-trip into the response.
+    // Re-read so preserved fields (backgrounds, room icons) round-trip into the response.
     load_fleet(conn, id)
 }
 
@@ -257,6 +277,30 @@ pub fn set_server_room_background(
     let json = room_backgrounds_to_json(&fleet.room_backgrounds)?;
     conn.execute(
         "UPDATE itops_fleets SET room_backgrounds_json = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+        params![json, fleet_id],
+    )?;
+    load_fleet(conn, fleet_id)
+}
+
+/// Set (or clear with `None`) a server room's icon. Stored on the owning Fleet.
+pub fn set_room_icon(
+    conn: &SqliteConnection,
+    fleet_id: &str,
+    server_room: &str,
+    icon: Option<RoomIcon>,
+) -> Result<Fleet> {
+    let mut fleet = load_fleet(conn, fleet_id)?;
+    match icon {
+        Some(entry) => {
+            fleet.room_icons.insert(server_room.to_string(), entry);
+        }
+        None => {
+            fleet.room_icons.remove(server_room);
+        }
+    }
+    let json = room_icons_to_json(&fleet.room_icons)?;
+    conn.execute(
+        "UPDATE itops_fleets SET room_icons_json = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
         params![json, fleet_id],
     )?;
     load_fleet(conn, fleet_id)
@@ -479,6 +523,9 @@ mod tests {
                     CHECK (transport IN ('ssh', 'winrm', 'psexec', 'auto')),
                 background_json TEXT,
                 room_backgrounds_json TEXT,
+                icon_data_url TEXT,
+                icon_background_color TEXT,
+                room_icons_json TEXT,
                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             );
@@ -523,6 +570,8 @@ mod tests {
             vec!["c1".into(), "c2".into()],
             None,
             Transport::Ssh,
+            None,
+            None,
         )
         .unwrap();
         assert_eq!(created.name, "Production Web"); // trimmed
@@ -544,6 +593,8 @@ mod tests {
                 folder_id: Some("f1".into()),
             }),
             Transport::Auto,
+            None,
+            None,
         )
         .unwrap();
         assert_eq!(updated.name, "Web");
@@ -564,7 +615,7 @@ mod tests {
     fn empty_name_is_rejected() {
         let conn = open_test_db();
         assert!(matches!(
-            create_fleet(&conn, "hg-x", "   ", vec![], None, Transport::Auto),
+            create_fleet(&conn, "hg-x", "   ", vec![], None, Transport::Auto, None, None),
             Err(ItopsStorageError::Validation(_))
         ));
     }
@@ -579,6 +630,8 @@ mod tests {
             vec![],
             Some(FleetFilter::default()),
             Transport::Auto,
+            None,
+            None,
         )
         .unwrap();
         assert!(group.filter.is_none());
@@ -604,6 +657,8 @@ mod tests {
                 folder_id: Some("prod".into()),
             }),
             Transport::Ssh,
+            None,
+            None,
         )
         .unwrap();
 
@@ -618,8 +673,8 @@ mod tests {
     #[test]
     fn reorder_rewrites_sort_order() {
         let conn = open_test_db();
-        create_fleet(&conn, "a", "A", vec![], None, Transport::Auto).unwrap();
-        create_fleet(&conn, "b", "B", vec![], None, Transport::Auto).unwrap();
+        create_fleet(&conn, "a", "A", vec![], None, Transport::Auto, None, None).unwrap();
+        create_fleet(&conn, "b", "B", vec![], None, Transport::Auto, None, None).unwrap();
         reorder_fleets(&conn, &["b".to_string(), "a".to_string()]).unwrap();
         let order: Vec<String> = list_fleets(&conn)
             .unwrap()

--- a/src-tauri/src/itops/types.rs
+++ b/src-tauri/src/itops/types.rs
@@ -131,6 +131,16 @@ impl FleetFilter {
     }
 }
 
+/// Icon + background colour for a server room, stored on the owning Fleet.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoomIcon {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon_data_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon_background_color: Option<String>,
+}
+
 /// A durable, named selection of existing Connections used as a fleet target.
 /// References Connection ids; owns no Session and no secret.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -151,6 +161,14 @@ pub struct Fleet {
     /// not entities, so their backgrounds live as a map on the owning Fleet.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub room_backgrounds: HashMap<String, DashboardBackground>,
+    /// Custom icon (data URL or lucide/material ref) and background colour.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon_data_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon_background_color: Option<String>,
+    /// Per-server-room icons, keyed by the room's string tag.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub room_icons: HashMap<String, RoomIcon>,
 }
 
 /// A Rack in a Fleet's virtual datacenter (docs/FLEET.md): a fixed-height cabinet

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3913,6 +3913,7 @@ pub fn run() {
             itops::commands::itops_update_rack,
             itops::commands::itops_set_fleet_background,
             itops::commands::itops_set_server_room_background,
+            itops::commands::itops_set_room_icon,
             itops::commands::itops_set_rack_background,
             itops::commands::itops_delete_rack,
             itops::commands::itops_reorder_racks,

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -295,6 +295,11 @@ CREATE TABLE IF NOT EXISTS itops_fleets (
     -- Rack View customization: Fleet-view background + per-server-room map.
     background_json       TEXT,
     room_backgrounds_json TEXT,
+    -- Custom icon (data URL or icon ref) and background colour.
+    icon_data_url         TEXT,
+    icon_background_color TEXT,
+    -- Per-server-room icons, keyed by the room's string tag (JSON map).
+    room_icons_json       TEXT,
     created_at      TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at      TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
@@ -1926,6 +1931,9 @@ impl Storage {
         ensure_column(&connection, "itops_fleet_racks", "background_json", "TEXT")?;
         ensure_column(&connection, "itops_fleets", "background_json", "TEXT")?;
         ensure_column(&connection, "itops_fleets", "room_backgrounds_json", "TEXT")?;
+        ensure_column(&connection, "itops_fleets", "icon_data_url", "TEXT")?;
+        ensure_column(&connection, "itops_fleets", "icon_background_color", "TEXT")?;
+        ensure_column(&connection, "itops_fleets", "room_icons_json", "TEXT")?;
         ensure_column(&connection, "connections", "rdp_options", "TEXT")?;
         ensure_column(&connection, "connections", "vnc_options", "TEXT")?;
         ensure_column(&connection, "connections", "ftp_options", "TEXT")?;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -48,6 +48,7 @@ import type {
   RackItemMetadata,
   RunScope,
   ResolvedHost,
+  RoomIconEntry,
   BatchTask,
   RunHistoryEntry,
   Automation,
@@ -1091,6 +1092,8 @@ type CommandMap = {
       memberIds: string[];
       filter: FleetFilter | null;
       transport: ItopsTransport;
+      iconDataUrl: string | null;
+      iconBackgroundColor: string | null;
     };
     result: Fleet;
   };
@@ -1101,6 +1104,8 @@ type CommandMap = {
       memberIds: string[];
       filter: FleetFilter | null;
       transport: ItopsTransport;
+      iconDataUrl: string | null;
+      iconBackgroundColor: string | null;
     };
     result: Fleet;
   };
@@ -1149,6 +1154,10 @@ type CommandMap = {
   };
   itops_set_server_room_background: {
     args: { fleetId: string; serverRoom: string; background: DashboardBackground | null };
+    result: Fleet;
+  };
+  itops_set_room_icon: {
+    args: { fleetId: string; serverRoom: string; icon: RoomIconEntry | null };
     result: Fleet;
   };
   itops_set_rack_background: {

--- a/src/modules/itops/FleetDialog.tsx
+++ b/src/modules/itops/FleetDialog.tsx
@@ -1,15 +1,15 @@
 // Create / edit a Fleet. Built from the shared dialog primitives
-// (docs/DESIGN_LANGUAGE.md): a name field, the per-host transport default, and a
-// multi-select of the active Workspace's Connections for static membership.
-//
-// Phase 1 edits static membership only; an existing group's dynamic filter is
-// preserved on save but not editable here yet (a later refinement).
+// (docs/DESIGN_LANGUAGE.md): a name field, an icon picker, the per-host
+// transport default (edit only), and a multi-select of the active Workspace's
+// Connections for static membership.
 
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Actions, Btn, DialogShell, Field, Sheet, TextInput } from "../../app/ui/dialog";
 import { invokeCommand, isTauriRuntime } from "../../lib/tauri";
 import { flattenConnections } from "../workspace/connections/treeUtils";
+import { ConnectionIconBackgroundPicker } from "../workspace/connections/ConnectionIconBackgroundPicker";
+import { ConnectionIconPicker } from "../workspace/connections/ConnectionIconPicker";
 import { useWorkspaceStore } from "../../store";
 import type { Connection, Fleet, ItopsTransport } from "../../types";
 import { ItIcon } from "./icons";
@@ -35,6 +35,10 @@ export function FleetDialog({
 
   const [name, setName] = useState(group?.name ?? "");
   const [transport, setTransport] = useState<ItopsTransport>(group?.transport ?? "auto");
+  const [iconDataUrl, setIconDataUrl] = useState<string | null>(group?.iconDataUrl ?? null);
+  const [iconBackgroundColor, setIconBackgroundColor] = useState<string | null>(
+    group?.iconBackgroundColor ?? null,
+  );
   const [selected, setSelected] = useState<Set<string>>(
     () => new Set(group?.memberIds ?? []),
   );
@@ -92,6 +96,8 @@ export function FleetDialog({
       memberIds: orderedMemberIds(group?.memberIds ?? [], selected),
       filter: group?.filter ?? null,
       transport,
+      iconDataUrl,
+      iconBackgroundColor,
     };
     try {
       const saved = isEdit
@@ -127,6 +133,19 @@ export function FleetDialog({
         }
       >
         {isEdit ? null : <p className="hg-dlg-help">{t("itops.fleets.createHelp")}</p>}
+        <div className="connection-type-summary">
+          <ConnectionIconPicker
+            customIconDataUrls={[]}
+            iconBackgroundColor={iconBackgroundColor}
+            iconDataUrl={iconDataUrl}
+            onChange={setIconDataUrl}
+            type="localFiles"
+          />
+          <ConnectionIconBackgroundPicker
+            color={iconBackgroundColor}
+            onChange={setIconBackgroundColor}
+          />
+        </div>
         <Field label={t("itops.fleets.nameLabel")} req>
           <TextInput
             value={name}
@@ -136,56 +155,60 @@ export function FleetDialog({
           />
         </Field>
 
-        <Field label={t("itops.fleets.perHostTransport")}>
-          <div className="hg-dlg-seg">
-            {TRANSPORTS.map((value) => (
-              <button
-                key={value}
-                type="button"
-                className={value === transport ? "on" : ""}
-                onClick={() => setTransport(value)}
-              >
-                {value === "auto" ? t("itops.transport.auto") : value.toUpperCase()}
-              </button>
-            ))}
-          </div>
-        </Field>
+        {isEdit ? (
+          <Field label={t("itops.fleets.perHostTransport")}>
+            <div className="hg-dlg-seg">
+              {TRANSPORTS.map((value) => (
+                <button
+                  key={value}
+                  type="button"
+                  className={value === transport ? "on" : ""}
+                  onClick={() => setTransport(value)}
+                >
+                  {value === "auto" ? t("itops.transport.auto") : value.toUpperCase()}
+                </button>
+              ))}
+            </div>
+          </Field>
+        ) : null}
 
-        <Field
-          label={t("itops.fleets.connectionsLabel")}
-          hint={t("itops.fleets.selectedCount", { count: selected.size })}
-        >
-          <div className="hg-dlg-list">
-            {orderedConnections.length === 0 ? (
-              <div className="hg-dlg-empty">{t("itops.fleets.noConnections")}</div>
-            ) : (
-              orderedConnections.map((connection) => {
-                const checked = selected.has(connection.id);
-                return (
-                  <button
-                    key={connection.id}
-                    type="button"
-                    className={`hg-dlg-row${checked ? " checked" : ""}`}
-                    aria-pressed={checked}
-                    onClick={() => toggle(connection.id)}
-                  >
-                    <span className="hg-dlg-check">
-                      {checked ? <ItIcon name="check" size={13} sw={2.4} /> : null}
-                    </span>
-                    <span className="hg-dlg-row-txt">
-                      <span className="nm">{connection.name}</span>
-                      <span className="host">
-                        {connection.user ? `${connection.user}@` : ""}
-                        {connection.host}
+        {isEdit ? (
+          <Field
+            label={t("itops.fleets.connectionsLabel")}
+            hint={t("itops.fleets.selectedCount", { count: selected.size })}
+          >
+            <div className="hg-dlg-list">
+              {orderedConnections.length === 0 ? (
+                <div className="hg-dlg-empty">{t("itops.fleets.noConnections")}</div>
+              ) : (
+                orderedConnections.map((connection) => {
+                  const checked = selected.has(connection.id);
+                  return (
+                    <button
+                      key={connection.id}
+                      type="button"
+                      className={`hg-dlg-row${checked ? " checked" : ""}`}
+                      aria-pressed={checked}
+                      onClick={() => toggle(connection.id)}
+                    >
+                      <span className="hg-dlg-check">
+                        {checked ? <ItIcon name="check" size={13} sw={2.4} /> : null}
                       </span>
-                    </span>
-                    <span className="hg-dlg-type">{connection.type}</span>
-                  </button>
-                );
-              })
-            )}
-          </div>
-        </Field>
+                      <span className="hg-dlg-row-txt">
+                        <span className="nm">{connection.name}</span>
+                        <span className="host">
+                          {connection.user ? `${connection.user}@` : ""}
+                          {connection.host}
+                        </span>
+                      </span>
+                      <span className="hg-dlg-type">{connection.type}</span>
+                    </button>
+                  );
+                })
+              )}
+            </div>
+          </Field>
+        ) : null}
       </Sheet>
     </DialogShell>
   );

--- a/src/modules/itops/FleetDialog.tsx
+++ b/src/modules/itops/FleetDialog.tsx
@@ -172,43 +172,41 @@ export function FleetDialog({
           </Field>
         ) : null}
 
-        {isEdit ? (
-          <Field
-            label={t("itops.fleets.connectionsLabel")}
-            hint={t("itops.fleets.selectedCount", { count: selected.size })}
-          >
-            <div className="hg-dlg-list">
-              {orderedConnections.length === 0 ? (
-                <div className="hg-dlg-empty">{t("itops.fleets.noConnections")}</div>
-              ) : (
-                orderedConnections.map((connection) => {
-                  const checked = selected.has(connection.id);
-                  return (
-                    <button
-                      key={connection.id}
-                      type="button"
-                      className={`hg-dlg-row${checked ? " checked" : ""}`}
-                      aria-pressed={checked}
-                      onClick={() => toggle(connection.id)}
-                    >
-                      <span className="hg-dlg-check">
-                        {checked ? <ItIcon name="check" size={13} sw={2.4} /> : null}
+        <Field
+          label={t("itops.fleets.connectionsLabel")}
+          hint={t("itops.fleets.selectedCount", { count: selected.size })}
+        >
+          <div className="hg-dlg-list">
+            {orderedConnections.length === 0 ? (
+              <div className="hg-dlg-empty">{t("itops.fleets.noConnections")}</div>
+            ) : (
+              orderedConnections.map((connection) => {
+                const checked = selected.has(connection.id);
+                return (
+                  <button
+                    key={connection.id}
+                    type="button"
+                    className={`hg-dlg-row${checked ? " checked" : ""}`}
+                    aria-pressed={checked}
+                    onClick={() => toggle(connection.id)}
+                  >
+                    <span className="hg-dlg-check">
+                      {checked ? <ItIcon name="check" size={13} sw={2.4} /> : null}
+                    </span>
+                    <span className="hg-dlg-row-txt">
+                      <span className="nm">{connection.name}</span>
+                      <span className="host">
+                        {connection.user ? `${connection.user}@` : ""}
+                        {connection.host}
                       </span>
-                      <span className="hg-dlg-row-txt">
-                        <span className="nm">{connection.name}</span>
-                        <span className="host">
-                          {connection.user ? `${connection.user}@` : ""}
-                          {connection.host}
-                        </span>
-                      </span>
-                      <span className="hg-dlg-type">{connection.type}</span>
-                    </button>
-                  );
-                })
-              )}
-            </div>
-          </Field>
-        ) : null}
+                    </span>
+                    <span className="hg-dlg-type">{connection.type}</span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </Field>
       </Sheet>
     </DialogShell>
   );

--- a/src/modules/itops/FleetsTab.tsx
+++ b/src/modules/itops/FleetsTab.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import { invokeCommand } from "../../lib/tauri";
 import { useWorkspaceStore } from "../../store";
 import type { Fleet, Rack, RackItem, ResolvedHost } from "../../types";
+import { ConnectionIcon } from "../workspace/connections/ConnectionIcon";
 import { ItIcon, IT_ACCENTS, type ItIconName } from "./icons";
 import { FleetDialog } from "./FleetDialog";
 import { RackElevation } from "./RackElevation";
@@ -46,6 +47,11 @@ const TILE_COLORS = [
   IT_ACCENTS.orange,
   IT_ACCENTS.purple,
 ];
+
+type ItOpsCustomIcon = {
+  iconDataUrl?: string | null;
+  iconBackgroundColor?: string | null;
+};
 
 // A stable per-group tile colour (Fleets don't store one); hashing the id
 // keeps a group's colour steady across reloads without a durable field.
@@ -420,6 +426,7 @@ export function FleetsTab({
                     <TreeRow
                       depth={0}
                       icon={groupIcon(fleet)}
+                      customIcon={fleet}
                       label={fleet.name}
                       tint={groupColor(fleet.id)}
                       hasChildren={fleetRacks.length > 0}
@@ -442,6 +449,7 @@ export function FleetsTab({
                                 <TreeRow
                                   depth={1}
                                   icon="room"
+                                  customIcon={fleet.roomIcons?.[room.key]}
                                   label={room.key || t("itops.racks.unassigned")}
                                   count={room.racks.length}
                                   hasChildren={room.racks.length > 0}
@@ -496,6 +504,7 @@ export function FleetsTab({
             drill={drill}
             setDrill={setDrill}
             viewBackground={viewBackground}
+            roomIcons={activeGroup.roomIcons}
             hostForItem={hostForItem}
             isGhostItem={isGhostItem}
             onSlotClick={(rack, startU) => setItemDialog({ rack, item: null, startU })}
@@ -552,10 +561,40 @@ export function FleetsTab({
   );
 }
 
+function ItOpsIcon({
+  icon,
+  customIcon,
+  size,
+}: {
+  icon: ItIconName;
+  customIcon?: ItOpsCustomIcon;
+  size: number;
+}) {
+  if (customIcon?.iconDataUrl) {
+    return (
+      <ConnectionIcon
+        iconBackgroundColor={customIcon.iconBackgroundColor}
+        iconDataUrl={customIcon.iconDataUrl}
+        size={size}
+        type="localFiles"
+      />
+    );
+  }
+  if (customIcon?.iconBackgroundColor) {
+    return (
+      <span className="ft-custom-icon" style={{ background: customIcon.iconBackgroundColor }}>
+        <ItIcon name={icon} size={size} sw={1.6} />
+      </span>
+    );
+  }
+  return <ItIcon name={icon} size={size} sw={1.6} />;
+}
+
 // ── Tree row ──────────────────────────────────────────────────────────────
 function TreeRow({
   depth,
   icon,
+  customIcon,
   label,
   count,
   tint,
@@ -567,6 +606,7 @@ function TreeRow({
 }: {
   depth: number;
   icon: ItIconName;
+  customIcon?: ItOpsCustomIcon;
   label: string;
   count?: number;
   tint?: string;
@@ -595,7 +635,7 @@ function TreeRow({
         {hasChildren ? <ItIcon name={open ? "chevD" : "chevR"} size={11} /> : null}
       </button>
       <span className="ft-ic" style={tint ? { color: tint } : undefined}>
-        <ItIcon name={icon} size={14} sw={1.6} />
+        <ItOpsIcon icon={icon} customIcon={customIcon} size={14} />
       </span>
       <span className="ft-label">{label}</span>
       {count != null ? <span className="ft-count">{count}</span> : null}
@@ -610,6 +650,7 @@ function RackDrill({
   drill,
   setDrill,
   viewBackground,
+  roomIcons,
   hostForItem,
   isGhostItem,
   onSlotClick,
@@ -622,6 +663,7 @@ function RackDrill({
   drill: DrillPath;
   setDrill: (next: DrillPath) => void;
   viewBackground: DashboardBackground | null | undefined;
+  roomIcons?: Record<string, ItOpsCustomIcon>;
   hostForItem: (item: RackItem) => string | null;
   isGhostItem: (item: RackItem) => boolean;
   onSlotClick: (rack: Rack, startU: number) => void;
@@ -686,6 +728,7 @@ function RackDrill({
               <DrillCard
                 key={room.key}
                 icon="room"
+                customIcon={roomIcons?.[room.key]}
                 title={room.key || unassigned}
                 meta={t("itops.racks.rackCount", { count: room.racks.length })}
                 onClick={() => setDrill({ serverRoom: room.key, rackId: null })}
@@ -700,11 +743,13 @@ function RackDrill({
 
 function DrillCard({
   icon,
+  customIcon,
   title,
   meta,
   onClick,
 }: {
   icon: ItIconName;
+  customIcon?: ItOpsCustomIcon;
   title: string;
   meta: string;
   onClick: () => void;
@@ -712,7 +757,7 @@ function DrillCard({
   return (
     <button type="button" className="ft-card" onClick={onClick}>
       <span className="ft-card-ic">
-        <ItIcon name={icon} size={20} sw={1.6} />
+        <ItOpsIcon icon={icon} customIcon={customIcon} size={20} />
       </span>
       <span className="ft-card-txt">
         <span className="ft-card-title">{title}</span>

--- a/src/modules/itops/FleetsTab.tsx
+++ b/src/modules/itops/FleetsTab.tsx
@@ -58,7 +58,7 @@ function groupColor(id: string): string {
 }
 
 function groupIcon(group: Fleet): ItIconName {
-  return group.filter ? "filter" : "group";
+  return group.filter ? "filter" : "network";
 }
 
 export function FleetsTab({
@@ -115,33 +115,48 @@ export function FleetsTab({
     });
   }, []);
 
-  // Drag the splitter to resize the tree; persist on release.
-  useEffect(() => {
-    function onMove(event: MouseEvent) {
-      if (!resizing.current) return;
-      const left = treeRef.current?.getBoundingClientRect().left ?? 0;
-      const width = Math.min(
+  // Drag the splitter to resize the tree. During the drag we set the width
+  // directly on the DOM element so the cursor stays in sync with the bar —
+  // calling setTreeWidth on every pointermove triggers a full tree re-render
+  // which causes the 1–2 second lag. React state (and persistence) sync on
+  // pointer up.
+  const handleResizeStart = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (treeCollapsed) return;
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    resizing.current = true;
+    document.body.style.cursor = "col-resize";
+
+    const startX = event.clientX;
+    const startWidth = treeWidth;
+    const el = treeRef.current;
+    let lastWidth = startWidth;
+
+    function onMove(event: PointerEvent) {
+      if (!resizing.current || !el) return;
+      lastWidth = Math.min(
         FLEET_TREE_MAX_WIDTH,
-        Math.max(FLEET_TREE_MIN_WIDTH, event.clientX - left),
+        Math.max(FLEET_TREE_MIN_WIDTH, startWidth + event.clientX - startX),
       );
-      setTreeWidth(width);
+      el.style.width = `${lastWidth}px`;
+      el.style.flex = `0 0 ${lastWidth}px`;
     }
+
     function onUp() {
       if (!resizing.current) return;
       resizing.current = false;
       document.body.style.cursor = "";
-      setTreeWidth((width) => {
-        saveFleetTreeWidth(width);
-        return width;
-      });
+      setTreeWidth(lastWidth);
+      saveFleetTreeWidth(lastWidth);
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
     }
-    window.addEventListener("mousemove", onMove);
-    window.addEventListener("mouseup", onUp);
-    return () => {
-      window.removeEventListener("mousemove", onMove);
-      window.removeEventListener("mouseup", onUp);
-    };
-  }, []);
+
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
+  }, [treeCollapsed, treeWidth]);
 
   const activeGroup = useMemo(
     () => fleets.find((group) => group.id === activeId) ?? fleets[0] ?? null,
@@ -263,7 +278,7 @@ export function FleetsTab({
       <>
         <div className="it-empty">
           <span className="glyph">
-            <ItIcon name="group" size={30} sw={1.5} />
+            <ItIcon name="network" size={30} sw={1.5} />
           </span>
           <h2>{t("itops.fleets.emptyTitle")}</h2>
           <p>{t("itops.fleets.emptyBody")}</p>
@@ -344,7 +359,7 @@ export function FleetsTab({
                           setDialog({ group: null });
                         }}
                       >
-                        <ItIcon name="group" size={14} />
+                        <ItIcon name="network" size={14} />
                         {t("itops.racks.addFleet")}
                       </button>
                       <button
@@ -356,7 +371,7 @@ export function FleetsTab({
                           setServerRoomDialogOpen(true);
                         }}
                       >
-                        <ItIcon name="ops" size={14} />
+                        <ItIcon name="room" size={14} />
                         {t("itops.racks.addServerRoom")}
                       </button>
                       <button
@@ -426,7 +441,7 @@ export function FleetsTab({
                               <div key={mId}>
                                 <TreeRow
                                   depth={1}
-                                  icon="ops"
+                                  icon="room"
                                   label={room.key || t("itops.racks.unassigned")}
                                   count={room.racks.length}
                                   hasChildren={room.racks.length > 0}
@@ -468,11 +483,7 @@ export function FleetsTab({
         ) : null}
         <div
           className="ft-resize"
-          onMouseDown={() => {
-            if (treeCollapsed) return;
-            resizing.current = true;
-            document.body.style.cursor = "col-resize";
-          }}
+          onPointerDown={handleResizeStart}
         />
       </div>
 
@@ -674,7 +685,7 @@ function RackDrill({
             {topology.map((room) => (
               <DrillCard
                 key={room.key}
-                icon="ops"
+                icon="room"
                 title={room.key || unassigned}
                 meta={t("itops.racks.rackCount", { count: room.racks.length })}
                 onClick={() => setDrill({ serverRoom: room.key, rackId: null })}

--- a/src/modules/itops/ServerRoomDialog.tsx
+++ b/src/modules/itops/ServerRoomDialog.tsx
@@ -13,6 +13,8 @@ import {
   Sheet,
   TextInput,
 } from "../../app/ui/dialog";
+import { ConnectionIconBackgroundPicker } from "../workspace/connections/ConnectionIconBackgroundPicker";
+import { ConnectionIconPicker } from "../workspace/connections/ConnectionIconPicker";
 import { useWorkspaceStore } from "../../store";
 import type { Fleet, Rack, RackShell } from "../../types";
 import { useItOpsStore } from "./state";
@@ -33,10 +35,13 @@ export function ServerRoomDialog({
   const { t } = useTranslation();
   const showStatusBarNotice = useWorkspaceStore((state) => state.showStatusBarNotice);
   const createRack = useItOpsStore((state) => state.createRack);
+  const setRoomIcon = useItOpsStore((state) => state.setRoomIcon);
 
   const [fleetId, setFleetId] = useState(defaultFleetId || fleets[0]?.id || "");
   const [serverRoom, setServerRoom] = useState("");
   const [rackName, setRackName] = useState("");
+  const [iconDataUrl, setIconDataUrl] = useState<string | null>(null);
+  const [iconBackgroundColor, setIconBackgroundColor] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
@@ -63,6 +68,10 @@ export function ServerRoomDialog({
         shell: DEFAULT_SHELL,
         heightU: 42,
       });
+      // Persist the server room icon on the owning Fleet.
+      if (iconDataUrl || iconBackgroundColor) {
+        await setRoomIcon(fleetId, trimmedServerRoom, { iconDataUrl, iconBackgroundColor });
+      }
       onCreated(rack);
       onClose();
     } catch (error) {
@@ -90,6 +99,19 @@ export function ServerRoomDialog({
         }
       >
         <p className="hg-dlg-help">{t("itops.racks.serverRoomCreateHelp")}</p>
+        <div className="connection-type-summary">
+          <ConnectionIconPicker
+            customIconDataUrls={[]}
+            iconBackgroundColor={iconBackgroundColor}
+            iconDataUrl={iconDataUrl}
+            onChange={setIconDataUrl}
+            type="localFiles"
+          />
+          <ConnectionIconBackgroundPicker
+            color={iconBackgroundColor}
+            onChange={setIconBackgroundColor}
+          />
+        </div>
         <Field label={t("itops.racks.serverRoomFleetLabel")} req>
           <Select
             value={fleetId}

--- a/src/modules/itops/icons.tsx
+++ b/src/modules/itops/icons.tsx
@@ -8,6 +8,8 @@ import type { ReactNode } from "react";
 export type ItIconName =
   | "ops"
   | "group"
+  | "network"
+  | "room"
   | "run"
   | "auto"
   | "server"
@@ -91,6 +93,27 @@ const GLYPHS: Record<ItIconName, (p: GlyphProps) => ReactNode> = {
       <path d="M17 8.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" />
       <path d="M2.5 19v-1a3.5 3.5 0 0 1 3.5-3.5h2A3.5 3.5 0 0 1 11.5 18v1" />
       <path d="M12.5 19v-1A3.5 3.5 0 0 1 16 14.5h2a3.5 3.5 0 0 1 3.5 3.5v1" />
+    </Svg>
+  ),
+  network: (p) => (
+    <Svg {...p} sw={1.6}>
+      <circle cx="12" cy="5" r="2" />
+      <circle cx="5" cy="19" r="2" />
+      <circle cx="19" cy="19" r="2" />
+      <path d="M12 7v4" />
+      <path d="M12 11l-5 6" />
+      <path d="M12 11l5 6" />
+    </Svg>
+  ),
+  room: (p) => (
+    <Svg {...p} sw={1.6}>
+      <path d="M4 21V5a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v16" />
+      <path d="M4 21h16" />
+      <path d="M9 21v-5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v5" />
+      <path d="M8 8h2" />
+      <path d="M14 8h2" />
+      <path d="M8 11h2" />
+      <path d="M14 11h2" />
     </Svg>
   ),
   run: (p) => (

--- a/src/modules/itops/itops.css
+++ b/src/modules/itops/itops.css
@@ -3235,6 +3235,18 @@
 .itops-page .ft-row.sel .ft-ic {
   color: #fff;
 }
+.itops-page .ft-ic .connection-icon-shell {
+  flex: 0 0 auto;
+}
+.itops-page .ft-custom-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  color: #fff;
+}
 .itops-page .ft-label {
   flex: 1 1 auto;
   white-space: nowrap;
@@ -3351,6 +3363,14 @@
   border-radius: 10px;
   background: var(--accent-soft);
   color: var(--accent);
+}
+.itops-page .ft-card-ic .connection-icon-shell {
+  flex: 0 0 auto;
+}
+.itops-page .ft-card-ic .ft-custom-icon {
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
 }
 .itops-page .ft-card-txt {
   flex: 1 1 auto;

--- a/src/modules/itops/state.ts
+++ b/src/modules/itops/state.ts
@@ -17,6 +17,7 @@ import type {
   RackItemKind,
   RackItemMetadata,
   ResolvedHost,
+  RoomIconEntry,
   RunEvent,
   RunHistoryEntry,
   RunScope,
@@ -29,6 +30,8 @@ export interface FleetInput {
   memberIds: string[];
   filter: FleetFilter | null;
   transport: ItopsTransport;
+  iconDataUrl?: string | null;
+  iconBackgroundColor?: string | null;
 }
 
 export interface RackInput {
@@ -201,6 +204,11 @@ interface ItOpsState {
     serverRoom: string,
     background: DashboardBackground | null,
   ) => Promise<void>;
+  setRoomIcon: (
+    fleetId: string,
+    serverRoom: string,
+    icon: RoomIconEntry | null,
+  ) => Promise<void>;
   setRackBackground: (
     fleetId: string,
     rackId: string,
@@ -282,6 +290,8 @@ export const useItOpsStore = create<ItOpsState>((set, get) => ({
       memberIds: input.memberIds,
       filter: input.filter,
       transport: input.transport,
+      iconDataUrl: input.iconDataUrl ?? null,
+      iconBackgroundColor: input.iconBackgroundColor ?? null,
     });
     set({ fleets: [...get().fleets, created] });
     return created;
@@ -294,6 +304,8 @@ export const useItOpsStore = create<ItOpsState>((set, get) => ({
       memberIds: input.memberIds,
       filter: input.filter,
       transport: input.transport,
+      iconDataUrl: input.iconDataUrl ?? null,
+      iconBackgroundColor: input.iconBackgroundColor ?? null,
     });
     set({
       fleets: get().fleets.map((group) => (group.id === id ? updated : group)),
@@ -371,6 +383,15 @@ export const useItOpsStore = create<ItOpsState>((set, get) => ({
       fleetId,
       serverRoom,
       background,
+    });
+    set({ fleets: get().fleets.map((fleet) => (fleet.id === fleetId ? updated : fleet)) });
+  },
+
+  async setRoomIcon(fleetId, serverRoom, icon) {
+    const updated = await invokeCommand("itops_set_room_icon", {
+      fleetId,
+      serverRoom,
+      icon,
     });
     set({ fleets: get().fleets.map((fleet) => (fleet.id === fleetId ? updated : fleet)) });
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,6 +157,16 @@ export interface Fleet {
   background?: DashboardBackground | null;
   // Per-server-room backgrounds, keyed by the room's string tag.
   roomBackgrounds?: Record<string, DashboardBackground>;
+  // Custom icon (data URL or lucide/material ref) and background colour.
+  iconDataUrl?: string | null;
+  iconBackgroundColor?: string | null;
+  // Per-server-room icons, keyed by the room's string tag.
+  roomIcons?: Record<string, RoomIconEntry>;
+}
+
+export interface RoomIconEntry {
+  iconDataUrl?: string | null;
+  iconBackgroundColor?: string | null;
 }
 
 export interface ResolvedHost {

--- a/tests/itops-fleet-only-ui.test.mjs
+++ b/tests/itops-fleet-only-ui.test.mjs
@@ -62,7 +62,12 @@ test("Fleet tree add menu opens distinct Fleet, Server Room, and Rack dialogs", 
   assert.match(fleets, /selectedServerRoomForDialog/);
   assert.match(fleets, /setServerRoomDialogOpen\(true\)/);
   assert.match(fleets, /setRackDialog\(\{[\s\S]*fleetId: selectedFleetIdForDialog[\s\S]*rack: null/);
+  assert.match(fleets, /customIcon=\{fleet\}/);
+  assert.match(fleets, /customIcon=\{fleet\.roomIcons\?\.\[room\.key\]\}/);
+  assert.match(fleets, /<ConnectionIcon\b/);
   assert.match(fleetDialog, /itops\.fleets\.createHelp/);
+  assert.match(fleetDialog, /\{isEdit \? \([\s\S]*itops\.fleets\.perHostTransport/);
+  assert.doesNotMatch(fleetDialog, /\{isEdit \? \([\s\S]{0,120}<Field\s+label=\{t\("itops\.fleets\.connectionsLabel"\)\}/);
   assert.match(serverRoomDialog, /itops\.racks\.serverRoomFleetLabel/);
   assert.match(serverRoomDialog, /createRack\(/);
   assert.match(rackDialog, /itops\.racks\.fleetLabel/);


### PR DESCRIPTION
## Summary

Four improvements to the IT Ops Fleets tab:

### 1. Fleets nav resize lag fix
The fleets tree resize handle had a 1-2 second cursor lag compared to the workspace connection tree. Root cause: setTreeWidth() was called on every pointermove, triggering a full React re-render of the entire tree on each mouse move.

**Fix:** During drag, set el.style.width and el.style.flex directly on the DOM element. React state (setTreeWidth) and persistence (saveFleetTreeWidth) only sync on pointerup, matching the workspace connection tree's approach.

### 2. Remove per-host transport from new fleet dialog
The per-host transport selector is no longer shown when creating a new fleet — only when editing an existing one.

### 3. Icon picker for Fleet and Server Room dialogs
Both FleetDialog and ServerRoomDialog now include the same ConnectionIconPicker + ConnectionIconBackgroundPicker used by workspace connections. This required:

- New Fleet fields: iconDataUrl, iconBackgroundColor, roomIcons (per-server-room icon map)
- New RoomIconEntry type (frontend) / RoomIcon struct (backend)
- New DB columns: icon_data_url, icon_background_color, room_icons_json on itops_fleets
- New command: itops_set_room_icon for persisting server room icons
- Updated commands: itops_create_fleet and itops_update_fleet now accept icon parameters

### 4. Better icons
- Fleet: replaced group (two people) with network (three connected nodes)
- Server Room: replaced ops (server boxes) with room (building with door and windows)
- Rack: keeps server icon (stacked server boxes) — appropriate for a rack