### PR TITLE
feat(ai): optional API key + custom headers for local Ollama provider

### DIFF
--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -6645,7 +6645,10 @@ fn extra_headers_for_provider_kind<'a>(
     provider_kind: &str,
     extra_headers: &'a str,
 ) -> Option<&'a str> {
-    if provider_kind == "openai-compatible" {
+    // Providers whose registry definition exposes the `extraHeaders` settings
+    // field. Local Ollama joins openai-compatible here so users can reach a
+    // self-hosted Ollama behind a proxy that wants an arbitrary custom header.
+    if matches!(provider_kind, "openai-compatible" | "ollama") {
         let trimmed = extra_headers.trim();
         if !trimmed.is_empty() {
             return Some(trimmed);

--- a/src-tauri/src/ai/tests.rs
+++ b/src-tauri/src/ai/tests.rs
@@ -2697,6 +2697,30 @@ fn explicit_strict_tool_flags_are_only_sent_to_openai_family_providers() {
 }
 
 #[test]
+fn extra_headers_apply_to_proxy_capable_providers_only() {
+    // openai-compatible and local Ollama expose the extra-headers field, so a
+    // user-supplied custom header (e.g. for an authenticating Ollama proxy)
+    // flows through. Hosted providers ignore it.
+    assert_eq!(
+        extra_headers_for_provider_kind("ollama", "  x-proxy-key=secret  "),
+        Some("x-proxy-key=secret")
+    );
+    assert_eq!(
+        extra_headers_for_provider_kind("openai-compatible", "x-env=prod"),
+        Some("x-env=prod")
+    );
+    assert_eq!(extra_headers_for_provider_kind("ollama", "   "), None);
+    assert_eq!(
+        extra_headers_for_provider_kind("ollama-cloud", "x-proxy-key=secret"),
+        None
+    );
+    assert_eq!(
+        extra_headers_for_provider_kind("openai", "x-proxy-key=secret"),
+        None
+    );
+}
+
+#[test]
 fn generic_openai_compatible_provider_uses_configured_api_mode() {
     let provider = openai_provider("openai-compatible");
     assert!(matches!(

--- a/src/ai/providerRegistry/ollama.ts
+++ b/src/ai/providerRegistry/ollama.ts
@@ -1,6 +1,12 @@
-import { CONFIGURABLE_ENDPOINT_WITHOUT_KEY_FIELDS, STANDARD_REASONING_EFFORTS } from "./shared";
+import { STANDARD_REASONING_EFFORTS } from "./shared";
 import type { AiProviderDefinition } from "./types";
 
+// Vanilla local Ollama (http://localhost:11434) needs no auth, so the API key
+// stays optional. But the base URL is user-configurable, and people routinely
+// point this provider at a remote/self-hosted Ollama placed behind an
+// authenticating reverse proxy (nginx/Caddy bearer, OpenWebUI keys, etc.). The
+// optional key rides as `Authorization: Bearer` only when filled, and the extra
+// headers field covers proxies that expect an arbitrary custom header instead.
 export const ollamaProvider: AiProviderDefinition = {
   kind: "ollama",
   label: "Ollama",
@@ -11,7 +17,7 @@ export const ollamaProvider: AiProviderDefinition = {
   requiresApiKey: false,
   allowsCustomBaseUrl: true,
   allowsCustomModel: true,
-  apiKeyLabel: "Ollama API key",
+  apiKeyLabel: "Ollama API key (optional, for authenticating proxies)",
   modelListStrategy: "ollamaTags",
   strictModelList: true,
   modelOptions: [
@@ -20,6 +26,6 @@ export const ollamaProvider: AiProviderDefinition = {
     { id: "deepseek-r1", label: "DeepSeek-R1", note: "Local reasoning", supportsImageInput: false },
     { id: "gemma3", label: "Gemma 3", supportsImageInput: true },
   ],
-  settingsFields: CONFIGURABLE_ENDPOINT_WITHOUT_KEY_FIELDS,
+  settingsFields: ["baseUrl", "model", "reasoningEffort", "apiKey", "extraHeaders"],
   capabilities: ["chat", "imageInput", "streaming", "toolCalling", "localRuntime", "openAiCompatible"],
 };

--- a/src/ai/providerRegistry/shared.ts
+++ b/src/ai/providerRegistry/shared.ts
@@ -18,11 +18,5 @@ export const CONFIGURABLE_ENDPOINT_SETTINGS_FIELDS: AiProviderSettingsField[] = 
   "apiKey",
 ];
 
-export const CONFIGURABLE_ENDPOINT_WITHOUT_KEY_FIELDS: AiProviderSettingsField[] = [
-  "baseUrl",
-  "model",
-  "reasoningEffort",
-];
-
 export const STANDARD_REASONING_EFFORTS = ["default", "low", "medium", "high", "max"] as const;
 export const HIGH_REASONING_EFFORTS = ["default", "high", "max"] as const;

--- a/src/ai/providers.test.ts
+++ b/src/ai/providers.test.ts
@@ -39,10 +39,30 @@ const ollamaDefinition = getAiProviderDefinition("ollama");
 if (ollamaDefinition.modelListStrategy !== "ollamaTags" || !ollamaDefinition.strictModelList) {
   throw new Error("Ollama should refresh from native tags and treat pulled models as strict.");
 }
-if (ollamaDefinition.settingsFields.includes("apiKey") || ollamaDefinition.requiresApiKey) {
-  throw new Error("Local Ollama should not expose an API key field.");
+if (ollamaDefinition.requiresApiKey) {
+  throw new Error("Local Ollama should keep the API key optional (vanilla localhost needs no auth).");
 }
+if (
+  !ollamaDefinition.settingsFields.includes("apiKey") ||
+  !ollamaDefinition.settingsFields.includes("extraHeaders")
+) {
+  throw new Error(
+    "Local Ollama should expose optional API key and extra header fields for proxied/self-hosted endpoints.",
+  );
+}
+// No key supplied: still valid, because the key is optional for local Ollama.
 validateAiProviderForChat(providerDefaultsFor("ollama"), false);
+// Custom headers entered against Ollama should be preserved (not stripped like hosted providers).
+const ollamaSettings = validateAiProviderForChat(
+  {
+    ...providerDefaultsFor("ollama"),
+    extraHeaders: " x-proxy-key=secret ",
+  },
+  false,
+);
+if (ollamaSettings.extraHeaders !== "x-proxy-key=secret") {
+  throw new Error(`Local Ollama extra headers should be trimmed and kept, got: ${ollamaSettings.extraHeaders}`);
+}
 
 const ollamaCloudDefinition = getAiProviderDefinition("ollama-cloud");
 if (ollamaCloudDefinition.modelListStrategy !== "ollamaTags") {

--- a/src/ai/providers.ts
+++ b/src/ai/providers.ts
@@ -108,8 +108,9 @@ export function normalizeAiProviderDraft(draft: AiProviderSettings): AiProviderS
     reasoningEffort,
     customInstructions,
     apiMode: normalizeApiMode(definition.kind, draft.apiMode),
-    extraHeaders:
-      definition.kind === "openai-compatible" ? (draft.extraHeaders ?? "").trim() : "",
+    extraHeaders: definition.settingsFields.includes("extraHeaders")
+      ? (draft.extraHeaders ?? "").trim()
+      : "",
     allowInsecureTls: Boolean(draft.allowInsecureTls),
     allowInsecureMcpHttp: Boolean(draft.allowInsecureMcpHttp),
     showAllModels: Boolean(draft.showAllModels),


### PR DESCRIPTION
## Summary

Local Ollama on `localhost` needs no auth, but the provider's base URL is user-configurable and people routinely point it at a **remote / self-hosted Ollama behind an authenticating reverse proxy** (nginx/Caddy bearer, OpenWebUI keys, etc.). Until now there was no way to attach credentials, so those endpoints were unreachable.

This exposes two **optional** fields on the local Ollama provider:
- **API key** — sent as `Authorization: Bearer <key>` only when filled, so vanilla `localhost` keeps working with no header (no 403).
- **Custom headers** — arbitrary header field (same as OpenAI Compatible) for proxies that expect a non-`Authorization` header (e.g. OpenWebUI's `x-api-key`).

Design notes from the discussion that led here: a JWT is just a Bearer token (no separate option needed), and HTTP Basic auth was intentionally skipped as rare for this access pattern — it's a trivial follow-up via the existing `OpenAiAuthStyle` enum if anyone asks.

The backend Bearer path needed **no change**: Ollama is already `auth_style: Bearer` with `requires_api_key: false`, and `openai_compatible_headers` only attaches the header when a key is present.

Closes #479.

## Type of change

- [x] Feature

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)
- [x] Backend (Rust/Tauri — `src-tauri/`)

## Changes

- `src/ai/providerRegistry/ollama.ts` — add `apiKey` + `extraHeaders` to `settingsFields`; key stays optional (`requiresApiKey: false`).
- `src/ai/providers.ts` — gate `extraHeaders` normalization on `settingsFields.includes("extraHeaders")` instead of hardcoding the `openai-compatible` kind.
- `src-tauri/src/ai.rs` — allow `ollama` in `extra_headers_for_provider_kind` alongside `openai-compatible`.
- `src/ai/providerRegistry/shared.ts` — drop the now-unused `CONFIGURABLE_ENDPOINT_WITHOUT_KEY_FIELDS` constant.
- Tests: `providers.test.ts` covers the new fields + header trimming/preservation; `src-tauri/src/ai/tests.rs` covers the provider gate (ollama/openai-compatible kept, ollama-cloud/openai stripped).

## i18n

- [x] The one changed user-visible string is the provider's `apiKeyLabel` ("Ollama API key (optional, for authenticating proxies)"). `apiKeyLabel` is a registry constant rendered directly, consistent with every other provider's non-i18n label — no new i18n keys introduced. The `extraHeaders` field reuses the existing `settings.extraHeaders` / `settings.extraHeadersPlaceholder` keys.

## Checks

- [x] `node tests/run-all.mjs` (680 pass) + `tsc --noEmit` (clean)
- [x] `cargo test` — new `extra_headers_apply_to_proxy_capable_providers_only` passes
- [ ] Validated in the real Tauri desktop runtime — not run; change is registry/header plumbing with unit coverage.

## Notes for reviewers

- The key field label calls out that it's optional / for proxies, since the same provider serves both plain localhost and authenticated remote endpoints — worth confirming the wording reads well, or whether you'd prefer a terser label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
