### PR TITLE
fix: correct garbled non-English values in PC Info widget

### DIFF
--- a/src-tauri/src/pc_info.rs
+++ b/src-tauri/src/pc_info.rs
@@ -359,9 +359,15 @@ mod platform {
     const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
     // One hidden PowerShell pass that returns every section as structured JSON.
-    // CIM property names are invariant English, so values like Caption/Model are
-    // stable regardless of the Windows display language.
-    const QUERY: &str = r#"$ErrorActionPreference='SilentlyContinue';
+    // CIM property *names* are invariant English, so the field layout is stable
+    // regardless of the Windows display language. The *values*, however, can be
+    // localized/non-ASCII (OS Caption, time-zone caption, user and device names).
+    // Windows PowerShell 5.1 encodes redirected stdout with the OEM code page by
+    // default, which `String::from_utf8_lossy` would mangle into  replacement
+    // characters — so force UTF-8 (no BOM; a BOM would survive `trim()` and break
+    // the JSON parse) before emitting anything.
+    const QUERY: &str = r#"[Console]::OutputEncoding=New-Object System.Text.UTF8Encoding $false;
+$ErrorActionPreference='SilentlyContinue';
 function E($d){ if($d){[int64]([math]::Floor((($d).ToUniversalTime() - [datetime]'1970-01-01').TotalSeconds))} else {$null} }
 function S($a){ if($a){ (($a | Where-Object {$_ -gt 0} | ForEach-Object {[char]$_}) -join '').Trim() } else {$null} }
 $os=Get-CimInstance Win32_OperatingSystem;


### PR DESCRIPTION
## Summary

The PC Info widget showed garbled (`` replacement) text for some system values on non-English Windows machines. Root cause: the gather runs Windows PowerShell 5.1 and reads its stdout with `String::from_utf8_lossy` (`src-tauri/src/pc_info.rs`), but PowerShell 5.1 encodes redirected stdout using the machine's **OEM code page** (CP936/GBK, CP932, …), not UTF-8. CIM property *names* are invariant English, but the *values* are not — OS `Caption` ("Windows 11 家庭中文版"), time-zone caption, user names, and some device/manufacturer strings are localized and got mangled.

Fix: set `[Console]::OutputEncoding` to UTF-8 **without a BOM** at the top of the PowerShell query, before any output is emitted. No BOM because a U+FEFF preamble would survive the Rust `trim()` (`char::is_whitespace` does not treat U+FEFF as whitespace) and break the `serde_json` parse.

## Type of change

- [x] Bug fix

## Areas touched

- [x] Backend (Rust/Tauri — `src-tauri/`)

## i18n

- [x] No user-visible strings (data-encoding fix; the widget already renders backend-provided values verbatim)

## Checks

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` (passes)
- [ ] Validated in the real Tauri desktop runtime — recommended on a non-English (e.g. zh-CN / ja-JP) Windows install to confirm localized values now render correctly. I could not reproduce the localized-locale condition in this environment.

## Notes for reviewers

- Single-line change inside the `QUERY` string plus an updated comment explaining the keys-vs-values distinction.
- Frontend (`normalize.ts`) is a pure pass-through and needs no change.
- macOS path (`system_profiler -json`) already emits UTF-8 and is unaffected.