### PR TITLE
Add virtualized LargeTextViewer and status-bar progress to FileViewer

### DIFF
--- a/src/modules/workspace/connections/file-viewer/FileViewerWorkspace.tsx
+++ b/src/modules/workspace/connections/file-viewer/FileViewerWorkspace.tsx
@@ -46,6 +46,7 @@ import { JsonViewer } from "./viewers/JsonViewer";
 import { ImageViewer } from "./viewers/ImageViewer";
 import { LogViewer } from "./viewers/LogViewer";
 import { HexViewer } from "./viewers/HexViewer";
+import { LargeTextViewer } from "./viewers/LargeTextViewer";
 import { PdfDependencyGate } from "./viewers/PdfDependencyGate";
 import { FileViewerBackgroundPopover } from "./FileViewerBackgroundLayer";
 
@@ -116,6 +117,9 @@ export function FileViewerWorkspace({
   const updateOpenConnectionTerminalAppearance = useWorkspaceStore(
     (state) => state.updateOpenConnectionTerminalAppearance,
   );
+  const showStatusBarProgress = useWorkspaceStore((state) => state.showStatusBarProgress);
+  const updateStatusBarProgress = useWorkspaceStore((state) => state.updateStatusBarProgress);
+  const clearStatusBarNotice = useWorkspaceStore((state) => state.clearStatusBarNotice);
   const [probe, setProbe] = useState<FileViewProbe | null>(null);
   const [override, setOverride] = useState<ViewerKind | null>(null);
   const [content, setContent] = useState<LoadedContent | null>(null);
@@ -160,26 +164,31 @@ export function FileViewerWorkspace({
       setError("");
       setSaveError("");
       setEditedText(null);
+      const progressId = showStatusBarProgress(t("workspace.fileViewer.loading"), { progress: 5 });
       try {
         const probed = await invokeCommand("probe_file_view", {
           request: { path: filePath },
         });
+        updateStatusBarProgress(progressId, 20);
         setProbe(probed);
         const kind =
           forcedKind ??
           detectViewerKind({ path: filePath, magic: probed.magic, isText: probed.isText });
         if (isUnsupportedViewerKind(kind)) {
           setContent({ kind, magic: probed.magic, truncated: false });
+          updateStatusBarProgress(progressId, 100);
           return;
         }
         if (viewerUsesExternalDependency(kind)) {
           // The dependency-backed viewer (PDF) loads its own content through the
           // external tool; no direct read here.
           setContent({ kind, magic: probed.magic, truncated: false });
+          updateStatusBarProgress(progressId, 100);
           return;
         }
         const maxBytes = maxBytesForKind(kind);
         if (viewerLoadsText(kind)) {
+          updateStatusBarProgress(progressId, 35);
           const result = await invokeCommand("read_file_view_text", {
             request: {
               path: filePath,
@@ -187,6 +196,7 @@ export function FileViewerWorkspace({
               encoding: encoding === AUTO_ENCODING ? undefined : encoding,
             },
           });
+          updateStatusBarProgress(progressId, 85);
           setContent({
             kind,
             text: result.text,
@@ -199,11 +209,14 @@ export function FileViewerWorkspace({
           if (kind === "image" && probed.totalSize > IMAGE_MAX_BYTES) {
             setContent(null);
             setError(t("workspace.fileViewer.imageTooLarge"));
+            updateStatusBarProgress(progressId, 100);
             return;
           }
+          updateStatusBarProgress(progressId, 35);
           const result = await invokeCommand("read_file_view_bytes", {
             request: { path: filePath, offset: 0, length: maxBytes },
           });
+          updateStatusBarProgress(progressId, 85);
           setContent({
             kind,
             base64: result.base64,
@@ -211,14 +224,17 @@ export function FileViewerWorkspace({
             truncated: !result.eof,
           });
         }
+        updateStatusBarProgress(progressId, 100);
       } catch (loadError) {
         setContent(null);
         setError(loadError instanceof Error ? loadError.message : String(loadError));
+        updateStatusBarProgress(progressId, 100);
       } finally {
+        window.setTimeout(() => clearStatusBarNotice(progressId), 700);
         setLoading(false);
       }
     },
-    [filePath, t, encoding],
+    [filePath, t, encoding, showStatusBarProgress, updateStatusBarProgress, clearStatusBarNotice],
   );
 
   useEffect(() => {
@@ -726,6 +742,9 @@ function FileViewerContent({
       );
     case "text":
     default:
+      if (content.truncated) {
+        return <LargeTextViewer text={content.text ?? ""} />;
+      }
       return (
         <TextCodeViewer
           editable={editable}

--- a/src/modules/workspace/connections/file-viewer/file-viewer.css
+++ b/src/modules/workspace/connections/file-viewer/file-viewer.css
@@ -1111,3 +1111,53 @@
   gap: 8px;
   margin-top: 22px;
 }
+
+.fv-large-text-pane {
+  min-height: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.fv-large-text-scroll {
+  min-height: 0;
+  flex: 1;
+  overflow: auto;
+  font-family: var(--fv-font-family, var(--mono));
+  font-size: var(--fv-font-size, 13px);
+  background: color-mix(in srgb, var(--surface) 94%, var(--surface-raised));
+}
+
+.fv-large-text-spacer {
+  position: relative;
+  min-width: max-content;
+}
+
+.fv-large-text-window {
+  position: absolute;
+  inset-inline: 0;
+  top: 0;
+}
+
+.fv-large-text-line {
+  display: grid;
+  grid-template-columns: minmax(52px, max-content) 1fr;
+  min-height: 20px;
+  line-height: 20px;
+  white-space: pre;
+}
+
+.fv-large-text-ln {
+  position: sticky;
+  left: 0;
+  padding: 0 10px;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--surface) 96%, var(--surface-raised));
+  border-right: 1px solid var(--border-subtle);
+  text-align: right;
+  user-select: none;
+}
+
+.fv-large-text-code {
+  padding: 0 12px;
+}

--- a/src/modules/workspace/connections/file-viewer/viewers/LargeTextViewer.tsx
+++ b/src/modules/workspace/connections/file-viewer/viewers/LargeTextViewer.tsx
@@ -1,0 +1,80 @@
+import { useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChromePortals } from "../chrome/FileViewerChromeContext";
+import { FootSeg } from "../chrome/controls";
+
+const LINE_HEIGHT = 20;
+const OVERSCAN = 20;
+
+/**
+ * Read-only large-text preview. It deliberately avoids CodeMirror/editor state
+ * for oversized text slices and renders only the visible line window, keeping
+ * mode switches responsive when a file is large enough to be truncated by the
+ * bounded reader.
+ */
+export function LargeTextViewer({ text }: { text: string }) {
+  const { t } = useTranslation();
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const [viewport, setViewport] = useState({ scrollTop: 0, height: 0 });
+
+  const lines = useMemo(() => text.split(/\r\n|\n|\r/), [text]);
+  const totalHeight = lines.length * LINE_HEIGHT;
+  const start = Math.max(
+    0,
+    Math.floor(viewport.scrollTop / LINE_HEIGHT) - OVERSCAN,
+  );
+  const visibleCount =
+    Math.ceil((viewport.height || 1) / LINE_HEIGHT) + OVERSCAN * 2;
+  const end = Math.min(lines.length, start + visibleCount);
+  const visibleLines = lines.slice(start, end);
+
+  function updateViewport() {
+    const node = scrollerRef.current;
+    if (!node) {
+      return;
+    }
+    setViewport({ scrollTop: node.scrollTop, height: node.clientHeight });
+  }
+
+  return (
+    <div className="fv-large-text-pane">
+      <ChromePortals
+        footer={
+          <FootSeg>
+            {t("workspace.fileViewer.lineCountOf", {
+              count: lines.length,
+              total: lines.length,
+            })}
+          </FootSeg>
+        }
+      />
+      <div
+        className="fv-large-text-scroll"
+        ref={(node) => {
+          scrollerRef.current = node;
+          if (node) {
+            window.requestAnimationFrame(updateViewport);
+          }
+        }}
+        onScroll={updateViewport}
+      >
+        <div className="fv-large-text-spacer" style={{ height: totalHeight }}>
+          <div
+            className="fv-large-text-window"
+            style={{ transform: `translateY(${start * LINE_HEIGHT}px)` }}
+          >
+            {visibleLines.map((line, index) => {
+              const lineNumber = start + index + 1;
+              return (
+                <div className="fv-large-text-line" key={lineNumber}>
+                  <span className="fv-large-text-ln">{lineNumber}</span>
+                  <span className="fv-large-text-code">{line || "\u00a0"}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Improve responsiveness when opening very large text files by avoiding a full editor render for truncated reads.
- Provide visual feedback during file probe/read phases by reporting progress to the status bar so large loads feel responsive.

### Description
- Add a new `LargeTextViewer` component that virtualizes lines and renders only the visible window to support truncated large-text previews (`src/.../viewers/LargeTextViewer.tsx`).
- Add CSS styles for the large-text viewer (`.fv-large-text-*`) in `file-viewer.css` to support layout, sticky line numbers, and scroll behavior.
- Integrate the large-text fallback into `FileViewerWorkspace` by importing `LargeTextViewer` and returning it when `content.truncated` is true for `text` viewers.
- Wire status-bar progress calls into the file load flow using `showStatusBarProgress`, `updateStatusBarProgress`, and `clearStatusBarNotice`, and update the `load` dependency list accordingly.

### Testing
- Ran the TypeScript build and typecheck via `yarn build` which completed successfully.
- Ran the unit test suite via `yarn test` and the tests passed.
- Performed a local UI smoke test opening large files to verify the virtualized rendering and status-bar progress behavior, which behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a449543732c832f8db5d671597205d9)