### PR TITLE
fix(connections): let search override Show Connected filter

### DIFF
--- a/docs/manual/03-connections.md
+++ b/docs/manual/03-connections.md
@@ -40,7 +40,7 @@ Header row (top of the panel):
 - Quick Connect: `connections.quickConnect`
 - New Folder: `connections.newFolder`
 - Collapse / Expand all: `connections.collapseAll`, `connections.expandAll`
-- Show Connected: `connections.showConnected`; filters the Connection Tree to only connections that currently have a live session, pruning empty folders. Shows the button in its pressed state while enabled; the filter is session-only and is not persisted across app relaunches. It composes with both the search box and Hide Folders.
+- Show Connected: `connections.showConnected`; filters the Connection Tree to only connections that currently have a live session, pruning empty folders. Shows the button in its pressed state while enabled; the filter is session-only and is not persisted across app relaunches. It composes with Hide Folders. While a search query is active the search takes precedence: matching connections are surfaced even when they are not currently connected, so you can always find a connection by name regardless of the toggle.
 - Hide Folders: `connections.hideFolders` (formerly "Show All"); flattens the Connection Tree across folders into a single de-duplicated list while preserving the existing Connection order, shows the button in its pressed state while enabled, and persists the preference in the Settings database across app relaunches.
 - Search box: placeholder `connections.searchPlaceholder`. While a search is active, matching folders are shown expanded so nested result rows are immediately visible; clearing search restores the folder collapse/expand state from before the search.
 - Column toggle: custom title-bar `app.connections` icon or Workspace icon on the Activity Rail

--- a/src/modules/workspace/connections/ConnectionSidebar.tsx
+++ b/src/modules/workspace/connections/ConnectionSidebar.tsx
@@ -1669,10 +1669,15 @@ export function ConnectionSidebar({
   }, [deferredQuery, treeWithLiveStatuses]);
   // The tree actually rendered: the search-filtered tree, optionally narrowed to
   // connected-only by the "Show Connected" filter. Both the folder view and the
-  // "Hide Folders" flat view read from this so the two filters compose.
+  // "Hide Folders" flat view read from this so the two filters compose. An active
+  // search query takes precedence over "Show Connected" so a search still surfaces
+  // matching connections that aren't currently connected — better UX than hiding
+  // them behind the toggle.
+  const hasSearchQuery = deferredQuery.trim().length > 0;
   const displayTree = useMemo(
-    () => (showConnectedOnly ? filterConnectedConnections(filteredTree) : filteredTree),
-    [filteredTree, showConnectedOnly],
+    () =>
+      showConnectedOnly && !hasSearchQuery ? filterConnectedConnections(filteredTree) : filteredTree,
+    [filteredTree, showConnectedOnly, hasSearchQuery],
   );
   const quickConnectShellOptions = useMemo(
     () => localShellOptionsForPlatform(terminalSettings.customShells),


### PR DESCRIPTION
When the "Show Connected" filter is active, typing in the search box now
surfaces matching connections regardless of their live status. Previously
the connected-only narrowing was applied after search, hiding non-connected
matches and forcing users to toggle the filter off to find a connection by
name. An active search query now takes precedence over the toggle.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RR6BB4Pj4Nx6pmT6BcDAJn