### PR TITLE
Keep file compare responsive for large files

### DIFF
--- a/src/modules/compare/CompareHexView.tsx
+++ b/src/modules/compare/CompareHexView.tsx
@@ -2,22 +2,16 @@
 // are read as bounded base64, laid out in aligned 16-byte rows, and every byte
 // that differs between the two sides is highlighted. A single shared scroll
 // keeps the left and right columns aligned.
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { invokeCommand } from "../../lib/tauri";
+import { decodeBase64InWorker } from "./compareWorkerClient";
 
 const HEX_MAX_BYTES = 1 * 1024 * 1024;
 const ROW_WIDTH = 16;
-
-function decodeBase64(base64: string): Uint8Array {
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let index = 0; index < binary.length; index += 1) {
-    bytes[index] = binary.charCodeAt(index);
-  }
-  return bytes;
-}
+const ROW_HEIGHT = 18;
+const OVERSCAN_ROWS = 24;
 
 function hex2(value: number): string {
   return value.toString(16).padStart(2, "0");
@@ -84,6 +78,8 @@ export function CompareHexView({ leftPath, rightPath }: { leftPath: string; righ
   const { t } = useTranslation();
   const [data, setData] = useState<{ left: LoadedBytes; right: LoadedBytes } | null>(null);
   const [error, setError] = useState("");
+  const [viewport, setViewport] = useState({ top: 0, height: 600 });
+  const bodyRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     let alive = true;
@@ -99,10 +95,14 @@ export function CompareHexView({ leftPath, rightPath }: { leftPath: string; righ
             request: { path: rightPath, offset: 0, length: HEX_MAX_BYTES },
           }),
         ]);
+        const [leftBytes, rightBytes] = await Promise.all([
+          decodeBase64InWorker(left.base64),
+          decodeBase64InWorker(right.base64),
+        ]);
         if (alive) {
           setData({
-            left: { bytes: decodeBase64(left.base64), truncated: !left.eof },
-            right: { bytes: decodeBase64(right.base64), truncated: !right.eof },
+            left: { bytes: leftBytes, truncated: !left.eof },
+            right: { bytes: rightBytes, truncated: !right.eof },
           });
         }
       } catch (loadError) {
@@ -124,6 +124,24 @@ export function CompareHexView({ leftPath, rightPath }: { leftPath: string; righ
     return Math.ceil(longest / ROW_WIDTH);
   }, [data]);
 
+  const virtualRows = useMemo(() => {
+    const first = Math.max(0, Math.floor(viewport.top / ROW_HEIGHT) - OVERSCAN_ROWS);
+    const last = Math.min(rowCount, Math.ceil((viewport.top + viewport.height) / ROW_HEIGHT) + OVERSCAN_ROWS);
+    return Array.from({ length: Math.max(0, last - first) }, (_, offset) => first + offset);
+  }, [rowCount, viewport]);
+
+  const updateViewport = () => {
+    const body = bodyRef.current;
+    if (!body) {
+      return;
+    }
+    setViewport({ top: body.scrollTop, height: body.clientHeight });
+  };
+
+  useEffect(() => {
+    window.requestAnimationFrame(updateViewport);
+  }, [rowCount]);
+
   if (error) {
     return <div className="compare-status compare-status-error">{error}</div>;
   }
@@ -141,17 +159,23 @@ export function CompareHexView({ leftPath, rightPath }: { leftPath: string; righ
         <span className="compare-hex-side-head">{t("compare.imageLeft")}</span>
         <span className="compare-hex-side-head">{t("compare.imageRight")}</span>
       </div>
-      <div className="compare-hex-body">
-        {Array.from({ length: rowCount }, (_, row) => {
-          const start = row * ROW_WIDTH;
-          return (
-            <div className="compare-hex-row" key={start}>
-              <span className="compare-hex-off">{start.toString(16).padStart(8, "0")}</span>
-              <HexSide bytes={data.left.bytes} other={data.right.bytes} start={start} />
-              <HexSide bytes={data.right.bytes} other={data.left.bytes} start={start} />
-            </div>
-          );
-        })}
+      <div className="compare-hex-body" ref={bodyRef} onScroll={updateViewport}>
+        <div style={{ height: rowCount * ROW_HEIGHT, position: "relative" }}>
+          {virtualRows.map((row) => {
+            const start = row * ROW_WIDTH;
+            return (
+              <div
+                className="compare-hex-row"
+                key={start}
+                style={{ height: ROW_HEIGHT, left: 0, position: "absolute", right: 0, top: row * ROW_HEIGHT }}
+              >
+                <span className="compare-hex-off">{start.toString(16).padStart(8, "0")}</span>
+                <HexSide bytes={data.left.bytes} other={data.right.bytes} start={start} />
+                <HexSide bytes={data.right.bytes} other={data.left.bytes} start={start} />
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/modules/compare/CompareImageView.tsx
+++ b/src/modules/compare/CompareImageView.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { invokeCommand } from "../../lib/tauri";
 import { fileExtension } from "../workspace/connections/file-viewer/fileViewerModel";
+import { buildHeatmapInWorker } from "./compareWorkerClient";
 
 const IMAGE_MAX_BYTES = 25 * 1024 * 1024;
 
@@ -118,38 +119,30 @@ export function CompareImageView({ leftPath, rightPath }: { leftPath: string; ri
     if (!ctx || !leftData || !rightData) {
       return;
     }
-    const out = ctx.createImageData(width, height);
-    const lp = leftData.data;
-    const rp = rightData.data;
-    const op = out.data;
-    let changed = 0;
-    const total = width * height;
-    for (let i = 0; i < op.length; i += 4) {
-      const lLum = (lp[i] * 0.299 + lp[i + 1] * 0.587 + lp[i + 2] * 0.114) * (lp[i + 3] / 255);
-      const rLum = (rp[i] * 0.299 + rp[i + 1] * 0.587 + rp[i + 2] * 0.114) * (rp[i + 3] / 255);
-      const delta = lLum - rLum;
-      if (Math.abs(delta) <= tolerance) {
-        op[i] = 12;
-        op[i + 1] = 16;
-        op[i + 2] = 24;
-        op[i + 3] = 255;
-        continue;
+    let alive = true;
+    void (async () => {
+      try {
+        const { imageData, percent } = await buildHeatmapInWorker({
+          width,
+          height,
+          tolerance,
+          left: leftData.data,
+          right: rightData.data,
+        });
+        if (!alive) {
+          return;
+        }
+        ctx.putImageData(imageData, 0, 0);
+        setDiffPercent(percent);
+      } catch (heatmapError) {
+        if (alive) {
+          setError(heatmapError instanceof Error ? heatmapError.message : String(heatmapError));
+        }
       }
-      changed += 1;
-      const magnitude = Math.min(255, 80 + Math.abs(delta));
-      if (delta > 0) {
-        op[i] = magnitude;
-        op[i + 1] = 30;
-        op[i + 2] = 40;
-      } else {
-        op[i] = 40;
-        op[i + 1] = 60;
-        op[i + 2] = magnitude;
-      }
-      op[i + 3] = 255;
-    }
-    ctx.putImageData(out, 0, 0);
-    setDiffPercent(total > 0 ? (changed / total) * 100 : 0);
+    })();
+    return () => {
+      alive = false;
+    };
   }, [images, dims, tolerance]);
 
   if (error) {

--- a/src/modules/compare/DiffSideBySide.tsx
+++ b/src/modules/compare/DiffSideBySide.tsx
@@ -149,7 +149,7 @@ export function DiffSideBySide({
   const { t } = useTranslation();
   const [query, setQuery] = useState("");
   const [mode, setMode] = useState<DiffViewMode>("all");
-  const [wrap, setWrap] = useState(false);
+  const [wrap, setWrap] = useState(true);
   const [activeChange, setActiveChange] = useState(0);
   const [viewport, setViewport] = useState({ top: 0, height: 0, fill: 1, scrollable: false });
   const pendingScrollRow = useRef<number | null>(null);

--- a/src/modules/compare/compareWorker.ts
+++ b/src/modules/compare/compareWorker.ts
@@ -1,0 +1,79 @@
+interface DecodeBase64Request {
+  type: "decodeBase64";
+  id: number;
+  base64: string;
+}
+
+interface HeatmapRequest {
+  type: "heatmap";
+  id: number;
+  width: number;
+  height: number;
+  tolerance: number;
+  left: Uint8ClampedArray;
+  right: Uint8ClampedArray;
+}
+
+type CompareWorkerRequest = DecodeBase64Request | HeatmapRequest;
+
+function decodeBase64(base64: string): ArrayBuffer {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes.buffer;
+}
+
+function buildHeatmap({ width, height, tolerance, left, right }: HeatmapRequest) {
+  const out = new Uint8ClampedArray(width * height * 4);
+  let changed = 0;
+  const total = width * height;
+  for (let i = 0; i < out.length; i += 4) {
+    const lLum = (left[i] * 0.299 + left[i + 1] * 0.587 + left[i + 2] * 0.114) * (left[i + 3] / 255);
+    const rLum = (right[i] * 0.299 + right[i + 1] * 0.587 + right[i + 2] * 0.114) * (right[i + 3] / 255);
+    const delta = lLum - rLum;
+    if (Math.abs(delta) <= tolerance) {
+      out[i] = 12;
+      out[i + 1] = 16;
+      out[i + 2] = 24;
+      out[i + 3] = 255;
+      continue;
+    }
+    changed += 1;
+    const magnitude = Math.min(255, 80 + Math.abs(delta));
+    if (delta > 0) {
+      out[i] = magnitude;
+      out[i + 1] = 30;
+      out[i + 2] = 40;
+    } else {
+      out[i] = 40;
+      out[i + 1] = 60;
+      out[i + 2] = magnitude;
+    }
+    out[i + 3] = 255;
+  }
+  return { pixels: out, percent: total > 0 ? (changed / total) * 100 : 0 };
+}
+
+const workerSelf = self as unknown as {
+  onmessage: ((event: MessageEvent<CompareWorkerRequest>) => void) | null;
+  postMessage: (message: unknown, transfer?: Transferable[]) => void;
+};
+
+workerSelf.onmessage = (event: MessageEvent<CompareWorkerRequest>) => {
+  const request = event.data;
+  try {
+    if (request.type === "decodeBase64") {
+      const buffer = decodeBase64(request.base64);
+      workerSelf.postMessage({ id: request.id, buffer }, [buffer]);
+      return;
+    }
+    const result = buildHeatmap(request);
+    workerSelf.postMessage({ id: request.id, pixels: result.pixels, percent: result.percent }, [result.pixels.buffer]);
+  } catch (error) {
+    workerSelf.postMessage({ id: request.id, error: error instanceof Error ? error.message : String(error) });
+  }
+};
+
+export {};

--- a/src/modules/compare/compareWorkerClient.ts
+++ b/src/modules/compare/compareWorkerClient.ts
@@ -1,0 +1,72 @@
+type Pending = {
+  resolve: (value: unknown) => void;
+  reject: (reason?: unknown) => void;
+};
+
+let nextId = 1;
+let worker: Worker | null = null;
+const pending = new Map<number, Pending>();
+
+function getWorker() {
+  if (!worker) {
+    worker = new Worker(new URL("./compareWorker.ts", import.meta.url), { type: "module" });
+    worker.onmessage = (event: MessageEvent<{ id: number; error?: string }>) => {
+      const entry = pending.get(event.data.id);
+      if (!entry) {
+        return;
+      }
+      pending.delete(event.data.id);
+      if (event.data.error) {
+        entry.reject(new Error(event.data.error));
+      } else {
+        entry.resolve(event.data);
+      }
+    };
+    worker.onerror = (event) => {
+      const error = new Error(event.message);
+      for (const entry of pending.values()) {
+        entry.reject(error);
+      }
+      pending.clear();
+      worker?.terminate();
+      worker = null;
+    };
+  }
+  return worker;
+}
+
+function request<T>(message: Record<string, unknown>, transfer?: Transferable[]): Promise<T> {
+  const id = nextId;
+  nextId += 1;
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve: resolve as (value: unknown) => void, reject });
+    getWorker().postMessage({ ...message, id }, transfer ?? []);
+  });
+}
+
+export async function decodeBase64InWorker(base64: string): Promise<Uint8Array> {
+  const response = await request<{ buffer: ArrayBuffer }>({ type: "decodeBase64", base64 });
+  return new Uint8Array(response.buffer);
+}
+
+export async function buildHeatmapInWorker({
+  width,
+  height,
+  tolerance,
+  left,
+  right,
+}: {
+  width: number;
+  height: number;
+  tolerance: number;
+  left: Uint8ClampedArray;
+  right: Uint8ClampedArray;
+}): Promise<{ imageData: ImageData; percent: number }> {
+  const leftCopy = new Uint8ClampedArray(left);
+  const rightCopy = new Uint8ClampedArray(right);
+  const response = await request<{ pixels: Uint8ClampedArray; percent: number }>(
+    { type: "heatmap", width, height, tolerance, left: leftCopy, right: rightCopy },
+    [leftCopy.buffer, rightCopy.buffer],
+  );
+  return { imageData: new ImageData(response.pixels as Uint8ClampedArray<ArrayBuffer>, width, height), percent: response.percent };
+}

--- a/tests/compare-word-wrap-default.test.mjs
+++ b/tests/compare-word-wrap-default.test.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const diffSideBySideSource = await readFile("src/modules/compare/DiffSideBySide.tsx", "utf8");
+
+test("File Compare side-by-side diff word wrap defaults on", () => {
+  assert.match(
+    diffSideBySideSource,
+    /const \[wrap, setWrap\] = useState\(true\)/,
+    "word wrap should be enabled by default while remaining user-toggleable",
+  );
+});


### PR DESCRIPTION
### Motivation
- Prevent UI-thread hangs when comparing or rendering very large files by moving expensive work off the main thread and avoiding mounting every hex row at once.
- Ensure interactive controls (heatmap tolerance slider, scroll) remain responsive even for multi-megabyte images and binaries.

### Description
- Add a dedicated compare web worker (`src/modules/compare/compareWorker.ts`) that performs base64 decoding and image heatmap pixel computation and returns transferable buffers.
- Add a worker client (`src/modules/compare/compareWorkerClient.ts`) that lazily creates the worker, tracks pending requests, and exposes `decodeBase64InWorker` and `buildHeatmapInWorker` APIs.
- Update the hex viewer (`src/modules/compare/CompareHexView.tsx`) to decode file bytes in the worker and virtualize the hex rows (absolute-positioned virtual window with `ROW_HEIGHT` and `OVERSCAN_ROWS`) so only visible rows are mounted.
- Update the image viewer (`src/modules/compare/CompareImageView.tsx`) to compute the heatmap in the worker and transfer pixel buffers back to the main thread, avoiding CPU work on the UI thread.

### Testing
- Ran `npm run lint`, which completed successfully.
- Ran `npx tsc --noEmit`, which completed successfully (type-check passed).
- Ran `npm run build`, which completed successfully and produced the production build without runtime type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42520ea1f4832fb24768bfa64c2f9e)