### PR TITLE
Open connection icon foreground color picker upward to avoid clipping

### DIFF
--- a/src/modules/workspace/connections/connections.css
+++ b/src/modules/workspace/connections/connections.css
@@ -1148,6 +1148,14 @@
   border-top: 1px solid var(--border);
 }
 
+/* The custom foreground color picker sits near the bottom of the scrollable icon
+   selector. Open its palette upward so the picker remains usable instead of
+   being clipped by the popover's lower edge. */
+.connection-icon-foreground-section .color-palette-popover {
+  top: auto;
+  bottom: calc(100% + 8px);
+}
+
 .connection-icon-current {
   position: relative;
   width: 30px;


### PR DESCRIPTION
### Motivation
- The foreground color picker in the Connection icon selector was being clipped by the bottom of the scrollable popover, making custom foreground color selection unusable for items near the popover end.

### Description
- Add a small CSS rule in `src/modules/workspace/connections/connections.css` to make `.connection-icon-foreground-section .color-palette-popover` open upward by setting `top: auto` and `bottom: calc(100% + 8px)`, preventing the palette from being clipped.

### Testing
- Ran `npm run check` (ESLint + frontend tests + `tsc --noEmit`) which completed successfully; the test suite passed and the command exited successfully (ESLint reported 2 existing warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45ef771154832fbef6b6c85267933e)