### PR TITLE
feat(dashboard): animated PC Info widget + macOS/Linux enrichment

### DIFF
--- a/docs/localization_todo/dashboard.pcInfoLabel.audioDevices.md
+++ b/docs/localization_todo/dashboard.pcInfoLabel.audioDevices.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoLabel.audioDevices
+
+- **English value**: `Audio devices`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `heading`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Block title above the list of audio output/input devices.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoLabel.audioDevices.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoLabel.cpuLoad.md
+++ b/docs/localization_todo/dashboard.pcInfoLabel.cpuLoad.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoLabel.cpuLoad
+
+- **English value**: `CPU load`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Caption under the Summary CPU-load gauge ring (live processor utilization).
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoLabel.cpuLoad.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoLabel.daysUp.md
+++ b/docs/localization_todo/dashboard.pcInfoLabel.daysUp.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoLabel.daysUp
+
+- **English value**: `Days up`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Caption inside the OS uptime ring; the number above it is the count of full days the machine has been running.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoLabel.daysUp.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoLabel.freeOfTotal.md
+++ b/docs/localization_todo/dashboard.pcInfoLabel.freeOfTotal.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoLabel.freeOfTotal
+
+- **English value**: `{{free}} free · {{total}}`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `fragment`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: {{free}} = formatted free bytes, {{total}} = formatted total bytes; both must survive unchanged
+- **Context/meaning**: Sub-caption under a storage volume donut showing free space out of total (middle dot separator).
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoLabel.freeOfTotal.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoLabel.gbFree.md
+++ b/docs/localization_todo/dashboard.pcInfoLabel.gbFree.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoLabel.gbFree
+
+- **English value**: `GB free`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Caption under the free-RAM stat; the number is available memory in gigabytes.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoLabel.gbFree.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoLabel.gbTotal.md
+++ b/docs/localization_todo/dashboard.pcInfoLabel.gbTotal.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoLabel.gbTotal
+
+- **English value**: `GB total`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Caption under the total-RAM stat; the number is total memory in gigabytes.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoLabel.gbTotal.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoLabel.inUse.md
+++ b/docs/localization_todo/dashboard.pcInfoLabel.inUse.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoLabel.inUse
+
+- **English value**: `In use`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Caption inside the Memory usage ring meaning the percentage of RAM currently used.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoLabel.inUse.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoLabel.liveLoad.md
+++ b/docs/localization_todo/dashboard.pcInfoLabel.liveLoad.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoLabel.liveLoad
+
+- **English value**: `Live load`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Title of the CPU live-load sparkline panel (realtime processor utilization).
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoLabel.liveLoad.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoLabel.liveThroughput.md
+++ b/docs/localization_todo/dashboard.pcInfoLabel.liveThroughput.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoLabel.liveThroughput
+
+- **English value**: `Live throughput`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Title of the network live-throughput sparkline panel (realtime up/down bandwidth).
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoLabel.liveThroughput.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoLabel.maxGhz.md
+++ b/docs/localization_todo/dashboard.pcInfoLabel.maxGhz.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoLabel.maxGhz
+
+- **English value**: `GHz max`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Caption under the CPU max-clock stat; the number is the maximum clock speed in gigahertz.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoLabel.maxGhz.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoLabel.monitorOff.md
+++ b/docs/localization_todo/dashboard.pcInfoLabel.monitorOff.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoLabel.monitorOff
+
+- **English value**: `Live metrics off — enable the status-bar monitor`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `status`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Footer hint shown when the toolbar status-bar monitor is disabled, so the widget has no live CPU/RAM/network values.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoLabel.monitorOff.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoLabel.slotsPopulated.md
+++ b/docs/localization_todo/dashboard.pcInfoLabel.slotsPopulated.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoLabel.slotsPopulated
+
+- **English value**: `Slots populated`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Row label in the Memory section for how many DIMM slots are occupied.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoLabel.slotsPopulated.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoLabel.sourceCached.md
+++ b/docs/localization_todo/dashboard.pcInfoLabel.sourceCached.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoLabel.sourceCached
+
+- **English value**: `Source: {{source}} · snapshot cached`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `status`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: {{source}} = collector id such as windows-cim; must survive unchanged
+- **Context/meaning**: Footer note naming which collector produced the snapshot and that it is cached until Refresh.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoLabel.sourceCached.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoLabel.systemInventory.md
+++ b/docs/localization_todo/dashboard.pcInfoLabel.systemInventory.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoLabel.systemInventory
+
+- **English value**: `System inventory`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `heading`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Header subtitle of the PC Info widget describing the hardware/software snapshot.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoLabel.systemInventory.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoLabel.typeSpeed.md
+++ b/docs/localization_todo/dashboard.pcInfoLabel.typeSpeed.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoLabel.typeSpeed
+
+- **English value**: `Type · Speed`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Row label in the Memory section combining the module type and clock speed (middle dot separator).
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoLabel.typeSpeed.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoTab.audio.md
+++ b/docs/localization_todo/dashboard.pcInfoTab.audio.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoTab.audio
+
+- **English value**: `Audio`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Short tab label for the audio devices tab.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoTab.audio.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoTab.battery.md
+++ b/docs/localization_todo/dashboard.pcInfoTab.battery.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoTab.battery
+
+- **English value**: `Battery`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Short tab label for the battery tab; shown only on machines with a battery.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoTab.battery.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoTab.cpu.md
+++ b/docs/localization_todo/dashboard.pcInfoTab.cpu.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoTab.cpu
+
+- **English value**: `CPU`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Short tab label for the processor tab. Hardware acronym, usually stays CPU.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoTab.cpu.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoTab.graphics.md
+++ b/docs/localization_todo/dashboard.pcInfoTab.graphics.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoTab.graphics
+
+- **English value**: `GPU`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Short tab label for the graphics tab. Hardware acronym, usually stays GPU.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoTab.graphics.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoTab.memory.md
+++ b/docs/localization_todo/dashboard.pcInfoTab.memory.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoTab.memory
+
+- **English value**: `Memory`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Short tab label for the RAM/memory tab.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoTab.memory.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoTab.motherboard.md
+++ b/docs/localization_todo/dashboard.pcInfoTab.motherboard.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoTab.motherboard
+
+- **English value**: `Board`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Short tab label for the motherboard tab; abbreviated to fit a compact icon tab.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoTab.motherboard.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoTab.network.md
+++ b/docs/localization_todo/dashboard.pcInfoTab.network.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoTab.network
+
+- **English value**: `Net`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Short tab label for the network tab; abbreviated to fit a compact icon tab.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoTab.network.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoTab.os.md
+++ b/docs/localization_todo/dashboard.pcInfoTab.os.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoTab.os
+
+- **English value**: `OS`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Short tab label for the operating-system tab. Abbreviation of 'operating system'.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoTab.os.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoTab.storage.md
+++ b/docs/localization_todo/dashboard.pcInfoTab.storage.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoTab.storage
+
+- **English value**: `Disk`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Short tab label for the storage tab; abbreviated to fit a compact icon tab.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoTab.storage.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/docs/localization_todo/dashboard.pcInfoTab.summary.md
+++ b/docs/localization_todo/dashboard.pcInfoTab.summary.md
@@ -1,0 +1,16 @@
+# dashboard.pcInfoTab.summary
+
+- **English value**: `Summary`
+- **Namespace**: `dashboard`
+- **File/component**: `src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx`
+- **UI role**: `label`
+- **User flow**: User opens the PC Info widget on the Dashboard and views this in the relevant section/tab.
+- **Tone**: concise/neutral
+- **Placeholders**: `none`
+- **Context/meaning**: Short tab label for the at-a-glance overview tab in the PC Info widget.
+- **Domain notes**: PC Info is a Dashboard built-in widget. Live CPU/RAM/network values come from the status-bar host-usage monitor (no separate pipe). Acronyms CPU/GPU/OS/RAM/GHz/GB and the middle-dot separator ' · ' typically stay as-is.
+
+<!--
+Filename: dashboard.pcInfoTab.summary.md
+Best-effort translations were added to every locale; this file remains as the review record. Delete once translations are reviewed/finalized.
+-->

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4032,6 +4032,7 @@ dependencies = [
  "serial2",
  "sha2 0.10.9",
  "shared_library",
+ "starship-battery",
  "suppaftp",
  "surge-ping",
  "sysinfo",
@@ -4091,6 +4092,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lebe"
@@ -4337,6 +4344,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce716bf1a316f47a280fc76295f6495b5bea4752bca01c3b3885e101b1c23c02"
 dependencies = [
  "sha2 0.11.0",
+]
+
+[[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -5967,13 +5983,13 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.39.4",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -6298,6 +6314,15 @@ name = "quick-xml"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
 ]
@@ -7880,6 +7905,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "starship-battery"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0efc2c44c92705be724265a0c758e3b7c120ea63817d2d684bab86fbeced9a"
+dependencies = [
+ "cfg-if",
+ "core-foundation 0.10.1",
+ "lazycell",
+ "libc",
+ "mach2",
+ "nix 0.30.1",
+ "num-traits",
+ "plist",
+ "uom",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9105,6 +9148,16 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "uom"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd5cfe7d84f6774726717f358a37f5bca8fca273bed4de40604ad129d1107b49"
+dependencies = [
+ "num-traits",
+ "typenum",
+]
 
 [[package]]
 name = "ureq"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -128,10 +128,19 @@ objc2-foundation = { version = "0.3", default-features = false, features = [
 # AV mitigation #1: use IcmpSendEcho2 via winping (NOT raw sockets) on Windows.
 winping = "0.10"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# Dashboard PC Info enrichment on Linux: CPU brand/cores/frequency, disks, and
+# network adapters + MAC/IP. Windows uses CIM and macOS uses system_profiler.
+sysinfo = "0.39"
+
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 # Unix ICMP via surge-ping (raw sockets - Unix users typically have CAP_NET_RAW or root).
 # Windows uses winping instead (see Windows target block above).
 surge-ping = "0.8"
+# Cross-platform battery info for the Dashboard PC Info widget (IOKit on macOS,
+# sysfs on Linux). Windows reads batteries via CIM. `starship-battery` is the
+# maintained fork of the `battery` crate; aliased so the code can `use battery`.
+battery = { package = "starship-battery", version = "0.10" }
 # macOS RDP client via IronRDP (Windows uses the native ActiveX path in rdp.rs instead).
 # The umbrella crate pins a mutually-compatible sub-crate set.
 # ironrdp-tokio re-exports all of ironrdp-async (connect_begin, connect_finalize,

--- a/src-tauri/src/pc_info.rs
+++ b/src-tauri/src/pc_info.rs
@@ -278,6 +278,63 @@ fn clean(value: Option<String>) -> Option<String> {
     Some(trimmed.to_string())
 }
 
+// Cross-platform battery snapshot for the macOS/Linux paths (Windows reads
+// batteries via CIM). Backed by the `starship-battery` crate, which wraps IOKit
+// on macOS and sysfs on Linux. Any failure yields an empty list — a missing or
+// unreadable battery is a normal, non-error outcome (e.g. desktops).
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn collect_batteries() -> Vec<BatteryInfo> {
+    use battery::units::energy::watt_hour;
+    use battery::units::ratio::percent;
+
+    let Ok(manager) = battery::Manager::new() else {
+        return Vec::new();
+    };
+    let Ok(batteries) = manager.batteries() else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::new();
+    for entry in batteries {
+        let Ok(battery) = entry else {
+            continue;
+        };
+        let charge = battery.state_of_charge().get::<percent>();
+        let full_wh = battery.energy_full().get::<watt_hour>() as f64;
+        let design_wh = battery.energy_full_design().get::<watt_hour>() as f64;
+        // Wear = how far the full-charge capacity has dropped below the factory
+        // design capacity. Only report when both capacities are known and sane.
+        let wear = if design_wh > 0.0 && full_wh > 0.0 && full_wh <= design_wh {
+            Some(((1.0 - full_wh / design_wh) * 100.0 * 10.0).round() / 10.0)
+        } else {
+            None
+        };
+        out.push(BatteryInfo {
+            name: clean(battery.model().map(|s| s.to_string()))
+                .or_else(|| clean(battery.vendor().map(|s| s.to_string()))),
+            charge_percent: Some(charge.round().clamp(0.0, 100.0) as u32),
+            status: Some(battery_state_label(battery.state())),
+            design_capacity_mwh: (design_wh > 0.0).then(|| (design_wh * 1000.0).round() as u64),
+            full_charge_capacity_mwh: (full_wh > 0.0).then(|| (full_wh * 1000.0).round() as u64),
+            wear_percent: wear,
+        });
+    }
+    out
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn battery_state_label(state: battery::State) -> String {
+    use battery::State;
+    match state {
+        State::Charging => "Charging",
+        State::Discharging => "Discharging",
+        State::Empty => "Empty",
+        State::Full => "Fully charged",
+        _ => "Unknown",
+    }
+    .to_string()
+}
+
 #[cfg(target_os = "windows")]
 mod platform {
     use super::*;
@@ -1192,16 +1249,39 @@ mod platform {
         snapshot
     }
 
+    // `system_profiler` gives stable English keys but is sparse on CPU detail and
+    // omits live memory; `sysinfo` (already used for Status Bar monitoring) fills
+    // the gaps without a second OS-command parse. Only fields left empty by
+    // system_profiler are touched, so the richer JSON source always wins.
     fn fill_from_sysinfo(snapshot: &mut PcInfoSnapshot) {
         use sysinfo::System;
         let mut system = System::new();
         system.refresh_memory();
+        system.refresh_cpu_all();
         let total = system.total_memory();
         if total > 0 {
             snapshot.memory.total_bytes = Some(total);
             snapshot.memory.available_bytes = Some(system.available_memory());
             snapshot.memory.used_percent =
                 Some(system.used_memory() as f64 / total as f64 * 100.0);
+        }
+        if let Some(cpu) = system.cpus().first() {
+            if snapshot.cpu.name.is_none() {
+                snapshot.cpu.name = clean(Some(cpu.brand().to_string()))
+                    .or_else(|| clean(Some(cpu.name().to_string())));
+            }
+            if snapshot.cpu.vendor.is_none() {
+                snapshot.cpu.vendor = clean(Some(cpu.vendor_id().to_string()));
+            }
+            let mhz = cpu.frequency();
+            if mhz > 0 && snapshot.cpu.max_clock_mhz.is_none() {
+                snapshot.cpu.max_clock_mhz = Some(mhz);
+            }
+        }
+        if snapshot.cpu.physical_cores.is_none() {
+            snapshot.cpu.physical_cores = System::physical_core_count()
+                .and_then(|count| u32::try_from(count).ok())
+                .filter(|&count| count > 0);
         }
         if snapshot.cpu.logical_processors.is_none() {
             snapshot.cpu.logical_processors = std::thread::available_parallelism()
@@ -1211,6 +1291,9 @@ mod platform {
         snapshot.os.uptime_seconds = Some(System::uptime());
         if snapshot.os.name.is_none() {
             snapshot.os.name = System::long_os_version();
+        }
+        if snapshot.battery.is_empty() {
+            snapshot.battery = collect_batteries();
         }
     }
 }
@@ -1242,7 +1325,185 @@ mod platform {
 
         snapshot.cpu = cpu_from_proc();
         snapshot.memory = memory_from_proc();
+        snapshot.storage = storage_from_sysfs();
+        snapshot.graphics = gpus_from_lspci();
+        enrich_from_sysinfo(&mut snapshot);
         snapshot
+    }
+
+    // sysinfo fills cross-platform fields the /proc + lscpu parse misses: mounted
+    // volumes, network adapters (MAC + IPs), CPU brand/frequency, and battery.
+    // Linux-only because this build path also covers other Unix targets where the
+    // sysinfo dependency is not declared.
+    #[cfg(target_os = "linux")]
+    fn enrich_from_sysinfo(snapshot: &mut PcInfoSnapshot) {
+        use sysinfo::{Disks, Networks, System};
+
+        let mut system = System::new();
+        system.refresh_cpu_all();
+        if let Some(cpu) = system.cpus().first() {
+            if snapshot.cpu.name.is_none() {
+                snapshot.cpu.name = clean(Some(cpu.brand().to_string()));
+            }
+            if snapshot.cpu.vendor.is_none() {
+                snapshot.cpu.vendor = clean(Some(cpu.vendor_id().to_string()));
+            }
+            let mhz = cpu.frequency();
+            if mhz > 0 && snapshot.cpu.max_clock_mhz.is_none() {
+                snapshot.cpu.max_clock_mhz = Some(mhz);
+            }
+        }
+        if snapshot.cpu.physical_cores.is_none() {
+            snapshot.cpu.physical_cores = System::physical_core_count()
+                .and_then(|count| u32::try_from(count).ok())
+                .filter(|&count| count > 0);
+        }
+
+        let disks = Disks::new_with_refreshed_list();
+        for disk in disks.list() {
+            let total = disk.total_space();
+            if total == 0 {
+                continue;
+            }
+            snapshot.volumes.push(VolumeInfo {
+                mount: clean(Some(disk.mount_point().to_string_lossy().into_owned())),
+                label: clean(Some(disk.name().to_string_lossy().into_owned())),
+                file_system: clean(Some(disk.file_system().to_string_lossy().into_owned())),
+                total_bytes: Some(total),
+                free_bytes: Some(disk.available_space()),
+            });
+        }
+
+        let networks = Networks::new_with_refreshed_list();
+        for (name, data) in &networks {
+            let mac = data.mac_address().to_string();
+            let ips: Vec<String> = data
+                .ip_networks()
+                .iter()
+                .map(|ip| ip.addr.to_string())
+                .collect();
+            snapshot.network.push(NetworkAdapterInfo {
+                name: clean(Some(name.clone())),
+                mac_address: clean(Some(mac)).filter(|m| m != "00:00:00:00:00:00"),
+                ip_addresses: ips,
+                ..Default::default()
+            });
+        }
+
+        if snapshot.battery.is_empty() {
+            snapshot.battery = collect_batteries();
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn enrich_from_sysinfo(_snapshot: &mut PcInfoSnapshot) {}
+
+    // Physical drives from sysfs: model, capacity, and rotational flag → HDD/SSD.
+    // Skips virtual/removable nodes (loop, ram, zram, device-mapper, optical).
+    fn storage_from_sysfs() -> Vec<DiskInfo> {
+        let Ok(entries) = fs::read_dir("/sys/block") else {
+            return Vec::new();
+        };
+        let mut disks = Vec::new();
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name.starts_with("loop")
+                || name.starts_with("ram")
+                || name.starts_with("zram")
+                || name.starts_with("dm-")
+                || name.starts_with("sr")
+                || name.starts_with("md")
+            {
+                continue;
+            }
+            let base = entry.path();
+            let size_sectors = fs::read_to_string(base.join("size"))
+                .ok()
+                .and_then(|raw| raw.trim().parse::<u64>().ok());
+            let Some(sectors) = size_sectors.filter(|&s| s > 0) else {
+                continue;
+            };
+            let model_path = base.join("device/model");
+            let model = read_trimmed(model_path.to_string_lossy().as_ref());
+            let media_type = match fs::read_to_string(base.join("queue/rotational")) {
+                Ok(raw) if raw.trim() == "0" => Some("SSD".to_string()),
+                Ok(raw) if raw.trim() == "1" => Some("HDD".to_string()),
+                _ => None,
+            };
+            disks.push(DiskInfo {
+                // Linux block size is 512 bytes per sector for the `size` attribute.
+                model: model.or_else(|| clean(Some(name.clone()))),
+                size_bytes: Some(sectors * 512),
+                media_type,
+                ..Default::default()
+            });
+        }
+        disks
+    }
+
+    // Best-effort GPU list from `lspci -mm` (machine-readable, quoted fields).
+    // Force the C locale so the device-class label stays English. Absent lspci is
+    // a normal, non-error outcome.
+    fn gpus_from_lspci() -> Vec<GpuInfo> {
+        let Ok(output) = std::process::Command::new("lspci")
+            .args(["-mm"])
+            .env("LC_ALL", "C")
+            .output()
+        else {
+            return Vec::new();
+        };
+        if !output.status.success() {
+            return Vec::new();
+        }
+        let text = String::from_utf8_lossy(&output.stdout);
+        let mut gpus = Vec::new();
+        for line in text.lines() {
+            let fields = parse_lspci_fields(line);
+            // fields[0] = slot, [1] = class, [2] = vendor, [3] = device.
+            let Some(class) = fields.get(1) else {
+                continue;
+            };
+            if !(class.contains("VGA")
+                || class.contains("3D controller")
+                || class.contains("Display controller"))
+            {
+                continue;
+            }
+            gpus.push(GpuInfo {
+                name: clean(fields.get(3).cloned()),
+                vendor: clean(fields.get(2).cloned()),
+                ..Default::default()
+            });
+        }
+        gpus
+    }
+
+    // Split an `lspci -mm` line into its quoted fields, dropping trailing
+    // -rNN / -pNN revision tokens and the unquoted slot prefix's quoting.
+    fn parse_lspci_fields(line: &str) -> Vec<String> {
+        let mut fields = Vec::new();
+        let mut rest = line.trim();
+        // Leading slot id is unquoted (e.g. "01:00.0"); capture it as field 0.
+        if let Some(space) = rest.find(' ') {
+            fields.push(rest[..space].to_string());
+            rest = rest[space..].trim_start();
+        }
+        let bytes = rest.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'"' {
+                let start = i + 1;
+                let mut j = start;
+                while j < bytes.len() && bytes[j] != b'"' {
+                    j += 1;
+                }
+                fields.push(rest[start..j.min(bytes.len())].to_string());
+                i = j + 1;
+            } else {
+                i += 1;
+            }
+        }
+        fields
     }
 
     fn read_trimmed(path: &str) -> Option<String> {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -570,6 +570,35 @@
       "designCapacity": "Design-Kapazität",
       "fullCapacity": "Vollladekapazität"
     },
+    "pcInfoTab": {
+      "summary": "Übersicht",
+      "os": "OS",
+      "cpu": "CPU",
+      "memory": "Speicher",
+      "motherboard": "Board",
+      "graphics": "GPU",
+      "storage": "Disk",
+      "network": "Netz",
+      "audio": "Audio",
+      "battery": "Akku"
+    },
+    "pcInfoLabel": {
+      "systemInventory": "Systeminventar",
+      "cpuLoad": "CPU-Last",
+      "liveLoad": "Live-Last",
+      "liveThroughput": "Live-Durchsatz",
+      "inUse": "Belegt",
+      "daysUp": "Tage aktiv",
+      "maxGhz": "GHz max",
+      "gbTotal": "GB gesamt",
+      "gbFree": "GB frei",
+      "slotsPopulated": "Belegte Steckplätze",
+      "typeSpeed": "Typ · Takt",
+      "freeOfTotal": "{{free}} frei · {{total}}",
+      "audioDevices": "Audiogeräte",
+      "sourceCached": "Quelle: {{source}} · Snapshot zwischengespeichert",
+      "monitorOff": "Live-Metriken aus — Statusleisten-Monitor aktivieren"
+    },
     "networkToolsTitle": "Netzwerk-Tools",
     "networkToolsSummary": "Subnetzberechnung, DNS, Geschwindigkeitstests, Ping-Scans und WHOIS in einem Widget mit Tabs.",
     "networkToolsTab": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -570,6 +570,35 @@
       "designCapacity": "Design capacity",
       "fullCapacity": "Full-charge capacity"
     },
+    "pcInfoTab": {
+      "summary": "Summary",
+      "os": "OS",
+      "cpu": "CPU",
+      "memory": "Memory",
+      "motherboard": "Board",
+      "graphics": "GPU",
+      "storage": "Disk",
+      "network": "Net",
+      "audio": "Audio",
+      "battery": "Battery"
+    },
+    "pcInfoLabel": {
+      "systemInventory": "System inventory",
+      "cpuLoad": "CPU load",
+      "liveLoad": "Live load",
+      "liveThroughput": "Live throughput",
+      "inUse": "In use",
+      "daysUp": "Days up",
+      "maxGhz": "GHz max",
+      "gbTotal": "GB total",
+      "gbFree": "GB free",
+      "slotsPopulated": "Slots populated",
+      "typeSpeed": "Type · Speed",
+      "freeOfTotal": "{{free}} free · {{total}}",
+      "audioDevices": "Audio devices",
+      "sourceCached": "Source: {{source}} · snapshot cached",
+      "monitorOff": "Live metrics off — enable the status-bar monitor"
+    },
     "networkToolsTitle": "Network Tools",
     "networkToolsSummary": "Subnet math, DNS, speed tests, ping sweeps, and WHOIS in one tabbed widget.",
     "networkToolsTab": {

--- a/src/i18n/locales/es-MX.json
+++ b/src/i18n/locales/es-MX.json
@@ -570,6 +570,35 @@
       "designCapacity": "Capacidad de diseño",
       "fullCapacity": "Capacidad de carga completa"
     },
+    "pcInfoTab": {
+      "summary": "Resumen",
+      "os": "SO",
+      "cpu": "CPU",
+      "memory": "Memoria",
+      "motherboard": "Placa",
+      "graphics": "GPU",
+      "storage": "Disco",
+      "network": "Red",
+      "audio": "Audio",
+      "battery": "Batería"
+    },
+    "pcInfoLabel": {
+      "systemInventory": "Inventario del sistema",
+      "cpuLoad": "Carga de CPU",
+      "liveLoad": "Carga en vivo",
+      "liveThroughput": "Rendimiento en vivo",
+      "inUse": "En uso",
+      "daysUp": "Días activo",
+      "maxGhz": "GHz máx",
+      "gbTotal": "GB total",
+      "gbFree": "GB libre",
+      "slotsPopulated": "Ranuras ocupadas",
+      "typeSpeed": "Tipo · Velocidad",
+      "freeOfTotal": "{{free}} libre · {{total}}",
+      "audioDevices": "Dispositivos de audio",
+      "sourceCached": "Origen: {{source}} · instantánea en caché",
+      "monitorOff": "Métricas en vivo desactivadas — activa el monitor de la barra de estado"
+    },
     "networkToolsTitle": "Herramientas de red",
     "networkToolsSummary": "Cálculo de subredes, DNS, pruebas de velocidad, barridos de ping y WHOIS en un widget con pestañas.",
     "networkToolsTab": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -570,6 +570,35 @@
       "designCapacity": "Capacidad de diseño",
       "fullCapacity": "Capacidad de carga completa"
     },
+    "pcInfoTab": {
+      "summary": "Resumen",
+      "os": "SO",
+      "cpu": "CPU",
+      "memory": "Memoria",
+      "motherboard": "Placa",
+      "graphics": "GPU",
+      "storage": "Disco",
+      "network": "Red",
+      "audio": "Audio",
+      "battery": "Batería"
+    },
+    "pcInfoLabel": {
+      "systemInventory": "Inventario del sistema",
+      "cpuLoad": "Carga de CPU",
+      "liveLoad": "Carga en vivo",
+      "liveThroughput": "Rendimiento en vivo",
+      "inUse": "En uso",
+      "daysUp": "Días activo",
+      "maxGhz": "GHz máx",
+      "gbTotal": "GB total",
+      "gbFree": "GB libre",
+      "slotsPopulated": "Ranuras ocupadas",
+      "typeSpeed": "Tipo · Velocidad",
+      "freeOfTotal": "{{free}} libre · {{total}}",
+      "audioDevices": "Dispositivos de audio",
+      "sourceCached": "Origen: {{source}} · instantánea en caché",
+      "monitorOff": "Métricas en vivo desactivadas — activa el monitor de la barra de estado"
+    },
     "networkToolsTitle": "Herramientas de red",
     "networkToolsSummary": "Cálculo de subredes, DNS, pruebas de velocidad, barridos de ping y WHOIS en un widget con pestañas.",
     "networkToolsTab": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -570,6 +570,35 @@
       "designCapacity": "Capacité nominale",
       "fullCapacity": "Capacité à pleine charge"
     },
+    "pcInfoTab": {
+      "summary": "Résumé",
+      "os": "OS",
+      "cpu": "CPU",
+      "memory": "Mémoire",
+      "motherboard": "Carte",
+      "graphics": "GPU",
+      "storage": "Disque",
+      "network": "Réseau",
+      "audio": "Audio",
+      "battery": "Batterie"
+    },
+    "pcInfoLabel": {
+      "systemInventory": "Inventaire système",
+      "cpuLoad": "Charge CPU",
+      "liveLoad": "Charge en direct",
+      "liveThroughput": "Débit en direct",
+      "inUse": "Utilisé",
+      "daysUp": "Jours actifs",
+      "maxGhz": "GHz max",
+      "gbTotal": "Go total",
+      "gbFree": "Go libre",
+      "slotsPopulated": "Emplacements occupés",
+      "typeSpeed": "Type · Vitesse",
+      "freeOfTotal": "{{free}} libre · {{total}}",
+      "audioDevices": "Périphériques audio",
+      "sourceCached": "Source : {{source}} · instantané en cache",
+      "monitorOff": "Métriques en direct désactivées — activez le moniteur de la barre d'état"
+    },
     "networkToolsTitle": "Outils réseau",
     "networkToolsSummary": "Calcul de sous-réseau, DNS, tests de débit, balayages ping et WHOIS dans un widget à onglets.",
     "networkToolsTab": {

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -570,6 +570,35 @@
       "designCapacity": "Kapasitas desain",
       "fullCapacity": "Kapasitas isi penuh"
     },
+    "pcInfoTab": {
+      "summary": "Ringkasan",
+      "os": "OS",
+      "cpu": "CPU",
+      "memory": "Memori",
+      "motherboard": "Board",
+      "graphics": "GPU",
+      "storage": "Disk",
+      "network": "Jaringan",
+      "audio": "Audio",
+      "battery": "Baterai"
+    },
+    "pcInfoLabel": {
+      "systemInventory": "Inventaris sistem",
+      "cpuLoad": "Beban CPU",
+      "liveLoad": "Beban langsung",
+      "liveThroughput": "Throughput langsung",
+      "inUse": "Terpakai",
+      "daysUp": "Hari aktif",
+      "maxGhz": "GHz maks",
+      "gbTotal": "GB total",
+      "gbFree": "GB bebas",
+      "slotsPopulated": "Slot terisi",
+      "typeSpeed": "Tipe · Kecepatan",
+      "freeOfTotal": "{{free}} bebas · {{total}}",
+      "audioDevices": "Perangkat audio",
+      "sourceCached": "Sumber: {{source}} · snapshot di-cache",
+      "monitorOff": "Metrik langsung nonaktif — aktifkan monitor bilah status"
+    },
     "networkToolsTitle": "Alat Jaringan",
     "networkToolsSummary": "Perhitungan subnet, DNS, uji kecepatan, sweep ping, dan WHOIS dalam satu widget bertab.",
     "networkToolsTab": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -570,6 +570,35 @@
       "designCapacity": "Capacità di progetto",
       "fullCapacity": "Capacità a piena carica"
     },
+    "pcInfoTab": {
+      "summary": "Riepilogo",
+      "os": "OS",
+      "cpu": "CPU",
+      "memory": "Memoria",
+      "motherboard": "Scheda",
+      "graphics": "GPU",
+      "storage": "Disco",
+      "network": "Rete",
+      "audio": "Audio",
+      "battery": "Batteria"
+    },
+    "pcInfoLabel": {
+      "systemInventory": "Inventario di sistema",
+      "cpuLoad": "Carico CPU",
+      "liveLoad": "Carico live",
+      "liveThroughput": "Throughput live",
+      "inUse": "In uso",
+      "daysUp": "Giorni attivo",
+      "maxGhz": "GHz max",
+      "gbTotal": "GB totali",
+      "gbFree": "GB liberi",
+      "slotsPopulated": "Slot occupati",
+      "typeSpeed": "Tipo · Velocità",
+      "freeOfTotal": "{{free}} liberi · {{total}}",
+      "audioDevices": "Dispositivi audio",
+      "sourceCached": "Origine: {{source}} · snapshot in cache",
+      "monitorOff": "Metriche live disattivate — abilita il monitor della barra di stato"
+    },
     "networkToolsTitle": "Strumenti di rete",
     "networkToolsSummary": "Calcolo subnet, DNS, speed test, sweep ping e WHOIS in un widget a schede.",
     "networkToolsTab": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -570,6 +570,35 @@
       "designCapacity": "設計容量",
       "fullCapacity": "満充電容量"
     },
+    "pcInfoTab": {
+      "summary": "概要",
+      "os": "OS",
+      "cpu": "CPU",
+      "memory": "メモリ",
+      "motherboard": "ボード",
+      "graphics": "GPU",
+      "storage": "ディスク",
+      "network": "ネット",
+      "audio": "オーディオ",
+      "battery": "バッテリー"
+    },
+    "pcInfoLabel": {
+      "systemInventory": "システム情報",
+      "cpuLoad": "CPU負荷",
+      "liveLoad": "ライブ負荷",
+      "liveThroughput": "ライブスループット",
+      "inUse": "使用中",
+      "daysUp": "稼働日数",
+      "maxGhz": "最大GHz",
+      "gbTotal": "GB合計",
+      "gbFree": "GB空き",
+      "slotsPopulated": "使用スロット",
+      "typeSpeed": "種類 · 速度",
+      "freeOfTotal": "{{free}} 空き · {{total}}",
+      "audioDevices": "オーディオデバイス",
+      "sourceCached": "ソース: {{source}} · スナップショットをキャッシュ",
+      "monitorOff": "ライブ計測オフ — ステータスバーのモニターを有効にしてください"
+    },
     "networkToolsTitle": "ネットワークツール",
     "networkToolsSummary": "サブネット計算、DNS、速度テスト、ping スイープ、WHOIS を 1 つのタブ付きウィジェットにまとめます。",
     "networkToolsTab": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -570,6 +570,35 @@
       "designCapacity": "설계 용량",
       "fullCapacity": "완전 충전 용량"
     },
+    "pcInfoTab": {
+      "summary": "요약",
+      "os": "OS",
+      "cpu": "CPU",
+      "memory": "메모리",
+      "motherboard": "보드",
+      "graphics": "GPU",
+      "storage": "디스크",
+      "network": "네트워크",
+      "audio": "오디오",
+      "battery": "배터리"
+    },
+    "pcInfoLabel": {
+      "systemInventory": "시스템 정보",
+      "cpuLoad": "CPU 부하",
+      "liveLoad": "실시간 부하",
+      "liveThroughput": "실시간 처리량",
+      "inUse": "사용 중",
+      "daysUp": "가동 일수",
+      "maxGhz": "최대 GHz",
+      "gbTotal": "GB 전체",
+      "gbFree": "GB 여유",
+      "slotsPopulated": "사용 슬롯",
+      "typeSpeed": "종류 · 속도",
+      "freeOfTotal": "{{free}} 여유 · {{total}}",
+      "audioDevices": "오디오 장치",
+      "sourceCached": "출처: {{source}} · 스냅샷 캐시됨",
+      "monitorOff": "실시간 측정 꺼짐 — 상태 표시줄 모니터를 켜세요"
+    },
     "networkToolsTitle": "네트워크 도구",
     "networkToolsSummary": "서브넷 계산, DNS, 속도 테스트, ping 스윕, WHOIS를 하나의 탭 위젯에 제공합니다.",
     "networkToolsTab": {

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -570,6 +570,35 @@
       "designCapacity": "Capacidade de projeto",
       "fullCapacity": "Capacidade de carga total"
     },
+    "pcInfoTab": {
+      "summary": "Resumo",
+      "os": "SO",
+      "cpu": "CPU",
+      "memory": "Memória",
+      "motherboard": "Placa",
+      "graphics": "GPU",
+      "storage": "Disco",
+      "network": "Rede",
+      "audio": "Áudio",
+      "battery": "Bateria"
+    },
+    "pcInfoLabel": {
+      "systemInventory": "Inventário do sistema",
+      "cpuLoad": "Carga da CPU",
+      "liveLoad": "Carga ao vivo",
+      "liveThroughput": "Taxa ao vivo",
+      "inUse": "Em uso",
+      "daysUp": "Dias ativo",
+      "maxGhz": "GHz máx",
+      "gbTotal": "GB total",
+      "gbFree": "GB livre",
+      "slotsPopulated": "Slots ocupados",
+      "typeSpeed": "Tipo · Velocidade",
+      "freeOfTotal": "{{free}} livre · {{total}}",
+      "audioDevices": "Dispositivos de áudio",
+      "sourceCached": "Origem: {{source}} · snapshot em cache",
+      "monitorOff": "Métricas ao vivo desativadas — ative o monitor da barra de status"
+    },
     "networkToolsTitle": "Ferramentas de rede",
     "networkToolsSummary": "Cálculo de sub-redes, DNS, testes de velocidade, varreduras de ping e WHOIS em um widget com abas.",
     "networkToolsTab": {

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -570,6 +570,35 @@
       "designCapacity": "ความจุตามการออกแบบ",
       "fullCapacity": "ความจุเมื่อชาร์จเต็ม"
     },
+    "pcInfoTab": {
+      "summary": "สรุป",
+      "os": "OS",
+      "cpu": "CPU",
+      "memory": "หน่วยความจำ",
+      "motherboard": "บอร์ด",
+      "graphics": "GPU",
+      "storage": "ดิสก์",
+      "network": "เครือข่าย",
+      "audio": "เสียง",
+      "battery": "แบตเตอรี่"
+    },
+    "pcInfoLabel": {
+      "systemInventory": "ข้อมูลระบบ",
+      "cpuLoad": "โหลด CPU",
+      "liveLoad": "โหลดสด",
+      "liveThroughput": "ทรูพุตสด",
+      "inUse": "ใช้งานอยู่",
+      "daysUp": "วันทำงาน",
+      "maxGhz": "GHz สูงสุด",
+      "gbTotal": "GB ทั้งหมด",
+      "gbFree": "GB ว่าง",
+      "slotsPopulated": "สล็อตที่ใช้",
+      "typeSpeed": "ชนิด · ความเร็ว",
+      "freeOfTotal": "ว่าง {{free}} · {{total}}",
+      "audioDevices": "อุปกรณ์เสียง",
+      "sourceCached": "แหล่งที่มา: {{source}} · แคชสแนปช็อต",
+      "monitorOff": "ปิดเมตริกสด — เปิดการมอนิเตอร์แถบสถานะ"
+    },
     "networkToolsTitle": "เครื่องมือเครือข่าย",
     "networkToolsSummary": "คำนวณซับเน็ต, DNS, ทดสอบความเร็ว, กวาด ping และ WHOIS ในวิดเจ็ตแบบแท็บเดียว",
     "networkToolsTab": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -570,6 +570,35 @@
       "designCapacity": "Dung lượng thiết kế",
       "fullCapacity": "Dung lượng sạc đầy"
     },
+    "pcInfoTab": {
+      "summary": "Tóm tắt",
+      "os": "OS",
+      "cpu": "CPU",
+      "memory": "Bộ nhớ",
+      "motherboard": "Bo mạch",
+      "graphics": "GPU",
+      "storage": "Ổ đĩa",
+      "network": "Mạng",
+      "audio": "Âm thanh",
+      "battery": "Pin"
+    },
+    "pcInfoLabel": {
+      "systemInventory": "Thông tin hệ thống",
+      "cpuLoad": "Tải CPU",
+      "liveLoad": "Tải trực tiếp",
+      "liveThroughput": "Thông lượng trực tiếp",
+      "inUse": "Đang dùng",
+      "daysUp": "Số ngày hoạt động",
+      "maxGhz": "GHz tối đa",
+      "gbTotal": "GB tổng",
+      "gbFree": "GB trống",
+      "slotsPopulated": "Khe đã dùng",
+      "typeSpeed": "Loại · Tốc độ",
+      "freeOfTotal": "{{free}} trống · {{total}}",
+      "audioDevices": "Thiết bị âm thanh",
+      "sourceCached": "Nguồn: {{source}} · ảnh chụp đã lưu đệm",
+      "monitorOff": "Tắt số liệu trực tiếp — bật trình giám sát thanh trạng thái"
+    },
     "networkToolsTitle": "Công cụ mạng",
     "networkToolsSummary": "Tính subnet, DNS, kiểm tra tốc độ, quét ping và WHOIS trong một widget có tab.",
     "networkToolsTab": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -570,6 +570,35 @@
       "designCapacity": "设计容量",
       "fullCapacity": "满充电容量"
     },
+    "pcInfoTab": {
+      "summary": "概要",
+      "os": "系统",
+      "cpu": "CPU",
+      "memory": "内存",
+      "motherboard": "主板",
+      "graphics": "GPU",
+      "storage": "磁盘",
+      "network": "网络",
+      "audio": "音频",
+      "battery": "电池"
+    },
+    "pcInfoLabel": {
+      "systemInventory": "系统清单",
+      "cpuLoad": "CPU 负载",
+      "liveLoad": "实时负载",
+      "liveThroughput": "实时吞吐量",
+      "inUse": "已用",
+      "daysUp": "运行天数",
+      "maxGhz": "最大 GHz",
+      "gbTotal": "GB 总计",
+      "gbFree": "GB 可用",
+      "slotsPopulated": "已用插槽",
+      "typeSpeed": "类型 · 速度",
+      "freeOfTotal": "{{free}} 可用 · {{total}}",
+      "audioDevices": "音频设备",
+      "sourceCached": "来源：{{source}} · 已缓存快照",
+      "monitorOff": "实时指标已关闭 — 请启用状态栏监视器"
+    },
     "networkToolsTitle": "网络工具",
     "networkToolsSummary": "一个分页组件中包含子网计算、DNS、测速、ping 扫描和 WHOIS。",
     "networkToolsTab": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -570,6 +570,35 @@
       "designCapacity": "設計容量",
       "fullCapacity": "滿充電容量"
     },
+    "pcInfoTab": {
+      "summary": "概要",
+      "os": "系統",
+      "cpu": "CPU",
+      "memory": "記憶體",
+      "motherboard": "主機板",
+      "graphics": "GPU",
+      "storage": "磁碟",
+      "network": "網路",
+      "audio": "音訊",
+      "battery": "電池"
+    },
+    "pcInfoLabel": {
+      "systemInventory": "系統清單",
+      "cpuLoad": "CPU 負載",
+      "liveLoad": "即時負載",
+      "liveThroughput": "即時吞吐量",
+      "inUse": "已用",
+      "daysUp": "運作天數",
+      "maxGhz": "最大 GHz",
+      "gbTotal": "GB 總計",
+      "gbFree": "GB 可用",
+      "slotsPopulated": "已用插槽",
+      "typeSpeed": "類型 · 速度",
+      "freeOfTotal": "{{free}} 可用 · {{total}}",
+      "audioDevices": "音訊裝置",
+      "sourceCached": "來源：{{source}} · 已快取快照",
+      "monitorOff": "即時指標已關閉 — 請啟用狀態列監視器"
+    },
     "networkToolsTitle": "網路工具",
     "networkToolsSummary": "在單一分頁小工具中提供子網路計算、DNS、測速、ping 掃描和 WHOIS。",
     "networkToolsTab": {

--- a/src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx
+++ b/src/modules/dashboard/widgets/builtin/pc-info/PcInfoWidget.tsx
@@ -1,4 +1,4 @@
-import { RefreshCw } from "lucide-react";
+import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { isTauriRuntime } from "../../../../../lib/tauri";
@@ -7,15 +7,16 @@ import { useWidgetConfig } from "../../widgetLocalStorage";
 import {
   formatBitsPerSecond,
   formatBytes,
-  formatDate,
-  formatDateTime,
   formatMhz,
-  formatPercent,
   formatUptime,
+  gigabytes,
   orDash,
+  ringGeometry,
+  sparklinePoints,
 } from "./format";
 import { usePcInfoStore, usePcInfoSubscription } from "./store";
 import type { PcInfoSnapshot } from "./types";
+import { useHostUsageHistory, type HostUsageHistory } from "./useHostUsageHistory";
 
 const SECTIONS = [
   "summary",
@@ -35,6 +36,24 @@ interface PcInfoConfig {
   activeSection: SectionId;
 }
 
+// Lucide-style 24×24 icon path pairs, one per tab. Ported from the reference
+// design so the tab bar reads at a glance.
+const TAB_ICONS: Record<SectionId, [string, string]> = {
+  summary: ["M4 5h16v11H4z", "M9 20h6M12 16v4"],
+  os: ["M12 4a8 8 0 1 0 0 16 8 8 0 0 0 0-16z", "M12 9a3 3 0 1 0 0 6 3 3 0 0 0 0-6z"],
+  cpu: ["M7 7h10v10H7z", "M10 3v4M14 3v4M10 17v4M14 17v4M3 10h4M3 14h4M17 10h4M17 14h4"],
+  memory: ["M3 8h18v8H3z", "M7 16v3M11 16v3M15 16v3M19 16v3"],
+  motherboard: ["M4 4h16v16H4z", "M8 4v4h4M16 8h-4v4h4M8 12H4M12 16v4"],
+  graphics: ["M3 6h18v9H3z", "M9.5 10.5a2.5 2.5 0 1 0 5 0 2.5 2.5 0 0 0-5 0M6 15v4M18 15v4"],
+  storage: ["M4 5h16v6H4zM4 13h16v6H4z", "M7 8h.01M7 16h.01"],
+  network: [
+    "M6 5a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM18 15a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM6 15a2 2 0 1 0 0 4 2 2 0 0 0 0-4z",
+    "M8 7h6a2 2 0 0 1 2 2v6M7 13v2",
+  ],
+  audio: ["M5 9v6h4l5 4V5L9 9H5z", "M17 9a4 4 0 0 1 0 6"],
+  battery: ["M3 8h15v8H3z", "M21 11v2"],
+};
+
 function normalizeConfig(value: unknown): PcInfoConfig {
   const fallback: PcInfoConfig = { activeSection: "summary" };
   if (!value || typeof value !== "object") return fallback;
@@ -42,6 +61,44 @@ function normalizeConfig(value: unknown): PcInfoConfig {
   return SECTIONS.includes(candidate.activeSection as SectionId)
     ? { activeSection: candidate.activeSection as SectionId }
     : fallback;
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+const ease = (p: number): number => 1 - Math.pow(1 - p, 3);
+
+/**
+ * Eased 0→1 progress that replays whenever `key` changes (section switch or
+ * refresh), driving ring fills and count-ups. Honors reduced-motion by snapping
+ * straight to 1.
+ */
+function useEnterProgress(key: string | number, durationMs = 900): number {
+  const [progress, setProgress] = useState(prefersReducedMotion() ? 1 : 0);
+  useEffect(() => {
+    if (prefersReducedMotion()) {
+      setProgress(1);
+      return;
+    }
+    let raf = 0;
+    const start = performance.now();
+    setProgress(0);
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - start) / durationMs);
+      setProgress(t);
+      if (t < 1) {
+        raf = requestAnimationFrame(tick);
+      }
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [key, durationMs]);
+  return progress;
 }
 
 export function PcInfoBody({ instance }: BuiltInWidgetBodyProps) {
@@ -52,6 +109,7 @@ export function PcInfoBody({ instance }: BuiltInWidgetBodyProps) {
   const refreshing = usePcInfoStore((s) => s.refreshing);
   const error = usePcInfoStore((s) => s.error);
   const refresh = usePcInfoStore((s) => s.refresh);
+  const usage = useHostUsageHistory();
   const [config, setConfig] = useWidgetConfig(
     `kkterm.dashboard.pcInfo.${instance.id}.v1`,
     { activeSection: "summary" as SectionId },
@@ -71,27 +129,100 @@ export function PcInfoBody({ instance }: BuiltInWidgetBodyProps) {
     ? config.activeSection
     : "summary";
 
+  const stamp = snapshot
+    ? new Date(snapshot.generatedAtUnixSeconds * 1000).toLocaleTimeString([], {
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : "";
+
   return (
     <div className="dw-pcinfo">
-      <div className="dw-pcinfo-tabs" role="tablist" aria-label={t("dashboard.pcInfoTitle")}>
-        {visibleSections.map((section) => (
-          <button
-            key={section}
-            type="button"
-            role="tab"
-            aria-selected={section === activeSection}
-            className={`dw-pcinfo-tab${section === activeSection ? " is-active" : ""}`}
-            onClick={() => setConfig({ activeSection: section })}
+      <div className="dw-pcinfo-ambient dw-pcinfo-ambient-a" aria-hidden="true" />
+      <div className="dw-pcinfo-ambient dw-pcinfo-ambient-b" aria-hidden="true" />
+
+      <header className="dw-pcinfo-header">
+        <span className="dw-pcinfo-badge" aria-hidden="true">
+          &gt;_
+        </span>
+        <div className="dw-pcinfo-heading">
+          <span className="dw-pcinfo-eyebrow">{t("dashboard.pcInfoTitle")}</span>
+          <span className="dw-pcinfo-title">{t("dashboard.pcInfoLabel.systemInventory")}</span>
+        </div>
+        <div className="dw-pcinfo-headmeta">
+          <span className="dw-pcinfo-host">{orDash(snapshot?.os.hostname)}</span>
+          {snapshot ? (
+            <span className="dw-pcinfo-stamp">{t("dashboard.pcInfoUpdatedAt", { time: stamp })}</span>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          className="dw-pcinfo-refresh"
+          onClick={() => void refresh()}
+          disabled={busy}
+          title={t("common.refresh")}
+          aria-label={t("common.refresh")}
+        >
+          <svg
+            width="15"
+            height="15"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={busy ? "dw-pcinfo-spin" : undefined}
           >
-            {t(`dashboard.pcInfoSection.${section}`)}
-          </button>
-        ))}
+            <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+            <path d="M21 3v6h-6" />
+          </svg>
+        </button>
+      </header>
+
+      <div className="dw-pcinfo-tabs" role="tablist" aria-label={t("dashboard.pcInfoTitle")}>
+        {visibleSections.map((section) => {
+          const [p1, p2] = TAB_ICONS[section];
+          const isActive = section === activeSection;
+          return (
+            <button
+              key={section}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              className={`dw-pcinfo-tab${isActive ? " is-active" : ""}`}
+              onClick={() => setConfig({ activeSection: section })}
+              title={t(`dashboard.pcInfoTab.${section}`)}
+            >
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.7"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d={p1} />
+                {p2 ? <path d={p2} /> : null}
+              </svg>
+              <span className="dw-pcinfo-tab-label">{t(`dashboard.pcInfoTab.${section}`)}</span>
+            </button>
+          );
+        })}
       </div>
 
       <div className="dw-pcinfo-body">
         {error ? <div className="dw-pcinfo-error">{error}</div> : null}
         {snapshot ? (
-          <SectionView section={activeSection} snapshot={snapshot} />
+          <div
+            className="dw-pcinfo-enter"
+            key={`${activeSection}:${snapshot.generatedAtUnixSeconds}`}
+          >
+            <SectionView section={activeSection} snapshot={snapshot} usage={usage} />
+          </div>
         ) : (
           <div className="dw-pcinfo-empty">
             {loading ? t("dashboard.pcInfoLoading") : t("dashboard.pcInfoEmpty")}
@@ -99,67 +230,140 @@ export function PcInfoBody({ instance }: BuiltInWidgetBodyProps) {
         )}
       </div>
 
-      <div className="dw-pcinfo-footer">
-        <span className="dw-pcinfo-stamp">
-          {snapshot
-            ? t("dashboard.pcInfoUpdatedAt", {
-                time: new Date(snapshot.generatedAtUnixSeconds * 1000).toLocaleTimeString(),
-              })
-            : ""}
+      <footer className="dw-pcinfo-footer">
+        <span className="dw-pcinfo-foot-source">
+          {snapshot ? t("dashboard.pcInfoLabel.sourceCached", { source: snapshot.source }) : ""}
         </span>
-        <button
-          type="button"
-          className="secondary-button dw-pcinfo-refresh"
-          onClick={() => void refresh()}
-          disabled={busy}
-        >
-          <RefreshCw size={12} className={busy ? "dw-pcinfo-spin" : undefined} />
-          {t("common.refresh")}
-        </button>
-      </div>
+        <span className="dw-pcinfo-foot-arch">
+          {!usage.live ? (
+            <span className="dw-pcinfo-foot-hint">{t("dashboard.pcInfoLabel.monitorOff")}</span>
+          ) : null}
+          {orDash(snapshot?.os.architecture)}
+        </span>
+      </footer>
     </div>
   );
 }
 
-function SectionView({ section, snapshot }: { section: SectionId; snapshot: PcInfoSnapshot }) {
-  const { t } = useTranslation();
+function SectionView({
+  section,
+  snapshot,
+  usage,
+}: {
+  section: SectionId;
+  snapshot: PcInfoSnapshot;
+  usage: HostUsageHistory;
+}) {
+  const progress = useEnterProgress(section);
   switch (section) {
     case "summary":
-      return <SummarySection snapshot={snapshot} />;
+      return <SummarySection snapshot={snapshot} usage={usage} progress={progress} />;
     case "os":
-      return <OsSection snapshot={snapshot} />;
+      return <OsSection snapshot={snapshot} progress={progress} />;
     case "cpu":
-      return <CpuSection snapshot={snapshot} />;
+      return <CpuSection snapshot={snapshot} usage={usage} progress={progress} />;
     case "memory":
-      return <MemorySection snapshot={snapshot} />;
+      return <MemorySection snapshot={snapshot} usage={usage} progress={progress} />;
     case "motherboard":
       return <MotherboardSection snapshot={snapshot} />;
     case "graphics":
       return <GraphicsSection snapshot={snapshot} />;
     case "storage":
-      return <StorageSection snapshot={snapshot} />;
+      return <StorageSection snapshot={snapshot} progress={progress} />;
     case "network":
-      return <NetworkSection snapshot={snapshot} />;
+      return <NetworkSection snapshot={snapshot} usage={usage} />;
     case "audio":
       return <AudioSection snapshot={snapshot} />;
     case "battery":
-      return <BatterySection snapshot={snapshot} />;
+      return <BatterySection snapshot={snapshot} progress={progress} />;
     default:
-      return <div className="dw-pcinfo-empty">{t("dashboard.pcInfoEmpty")}</div>;
+      return null;
   }
 }
 
-function useBoolText() {
-  const { t } = useTranslation();
-  return (value: boolean | null | undefined): string =>
-    value === null || value === undefined
-      ? "—"
-      : value
-        ? t("dashboard.pcInfoYes")
-        : t("dashboard.pcInfoNo");
+// ── Shared building blocks ────────────────────────────────────────────────────
+
+function Ring({
+  size,
+  radius,
+  stroke,
+  color,
+  fraction,
+}: {
+  size: number;
+  radius: number;
+  stroke: number;
+  color: string;
+  fraction: number;
+}) {
+  const { circumference, offset } = ringGeometry(radius, fraction);
+  const center = size / 2;
+  return (
+    <svg viewBox={`0 0 ${size} ${size}`} width={size} height={size} className="dw-pcinfo-ring">
+      <circle cx={center} cy={center} r={radius} fill="none" stroke="var(--hairline)" strokeWidth={stroke} />
+      <circle
+        cx={center}
+        cy={center}
+        r={radius}
+        fill="none"
+        stroke={color}
+        strokeWidth={stroke}
+        strokeLinecap="round"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+      />
+    </svg>
+  );
 }
 
-function Row({ label, value }: { label: string; value: ReactNode }) {
+function Sparkline({
+  values,
+  max,
+  color,
+  fillId,
+}: {
+  values: number[];
+  max: number;
+  color: string;
+  fillId: string;
+}) {
+  const width = 240;
+  const height = 48;
+  const line = sparklinePoints(values, width, height, max);
+  const hasData = values.length >= 2;
+  const area = hasData ? `${line} ${width},${height} 0,${height}` : "";
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      width="100%"
+      height={height}
+      preserveAspectRatio="none"
+      className="dw-pcinfo-spark"
+    >
+      <defs>
+        <linearGradient id={fillId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={color} stopOpacity="0.32" />
+          <stop offset="100%" stopColor={color} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      {hasData ? <polygon points={area} fill={`url(#${fillId})`} /> : null}
+      {line ? (
+        <polyline
+          points={line}
+          fill="none"
+          stroke={color}
+          strokeWidth="1.8"
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+          opacity={hasData ? 1 : 0.4}
+        />
+      ) : null}
+    </svg>
+  );
+}
+
+function KeyRow({ label, value }: { label: string; value: ReactNode }) {
   return (
     <div className="dw-pcinfo-row">
       <span className="dw-pcinfo-label">{label}</span>
@@ -168,11 +372,20 @@ function Row({ label, value }: { label: string; value: ReactNode }) {
   );
 }
 
-function Group({ title, children }: { title: string; children: ReactNode }) {
+function Fact({ label, value }: { label: string; value: ReactNode }) {
   return (
-    <div className="dw-pcinfo-group">
-      <div className="dw-pcinfo-group-title">{title}</div>
-      {children}
+    <div className="dw-pcinfo-fact">
+      <span className="dw-pcinfo-fact-label">{label}</span>
+      <span className="dw-pcinfo-fact-value">{value}</span>
+    </div>
+  );
+}
+
+function Stat({ value, label, accent }: { value: ReactNode; label: string; accent?: boolean }) {
+  return (
+    <div className="dw-pcinfo-stat">
+      <span className={`dw-pcinfo-stat-value${accent ? " is-accent" : ""}`}>{value}</span>
+      <span className="dw-pcinfo-stat-label">{label}</span>
     </div>
   );
 }
@@ -182,204 +395,386 @@ function EmptyHint() {
   return <div className="dw-pcinfo-section-empty">{t("dashboard.pcInfoSectionEmpty")}</div>;
 }
 
-function SummarySection({ snapshot }: { snapshot: PcInfoSnapshot }) {
+function pct(value: number | null | undefined): number {
+  return value === null || value === undefined || !Number.isFinite(value) ? 0 : value;
+}
+
+// ── Sections ──────────────────────────────────────────────────────────────────
+
+function SummarySection({
+  snapshot,
+  usage,
+  progress,
+}: {
+  snapshot: PcInfoSnapshot;
+  usage: HostUsageHistory;
+  progress: number;
+}) {
   const { t } = useTranslation();
+  const ep = ease(progress);
   const gpu = snapshot.graphics[0];
+  const memUsed = usage.live ? usage.ramPercent : snapshot.memory.usedPercent;
+  const cpuLoad = usage.cpuPercent;
   return (
     <div className="dw-pcinfo-section">
-      <Row label={t("dashboard.pcInfoField.os")} value={orDash(snapshot.os.name)} />
-      <Row label={t("dashboard.pcInfoField.hostname")} value={orDash(snapshot.os.hostname)} />
-      <Row label={t("dashboard.pcInfoField.cpu")} value={orDash(snapshot.cpu.name)} />
-      <Row label={t("dashboard.pcInfoField.ram")} value={formatBytes(snapshot.memory.totalBytes)} />
-      <Row label={t("dashboard.pcInfoField.gpu")} value={orDash(gpu?.name)} />
-      <Row
-        label={t("dashboard.pcInfoField.motherboard")}
-        value={orDash(snapshot.motherboard.product)}
-      />
-      <Row label={t("dashboard.pcInfoField.uptime")} value={formatUptime(snapshot.os.uptimeSeconds)} />
+      <div className="dw-pcinfo-hero">
+        <div className="dw-pcinfo-illu" aria-hidden="true">
+          <div className="dw-pcinfo-breathe" />
+          <svg viewBox="0 0 132 132" className="dw-pcinfo-illu-svg">
+            <rect x="40" y="30" width="52" height="74" rx="9" fill="var(--surface-muted)" stroke="var(--border-strong)" strokeWidth="1.5" />
+            <rect x="48" y="40" width="36" height="5" rx="2.5" fill="var(--accent)" opacity="0.85" />
+            <rect x="48" y="50" width="36" height="3" rx="1.5" fill="var(--text-faint)" opacity="0.5" />
+            <circle cx="51" cy="92" r="3" fill="var(--green)" />
+            <circle cx="51" cy="92" r="6" fill="none" stroke="var(--green)" strokeWidth="1.2" opacity="0.5" />
+            <g stroke="var(--text-faint)" strokeWidth="1.4" strokeLinecap="round" opacity="0.55">
+              <path d="M62 88h22" />
+              <path d="M62 93h22" />
+              <path d="M62 98h22" />
+            </g>
+            <circle cx="66" cy="66" r="58" fill="none" stroke="color-mix(in srgb, var(--accent) 30%, transparent)" strokeWidth="1" strokeDasharray="3 6" opacity="0.6" />
+          </svg>
+        </div>
+        <div className="dw-pcinfo-hero-main">
+          <div className="dw-pcinfo-gauges">
+            <div className="dw-pcinfo-gauge">
+              <div className="dw-pcinfo-gauge-ring">
+                <Ring size={58} radius={24} stroke={5} color="var(--accent)" fraction={(pct(cpuLoad) / 100) * ep} />
+                <span className="dw-pcinfo-gauge-text">
+                  {usage.live && cpuLoad !== undefined ? `${Math.round(cpuLoad * ep)}%` : "—"}
+                </span>
+              </div>
+              <span className="dw-pcinfo-gauge-label">{t("dashboard.pcInfoLabel.cpuLoad")}</span>
+            </div>
+            <div className="dw-pcinfo-gauge">
+              <div className="dw-pcinfo-gauge-ring">
+                <Ring size={58} radius={24} stroke={5} color="var(--green)" fraction={(pct(memUsed) / 100) * ep} />
+                <span className="dw-pcinfo-gauge-text">
+                  {memUsed !== undefined && memUsed !== null ? `${Math.round(memUsed * ep)}%` : "—"}
+                </span>
+              </div>
+              <span className="dw-pcinfo-gauge-label">{t("dashboard.pcInfoSection.memory")}</span>
+            </div>
+          </div>
+          <Sparkline values={usage.cpuHistory} max={100} color="var(--accent)" fillId="dw-pcinfo-sum-fill" />
+        </div>
+      </div>
+      <div className="dw-pcinfo-facts">
+        <Fact label={t("dashboard.pcInfoField.os")} value={orDash(snapshot.os.name)} />
+        <Fact label={t("dashboard.pcInfoField.cpu")} value={orDash(snapshot.cpu.name)} />
+        <Fact label={t("dashboard.pcInfoField.gpu")} value={orDash(gpu?.name)} />
+        <Fact
+          label={t("dashboard.pcInfoSection.memory")}
+          value={<span className="dw-pcinfo-mono">{formatBytes(snapshot.memory.totalBytes)}</span>}
+        />
+        <Fact label={t("dashboard.pcInfoField.motherboard")} value={orDash(snapshot.motherboard.product)} />
+        <Fact
+          label={t("dashboard.pcInfoField.uptime")}
+          value={<span className="dw-pcinfo-mono">{formatUptime(snapshot.os.uptimeSeconds)}</span>}
+        />
+      </div>
     </div>
   );
 }
 
-function OsSection({ snapshot }: { snapshot: PcInfoSnapshot }) {
+function OsSection({ snapshot, progress }: { snapshot: PcInfoSnapshot; progress: number }) {
   const { t } = useTranslation();
+  const ep = ease(progress);
   const { os } = snapshot;
+  const uptime = os.uptimeSeconds ?? 0;
+  const days = Math.floor(uptime / 86_400);
+  const hours = Math.floor((uptime % 86_400) / 3_600);
+  const minutes = Math.floor((uptime % 3_600) / 60);
+  // Fill the ring as a fraction of a week, matching the reference's cadence.
+  const fraction = (uptime / 86_400 / 7) * ep;
+  const rows: Array<[string, ReactNode]> = [
+    [t("dashboard.pcInfoField.version"), orDash(os.version)],
+    [t("dashboard.pcInfoField.build"), orDash(os.build)],
+    [t("dashboard.pcInfoField.hostname"), orDash(os.hostname)],
+    [t("dashboard.pcInfoField.loggedInUser"), orDash(os.loggedInUser)],
+    [t("dashboard.pcInfoField.locale"), orDash(os.locale)],
+    [t("dashboard.pcInfoField.architecture"), orDash(os.architecture)],
+  ];
   return (
-    <div className="dw-pcinfo-section">
-      <Row label={t("dashboard.pcInfoField.name")} value={orDash(os.name)} />
-      <Row label={t("dashboard.pcInfoField.version")} value={orDash(os.version)} />
-      <Row label={t("dashboard.pcInfoField.build")} value={orDash(os.build)} />
-      <Row label={t("dashboard.pcInfoField.architecture")} value={orDash(os.architecture)} />
-      <Row label={t("dashboard.pcInfoField.hostname")} value={orDash(os.hostname)} />
-      <Row label={t("dashboard.pcInfoField.loggedInUser")} value={orDash(os.loggedInUser)} />
-      <Row label={t("dashboard.pcInfoField.registeredUser")} value={orDash(os.registeredUser)} />
-      <Row label={t("dashboard.pcInfoField.locale")} value={orDash(os.locale)} />
-      <Row label={t("dashboard.pcInfoField.timeZone")} value={orDash(os.timeZone)} />
-      <Row label={t("dashboard.pcInfoField.systemDrive")} value={orDash(os.systemDrive)} />
-      <Row label={t("dashboard.pcInfoField.productId")} value={orDash(os.productId)} />
-      <Row
-        label={t("dashboard.pcInfoField.installDate")}
-        value={formatDate(os.installDateUnixSeconds)}
-      />
-      <Row
-        label={t("dashboard.pcInfoField.lastBoot")}
-        value={formatDateTime(os.lastBootUnixSeconds)}
-      />
-      <Row label={t("dashboard.pcInfoField.uptime")} value={formatUptime(os.uptimeSeconds)} />
+    <div className="dw-pcinfo-section dw-pcinfo-split">
+      <div className="dw-pcinfo-bigring">
+        <Ring size={128} radius={52} stroke={8} color="var(--accent)" fraction={fraction} />
+        <div className="dw-pcinfo-bigring-center">
+          <span className="dw-pcinfo-bigring-value">{Math.round(days * ep)}</span>
+          <span className="dw-pcinfo-bigring-unit">{t("dashboard.pcInfoLabel.daysUp")}</span>
+          <span className="dw-pcinfo-bigring-sub">
+            {String(hours).padStart(2, "0")}:{String(minutes).padStart(2, "0")}h
+          </span>
+        </div>
+      </div>
+      <div className="dw-pcinfo-rows">
+        {rows.map(([label, value]) => (
+          <KeyRow key={label} label={label} value={value} />
+        ))}
+      </div>
     </div>
   );
 }
 
-function CpuSection({ snapshot }: { snapshot: PcInfoSnapshot }) {
+function CpuSection({
+  snapshot,
+  usage,
+  progress,
+}: {
+  snapshot: PcInfoSnapshot;
+  usage: HostUsageHistory;
+  progress: number;
+}) {
   const { t } = useTranslation();
-  const boolText = useBoolText();
+  const ep = ease(progress);
   const { cpu } = snapshot;
-  const cores =
-    cpu.enabledCores && cpu.physicalCores && cpu.enabledCores !== cpu.physicalCores
-      ? `${cpu.enabledCores} / ${cpu.physicalCores}`
-      : cpu.physicalCores
-        ? String(cpu.physicalCores)
-        : "—";
+  const coreCount = cpu.physicalCores ?? 0;
+  const cells = Math.min(16, Math.max(coreCount, 0));
+  const cores = Array.from({ length: 16 }, (_, i) => i);
+  const maxGhz = cpu.maxClockMhz ? cpu.maxClockMhz / 1000 : null;
+  const cpuLoad = usage.cpuPercent;
   return (
     <div className="dw-pcinfo-section">
-      <Row label={t("dashboard.pcInfoField.name")} value={orDash(cpu.name)} />
-      <Row label={t("dashboard.pcInfoField.vendor")} value={orDash(cpu.vendor)} />
-      <Row label={t("dashboard.pcInfoField.family")} value={orDash(cpu.family)} />
-      <Row label={t("dashboard.pcInfoField.cores")} value={cores} />
-      <Row
-        label={t("dashboard.pcInfoField.threads")}
-        value={cpu.logicalProcessors ? String(cpu.logicalProcessors) : "—"}
-      />
-      <Row label={t("dashboard.pcInfoField.maxClock")} value={formatMhz(cpu.maxClockMhz)} />
-      <Row label={t("dashboard.pcInfoField.currentClock")} value={formatMhz(cpu.currentClockMhz)} />
-      <Row label={t("dashboard.pcInfoField.l1Cache")} value={formatBytes(cpu.l1CacheBytes)} />
-      <Row label={t("dashboard.pcInfoField.l2Cache")} value={formatBytes(cpu.l2CacheBytes)} />
-      <Row label={t("dashboard.pcInfoField.l3Cache")} value={formatBytes(cpu.l3CacheBytes)} />
-      <Row label={t("dashboard.pcInfoField.socket")} value={orDash(cpu.socket)} />
-      <Row
-        label={t("dashboard.pcInfoField.virtualization")}
-        value={boolText(cpu.virtualizationEnabled)}
-      />
-      <Row
-        label={t("dashboard.pcInfoField.addressWidth")}
-        value={cpu.addressWidthBits ? `${cpu.addressWidthBits}-bit` : "—"}
-      />
+      <div className="dw-pcinfo-hero">
+        <div className="dw-pcinfo-illu dw-pcinfo-illu-cpu" aria-hidden="true">
+          <div className="dw-pcinfo-breathe dw-pcinfo-breathe-cpu" />
+          <svg viewBox="0 0 116 116" className="dw-pcinfo-illu-svg">
+            <rect x="30" y="30" width="56" height="56" rx="8" fill="var(--surface-muted)" stroke="var(--border-strong)" strokeWidth="1.5" />
+            <g>
+              {cores.map((i) => {
+                const row = Math.floor(i / 4);
+                const col = i % 4;
+                const lit = i < cells;
+                return (
+                  <rect
+                    key={i}
+                    x={35 + col * 12.5}
+                    y={35 + row * 12.5}
+                    width="9"
+                    height="9"
+                    rx="2"
+                    fill={lit ? (i % 5 === 2 ? "var(--accent)" : "var(--green)") : "var(--hairline)"}
+                    className={lit ? "dw-pcinfo-core" : undefined}
+                    style={lit ? { animationDelay: `${(i * 0.09).toFixed(2)}s` } : undefined}
+                  />
+                );
+              })}
+            </g>
+            <g stroke="var(--text-faint)" strokeWidth="1.4" strokeLinecap="round" opacity="0.65">
+              <path d="M40 30v-8M52 30v-8M64 30v-8M76 30v-8M40 86v8M52 86v8M64 86v8M76 86v8M30 40h-8M30 52h-8M30 64h-8M30 76h-8M86 40h8M86 52h8M86 64h8M86 76h8" />
+            </g>
+          </svg>
+        </div>
+        <div className="dw-pcinfo-hero-main">
+          <div className="dw-pcinfo-title-lg">{orDash(cpu.name)}</div>
+          <div className="dw-pcinfo-subtle">
+            {orDash(cpu.vendor)} · {orDash(cpu.socket)}
+          </div>
+          <div className="dw-pcinfo-stats">
+            <Stat value={cpu.physicalCores ? Math.round(cpu.physicalCores * ep) : "—"} label={t("dashboard.pcInfoField.cores")} />
+            <Stat value={cpu.logicalProcessors ? Math.round(cpu.logicalProcessors * ep) : "—"} label={t("dashboard.pcInfoField.threads")} />
+            <Stat value={maxGhz ? (maxGhz * ep).toFixed(1) : "—"} label={t("dashboard.pcInfoLabel.maxGhz")} accent />
+          </div>
+        </div>
+      </div>
+      <div className="dw-pcinfo-panel">
+        <div className="dw-pcinfo-panel-head">
+          <span className="dw-pcinfo-panel-title">{t("dashboard.pcInfoLabel.liveLoad")}</span>
+          <span className="dw-pcinfo-panel-metric">
+            {usage.live && cpuLoad !== undefined ? `${Math.round(cpuLoad)}%` : "—"}
+          </span>
+        </div>
+        <Sparkline values={usage.cpuHistory} max={100} color="var(--accent)" fillId="dw-pcinfo-cpu-fill" />
+        <div className="dw-pcinfo-panel-foot">
+          <span>L2 {formatBytes(cpu.l2CacheBytes)}</span>
+          <span>L3 {formatBytes(cpu.l3CacheBytes)}</span>
+          <span>{cpu.addressWidthBits ? `${cpu.addressWidthBits}-bit` : "—"}</span>
+        </div>
+      </div>
     </div>
   );
 }
 
-function MemorySection({ snapshot }: { snapshot: PcInfoSnapshot }) {
+function MemorySection({
+  snapshot,
+  usage,
+  progress,
+}: {
+  snapshot: PcInfoSnapshot;
+  usage: HostUsageHistory;
+  progress: number;
+}) {
   const { t } = useTranslation();
+  const ep = ease(progress);
   const { memory } = snapshot;
+  const used = usage.live ? usage.ramPercent : memory.usedPercent;
+  const totalGb = gigabytes(memory.totalBytes);
+  const freeGb = gigabytes(memory.availableBytes);
+  const sticks = memory.modules.length > 0 ? memory.modules : [];
+  const firstModule = memory.modules[0];
+  const spec =
+    firstModule?.memoryType || firstModule?.speedMhz
+      ? `${orDash(firstModule?.memoryType)} · ${formatMhz(firstModule?.speedMhz)}`
+      : "—";
+  const slots = memory.slotsTotal
+    ? t("dashboard.pcInfoSlotsValue", {
+        used: memory.slotsUsed ?? memory.modules.length,
+        total: memory.slotsTotal,
+      })
+    : memory.slotsUsed
+      ? String(memory.slotsUsed)
+      : "—";
   return (
     <div className="dw-pcinfo-section">
-      <Row label={t("dashboard.pcInfoField.total")} value={formatBytes(memory.totalBytes)} />
-      <Row label={t("dashboard.pcInfoField.available")} value={formatBytes(memory.availableBytes)} />
-      <Row label={t("dashboard.pcInfoField.used")} value={formatPercent(memory.usedPercent)} />
-      <Row
-        label={t("dashboard.pcInfoField.slots")}
-        value={
-          memory.slotsTotal
-            ? t("dashboard.pcInfoSlotsValue", {
-                used: memory.slotsUsed ?? memory.modules.length,
-                total: memory.slotsTotal,
-              })
-            : memory.slotsUsed
-              ? String(memory.slotsUsed)
-              : "—"
-        }
-      />
-      <Row
-        label={t("dashboard.pcInfoField.maxCapacity")}
-        value={formatBytes(memory.maxCapacityBytes)}
-      />
-      {memory.modules.length > 0 ? (
-        memory.modules.map((module, index) => (
-          <Group
-            key={module.slot ?? index}
-            title={orDash(module.slot) === "—" ? `#${index + 1}` : orDash(module.slot)}
-          >
-            <Row
-              label={t("dashboard.pcInfoField.capacity")}
-              value={formatBytes(module.capacityBytes)}
-            />
-            <Row label={t("dashboard.pcInfoField.speed")} value={formatMhz(module.speedMhz)} />
-            <Row label={t("dashboard.pcInfoField.type")} value={orDash(module.memoryType)} />
-            <Row label={t("dashboard.pcInfoField.formFactor")} value={orDash(module.formFactor)} />
-            <Row label={t("dashboard.pcInfoField.bank")} value={orDash(module.bank)} />
-            <Row
-              label={t("dashboard.pcInfoField.voltage")}
-              value={module.voltageMillivolts ? `${module.voltageMillivolts} mV` : "—"}
-            />
-            <Row
-              label={t("dashboard.pcInfoField.manufacturer")}
-              value={orDash(module.manufacturer)}
-            />
-            <Row label={t("dashboard.pcInfoField.partNumber")} value={orDash(module.partNumber)} />
-          </Group>
-        ))
-      ) : (
-        <EmptyHint />
-      )}
+      <div className="dw-pcinfo-hero">
+        <div className="dw-pcinfo-bigring dw-pcinfo-bigring-sm">
+          <Ring size={116} radius={46} stroke={9} color="var(--green)" fraction={(pct(used) / 100) * ep} />
+          <div className="dw-pcinfo-bigring-center">
+            <span className="dw-pcinfo-bigring-value">
+              {used !== undefined && used !== null ? `${Math.round(used * ep)}%` : "—"}
+            </span>
+            <span className="dw-pcinfo-bigring-unit">{t("dashboard.pcInfoLabel.inUse")}</span>
+          </div>
+        </div>
+        <div className="dw-pcinfo-hero-main">
+          <div className="dw-pcinfo-stats">
+            <Stat value={totalGb !== null ? Math.round(totalGb * ep) : "—"} label={t("dashboard.pcInfoLabel.gbTotal")} />
+            <Stat value={freeGb !== null ? Math.round(freeGb * ep) : "—"} label={t("dashboard.pcInfoLabel.gbFree")} accent />
+          </div>
+          {sticks.length > 0 ? (
+            <div className="dw-pcinfo-sticks">
+              {sticks.map((module, index) => (
+                <div className="dw-pcinfo-stick" key={module.slot ?? index}>
+                  <div className="dw-pcinfo-stick-body">
+                    <div className="dw-pcinfo-stick-fill" style={{ height: `${Math.round(ep * 100)}%` }} />
+                    <div className="dw-pcinfo-stick-pins">
+                      <span />
+                      <span />
+                      <span />
+                    </div>
+                  </div>
+                  <span className="dw-pcinfo-stick-cap">{formatBytes(module.capacityBytes)}</span>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+      <div className="dw-pcinfo-rows">
+        <KeyRow label={t("dashboard.pcInfoLabel.typeSpeed")} value={<span className="dw-pcinfo-mono">{spec}</span>} />
+        <KeyRow
+          label={t("dashboard.pcInfoField.manufacturer")}
+          value={<span className="dw-pcinfo-mono">{orDash(firstModule?.manufacturer)}</span>}
+        />
+        <KeyRow label={t("dashboard.pcInfoLabel.slotsPopulated")} value={<span className="dw-pcinfo-mono">{slots}</span>} />
+      </div>
     </div>
   );
 }
 
 function MotherboardSection({ snapshot }: { snapshot: PcInfoSnapshot }) {
   const { t } = useTranslation();
-  const { motherboard } = snapshot;
+  const { motherboard: mb } = snapshot;
+  const rows: Array<[string, ReactNode]> = [
+    [t("dashboard.pcInfoField.manufacturer"), orDash(mb.manufacturer)],
+    [t("dashboard.pcInfoField.product"), orDash(mb.product)],
+    [t("dashboard.pcInfoField.version"), orDash(mb.version)],
+    [
+      t("dashboard.pcInfoField.bios"),
+      mb.biosVendor || mb.biosVersion ? `${orDash(mb.biosVendor)} ${orDash(mb.biosVersion)}`.trim() : "—",
+    ],
+    [t("dashboard.pcInfoField.date"), orDash(mb.biosDate)],
+    [t("dashboard.pcInfoField.serialNumber"), orDash(mb.serialNumber)],
+  ];
   return (
-    <div className="dw-pcinfo-section">
-      <Row
-        label={t("dashboard.pcInfoField.manufacturer")}
-        value={orDash(motherboard.manufacturer)}
-      />
-      <Row label={t("dashboard.pcInfoField.product")} value={orDash(motherboard.product)} />
-      <Row label={t("dashboard.pcInfoField.version")} value={orDash(motherboard.version)} />
-      <Row label={t("dashboard.pcInfoField.serialNumber")} value={orDash(motherboard.serialNumber)} />
-      <Row label={t("dashboard.pcInfoField.systemType")} value={orDash(motherboard.systemType)} />
-      <Row label={t("dashboard.pcInfoField.chassis")} value={orDash(motherboard.chassisType)} />
-      <Row label={t("dashboard.pcInfoField.systemSku")} value={orDash(motherboard.systemSku)} />
-      <Row label={t("dashboard.pcInfoField.systemUuid")} value={orDash(motherboard.systemUuid)} />
-      <Group title={t("dashboard.pcInfoField.bios")}>
-        <Row label={t("dashboard.pcInfoField.vendor")} value={orDash(motherboard.biosVendor)} />
-        <Row label={t("dashboard.pcInfoField.version")} value={orDash(motherboard.biosVersion)} />
-        <Row label={t("dashboard.pcInfoField.date")} value={orDash(motherboard.biosDate)} />
-      </Group>
+    <div className="dw-pcinfo-section dw-pcinfo-split">
+      <div className="dw-pcinfo-illu dw-pcinfo-illu-board" aria-hidden="true">
+        <svg viewBox="0 0 134 128" className="dw-pcinfo-illu-svg">
+          <rect x="6" y="6" width="122" height="116" rx="10" fill="var(--surface-muted)" stroke="var(--border-strong)" strokeWidth="1.5" />
+          <rect x="20" y="20" width="40" height="40" rx="5" fill="none" stroke="var(--accent)" strokeWidth="1.6" />
+          <rect x="29" y="29" width="22" height="22" rx="3" fill="color-mix(in srgb, var(--accent) 22%, transparent)" stroke="var(--accent)" strokeWidth="1.2" />
+          <g fill="none" stroke="var(--text-faint)" strokeWidth="1.4">
+            <rect x="74" y="18" width="48" height="5" rx="2" />
+            <rect x="74" y="26" width="48" height="5" rx="2" />
+            <rect x="74" y="34" width="48" height="5" rx="2" />
+            <rect x="74" y="42" width="48" height="5" rx="2" />
+          </g>
+          <rect x="92" y="92" width="26" height="20" rx="3" fill="var(--surface)" stroke="var(--border-strong)" strokeWidth="1.3" />
+          <text x="105" y="105" fontSize="7" fill="var(--text-muted)" textAnchor="middle">
+            BIOS
+          </text>
+          <rect x="18" y="100" width="56" height="6" rx="2" fill="none" stroke="var(--text-faint)" strokeWidth="1.4" />
+          <g fill="none" stroke="var(--accent)" strokeWidth="1.5" strokeLinecap="round" strokeDasharray="6 5" opacity="0.75" className="dw-pcinfo-trace">
+            <path d="M60 40h10M70 40v34h-8M40 60v30M40 90h-22" />
+          </g>
+        </svg>
+      </div>
+      <div className="dw-pcinfo-rows">
+        {rows.map(([label, value]) => (
+          <KeyRow key={label} label={label} value={value} />
+        ))}
+      </div>
     </div>
   );
 }
 
 function GraphicsSection({ snapshot }: { snapshot: PcInfoSnapshot }) {
   const { t } = useTranslation();
+  const gpu = snapshot.graphics[0];
+  if (!gpu && snapshot.displays.length === 0) {
+    return (
+      <div className="dw-pcinfo-section">
+        <EmptyHint />
+      </div>
+    );
+  }
   return (
     <div className="dw-pcinfo-section">
-      {snapshot.graphics.length > 0 ? (
-        snapshot.graphics.map((gpu, index) => (
-          <Group key={gpu.name ?? index} title={orDash(gpu.name)}>
-            <Row label={t("dashboard.pcInfoField.vendor")} value={orDash(gpu.vendor)} />
-            <Row label={t("dashboard.pcInfoField.chip")} value={orDash(gpu.chip)} />
-            <Row label={t("dashboard.pcInfoField.vram")} value={formatBytes(gpu.vramBytes)} />
-            <Row label={t("dashboard.pcInfoField.driver")} value={orDash(gpu.driverVersion)} />
-            <Row label={t("dashboard.pcInfoField.driverDate")} value={orDash(gpu.driverDate)} />
-            <Row label={t("dashboard.pcInfoField.mode")} value={orDash(gpu.currentMode)} />
-          </Group>
-        ))
-      ) : (
-        <EmptyHint />
-      )}
+      <div className="dw-pcinfo-hero">
+        <div className="dw-pcinfo-illu dw-pcinfo-illu-gpu" aria-hidden="true">
+          <svg viewBox="0 0 130 100" className="dw-pcinfo-illu-svg">
+            <rect x="8" y="20" width="114" height="56" rx="8" fill="var(--surface-muted)" stroke="var(--border-strong)" strokeWidth="1.5" />
+            <rect x="8" y="76" width="14" height="14" rx="2" fill="var(--surface-muted)" stroke="var(--border-strong)" strokeWidth="1.3" />
+            <rect x="40" y="76" width="14" height="14" rx="2" fill="var(--surface-muted)" stroke="var(--border-strong)" strokeWidth="1.3" />
+            <g className="dw-pcinfo-fan" style={{ transformOrigin: "40px 48px" }}>
+              <circle cx="40" cy="48" r="17" fill="none" stroke="var(--border-strong)" strokeWidth="1.3" />
+              <path d="M40 48 L40 33 M40 48 L53 56 M40 48 L27 56" stroke="var(--accent)" strokeWidth="2.4" strokeLinecap="round" fill="none" />
+            </g>
+            <g className="dw-pcinfo-fan dw-pcinfo-fan-slow" style={{ transformOrigin: "90px 48px" }}>
+              <circle cx="90" cy="48" r="17" fill="none" stroke="var(--border-strong)" strokeWidth="1.3" />
+              <path d="M90 48 L90 33 M90 48 L103 56 M90 48 L77 56" stroke="var(--accent)" strokeWidth="2.4" strokeLinecap="round" fill="none" />
+            </g>
+          </svg>
+        </div>
+        <div className="dw-pcinfo-hero-main">
+          <div className="dw-pcinfo-title-lg">{orDash(gpu?.name)}</div>
+          <div className="dw-pcinfo-subtle">
+            {orDash(gpu?.vendor)}
+            {gpu?.driverVersion ? ` · ${t("dashboard.pcInfoField.driver")} ${gpu.driverVersion}` : ""}
+          </div>
+          <div className="dw-pcinfo-vram">
+            <span className="dw-pcinfo-vram-value">{formatBytes(gpu?.vramBytes)}</span>
+            <span className="dw-pcinfo-vram-label">{t("dashboard.pcInfoField.vram")}</span>
+          </div>
+        </div>
+      </div>
       {snapshot.displays.length > 0 ? (
-        <Group title={t("dashboard.pcInfoField.displays")}>
-          {snapshot.displays.map((display, index) => (
-            <Row
-              key={display.name ?? index}
-              label={`${display.manufacturer?.trim() ? `${display.manufacturer.trim()} ` : ""}${orDash(
-                display.name,
-              )}`}
-              value={describeDisplay(display)}
-            />
-          ))}
-        </Group>
+        <>
+          <div className="dw-pcinfo-panel-title dw-pcinfo-block-title">{t("dashboard.pcInfoField.displays")}</div>
+          <div className="dw-pcinfo-display-grid">
+            {snapshot.displays.map((display, index) => (
+              <div className="dw-pcinfo-display" key={display.name ?? index}>
+                <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <rect x="3" y="4" width="18" height="12" rx="2" />
+                  <path d="M9 20h6M12 16v4" />
+                </svg>
+                <div className="dw-pcinfo-display-text">
+                  <span className="dw-pcinfo-display-name">{orDash(display.name)}</span>
+                  <span className="dw-pcinfo-mono dw-pcinfo-display-sub">{describeDisplay(display)}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
       ) : null}
     </div>
   );
@@ -388,9 +783,7 @@ function GraphicsSection({ snapshot }: { snapshot: PcInfoSnapshot }) {
 function describeDisplay(display: PcInfoSnapshot["displays"][number]): string {
   const parts: string[] = [];
   if (display.resolution?.trim()) {
-    parts.push(
-      `${display.resolution.trim()}${display.refreshHz ? ` @ ${display.refreshHz} Hz` : ""}`,
-    );
+    parts.push(`${display.resolution.trim()}${display.refreshHz ? ` @ ${display.refreshHz} Hz` : ""}`);
   }
   if (display.sizeInches) {
     parts.push(`${display.sizeInches}"`);
@@ -401,151 +794,252 @@ function describeDisplay(display: PcInfoSnapshot["displays"][number]): string {
   return parts.length > 0 ? parts.join(" · ") : "—";
 }
 
-function StorageSection({ snapshot }: { snapshot: PcInfoSnapshot }) {
+function StorageSection({ snapshot, progress }: { snapshot: PcInfoSnapshot; progress: number }) {
   const { t } = useTranslation();
+  const ep = ease(progress);
+  if (snapshot.storage.length === 0 && snapshot.volumes.length === 0) {
+    return (
+      <div className="dw-pcinfo-section">
+        <EmptyHint />
+      </div>
+    );
+  }
+  const palette = ["var(--accent)", "var(--green)", "var(--amber)"];
   return (
     <div className="dw-pcinfo-section">
-      {snapshot.storage.length > 0 ? (
-        snapshot.storage.map((disk, index) => (
-          <Group key={disk.serialNumber ?? disk.model ?? index} title={orDash(disk.model)}>
-            <Row label={t("dashboard.pcInfoField.capacity")} value={formatBytes(disk.sizeBytes)} />
-            <Row label={t("dashboard.pcInfoField.type")} value={orDash(disk.mediaType)} />
-            <Row label={t("dashboard.pcInfoField.interface")} value={orDash(disk.interface)} />
-            <Row label={t("dashboard.pcInfoField.health")} value={orDash(disk.healthStatus)} />
-            <Row
-              label={t("dashboard.pcInfoField.rpm")}
-              value={disk.spindleSpeedRpm ? `${disk.spindleSpeedRpm} RPM` : "—"}
-            />
-            <Row label={t("dashboard.pcInfoField.serialNumber")} value={orDash(disk.serialNumber)} />
-          </Group>
-        ))
-      ) : (
-        <EmptyHint />
-      )}
       {snapshot.volumes.length > 0 ? (
-        <Group title={t("dashboard.pcInfoField.volumes")}>
-          {snapshot.volumes.map((volume, index) => (
-            <Row
-              key={volume.mount ?? index}
-              label={`${orDash(volume.mount)}${
-                volume.label?.trim() ? ` (${volume.label.trim()})` : ""
-              }`}
-              value={`${formatBytes(volume.freeBytes)} / ${formatBytes(volume.totalBytes)}${
-                volume.fileSystem?.trim() ? ` · ${volume.fileSystem.trim()}` : ""
-              }`}
-            />
+        <div className="dw-pcinfo-vol-grid">
+          {snapshot.volumes.map((volume, index) => {
+            const total = volume.totalBytes ?? 0;
+            const free = volume.freeBytes ?? 0;
+            const usedFrac = total > 0 ? (total - free) / total : 0;
+            const color = palette[index % palette.length];
+            return (
+              <div className="dw-pcinfo-vol" key={volume.mount ?? index}>
+                <div className="dw-pcinfo-vol-ring">
+                  <Ring size={84} radius={34} stroke={8} color={color} fraction={usedFrac * ep} />
+                  <div className="dw-pcinfo-vol-center">
+                    <span className="dw-pcinfo-vol-mount">{orDash(volume.mount)}</span>
+                    <span className="dw-pcinfo-mono dw-pcinfo-vol-pct">{Math.round(usedFrac * 100 * ep)}%</span>
+                  </div>
+                </div>
+                <span className="dw-pcinfo-vol-label">{orDash(volume.label)}</span>
+                <span className="dw-pcinfo-mono dw-pcinfo-vol-sub">
+                  {t("dashboard.pcInfoLabel.freeOfTotal", {
+                    free: formatBytes(volume.freeBytes),
+                    total: formatBytes(volume.totalBytes),
+                  })}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+      {snapshot.storage.length > 0 ? (
+        <div className="dw-pcinfo-drives">
+          {snapshot.storage.map((disk, index) => (
+            <div className="dw-pcinfo-drive" key={disk.serialNumber ?? disk.model ?? index}>
+              <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <rect x="3" y="4" width="18" height="7" rx="2" />
+                <rect x="3" y="13" width="18" height="7" rx="2" />
+                <path d="M7 7.5h.01M7 16.5h.01" />
+              </svg>
+              <div className="dw-pcinfo-drive-text">
+                <span className="dw-pcinfo-drive-name">{orDash(disk.model)}</span>
+                <span className="dw-pcinfo-drive-sub">
+                  {orDash(disk.mediaType)} · {orDash(disk.interface)}
+                </span>
+              </div>
+              <span className="dw-pcinfo-mono dw-pcinfo-drive-size">{formatBytes(disk.sizeBytes)}</span>
+            </div>
           ))}
-        </Group>
+        </div>
       ) : null}
     </div>
   );
 }
 
-function NetworkSection({ snapshot }: { snapshot: PcInfoSnapshot }) {
+function isWifi(adapter: PcInfoSnapshot["network"][number]): boolean {
+  const haystack = `${adapter.name ?? ""} ${adapter.adapterType ?? ""}`.toLowerCase();
+  return /wi-?fi|wireless|802\.11/.test(haystack);
+}
+
+function NetworkSection({
+  snapshot,
+  usage,
+}: {
+  snapshot: PcInfoSnapshot;
+  usage: HostUsageHistory;
+}) {
   const { t } = useTranslation();
-  const boolText = useBoolText();
-  return (
-    <div className="dw-pcinfo-section">
-      {snapshot.network.length > 0 ? (
-        snapshot.network.map((adapter, index) => (
-          <Group key={adapter.macAddress ?? adapter.name ?? index} title={orDash(adapter.name)}>
-            <Row
-              label={t("dashboard.pcInfoField.status")}
-              value={boolText(adapter.connected)}
-            />
-            <Row label={t("dashboard.pcInfoField.macAddress")} value={orDash(adapter.macAddress)} />
-            <Row label={t("dashboard.pcInfoField.adapterType")} value={orDash(adapter.adapterType)} />
-            <Row
-              label={t("dashboard.pcInfoField.linkSpeed")}
-              value={formatBitsPerSecond(adapter.speedBitsPerSecond)}
-            />
-            <Row
-              label={t("dashboard.pcInfoField.ipAddresses")}
-              value={adapter.ipAddresses.length > 0 ? adapter.ipAddresses.join(", ") : "—"}
-            />
-            {adapter.subnetMasks.length > 0 ? (
-              <Row
-                label={t("dashboard.pcInfoField.subnetMask")}
-                value={adapter.subnetMasks.join(", ")}
-              />
-            ) : null}
-            {adapter.gateways.length > 0 ? (
-              <Row label={t("dashboard.pcInfoField.gateway")} value={adapter.gateways.join(", ")} />
-            ) : null}
-            {adapter.dnsServers.length > 0 ? (
-              <Row label={t("dashboard.pcInfoField.dns")} value={adapter.dnsServers.join(", ")} />
-            ) : null}
-            {adapter.dnsSuffix?.trim() ? (
-              <Row label={t("dashboard.pcInfoField.dnsSuffix")} value={adapter.dnsSuffix.trim()} />
-            ) : null}
-            <Row label={t("dashboard.pcInfoField.dhcp")} value={boolText(adapter.dhcpEnabled)} />
-            {adapter.dhcpServer?.trim() ? (
-              <Row
-                label={t("dashboard.pcInfoField.dhcpServer")}
-                value={adapter.dhcpServer.trim()}
-              />
-            ) : null}
-          </Group>
-        ))
-      ) : (
+  if (snapshot.network.length === 0) {
+    return (
+      <div className="dw-pcinfo-section">
+        {usage.live ? <LiveThroughput usage={usage} /> : null}
         <EmptyHint />
-      )}
+      </div>
+    );
+  }
+  return (
+    <div className="dw-pcinfo-section dw-pcinfo-net">
+      {usage.live ? <LiveThroughput usage={usage} /> : null}
+      {snapshot.network.map((adapter, index) => {
+        const wifi = isWifi(adapter);
+        const ip = adapter.ipAddresses[0];
+        return (
+          <div className="dw-pcinfo-adapter" key={adapter.macAddress ?? adapter.name ?? index}>
+            <div className="dw-pcinfo-adapter-head">
+              <span className="dw-pcinfo-adapter-icon" aria-hidden="true">
+                {wifi ? (
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+                    <path className="dw-pcinfo-wifi" style={{ animationDelay: "0.3s" }} d="M5 12.5a10 10 0 0 1 14 0" />
+                    <path className="dw-pcinfo-wifi" style={{ animationDelay: "0.15s" }} d="M8 15.5a6 6 0 0 1 8 0" />
+                    <path className="dw-pcinfo-wifi" d="M12 18.5h.01" />
+                  </svg>
+                ) : (
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="4" y="9" width="16" height="11" rx="2" />
+                    <path d="M8 9V6h8v3M8 13v3M12 13v3M16 13v3" />
+                  </svg>
+                )}
+              </span>
+              <div className="dw-pcinfo-adapter-id">
+                <span className="dw-pcinfo-adapter-name">{orDash(adapter.name)}</span>
+                <span className="dw-pcinfo-adapter-type">{orDash(adapter.adapterType)}</span>
+              </div>
+              <div className="dw-pcinfo-adapter-speed">
+                <span className={`dw-pcinfo-dot${adapter.connected ? " is-on" : ""}`} aria-hidden="true" />
+                <span className="dw-pcinfo-mono">{formatBitsPerSecond(adapter.speedBitsPerSecond)}</span>
+              </div>
+            </div>
+            <div className="dw-pcinfo-packet" aria-hidden="true">
+              <span className="dw-pcinfo-packet-line" />
+              <span className="dw-pcinfo-packet-dot" style={{ animationDelay: `${(index * 0.7).toFixed(1)}s` }} />
+            </div>
+            <div className="dw-pcinfo-adapter-foot">
+              <span className="dw-pcinfo-mono">
+                {t("dashboard.pcInfoField.ipAddresses")} <span className="dw-pcinfo-strong">{ip ?? "—"}</span>
+              </span>
+              <span className="dw-pcinfo-mono dw-pcinfo-muted">{orDash(adapter.macAddress)}</span>
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }
 
-function BatterySection({ snapshot }: { snapshot: PcInfoSnapshot }) {
+function LiveThroughput({ usage }: { usage: HostUsageHistory }) {
   const { t } = useTranslation();
+  const max = Math.max(...usage.netHistory, 1);
   return (
-    <div className="dw-pcinfo-section">
-      {snapshot.battery.length > 0 ? (
-        snapshot.battery.map((battery, index) => (
-          <Group key={battery.name ?? index} title={orDash(battery.name)}>
-            <Row
-              label={t("dashboard.pcInfoField.charge")}
-              value={
-                battery.chargePercent !== null && battery.chargePercent !== undefined
-                  ? `${battery.chargePercent}%`
-                  : "—"
-              }
-            />
-            <Row label={t("dashboard.pcInfoField.status")} value={orDash(battery.status)} />
-            <Row label={t("dashboard.pcInfoField.wear")} value={formatPercent(battery.wearPercent)} />
-            <Row
-              label={t("dashboard.pcInfoField.designCapacity")}
-              value={
-                battery.designCapacityMwh ? `${battery.designCapacityMwh} mWh` : "—"
-              }
-            />
-            <Row
-              label={t("dashboard.pcInfoField.fullCapacity")}
-              value={
-                battery.fullChargeCapacityMwh ? `${battery.fullChargeCapacityMwh} mWh` : "—"
-              }
-            />
-          </Group>
-        ))
-      ) : (
-        <EmptyHint />
-      )}
+    <div className="dw-pcinfo-throughput">
+      <div className="dw-pcinfo-throughput-head">
+        <span className="dw-pcinfo-panel-title">{t("dashboard.pcInfoLabel.liveThroughput")}</span>
+        <span className="dw-pcinfo-mono dw-pcinfo-throughput-rate">
+          ↓ {formatRate(usage.downBytesPerSecond)} · ↑ {formatRate(usage.upBytesPerSecond)}
+        </span>
+      </div>
+      <Sparkline values={usage.netHistory} max={max} color="var(--green)" fillId="dw-pcinfo-net-fill" />
     </div>
   );
+}
+
+function formatRate(bytesPerSecond: number | undefined): string {
+  if (bytesPerSecond === undefined || !Number.isFinite(bytesPerSecond)) {
+    return "—";
+  }
+  const mb = bytesPerSecond / 1_000_000;
+  if (mb < 0.1) {
+    return `${Math.round(bytesPerSecond / 1000)} KB/s`;
+  }
+  if (mb < 10) {
+    return `${mb.toFixed(1)} MB/s`;
+  }
+  return `${Math.round(mb)} MB/s`;
 }
 
 function AudioSection({ snapshot }: { snapshot: PcInfoSnapshot }) {
+  const { t } = useTranslation();
+  if (snapshot.audio.length === 0) {
+    return (
+      <div className="dw-pcinfo-section">
+        <EmptyHint />
+      </div>
+    );
+  }
+  const bars = Array.from({ length: 9 }, (_, i) => i);
+  return (
+    <div className="dw-pcinfo-section dw-pcinfo-split">
+      <div className="dw-pcinfo-eq" aria-hidden="true">
+        {bars.map((i) => (
+          <span
+            key={i}
+            className="dw-pcinfo-eq-bar"
+            style={{
+              animationDuration: `${(0.7 + (i % 3) * 0.25).toFixed(2)}s`,
+              animationDelay: `${(i * 0.11).toFixed(2)}s`,
+            }}
+          />
+        ))}
+      </div>
+      <div className="dw-pcinfo-rows dw-pcinfo-rows-grow">
+        <div className="dw-pcinfo-panel-title dw-pcinfo-block-title">{t("dashboard.pcInfoLabel.audioDevices")}</div>
+        {snapshot.audio.map((device, index) => (
+          <KeyRow key={device.name ?? index} label={orDash(device.name)} value={orDash(device.manufacturer)} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function BatterySection({ snapshot, progress }: { snapshot: PcInfoSnapshot; progress: number }) {
+  const { t } = useTranslation();
+  const ep = ease(progress);
+  if (snapshot.battery.length === 0) {
+    return (
+      <div className="dw-pcinfo-section">
+        <EmptyHint />
+      </div>
+    );
+  }
   return (
     <div className="dw-pcinfo-section">
-      {snapshot.audio.length > 0 ? (
-        snapshot.audio.map((device, index) => (
-          <Row
-            key={device.name ?? index}
-            label={orDash(device.name)}
-            value={orDash(device.manufacturer)}
-          />
-        ))
-      ) : (
-        <EmptyHint />
-      )}
+      {snapshot.battery.map((battery, index) => {
+        const charge = battery.chargePercent;
+        return (
+          <div className="dw-pcinfo-hero" key={battery.name ?? index}>
+            <div className="dw-pcinfo-bigring dw-pcinfo-bigring-sm">
+              <Ring size={116} radius={46} stroke={9} color="var(--green)" fraction={(pct(charge) / 100) * ep} />
+              <div className="dw-pcinfo-bigring-center">
+                <span className="dw-pcinfo-bigring-value">
+                  {charge !== undefined && charge !== null ? `${Math.round(charge * ep)}%` : "—"}
+                </span>
+                <span className="dw-pcinfo-bigring-unit">{orDash(battery.status)}</span>
+              </div>
+            </div>
+            <div className="dw-pcinfo-rows dw-pcinfo-rows-grow">
+              <KeyRow label={t("dashboard.pcInfoField.name")} value={orDash(battery.name)} />
+              <KeyRow
+                label={t("dashboard.pcInfoField.wear")}
+                value={
+                  battery.wearPercent !== null && battery.wearPercent !== undefined
+                    ? `${Math.round(battery.wearPercent)}%`
+                    : "—"
+                }
+              />
+              <KeyRow
+                label={t("dashboard.pcInfoField.designCapacity")}
+                value={battery.designCapacityMwh ? `${battery.designCapacityMwh} mWh` : "—"}
+              />
+              <KeyRow
+                label={t("dashboard.pcInfoField.fullCapacity")}
+                value={battery.fullChargeCapacityMwh ? `${battery.fullChargeCapacityMwh} mWh` : "—"}
+              />
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/modules/dashboard/widgets/builtin/pc-info/format.ts
+++ b/src/modules/dashboard/widgets/builtin/pc-info/format.ts
@@ -82,3 +82,63 @@ export function orDash(value: string | null | undefined): string {
   const trimmed = value?.trim();
   return trimmed ? trimmed : EM_DASH;
 }
+
+// ── Visual helpers for the animated widget ─────────────────────────────────────
+
+/** Whole/decimal gigabytes as a bare number (for "GB total" / "GB free" stats). */
+export function gigabytes(bytes: number | null | undefined): number | null {
+  if (bytes === null || bytes === undefined || !Number.isFinite(bytes) || bytes <= 0) {
+    return null;
+  }
+  const gb = bytes / 1024 ** 3;
+  return gb >= 100 ? Math.round(gb) : Math.round(gb * 10) / 10;
+}
+
+/** SVG circle circumference and the stroke-dashoffset for a 0–1 fill fraction. */
+export function ringGeometry(
+  radius: number,
+  fraction: number,
+): { circumference: number; offset: number } {
+  const circumference = 2 * Math.PI * radius;
+  const clamped = Math.max(0, Math.min(1, Number.isFinite(fraction) ? fraction : 0));
+  return {
+    circumference: Math.round(circumference * 100) / 100,
+    offset: Math.round(circumference * (1 - clamped) * 100) / 100,
+  };
+}
+
+/**
+ * Build an SVG polyline `points` string from a series, oldest first, mapped into
+ * a `width`×`height` box. `max` scales the vertical axis (peak of the data, or a
+ * fixed ceiling like 100 for percentages).
+ */
+export function sparklinePoints(
+  values: number[],
+  width: number,
+  height: number,
+  max: number,
+): string {
+  const n = values.length;
+  if (n === 0) {
+    return "";
+  }
+  const ceiling = max > 0 ? max : 1;
+  if (n === 1) {
+    const y = height - clampUnit(values[0] / ceiling) * (height - 2) - 1;
+    return `0,${y.toFixed(1)} ${width},${y.toFixed(1)}`;
+  }
+  return values
+    .map((value, index) => {
+      const x = (index / (n - 1)) * width;
+      const y = height - clampUnit(value / ceiling) * (height - 2) - 1;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+function clampUnit(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, value));
+}

--- a/src/modules/dashboard/widgets/builtin/pc-info/pc-info.css
+++ b/src/modules/dashboard/widgets/builtin/pc-info/pc-info.css
@@ -1,41 +1,207 @@
+/* PC Info — animated, theme-token-driven Dashboard widget. Every color reads a
+   custom property from src/styles/colorSchemes.css (no hard-coded hex), and all
+   ambient/loop animations are disabled under prefers-reduced-motion. */
+
 .dw-pcinfo {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 8px;
   height: 100%;
   min-height: 0;
+  overflow: hidden;
+  font-variant-numeric: tabular-nums;
 }
+
+/* Ambient drifting glows behind the content. */
+.dw-pcinfo-ambient {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(8px);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.dw-pcinfo-ambient-a {
+  top: -60px;
+  right: -40px;
+  width: 220px;
+  height: 220px;
+  background: radial-gradient(circle, color-mix(in srgb, var(--accent) 22%, transparent), transparent 70%);
+  animation: dw-pcinfo-drift 14s ease-in-out infinite;
+}
+
+.dw-pcinfo-ambient-b {
+  bottom: -70px;
+  left: -50px;
+  width: 200px;
+  height: 200px;
+  background: radial-gradient(circle, color-mix(in srgb, var(--green) 16%, transparent), transparent 70%);
+  animation: dw-pcinfo-drift 18s ease-in-out infinite reverse;
+}
+
+.dw-pcinfo > .dw-pcinfo-header,
+.dw-pcinfo > .dw-pcinfo-tabs,
+.dw-pcinfo > .dw-pcinfo-body,
+.dw-pcinfo > .dw-pcinfo-footer {
+  position: relative;
+  z-index: 1;
+}
+
+/* ── Header ──────────────────────────────────────────────────────────────── */
+
+.dw-pcinfo-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 0 0 auto;
+}
+
+.dw-pcinfo-badge {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  background: linear-gradient(160deg, var(--green), color-mix(in srgb, var(--green) 70%, #000));
+  color: color-mix(in srgb, var(--green) 18%, #000);
+  font-family: var(--app-mono-font-family, ui-monospace, monospace);
+  font-size: 13px;
+  font-weight: 700;
+  box-shadow: 0 2px 8px -2px color-mix(in srgb, var(--green) 55%, transparent);
+}
+
+.dw-pcinfo-heading {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.dw-pcinfo-eyebrow {
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.dw-pcinfo-title {
+  font-size: 15px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  color: var(--text);
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dw-pcinfo-headmeta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  min-width: 0;
+  text-align: right;
+}
+
+.dw-pcinfo-host {
+  font-family: var(--app-mono-font-family, ui-monospace, monospace);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dw-pcinfo-stamp {
+  font-size: 10px;
+  color: var(--text-faint);
+  white-space: nowrap;
+}
+
+.dw-pcinfo-refresh {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+  border: 1px solid var(--border);
+  background: var(--surface-muted);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background-color 140ms ease, color 140ms ease;
+}
+
+.dw-pcinfo-refresh:hover:not(:disabled) {
+  background: var(--hover);
+  color: var(--text);
+}
+
+.dw-pcinfo-refresh:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+/* ── Tabs ────────────────────────────────────────────────────────────────── */
 
 .dw-pcinfo-tabs {
   display: flex;
   flex: 0 0 auto;
   gap: 2px;
-  padding: 2px;
+  padding: 4px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 11px;
   background: var(--surface-muted);
   max-width: 100%;
   overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.dw-pcinfo-tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .dw-pcinfo-tab {
-  flex: 0 0 auto;
-  padding: 3px 9px;
+  flex: 1 1 0;
+  min-width: 44px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 7px 2px 5px;
   border: 0;
-  border-radius: 4px;
+  border-radius: 8px;
   background: transparent;
   color: var(--text-muted);
-  font-size: 11px;
-  white-space: nowrap;
   cursor: pointer;
-  transition: background-color 140ms ease, color 140ms ease;
+  transition: background-color 140ms ease, box-shadow 140ms ease, color 140ms ease;
 }
 
 .dw-pcinfo-tab.is-active {
   background: var(--surface);
-  color: var(--text);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+  color: var(--accent);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--text) 12%, transparent);
 }
+
+.dw-pcinfo-tab-label {
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  color: var(--text-muted);
+}
+
+.dw-pcinfo-tab.is-active .dw-pcinfo-tab-label {
+  color: var(--text);
+  font-weight: 650;
+}
+
+/* ── Body ────────────────────────────────────────────────────────────────── */
 
 .dw-pcinfo-body {
   flex: 1 1 auto;
@@ -43,10 +209,217 @@
   overflow-y: auto;
 }
 
+.dw-pcinfo-enter {
+  animation: dw-pcinfo-enter 360ms ease both;
+}
+
 .dw-pcinfo-section {
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: 12px;
+  padding: 2px;
+}
+
+.dw-pcinfo-split {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.dw-pcinfo-hero {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.dw-pcinfo-hero-main {
+  flex: 1 1 200px;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+/* Illustrations */
+.dw-pcinfo-illu {
+  position: relative;
+  flex: 0 0 auto;
+  width: clamp(96px, 30%, 132px);
+  aspect-ratio: 1 / 1;
+}
+
+.dw-pcinfo-illu-gpu {
+  aspect-ratio: 130 / 100;
+  width: clamp(110px, 32%, 130px);
+}
+
+.dw-pcinfo-illu-board {
+  aspect-ratio: 134 / 128;
+}
+
+.dw-pcinfo-illu-svg {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.dw-pcinfo-breathe {
+  position: absolute;
+  inset: 0;
+  border-radius: 22px;
+  background: radial-gradient(circle at 50% 40%, color-mix(in srgb, var(--accent) 22%, transparent), transparent 68%);
+  animation: dw-pcinfo-breathe 4.5s ease-in-out infinite;
+}
+
+.dw-pcinfo-breathe-cpu {
+  inset: 14px;
+  border-radius: 14px;
+  animation-duration: 3.8s;
+}
+
+/* Rings */
+.dw-pcinfo-ring {
+  display: block;
+  transform: rotate(-90deg);
+}
+
+/* Summary gauges */
+.dw-pcinfo-gauges {
+  display: flex;
+  gap: 10px;
+}
+
+.dw-pcinfo-gauge {
+  flex: 1 1 0;
+  text-align: center;
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 9px 6px;
+}
+
+.dw-pcinfo-gauge-ring {
+  position: relative;
+  width: 58px;
+  height: 58px;
+  margin: 0 auto;
+}
+
+.dw-pcinfo-gauge-text {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-family: var(--app-mono-font-family, ui-monospace, monospace);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.dw-pcinfo-gauge-label {
+  display: block;
+  margin-top: 4px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.dw-pcinfo-spark {
+  display: block;
+  width: 100%;
+}
+
+/* Facts grid */
+.dw-pcinfo-facts {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px 18px;
+}
+
+.dw-pcinfo-fact {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.dw-pcinfo-fact-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-faint);
+}
+
+.dw-pcinfo-fact-value {
+  font-size: 12.5px;
+  font-weight: 550;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Big rings (OS uptime, memory, battery) */
+.dw-pcinfo-bigring {
+  position: relative;
+  flex: 0 0 auto;
+  width: 128px;
+  height: 128px;
+}
+
+.dw-pcinfo-bigring-sm {
+  width: 116px;
+  height: 116px;
+}
+
+.dw-pcinfo-bigring-center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.dw-pcinfo-bigring-value {
+  font-family: var(--app-mono-font-family, ui-monospace, monospace);
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1;
+}
+
+.dw-pcinfo-bigring-unit {
+  margin-top: 3px;
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-faint);
+}
+
+.dw-pcinfo-bigring-sub {
+  margin-top: 4px;
+  font-family: var(--app-mono-font-family, ui-monospace, monospace);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* Key/value rows */
+.dw-pcinfo-rows {
+  display: flex;
+  flex-direction: column;
+}
+
+.dw-pcinfo-rows-grow,
+.dw-pcinfo-split > .dw-pcinfo-rows {
+  flex: 1 1 220px;
+  min-width: 0;
 }
 
 .dw-pcinfo-row {
@@ -54,9 +427,9 @@
   align-items: baseline;
   justify-content: space-between;
   gap: 12px;
-  padding: 3px 2px;
-  font-size: 12px;
-  border-bottom: 1px solid color-mix(in srgb, var(--border) 45%, transparent);
+  padding: 5px 0;
+  font-size: 11.5px;
+  border-bottom: 1px solid var(--hairline);
 }
 
 .dw-pcinfo-row:last-child {
@@ -74,48 +447,479 @@
   text-align: right;
   color: var(--text);
   word-break: break-word;
-  font-variant-numeric: tabular-nums;
 }
 
-.dw-pcinfo-group {
+.dw-pcinfo-mono {
+  font-family: var(--app-mono-font-family, ui-monospace, monospace);
+}
+
+.dw-pcinfo-muted {
+  color: var(--text-muted);
+}
+
+.dw-pcinfo-strong {
+  color: var(--text);
+}
+
+/* Stat clusters (cores/threads/GHz, GB total/free) */
+.dw-pcinfo-title-lg {
+  font-size: 13.5px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+
+.dw-pcinfo-subtle {
+  margin-top: 1px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.dw-pcinfo-stats {
+  display: flex;
+  gap: 18px;
+  margin-top: 10px;
+}
+
+.dw-pcinfo-stat {
+  display: flex;
+  flex-direction: column;
+}
+
+.dw-pcinfo-stat-value {
+  font-family: var(--app-mono-font-family, ui-monospace, monospace);
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1;
+}
+
+.dw-pcinfo-stat-value.is-accent {
+  color: var(--accent);
+}
+
+.dw-pcinfo-stat-label {
+  margin-top: 3px;
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-faint);
+}
+
+/* Panels (CPU live load, throughput) */
+.dw-pcinfo-panel {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 10px 12px;
+}
+
+.dw-pcinfo-panel-head,
+.dw-pcinfo-throughput-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 4px;
+}
+
+.dw-pcinfo-panel-title {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.dw-pcinfo-block-title {
+  margin-bottom: 6px;
+}
+
+.dw-pcinfo-panel-metric,
+.dw-pcinfo-throughput-rate {
+  font-family: var(--app-mono-font-family, ui-monospace, monospace);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.dw-pcinfo-panel-foot {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
   margin-top: 8px;
+  font-family: var(--app-mono-font-family, ui-monospace, monospace);
+  font-size: 10.5px;
+  color: var(--text-muted);
 }
 
-.dw-pcinfo-group-title {
+/* Memory sticks */
+.dw-pcinfo-sticks {
+  display: flex;
+  gap: 7px;
+  align-items: flex-end;
+  height: 50px;
+}
+
+.dw-pcinfo-stick {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.dw-pcinfo-stick-body {
+  position: relative;
+  width: 100%;
+  height: 40px;
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.dw-pcinfo-stick-fill {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(0deg, var(--green), color-mix(in srgb, var(--green) 55%, var(--surface)));
+  border-radius: 0 0 4px 4px;
+  transition: height 200ms ease;
+}
+
+.dw-pcinfo-stick-pins {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  padding: 3px 4px;
+  opacity: 0.4;
+}
+
+.dw-pcinfo-stick-pins span {
+  height: 1px;
+  background: var(--text);
+}
+
+.dw-pcinfo-stick-cap {
+  font-family: var(--app-mono-font-family, ui-monospace, monospace);
+  font-size: 8.5px;
+  color: var(--text-muted);
+}
+
+/* VRAM badge */
+.dw-pcinfo-vram {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.dw-pcinfo-vram-value {
+  font-family: var(--app-mono-font-family, ui-monospace, monospace);
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.dw-pcinfo-vram-label {
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-faint);
+}
+
+/* Displays */
+.dw-pcinfo-display-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px;
+}
+
+.dw-pcinfo-display,
+.dw-pcinfo-drive {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 8px 10px;
+}
+
+.dw-pcinfo-display-text,
+.dw-pcinfo-drive-text {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.dw-pcinfo-display-name,
+.dw-pcinfo-drive-name {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dw-pcinfo-display-sub,
+.dw-pcinfo-drive-sub {
+  font-size: 10.5px;
+  color: var(--text-muted);
+}
+
+/* Storage volumes */
+.dw-pcinfo-vol-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+}
+
+.dw-pcinfo-vol {
+  text-align: center;
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px 8px;
+}
+
+.dw-pcinfo-vol-ring {
+  position: relative;
+  width: 84px;
+  height: 84px;
+  margin: 0 auto;
+}
+
+.dw-pcinfo-vol-center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.dw-pcinfo-vol-mount {
+  font-family: var(--app-mono-font-family, ui-monospace, monospace);
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1;
+}
+
+.dw-pcinfo-vol-pct {
+  margin-top: 2px;
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.dw-pcinfo-vol-label {
+  display: block;
+  margin-top: 8px;
   font-size: 11px;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--text-muted);
-  padding: 2px 2px 3px;
-  border-bottom: 1px solid var(--border);
-  margin-bottom: 2px;
+  color: var(--text);
 }
 
+.dw-pcinfo-vol-sub {
+  display: block;
+  margin-top: 2px;
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.dw-pcinfo-drives {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dw-pcinfo-drive-size {
+  flex: 0 0 auto;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+/* Network */
+.dw-pcinfo-net {
+  gap: 10px;
+}
+
+.dw-pcinfo-throughput {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 10px 12px;
+}
+
+.dw-pcinfo-throughput-rate {
+  color: var(--green);
+}
+
+.dw-pcinfo-adapter {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 11px 13px;
+}
+
+.dw-pcinfo-adapter-head {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+
+.dw-pcinfo-adapter-icon {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.dw-pcinfo-adapter-id {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.dw-pcinfo-adapter-name {
+  font-size: 12.5px;
+  font-weight: 620;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dw-pcinfo-adapter-type {
+  font-size: 10.5px;
+  color: var(--text-muted);
+}
+
+.dw-pcinfo-adapter-speed {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+.dw-pcinfo-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--text-faint);
+}
+
+.dw-pcinfo-dot.is-on {
+  background: var(--green);
+  box-shadow: 0 0 6px var(--green);
+}
+
+.dw-pcinfo-packet {
+  position: relative;
+  height: 14px;
+  margin: 8px 2px 2px;
+}
+
+.dw-pcinfo-packet-line {
+  position: absolute;
+  top: 7px;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--border);
+}
+
+.dw-pcinfo-packet-dot {
+  position: absolute;
+  top: 4px;
+  left: 0;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 7px var(--accent);
+  animation: dw-pcinfo-packet 2.2s linear infinite;
+}
+
+.dw-pcinfo-adapter-foot {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 6px;
+  font-size: 10.5px;
+  color: var(--text-muted);
+}
+
+/* Audio equalizer */
+.dw-pcinfo-eq {
+  flex: 0 0 auto;
+  width: 110px;
+  height: 96px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 5px;
+  padding-bottom: 6px;
+}
+
+.dw-pcinfo-eq-bar {
+  width: 7px;
+  height: 70px;
+  border-radius: 4px;
+  background: linear-gradient(0deg, var(--accent), color-mix(in srgb, var(--accent) 40%, var(--surface)));
+  transform-origin: bottom;
+  transform: scaleY(0.4);
+  animation: dw-pcinfo-eq 0.9s ease-in-out infinite;
+}
+
+/* Footer */
 .dw-pcinfo-footer {
   display: flex;
   flex: 0 0 auto;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--hairline);
+  font-size: 10.5px;
+  color: var(--text-faint);
 }
 
-.dw-pcinfo-stamp {
-  font-size: 11px;
-  color: var(--text-muted);
+.dw-pcinfo-foot-source {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.dw-pcinfo-refresh {
-  flex: 0 0 auto;
-  display: inline-flex;
+.dw-pcinfo-foot-arch {
+  display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 10px;
+  flex: 0 0 auto;
+  font-family: var(--app-mono-font-family, ui-monospace, monospace);
 }
 
+.dw-pcinfo-foot-hint {
+  font-family: var(--app-ui-font-family);
+  color: var(--amber);
+}
+
+/* States */
 .dw-pcinfo-empty,
 .dw-pcinfo-section-empty {
   padding: 10px 2px;
@@ -129,12 +933,35 @@
   font-size: 12px;
   border-radius: 6px;
   color: var(--text);
-  background: color-mix(in srgb, var(--danger, #ef4444) 14%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger, #ef4444) 35%, transparent);
+  background: color-mix(in srgb, var(--red) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--red) 35%, transparent);
 }
+
+/* ── Animations ──────────────────────────────────────────────────────────── */
 
 .dw-pcinfo-spin {
   animation: dw-pcinfo-spin 900ms linear infinite;
+  transform-origin: center;
+}
+
+.dw-pcinfo-core {
+  animation: dw-pcinfo-core 1.8s ease-in-out infinite;
+}
+
+.dw-pcinfo-fan {
+  animation: dw-pcinfo-fan 3s linear infinite;
+}
+
+.dw-pcinfo-fan-slow {
+  animation-duration: 3.6s;
+}
+
+.dw-pcinfo-trace {
+  animation: dw-pcinfo-trace 1.4s linear infinite;
+}
+
+.dw-pcinfo-wifi {
+  animation: dw-pcinfo-wifi 1.8s ease-in-out infinite;
 }
 
 @keyframes dw-pcinfo-spin {
@@ -143,8 +970,115 @@
   }
 }
 
+@keyframes dw-pcinfo-enter {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes dw-pcinfo-drift {
+  0% {
+    transform: translate(0, 0);
+  }
+  50% {
+    transform: translate(18px, -14px);
+  }
+  100% {
+    transform: translate(0, 0);
+  }
+}
+
+@keyframes dw-pcinfo-breathe {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 0.85;
+  }
+}
+
+@keyframes dw-pcinfo-core {
+  0%,
+  100% {
+    opacity: 0.22;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes dw-pcinfo-fan {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes dw-pcinfo-trace {
+  to {
+    stroke-dashoffset: -36;
+  }
+}
+
+@keyframes dw-pcinfo-packet {
+  0% {
+    transform: translateX(0);
+    opacity: 0;
+  }
+  12% {
+    opacity: 1;
+  }
+  88% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(132px);
+    opacity: 0;
+  }
+}
+
+@keyframes dw-pcinfo-eq {
+  0%,
+  100% {
+    transform: scaleY(0.28);
+  }
+  50% {
+    transform: scaleY(1);
+  }
+}
+
+@keyframes dw-pcinfo-wifi {
+  0%,
+  100% {
+    opacity: 0.18;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .dw-pcinfo-spin {
-    animation: none;
+  .dw-pcinfo-ambient,
+  .dw-pcinfo-breathe,
+  .dw-pcinfo-enter,
+  .dw-pcinfo-spin,
+  .dw-pcinfo-core,
+  .dw-pcinfo-fan,
+  .dw-pcinfo-trace,
+  .dw-pcinfo-wifi,
+  .dw-pcinfo-packet-dot,
+  .dw-pcinfo-eq-bar,
+  .dw-pcinfo-stick-fill {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  .dw-pcinfo-eq-bar {
+    transform: scaleY(0.7);
   }
 }

--- a/src/modules/dashboard/widgets/builtin/pc-info/useHostUsageHistory.ts
+++ b/src/modules/dashboard/widgets/builtin/pc-info/useHostUsageHistory.ts
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from "react";
+import { useWorkspaceStore } from "../../../../../store";
+
+// Rolling history length for the sparklines. The status-bar monitor samples at
+// the user's configured interval, so this is "last N samples" rather than a
+// fixed time window.
+const HISTORY_LENGTH = 48;
+
+export interface HostUsageHistory {
+  /** True only while the toolbar host-usage monitor is actually feeding data. */
+  live: boolean;
+  cpuPercent?: number;
+  ramPercent?: number;
+  downBytesPerSecond?: number;
+  upBytesPerSecond?: number;
+  /** Most recent CPU-load samples (0–100), oldest first. */
+  cpuHistory: number[];
+  /** Most recent combined network throughput samples (bytes/s), oldest first. */
+  netHistory: number[];
+}
+
+const EMPTY: HostUsageHistory = {
+  live: false,
+  cpuHistory: [],
+  netHistory: [],
+};
+
+/**
+ * Consume the existing toolbar host-usage monitor (no new data pipe). The
+ * snapshot lives in `performanceMetrics.hostUsage` and is refreshed by
+ * `useHostUsagePolling` at the user's `statusBarMonitorIntervalSeconds`, gated on
+ * the status-bar monitor being enabled. When the monitor is off there is no live
+ * data, so this hook reports `live: false` and an empty history; the widget then
+ * falls back to static snapshot values.
+ */
+export function useHostUsageHistory(): HostUsageHistory {
+  const hostUsage = useWorkspaceStore((state) => state.performanceMetrics.hostUsage);
+  const statusBarEnabled = useWorkspaceStore((state) => state.generalSettings.statusBarEnabled);
+  const statusBarMonitorEnabled = useWorkspaceStore(
+    (state) => state.generalSettings.statusBarMonitorEnabled,
+  );
+
+  const live = Boolean(statusBarEnabled && statusBarMonitorEnabled && hostUsage);
+
+  const [history, setHistory] = useState<{ cpu: number[]; net: number[] }>({
+    cpu: [],
+    net: [],
+  });
+  // Track the last sample we appended so re-renders that do not carry a new
+  // sample (e.g. unrelated store updates) do not duplicate points.
+  const lastSampleRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!live || !hostUsage) {
+      lastSampleRef.current = null;
+      setHistory((prev) => (prev.cpu.length === 0 && prev.net.length === 0 ? prev : { cpu: [], net: [] }));
+      return;
+    }
+    if (lastSampleRef.current === hostUsage.sampledAtUnixSeconds) {
+      return;
+    }
+    lastSampleRef.current = hostUsage.sampledAtUnixSeconds;
+    const cpu = clampPercent(hostUsage.cpuPercent);
+    const net =
+      (hostUsage.networkDownstreamBytesPerSecond ?? 0) +
+      (hostUsage.networkUpstreamBytesPerSecond ?? 0);
+    setHistory((prev) => ({
+      cpu: pushCapped(prev.cpu, cpu),
+      net: pushCapped(prev.net, net),
+    }));
+  }, [live, hostUsage]);
+
+  if (!live || !hostUsage) {
+    return EMPTY;
+  }
+
+  return {
+    live: true,
+    cpuPercent: hostUsage.cpuPercent,
+    ramPercent: hostUsage.ramPercent,
+    downBytesPerSecond: hostUsage.networkDownstreamBytesPerSecond,
+    upBytesPerSecond: hostUsage.networkUpstreamBytesPerSecond,
+    cpuHistory: history.cpu,
+    netHistory: history.net,
+  };
+}
+
+function pushCapped(arr: number[], value: number): number[] {
+  const next = arr.length >= HISTORY_LENGTH ? arr.slice(arr.length - HISTORY_LENGTH + 1) : arr.slice();
+  next.push(value);
+  return next;
+}
+
+function clampPercent(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(100, value));
+}


### PR DESCRIPTION
## Summary

Redesigns the Dashboard **PC Info** widget from a plain label/value table into the animated reference design, wires its realtime metrics to the existing status-bar host-usage monitor, and enriches the sparse macOS/Linux hardware collectors.

## Type of change

- [x] Feature

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)
- [x] Backend (Rust/Tauri — `src-tauri/`)
- [x] Docs (`docs/localization_todo/`)

## What changed

**Animated widget (frontend)**
- `PcInfoWidget.tsx` full rewrite: gradient header badge, icon tab bar with an animated active pill, section entrance transitions, and per-section animated SVGs (PC tower, pulsing CPU cores, spinning GPU fans, motherboard traces, donut rings, sparklines, equalizer bars, network packet-flow). A `useEnterProgress` rAF hook drives ring-fill/count-up and honors `prefers-reduced-motion`.
- `pc-info.css` full rewrite: every color reads a theme token from `colorSchemes.css` (no hard-coded hex; the reference's hard-coded greens became `var(--green)` gradients), fluid layout (`clamp()`/aspect-ratio/auto-fit grids), and a reduced-motion block disabling all loops.
- New `useHostUsageHistory` hook **consumes the existing** `performanceMetrics.hostUsage` (no new data pipe), keeping a rolling sample history. When the status-bar monitor is off → no live values: rings/sparklines fall back to static snapshot data and the footer shows a hint. The GPU "usage ring" is a VRAM **capacity** badge since there is no live VRAM source to fabricate.

**Cross-platform enrichment (backend)**
- `Cargo.toml`: `sysinfo` 0.39 on Linux + `battery` (`starship-battery` 0.10, aliased) on non-Windows.
- `pc_info.rs`: shared `collect_batteries()`; macOS fills CPU brand/vendor/frequency/physical-cores + battery via sysinfo; Linux gains sysinfo CPU/volumes/network (MAC+IP), `/sys/block` physical drives, and `lspci` GPU detection. The Windows CIM path and the `PcInfoSnapshot` shape are unchanged (TS types/normalizer untouched).

## i18n

- [x] English keys added first in `en.json` (`dashboard.pcInfoTab.*`, `dashboard.pcInfoLabel.*`); best-effort translations added across all 13 other locales (Taiwan terminology in zh-TW) with one `docs/localization_todo/` review record per new key
- [x] Named `{{…}}` placeholders, one full sentence per key

## UI / design language

- [x] Colors read from tokens (no hard-coded hex)
- [x] Animations gated by `prefers-reduced-motion`

## Checks

- [x] `npm run lint`, `tsc --noEmit`, `node tests/run-all.mjs` (697 pass), `node scripts/check-locale-keys.mjs` (all locales match)
- [x] `cargo check` (Windows) + `cargo test pc_info`

## Notes for reviewers

- **Cross-platform compile caveat:** only Windows Rust targets are installed in the dev environment, so the macOS/Linux `cfg` branches were not compiled locally. They were written against the confirmed sysinfo 0.39 / starship-battery 0.10 APIs and should be verified by CI / on those targets.
- **Manual in-app verification still pending** (needs the Tauri desktop runtime): tab/illustration animations, the status-bar monitor on/off toggle going live, tile resize fluidity, and multi-scheme color checks.
- The 13 non-English translations are best-effort AI output flagged for human review via the `docs/localization_todo/dashboard.pcInfo*.md` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)