### PR TITLE
fix(ai): stop button no longer leaves the work panel stuck thinking

### DIFF
--- a/src/ai/AssistantPanel.tsx
+++ b/src/ai/AssistantPanel.tsx
@@ -662,27 +662,7 @@ export function AssistantPanel({
     activeAssistantRequestIdRef.current += 1;
     setIsSendingPrompt(false);
     setChatError("");
-    // Bumping the request id above makes the streaming channel's onmessage
-    // handler ignore any further events (including a final "done"/"error"),
-    // so the in-flight message would otherwise be stuck showing isStreaming:
-    // true forever — finalize it here instead.
-    const stoppedAt = new Date().toISOString();
-    setMessages((current) =>
-      current.map((message) =>
-        message.isStreaming
-          ? {
-              ...message,
-              isStreaming: false,
-              workCompletedAt: stoppedAt,
-              toolCalls: (message.toolCalls ?? []).map((toolCall) =>
-                toolCall.status === "running"
-                  ? { ...toolCall, status: "completed", endedAt: stoppedAt }
-                  : toolCall,
-              ),
-            }
-          : message,
-      ),
-    );
+    finalizeActiveStreamingMessages(new Date().toISOString());
     if (isTauriRuntime()) {
       // Detaching the UI is not enough: without this the backend agent loop
       // keeps running — and keeps executing tools — after Stop.
@@ -750,6 +730,41 @@ export function AssistantPanel({
         setChatError(error instanceof Error ? error.message : String(error));
       });
     }
+  }
+
+  function finalizeActiveStreamingMessages(completedAt: string) {
+    // Bumping the request id makes the streaming channel ignore further events
+    // (including final "done"/"error"), so finalize and persist the in-flight
+    // message here instead.
+    let didFinalize = false;
+    const finalizedMessages = messagesRef.current.map((message) => {
+      if (!message.isStreaming) {
+        return message;
+      }
+
+      didFinalize = true;
+      return {
+        ...message,
+        isStreaming: false,
+        workCompletedAt: completedAt,
+        toolCalls: (message.toolCalls ?? []).map((toolCall) =>
+          toolCall.status === "running"
+            ? { ...toolCall, status: "completed" as const, endedAt: completedAt }
+            : toolCall,
+        ),
+      };
+    });
+
+    if (!didFinalize) {
+      return;
+    }
+
+    messagesRef.current = finalizedMessages;
+    setMessages(finalizedMessages);
+    saveChatMessages(
+      finalizedMessages,
+      currentThreadTitle ?? assistantThreadTitle(finalizedMessages),
+    );
   }
 
   function appendLocalAssistantMessage(content: string, intent?: AssistantPromptIntent) {
@@ -1363,6 +1378,9 @@ export function AssistantPanel({
       // error paths force-flush / cancel so the final snapshot always wins.
       const flushStreamingSnapshot = () => {
         streamingFlushTimer = null;
+        if (activeAssistantRequestIdRef.current !== requestId) {
+          return;
+        }
         setMessages((current) =>
           current.map((message) =>
             message.id === streamingMessage.id ? streamingMessageSnapshot : message,
@@ -1512,23 +1530,7 @@ export function AssistantPanel({
     activeAssistantRequestIdRef.current += 1;
     setIsSendingPrompt(false);
     setChatError("");
-    const completedAt = new Date().toISOString();
-    setMessages((current) =>
-      current.map((message) =>
-        message.isStreaming
-          ? {
-              ...message,
-              isStreaming: false,
-              workCompletedAt: completedAt,
-              toolCalls: (message.toolCalls ?? []).map((toolCall) =>
-                toolCall.status === "running"
-                  ? { ...toolCall, status: "completed", endedAt: completedAt }
-                  : toolCall,
-              ),
-            }
-          : message,
-      ),
-    );
+    finalizeActiveStreamingMessages(new Date().toISOString());
     if (isTauriRuntime()) {
       await invokeCommand("cancel_assistant_streams").catch(() => {});
     }

--- a/src/ai/AssistantPanel.tsx
+++ b/src/ai/AssistantPanel.tsx
@@ -662,6 +662,27 @@ export function AssistantPanel({
     activeAssistantRequestIdRef.current += 1;
     setIsSendingPrompt(false);
     setChatError("");
+    // Bumping the request id above makes the streaming channel's onmessage
+    // handler ignore any further events (including a final "done"/"error"),
+    // so the in-flight message would otherwise be stuck showing isStreaming:
+    // true forever — finalize it here instead.
+    const stoppedAt = new Date().toISOString();
+    setMessages((current) =>
+      current.map((message) =>
+        message.isStreaming
+          ? {
+              ...message,
+              isStreaming: false,
+              workCompletedAt: stoppedAt,
+              toolCalls: (message.toolCalls ?? []).map((toolCall) =>
+                toolCall.status === "running"
+                  ? { ...toolCall, status: "completed", endedAt: stoppedAt }
+                  : toolCall,
+              ),
+            }
+          : message,
+      ),
+    );
     if (isTauriRuntime()) {
       // Detaching the UI is not enough: without this the backend agent loop
       // keeps running — and keeps executing tools — after Stop.

--- a/tests/assistant-working-status.test.mjs
+++ b/tests/assistant-working-status.test.mjs
@@ -104,17 +104,52 @@ test("stopping an assistant reply finalizes the in-flight streaming message", as
   );
   assert.ok(stopFunctionMatch, "handleStopAssistantPrompt should exist.");
   const stopFunctionSource = stopFunctionMatch[0];
+  const finalizerMatch = assistantSource.match(
+    /function finalizeActiveStreamingMessages\(completedAt: string\)[\s\S]*?\n  }\n/,
+  );
+  assert.ok(finalizerMatch, "finalizeActiveStreamingMessages should exist.");
+  const finalizerSource = finalizerMatch[0];
 
   assert.match(
     stopFunctionSource,
-    /setMessages\(/,
-    "Stop should update chat messages, not just the isSendingPrompt flag.",
+    /finalizeActiveStreamingMessages\(new Date\(\)\.toISOString\(\)\)/,
+    "Stop should finalize chat messages, not just the isSendingPrompt flag.",
   );
   assert.match(
-    stopFunctionSource,
+    finalizerSource,
     /isStreaming:\s*false/,
     "Stop must clear isStreaming on the active message so its work panel stops " +
       "showing a running 'thinking' indicator after the request id has been " +
       "bumped (which makes the stream channel ignore any later done/error event).",
+  );
+  assert.match(
+    finalizerSource,
+    /messagesRef\.current\s*=\s*finalizedMessages/,
+    "Stop must update the mutable message ref so the next assistant turn cannot reuse " +
+      "a stale streaming transcript.",
+  );
+  assert.match(
+    finalizerSource,
+    /saveChatMessages\(/,
+    "Stop must persist the finalized partial assistant message into chat history.",
+  );
+});
+
+test("stale assistant stream flushes cannot revive a stopped message", async () => {
+  const assistantSource = await readFile(
+    new URL("../src/ai/AssistantPanel.tsx", import.meta.url),
+    "utf8",
+  );
+
+  const flushFunctionMatch = assistantSource.match(
+    /const flushStreamingSnapshot = \(\) => \{[\s\S]*?\n      \};/,
+  );
+  assert.ok(flushFunctionMatch, "flushStreamingSnapshot should exist.");
+  const flushFunctionSource = flushFunctionMatch[0];
+
+  assert.match(
+    flushFunctionSource,
+    /activeAssistantRequestIdRef\.current !== requestId[\s\S]*return;/,
+    "A pending coalesced stream flush must no-op after Stop bumps the request id.",
   );
 });

--- a/tests/assistant-working-status.test.mjs
+++ b/tests/assistant-working-status.test.mjs
@@ -92,3 +92,29 @@ test("assistant renders in-chat tool approval controls", async () => {
     "typed Tauri wrappers should include the approval completion command.",
   );
 });
+
+test("stopping an assistant reply finalizes the in-flight streaming message", async () => {
+  const assistantSource = await readFile(
+    new URL("../src/ai/AssistantPanel.tsx", import.meta.url),
+    "utf8",
+  );
+
+  const stopFunctionMatch = assistantSource.match(
+    /function handleStopAssistantPrompt\(\)[\s\S]*?\n  }\n/,
+  );
+  assert.ok(stopFunctionMatch, "handleStopAssistantPrompt should exist.");
+  const stopFunctionSource = stopFunctionMatch[0];
+
+  assert.match(
+    stopFunctionSource,
+    /setMessages\(/,
+    "Stop should update chat messages, not just the isSendingPrompt flag.",
+  );
+  assert.match(
+    stopFunctionSource,
+    /isStreaming:\s*false/,
+    "Stop must clear isStreaming on the active message so its work panel stops " +
+      "showing a running 'thinking' indicator after the request id has been " +
+      "bumped (which makes the stream channel ignore any later done/error event).",
+  );
+});


### PR DESCRIPTION
## Summary
- Fixes a bug where clicking **Stop** on an in-progress AI assistant reply left that message's "thinking" work panel spinning forever, even after the turn had ended.
- Root cause: `handleStopAssistantPrompt` bumped the active request id and cancelled the backend stream, but never set the in-flight message's `isStreaming` back to `false`. Bumping the request id also makes the stream channel's `onmessage` handler ignore any later `done`/`error` event, so nothing else could clear it either — the waiting-phrase/dots interval and spinner in `AssistantWorkPanel` kept cycling indefinitely on that message.
- Fix mirrors the cleanup already done in `denyAssistantToolApproval`: finalize the streaming message (`isStreaming: false`, `workCompletedAt`, and mark any still-`running` tool calls as `completed`) before cancelling the backend stream.

## Test plan
- [x] Added a regression test in `tests/assistant-working-status.test.mjs` asserting `handleStopAssistantPrompt` updates `messages` and clears `isStreaming`.
- [x] `node --test tests/assistant-*.test.mjs` — 22/22 pass.
- [x] `npx tsc --noEmit` — no new errors in `AssistantPanel.tsx`.