### PR TITLE
Suppress URL widget native WebViews while Dashboard overlays are open

### DIFF
--- a/docs/manual/10-dashboard.md
+++ b/docs/manual/10-dashboard.md
@@ -82,7 +82,7 @@ Presets are CSS wrappers that read the Instance's `--w-accent` / `--w-accent-sof
 
 Dashboard Views and terminal Connection backgrounds use the same shared background picker datasource. New preset, media-mode, fit, dim, or dynamic background options must be added through the shared picker/registry path so both `dashboard.changeBackground` and `terminal.background` show the same list.
 
-While the `dashboard.changeBackground` picker is open, embedded URL Connection widgets on the active View are temporarily marked inactive. This hides their owned WebView2 overlay windows so the app-owned background picker stays visible above the Dashboard.
+While Dashboard app-owned overlays are open — including `dashboard.catalogTitle`, `dashboard.customize`, `dashboard.changeBackground`, tab-gradient popovers, and delete confirmation dialogs — embedded URL Connection widgets on the active View are temporarily marked inactive. This hides their owned WebView2 overlay windows so those Dashboard overlays stay visible above the Dashboard.
 
 Dynamic and video backgrounds keep playing on the active View while the Dashboard Module is selected and any portion of the background is on screen, even when another OS window has focus on top of KKTerm. Playback pauses when the app is minimized (the document becomes hidden), when the user switches to another Module (Workspace or Settings), when a different Dashboard View becomes active, or when the background host is fully off-screen.
 

--- a/src/modules/dashboard/DashboardPage.tsx
+++ b/src/modules/dashboard/DashboardPage.tsx
@@ -170,6 +170,14 @@ export function DashboardPage({
   }, [editMode, toggleEditMode]);
 
   const activeView = views.find((v) => v.id === activeViewId) ?? views[0];
+  const suppressNativeWebviews = Boolean(
+    catalogOpen ||
+      customize ||
+      deleteViewTarget ||
+      deleteWidgetTarget ||
+      tabGradientPicker ||
+      backgroundOpen,
+  );
 
   useEffect(() => {
     if (!activeView) return;
@@ -550,7 +558,7 @@ export function DashboardPage({
                 onOpenBackground={() => setBackgroundOpen(true)}
                 onToggleEditMode={toggleEditMode}
                 onRequestWidgetDelete={setDeleteWidgetTarget}
-                suppressNativeWebviews={backgroundOpen}
+                suppressNativeWebviews={suppressNativeWebviews}
               />
             </div>
           );

--- a/tests/webview-visibility-lifecycle.test.mjs
+++ b/tests/webview-visibility-lifecycle.test.mjs
@@ -265,7 +265,7 @@ test("store creates top-level WebView Tabs for URL new-tab launches", async () =
   assert.doesNotMatch(openUrlConnection, /kind: "terminal"/);
 });
 
-test("Dashboard background picker directly suppresses embedded URL Connection widgets", async () => {
+test("Dashboard overlays directly suppress embedded URL Connection widgets", async () => {
   const page = await readFile(new URL("../src/modules/dashboard/DashboardPage.tsx", import.meta.url), "utf8");
   const canvas = await readFile(new URL("../src/modules/dashboard/view/DashboardCanvas.tsx", import.meta.url), "utf8");
   const frame = await readFile(new URL("../src/modules/dashboard/view/WidgetFrame.tsx", import.meta.url), "utf8");
@@ -276,7 +276,18 @@ test("Dashboard background picker directly suppresses embedded URL Connection wi
     "utf8",
   );
 
-  assert.match(page, /suppressNativeWebviews=\{backgroundOpen\}/);
+  assert.match(page, /const suppressNativeWebviews = Boolean\(/);
+  for (const overlayState of [
+    "catalogOpen",
+    "customize",
+    "deleteViewTarget",
+    "deleteWidgetTarget",
+    "tabGradientPicker",
+    "backgroundOpen",
+  ]) {
+    assert.match(page, new RegExp(overlayState));
+  }
+  assert.match(page, /suppressNativeWebviews=\{suppressNativeWebviews\}/);
   assert.match(canvas, /suppressNativeWebviews: boolean;/);
   assert.match(frame, /suppressNativeWebviews: boolean;/);
   assert.match(body, /suppressNativeWebviews: boolean;/);


### PR DESCRIPTION
### Motivation

- Embedded URL Connection widgets use native WebView windows that can sit above DOM overlays and were clipping/hiding app-owned Dashboard popovers and dialogs. 
- The goal is to temporarily mark embedded URL widgets inactive whenever any Dashboard-owned overlay is open so native overlay windows are hidden while the app renders its own popovers.

### Description

- Compute a `suppressNativeWebviews` boolean in `src/modules/dashboard/DashboardPage.tsx` from all Dashboard overlay state (`catalogOpen`, `customize`, `deleteViewTarget`, `deleteWidgetTarget`, `tabGradientPicker`, `backgroundOpen`) and pass it to the canvas instead of using `backgroundOpen` alone. 
- Update the Connection widget mounting condition to respect `isViewActive && !suppressNativeWebviews` so native URL WebView overlays are hidden while overlays are visible. 
- Broaden the existing visibility regression test to assert the new `suppressNativeWebviews` variable and the set of overlay states, and rename the test to reflect the general overlay behavior. 
- Update the Dashboard manual (`docs/manual/10-dashboard.md`) to document that Dashboard app-owned overlays temporarily inactivate embedded URL Connection widgets so native WebViews do not cover those overlays.

### Testing

- Ran `node --test tests/webview-visibility-lifecycle.test.mjs` and the suite passed (all tests in that file succeeded). 
- The change updates and extends the existing regression coverage that guards the Dashboard overlay → WebView suppression behavior and the modified test passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a435dcac080832faf6e64673672829f)