### PR TITLE
feat(compare): resizable diff window and word-wrap toggle

### DIFF
--- a/docs/localization_todo/git.wordWrap.md
+++ b/docs/localization_todo/git.wordWrap.md
@@ -1,0 +1,11 @@
+# git.wordWrap
+
+- **English value**: `Word wrap`
+- **Namespace**: `git`
+- **File/component**: `src/modules/compare/DiffSideBySide.tsx`
+- **UI role**: `tooltip`
+- **User flow**: Tooltip/aria-label for the toolbar toggle in the side-by-side diff (Git advanced diff and File Compare overlays) that wraps long lines instead of forcing horizontal scroll.
+- **Tone**: concise/neutral
+- **Placeholders**: none
+- **Context/meaning**: "Word wrap" = soft-wrap long diff lines onto multiple visual rows; it is a view toggle, not text reflow/justification.
+- **Domain notes**: Standard editor "word wrap" feature label; use each locale's established editor/terminal terminology.

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2898,6 +2898,7 @@
     "searchDiff": "Diff durchsuchen…",
     "previousDifference": "Vorherige Differenz",
     "nextDifference": "Nächste Differenz",
+    "wordWrap": "Zeilenumbruch",
     "diffOriginal": "Original",
     "diffModified": "Geändert",
     "diffDisplayMode": "Anzeigemodus",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2987,6 +2987,7 @@
     "searchDiff": "Search diff…",
     "previousDifference": "Previous difference",
     "nextDifference": "Next difference",
+    "wordWrap": "Word wrap",
     "diffOriginal": "Original",
     "diffModified": "Modified",
     "diffDisplayMode": "Display mode",

--- a/src/i18n/locales/es-MX.json
+++ b/src/i18n/locales/es-MX.json
@@ -2898,6 +2898,7 @@
     "searchDiff": "Buscar en el diff…",
     "previousDifference": "Diferencia anterior",
     "nextDifference": "Diferencia siguiente",
+    "wordWrap": "Ajuste de línea",
     "diffOriginal": "Original",
     "diffModified": "Modificado",
     "diffDisplayMode": "Modo de visualización",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2898,6 +2898,7 @@
     "searchDiff": "Buscar en el diff…",
     "previousDifference": "Diferencia anterior",
     "nextDifference": "Diferencia siguiente",
+    "wordWrap": "Ajuste de línea",
     "diffOriginal": "Original",
     "diffModified": "Modificado",
     "diffDisplayMode": "Modo de visualización",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2898,6 +2898,7 @@
     "searchDiff": "Rechercher dans le diff…",
     "previousDifference": "Différence précédente",
     "nextDifference": "Différence suivante",
+    "wordWrap": "Retour à la ligne",
     "diffOriginal": "Original",
     "diffModified": "Modifié",
     "diffDisplayMode": "Mode d'affichage",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -2898,6 +2898,7 @@
     "searchDiff": "Cari di diff…",
     "previousDifference": "Perbedaan sebelumnya",
     "nextDifference": "Perbedaan berikutnya",
+    "wordWrap": "Bungkus teks",
     "diffOriginal": "Asli",
     "diffModified": "Dimodifikasi",
     "diffDisplayMode": "Mode tampilan",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -2898,6 +2898,7 @@
     "searchDiff": "Cerca nel diff…",
     "previousDifference": "Differenza precedente",
     "nextDifference": "Differenza successiva",
+    "wordWrap": "A capo automatico",
     "diffOriginal": "Originale",
     "diffModified": "Modificato",
     "diffDisplayMode": "Modalità di visualizzazione",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2898,6 +2898,7 @@
     "searchDiff": "差分を検索…",
     "previousDifference": "前の差分",
     "nextDifference": "次の差分",
+    "wordWrap": "折り返し",
     "diffOriginal": "オリジナル",
     "diffModified": "変更後",
     "diffDisplayMode": "表示モード",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -2898,6 +2898,7 @@
     "searchDiff": "diff 검색…",
     "previousDifference": "이전 차이점",
     "nextDifference": "다음 차이점",
+    "wordWrap": "자동 줄 바꿈",
     "diffOriginal": "원본",
     "diffModified": "수정됨",
     "diffDisplayMode": "표시 모드",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2898,6 +2898,7 @@
     "searchDiff": "Buscar no diff…",
     "previousDifference": "Diferença anterior",
     "nextDifference": "Próxima diferença",
+    "wordWrap": "Quebra de linha",
     "diffOriginal": "Original",
     "diffModified": "Modificado",
     "diffDisplayMode": "Modo de exibição",

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -2898,6 +2898,7 @@
     "searchDiff": "ค้นหาใน diff…",
     "previousDifference": "จุดต่างก่อนหน้า",
     "nextDifference": "จุดต่างถัดไป",
+    "wordWrap": "ตัดบรรทัด",
     "diffOriginal": "ต้นฉบับ",
     "diffModified": "ที่แก้ไข",
     "diffDisplayMode": "โหมดการแสดงผล",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -2898,6 +2898,7 @@
     "searchDiff": "Tìm trong diff…",
     "previousDifference": "Khác biệt trước",
     "nextDifference": "Khác biệt tiếp theo",
+    "wordWrap": "Ngắt dòng",
     "diffOriginal": "Gốc",
     "diffModified": "Đã sửa",
     "diffDisplayMode": "Chế độ hiển thị",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2898,6 +2898,7 @@
     "searchDiff": "搜索差异…",
     "previousDifference": "上一个差异",
     "nextDifference": "下一个差异",
+    "wordWrap": "自动换行",
     "diffOriginal": "原始",
     "diffModified": "已修改",
     "diffDisplayMode": "显示模式",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2898,6 +2898,7 @@
     "searchDiff": "搜尋差異…",
     "previousDifference": "上一個差異",
     "nextDifference": "下一個差異",
+    "wordWrap": "自動換行",
     "diffOriginal": "原始",
     "diffModified": "已修改",
     "diffDisplayMode": "顯示模式",

--- a/src/modules/compare/DiffSideBySide.tsx
+++ b/src/modules/compare/DiffSideBySide.tsx
@@ -6,7 +6,7 @@
 // caller's responsibility. Reuses the `git-adv-*` classes from git.css.
 import { type PointerEvent as ReactPointerEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronDown, ChevronUp, Search } from "lucide-react";
+import { ChevronDown, ChevronUp, Search, WrapText } from "lucide-react";
 import type { GitDiffLine } from "../git/gitTypes";
 
 type DiffSideKind = "ctx" | "add" | "del" | "blank";
@@ -149,6 +149,7 @@ export function DiffSideBySide({
   const { t } = useTranslation();
   const [query, setQuery] = useState("");
   const [mode, setMode] = useState<DiffViewMode>("all");
+  const [wrap, setWrap] = useState(false);
   const [activeChange, setActiveChange] = useState(0);
   const [viewport, setViewport] = useState({ top: 0, height: 0, fill: 1, scrollable: false });
   const pendingScrollRow = useRef<number | null>(null);
@@ -312,7 +313,7 @@ export function DiffSideBySide({
   };
 
   return (
-    <div className="diff-sbs">
+    <div className={`diff-sbs${wrap ? " wrap" : ""}`}>
       <div className="diff-sbs-toolbar">
         <div className="git-adv-search">
           <Search size={14} />
@@ -336,6 +337,16 @@ export function DiffSideBySide({
           ))}
         </div>
         <div className="diff-sbs-toolbar-spacer" />
+        <button
+          type="button"
+          className={`git-icon-btn${wrap ? " is-active" : ""}`}
+          onClick={() => setWrap((value) => !value)}
+          aria-label={t("git.wordWrap")}
+          aria-pressed={wrap}
+          title={t("git.wordWrap")}
+        >
+          <WrapText size={16} />
+        </button>
         <button type="button" className="git-icon-btn" onClick={() => goChange(-1)} aria-label={t("git.previousDifference")}>
           <ChevronUp size={16} />
         </button>

--- a/src/modules/git/git.css
+++ b/src/modules/git/git.css
@@ -92,6 +92,10 @@
   background: transparent; border: 0; color: var(--git-text-2); cursor: pointer;
 }
 .git-icon-btn:hover { background: var(--git-hover); color: var(--git-text); }
+.git-icon-btn.is-active {
+  background: color-mix(in srgb, var(--git-accent) 18%, transparent);
+  color: var(--git-accent);
+}
 
 /* ── toolbar ────────────────────────────────────────────────────────────── */
 .git-toolbar {
@@ -417,11 +421,17 @@
   background: rgba(0, 0, 0, 0.34);
 }
 .git-adv {
-  width: min(1320px, 92vw);
-  height: min(760px, 86vh);
+  width: min(1848px, 96vw);
+  height: min(1064px, 92vh);
+  min-width: 640px;
+  min-height: 420px;
+  max-width: 96vw;
+  max-height: 92vh;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  /* User-resizable from the bottom-right corner. */
+  resize: both;
   border-radius: 10px;
   border: 1px solid var(--git-border);
   background: var(--git-bg);
@@ -594,6 +604,19 @@
 }
 .git-adv-cell.search-hit .txt {
   background: color-mix(in srgb, var(--git-amber) 26%, transparent);
+}
+/* Word-wrap mode: let long lines wrap instead of forcing horizontal scroll. */
+.diff-sbs.wrap .git-adv-content {
+  min-width: 0;
+}
+.diff-sbs.wrap .git-adv-row {
+  min-width: 0;
+}
+.diff-sbs.wrap .git-adv-cell .txt {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  overflow: visible;
+  text-overflow: clip;
 }
 .git-adv-mode {
   display: inline-flex;


### PR DESCRIPTION
## What

Two fixes to the side-by-side diff used by the **File Compare** overlay and the **Git Browser advanced diff viewer** (they share the `.git-adv` frame and the `DiffSideBySide` body):

1. **Resizable window + larger default** — the modal was fixed-size. It's now user-resizable by dragging the bottom-right corner (`resize: both` with sensible min/max bounds), and the default size is enlarged ~1.4× (`1320×760` → `min(1848px, 96vw) × min(1064px, 92vh)`).
2. **Word-wrap toggle** — new toolbar button (lucide `WrapText`, with active highlight and `aria-pressed`). When on, diff cells switch from `white-space: pre` to `pre-wrap` / `overflow-wrap: anywhere` and the row min-widths are dropped, so long lines wrap instead of producing an enormous horizontal scrollbar. Defaults off, preserving current behavior.

## Why

Reported bugs in the diff viewer: no way to resize the window, and long lines (e.g. minified HTML/README markup) forced a huge horizontal scroll.

## Notes for reviewers

- Changes live in `src/modules/compare/DiffSideBySide.tsx` and `src/modules/git/git.css`; both consumers (`CompareViewer`, `GitAdvancedDiffViewer`) inherit them automatically.
- i18n: added `git.wordWrap` to all 14 locales with best-effort translations, plus a `docs/localization_todo/git.wordWrap.md` backlog record for review. `npm run i18n:check` reports no mismatch for the new key (the pre-existing `dashboard.pcInfo*` mismatches are unrelated to this change).
- `tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)