### PR TITLE
Add clear button to Connection Tree search box

### DIFF
--- a/src/modules/workspace/connections/ConnectionSidebar.tsx
+++ b/src/modules/workspace/connections/ConnectionSidebar.tsx
@@ -349,6 +349,7 @@ export function ConnectionSidebar({
   }, [childConnections, tree]);
   const addConnectionRef = useRef<HTMLDivElement | null>(null);
   const quickConnectRef = useRef<HTMLDivElement | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
   const treeListRef = useRef<HTMLDivElement | null>(null);
   const draggedItemRef = useRef<DraggedTreeItem | null>(null);
   const pointerDragTargetRef = useRef<TreeDropTarget | null>(null);
@@ -2862,14 +2863,30 @@ export function ConnectionSidebar({
       </div>
 
       <div className="connection-search-row">
-        <label className="search-box" data-tutorial-id="connections.search">
+        <div className="search-box" data-tutorial-id="connections.search">
           <Search size={15} />
           <input
+            ref={searchInputRef}
+            aria-label={t("connections.searchPlaceholder")}
             value={query}
             onChange={(event) => setQuery(event.currentTarget.value)}
             placeholder={t("connections.searchPlaceholder")}
           />
-        </label>
+          {query.trim().length > 0 ? (
+            <button
+              aria-label={t("common.clear")}
+              className="connection-search-clear"
+              onClick={() => {
+                setQuery("");
+                searchInputRef.current?.focus();
+              }}
+              title={t("common.clear")}
+              type="button"
+            >
+              <X size={12} />
+            </button>
+          ) : null}
+        </div>
 
         <div className="quick-connect-anchor" ref={quickConnectRef}>
           <button

--- a/src/modules/workspace/connections/connections.css
+++ b/src/modules/workspace/connections/connections.css
@@ -47,6 +47,27 @@
   margin: 0;
 }
 
+.connection-search-clear {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  color: var(--text-muted);
+  background: transparent;
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.connection-search-clear:hover,
+.connection-search-clear:focus-visible {
+  color: var(--text);
+  background: var(--surface-muted);
+}
+
 .connection-search-row .quick-connect-anchor {
   flex: 0 0 auto;
   margin: 0;


### PR DESCRIPTION
### Motivation
- Provide a quick, discoverable way to clear the Connection Tree search input when a query exists and keep focus so the user can immediately type a new search.

### Description
- Add an inline clear `X` button to the Connection Tree search field by introducing `searchInputRef` and conditional render logic in `src/modules/workspace/connections/ConnectionSidebar.tsx`, replace the `label.search-box` wrapper with a `div` to host the control, and wire the button to `setQuery("")` and refocus the input.
- Add compact styles for the clear affordance in `src/modules/workspace/connections/connections.css` under the `.connection-search-clear` selector and use the existing `X` icon from `lucide-react` for the glyph.

### Testing
- Ran `git diff --check` (passed) and `npx tsc --noEmit` (passed).  
- Ran `npm run lint -- --max-warnings=0`, which failed due to pre-existing unrelated warnings in `src/modules/itops/*` and not because of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46415deb84832f83b589f7f46a0f9c)