### PR TITLE
fix(sftp): clamp file context menu above status bar

### DIFF
--- a/src/modules/workspace/connections/sftp/SftpOverlays.tsx
+++ b/src/modules/workspace/connections/sftp/SftpOverlays.tsx
@@ -225,13 +225,22 @@ export function SftpContextMenu({
     }
     const margin = 8;
     const rect = node.getBoundingClientRect();
+    // Clamp against the status bar's top edge rather than the full viewport so the
+    // menu's bottom items are not hidden behind the status bar (which paints above it).
+    const statusBar = document.querySelector(".status-bar");
+    const bottomLimit = statusBar
+      ? statusBar.getBoundingClientRect().top
+      : window.innerHeight;
     let x = menu.x;
     let y = menu.y;
     if (x + rect.width > window.innerWidth - margin) {
       x = window.innerWidth - rect.width - margin;
     }
-    if (y + rect.height > window.innerHeight - margin) {
-      y = window.innerHeight - rect.height - margin;
+    if (y + rect.height > bottomLimit - margin) {
+      y = bottomLimit - rect.height - margin;
+    }
+    if (y < margin) {
+      y = margin;
     }
     node.style.left = `${x}px`;
     node.style.top = `${y}px`;


### PR DESCRIPTION
## What changed

The file pane context menu now clamps its vertical position against the **status bar's top edge** instead of the full `window.innerHeight`.

## Why

The status bar (`z-index: 80`, ~28px tall) paints over the bottom of the viewport. When a tall context menu opened near the bottom of the file explorer, its last items (e.g. "Get Info") were tucked behind the status bar and unclickable — see the reported cutoff.

The clamp in `SftpOverlays.tsx` previously used `window.innerHeight - margin` as the bottom bound, which doesn't account for the overlapping status bar.

## How

- Query the `.status-bar` element and use its `getBoundingClientRect().top` as the bottom limit (falling back to `window.innerHeight` if absent).
- Added a top-margin guard so a menu taller than the available space pins to the top rather than sliding off-screen.

## Notes for reviewer

- Behavior-only change to menu positioning; no API or menu-content changes.
- `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)