### PR TITLE
Fix ACP bridge protocol bugs, stream CLI agent progress, strengthen harness contract

### DIFF
--- a/docs/AI_PROVIDERS.md
+++ b/docs/AI_PROVIDERS.md
@@ -48,7 +48,21 @@ adapters: KKTerm first tries an Agent Client Protocol (ACP) stdio backend using
 the registry adapters for Codex and Claude Agent. If the ACP adapter is not
 available or fails to initialize, KKTerm falls back to the documented one-shot
 vendor CLI commands (`codex exec` or `claude -p`) using the vendor CLI's own
-cached authentication. The API key field is disabled in these modes. Keep this
+cached authentication. The fallback is strictly a setup-failure path: once the
+ACP `session/prompt` turn has been dispatched, an error or timeout surfaces to
+the user instead of re-running the same turn through the one-shot command,
+because the ACP agent may already have streamed text or executed kkterm MCP
+tools and a re-run would duplicate both. ACP stdio is treated as line-delimited
+JSON-RPC with an idle timeout that resets on every received message, so long
+agent turns that keep streaming updates (or wait on an in-app tool approval) do
+not abort at a fixed wall-clock cutoff; agent-initiated requests are never
+mistaken for responses even when their JSON-RPC ids collide with KKTerm's, and
+unknown agent requests get a method-not-found reply whether their id is a
+number or a string. ACP `session/update` notifications beyond assistant text —
+thought chunks, tool-call lifecycle updates, and agent plans — are forwarded to
+the same `reasoningDelta` / `toolCallStart` / `toolCallEnd` / `planUpdate`
+stream events the native providers emit, so the Assistant work panel renders
+CLI-backed turns with the same progress affordances. The API key field is disabled in these modes. Keep this
 bridge conservative: use documented ACP or non-interactive CLI modes, avoid
 passing KKTerm secrets through environment variables or prompt text, and do not
 claim parity with KKTerm's native tool-calling loop unless ACP tool/client

--- a/docs/manual/13-ai-assistant.md
+++ b/docs/manual/13-ai-assistant.md
@@ -22,7 +22,7 @@ Chat history is stored in SQLite table `assistant_chat_threads`, indexed for rec
 
 ## Composer
 
-Default placeholder `ai.composerPlaceholder`. Send `ai.sendMessage` / `ai.send`. Stop in-flight `ai.stopMessage`; Stop also cancels the backend agent run, so no further provider calls or tool executions happen after it. Cancelling an ACP-backed CLI turn does not start the one-shot fallback, and one-shot fallback processes honor the same cancellation and response timeout. Copy `ai.copy` / `ai.copyMessage`. Highlighted Assistant Panel text can also be copied from the right-click native context menu item `common.copy`. Code label `ai.code`. Show-less / more `ai.showLess` / `ai.more`.
+Default placeholder `ai.composerPlaceholder`. Send `ai.sendMessage` / `ai.send`. Stop in-flight `ai.stopMessage`; Stop also cancels the backend agent run, so no further provider calls or tool executions happen after it. Cancelling an ACP-backed CLI turn does not start the one-shot fallback, and one-shot fallback processes honor the same cancellation and response timeout. The one-shot fallback only runs when ACP fails before the prompt turn starts; once an ACP turn is underway, an error surfaces in the chat instead of silently re-running the request. Copy `ai.copy` / `ai.copyMessage`. Highlighted Assistant Panel text can also be copied from the right-click native context menu item `common.copy`. Code label `ai.code`. Show-less / more `ai.showLess` / `ai.more`.
 
 Assistant responses wrap to the available panel width. Wide code blocks remain contained within the response and scroll horizontally inside the code block instead of clipping the surrounding response text.
 
@@ -83,7 +83,7 @@ The assistant memory tools (`settings.aiTools.memory.label`, default on) let the
 
 The assistant can also call the read-only `mcp_list_tools` tool to list the remote MCP servers configured in Settings together with their cached tool schemas. It serves the cached `tools/list` results from local storage without contacting the servers and is used to ground widget code that calls `KK.callMcpTool` in real tool names and argument shapes.
 
-When `settings.useCodexCli` or `settings.useClaudeCli` routes a provider through a local CLI backend, ACP-backed sessions attach KKTerm's built-in `kkterm` MCP server so published safe tools, including Connection creation, can run through the same local bridge as external MCP clients. If ACP is unavailable and KKTerm falls back to a one-shot CLI command, the assistant can only suggest actions or Connection details instead of calling KKTerm tools.
+When `settings.useCodexCli` or `settings.useClaudeCli` routes a provider through a local CLI backend, ACP-backed sessions attach KKTerm's built-in `kkterm` MCP server so published safe tools, including Connection creation, can run through the same local bridge as external MCP clients. If ACP is unavailable and KKTerm falls back to a one-shot CLI command, the assistant can only suggest actions or Connection details instead of calling KKTerm tools. ACP-backed turns also stream the CLI agent's thinking, tool-call progress chips, and work plan into the assistant work panel using the same progress treatment as native providers; the tool names shown are the CLI agent's own tool titles.
 
 Names shown during a tool call (`ai.toolCallRunning` → `ai.toolCallComplete`):
 

--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -1206,15 +1206,16 @@ impl AgentProvider for CliAgentProvider {
         let settings_for_acp = settings.clone();
         let output = tauri::async_runtime::spawn_blocking(move || {
             run_acp_agent_command(backend, &model, &prompt, &app_for_acp, &settings_for_acp)
-                .or_else(|acp_error| {
-                    if !should_fallback_from_acp_error(&acp_error) {
-                        return Err(acp_error);
+                .or_else(|acp_failure| {
+                    if !should_fallback_from_acp_error(&acp_failure) {
+                        return Err(acp_failure.error);
                     }
                     ai_interaction_debug!(
                         "agent.cli_acp_fallback",
                         json!({
                             "backend": backend,
-                            "error": acp_error,
+                            "error": acp_failure.error,
+                            "promptStarted": acp_failure.prompt_started,
                             "model": &model,
                             "promptBytes": prompt.len(),
                             "promptChars": prompt.chars().count(),
@@ -1270,15 +1271,16 @@ impl AgentProvider for CliAgentProvider {
                     &app_for_acp,
                     &settings_for_acp,
                 )
-                .or_else(|acp_error| {
-                    if !should_fallback_from_acp_error(&acp_error) {
-                        return Err(acp_error);
+                .or_else(|acp_failure| {
+                    if !should_fallback_from_acp_error(&acp_failure) {
+                        return Err(acp_failure.error);
                     }
                     ai_interaction_debug!(
                         "agent.cli_acp_streaming_fallback",
                         json!({
                             "backend": backend,
-                            "error": acp_error,
+                            "error": acp_failure.error,
+                            "promptStarted": acp_failure.prompt_started,
                             "model": &model,
                             "promptBytes": prompt.len(),
                             "promptChars": prompt.chars().count(),

--- a/src-tauri/src/ai/cli_backend.rs
+++ b/src-tauri/src/ai/cli_backend.rs
@@ -96,7 +96,11 @@ impl AcpStdioSession {
         timeout_duration: Duration,
         notification_handler: &mut impl FnMut(&mut Self, Value) -> Result<(), String>,
     ) -> Result<Value, String> {
-        let deadline = Instant::now() + timeout_duration;
+        // Idle timeout: every received line proves the backend is alive, so the
+        // deadline restarts after each processed message. Long agent turns that
+        // keep streaming updates (or wait on an in-app permission answer) no
+        // longer abort at a fixed wall-clock cutoff; only true silence times out.
+        let mut deadline = Instant::now() + timeout_duration;
         while Instant::now() < deadline {
             if self.cancel_probe.as_ref().is_some_and(|probe| probe()) {
                 return Err(ASSISTANT_STREAM_CANCELED_ERROR.to_string());
@@ -108,10 +112,14 @@ impl AcpStdioSession {
             else {
                 continue;
             };
-            let value = serde_json::from_str::<Value>(&line)
-                .map_err(|error| format!("ACP backend returned invalid JSON-RPC: {error}"))?;
+            let Ok(value) = serde_json::from_str::<Value>(&line) else {
+                // Tolerate stray non-JSON stdout lines (npm/npx notices, adapter
+                // banners) instead of abandoning the whole session over one line.
+                ai_interaction_debug!("agent.acp_recv_invalid", json!({ "line": line }));
+                continue;
+            };
             ai_interaction_debug!("agent.acp_recv", value.clone());
-            if value.get("id").and_then(Value::as_u64) == Some(id) {
+            if acp_message_is_response_for(&value, id) {
                 if let Some(error) = value.get("error") {
                     return Err(format!("ACP backend returned an error: {error}"));
                 }
@@ -123,6 +131,7 @@ impl AcpStdioSession {
             if value.get("method").is_some() {
                 notification_handler(self, value)?;
             }
+            deadline = Instant::now() + timeout_duration;
         }
         Err(format!("timed out waiting for ACP response id {id}"))
     }
@@ -144,13 +153,30 @@ impl Drop for AcpStdioSession {
     }
 }
 
+/// A message is the response to KKTerm's request only when it carries no
+/// `method`: agent-initiated requests and notifications always have one, and
+/// their JSON-RPC ids live in the agent's own id namespace, which may collide
+/// numerically with KKTerm's request ids.
+pub(crate) fn acp_message_is_response_for(value: &Value, id: u64) -> bool {
+    value.get("method").is_none() && value.get("id").and_then(Value::as_u64) == Some(id)
+}
+
+/// Why an ACP turn failed, plus whether `session/prompt` had already been
+/// dispatched. Once the prompt starts, real agent work may have happened
+/// (streamed text, kkterm MCP tool side effects), so callers must not re-run
+/// the same turn through the one-shot CLI fallback.
+pub(crate) struct AcpRunFailure {
+    pub(crate) error: String,
+    pub(crate) prompt_started: bool,
+}
+
 pub(crate) fn run_acp_agent_command(
     backend: AiCliBackendKind,
     model: &str,
     prompt: &str,
     app: &tauri::AppHandle,
     settings: &AiProviderSettings,
-) -> Result<String, String> {
+) -> Result<String, AcpRunFailure> {
     run_acp_agent_command_streaming(backend, model, prompt, None, app, settings)
 }
 
@@ -161,6 +187,31 @@ pub(crate) fn run_acp_agent_command_streaming(
     channel: Option<&Channel<Value>>,
     app: &tauri::AppHandle,
     settings: &AiProviderSettings,
+) -> Result<String, AcpRunFailure> {
+    let mut prompt_started = false;
+    run_acp_agent_turn(
+        backend,
+        model,
+        prompt,
+        channel,
+        app,
+        settings,
+        &mut prompt_started,
+    )
+    .map_err(|error| AcpRunFailure {
+        error,
+        prompt_started,
+    })
+}
+
+fn run_acp_agent_turn(
+    backend: AiCliBackendKind,
+    model: &str,
+    prompt: &str,
+    channel: Option<&Channel<Value>>,
+    app: &tauri::AppHandle,
+    settings: &AiProviderSettings,
+    prompt_started: &mut bool,
 ) -> Result<String, String> {
     let spec = acp_command_spec(backend);
     let cwd = app
@@ -218,6 +269,7 @@ pub(crate) fn run_acp_agent_command_streaming(
         .ok_or_else(|| "ACP session/new response did not include sessionId".to_string())?
         .to_string();
     let prompt = format!("Requested model: {model}\n\n{prompt}");
+    *prompt_started = true;
     session.request(
         3,
         "session/prompt",
@@ -261,6 +313,10 @@ pub(crate) fn handle_acp_backend_message(
                 if let Some(channel) = channel {
                     emit_stream(channel, &AiStreamEvent::ContentDelta { delta })?;
                 }
+            } else if let Some(channel) = channel {
+                if let Some(event) = acp_session_update_stream_event(&message) {
+                    emit_stream(channel, &event)?;
+                }
             }
         }
         "session/request_permission" => {
@@ -277,7 +333,9 @@ pub(crate) fn handle_acp_backend_message(
             }
         }
         _ => {
-            if let Some(id) = message.get("id").and_then(Value::as_u64) {
+            // Reply method-not-found to any unknown agent request — numeric or
+            // string id — so the CLI backend never hangs waiting on KKTerm.
+            if let Some(id) = acp_jsonrpc_id(&message) {
                 session.write_json(json!({
                     "jsonrpc": "2.0",
                     "id": id,
@@ -402,6 +460,83 @@ pub(crate) fn acp_agent_message_delta_text(message: &Value) -> Option<String> {
         return None;
     }
     acp_content_text(update.get("content")?)
+}
+
+/// Maps non-content ACP `session/update` notifications onto the stream-event
+/// vocabulary the Assistant work panel already renders: thought chunks become
+/// reasoning deltas, tool-call lifecycle updates become tool chips, and agent
+/// plans become the work-plan step list.
+pub(crate) fn acp_session_update_stream_event(message: &Value) -> Option<AiStreamEvent> {
+    let update = message.pointer("/params/update")?;
+    let kind = update.get("sessionUpdate").and_then(Value::as_str)?;
+    match kind {
+        "agent_thought_chunk" => acp_content_text(update.get("content")?)
+            .map(|delta| AiStreamEvent::ReasoningDelta { delta }),
+        "tool_call" | "tool_call_update" => {
+            let tool_id = update
+                .get("toolCallId")
+                .and_then(Value::as_str)?
+                .to_string();
+            let tool_name = update
+                .get("title")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            let status = update
+                .get("status")
+                .and_then(Value::as_str)
+                // A fresh `tool_call` without a status starts pending per ACP;
+                // a status-less `tool_call_update` changes nothing chip-worthy.
+                .unwrap_or(if kind == "tool_call" { "pending" } else { "" });
+            match status {
+                "completed" => Some(AiStreamEvent::ToolCallEnd {
+                    tool_id,
+                    tool_name,
+                    error: None,
+                }),
+                "failed" => Some(AiStreamEvent::ToolCallEnd {
+                    tool_id,
+                    tool_name,
+                    error: Some("failed".to_string()),
+                }),
+                "pending" | "in_progress" if !tool_name.is_empty() => {
+                    Some(AiStreamEvent::ToolCallStart { tool_id, tool_name })
+                }
+                _ => None,
+            }
+        }
+        "plan" => {
+            let entries = update.get("entries").and_then(Value::as_array)?;
+            let steps = entries
+                .iter()
+                .enumerate()
+                .filter_map(|(index, entry)| {
+                    let label = entry.get("content").and_then(Value::as_str)?.trim();
+                    if label.is_empty() {
+                        return None;
+                    }
+                    let status = match entry.get("status").and_then(Value::as_str) {
+                        Some("in_progress") => "running",
+                        Some("completed") => "completed",
+                        _ => "pending",
+                    };
+                    Some(AssistantPlanStep {
+                        id: format!("acp-plan-{index}"),
+                        label: label.to_string(),
+                        status: status.to_string(),
+                        detail: None,
+                    })
+                })
+                .collect::<Vec<_>>();
+            if steps.is_empty() {
+                None
+            } else {
+                Some(AiStreamEvent::PlanUpdate { goal: None, steps })
+            }
+        }
+        _ => None,
+    }
 }
 
 pub(crate) fn acp_content_text(content: &Value) -> Option<String> {
@@ -656,7 +791,7 @@ pub(crate) fn cli_backend_status(
             }),
             AiCliBackendKind::ClaudeCode => {
                 run_cli_capture(&command, &["auth", "status"], Some(Duration::from_secs(20)))
-                    .map(|_| true)
+                    .map(|output| claude_auth_status_logged_in(&output))
                     .unwrap_or_else(|message| {
                         error = Some(message);
                         false
@@ -673,6 +808,20 @@ pub(crate) fn cli_backend_status(
         authenticated,
         version,
         error,
+    }
+}
+
+/// `claude auth status` can exit 0 while logged out, reporting
+/// `"loggedIn": false` in its default JSON output — exit code alone is not an
+/// authentication signal. Non-JSON output falls back to exit-code success so a
+/// future CLI format change degrades to the old behavior instead of breaking.
+pub(crate) fn claude_auth_status_logged_in(output: &str) -> bool {
+    match serde_json::from_str::<Value>(output.trim()) {
+        Ok(value) => value
+            .get("loggedIn")
+            .and_then(Value::as_bool)
+            .unwrap_or(true),
+        Err(_) => true,
     }
 }
 
@@ -910,8 +1059,13 @@ pub(crate) fn run_cli_capture_with_stdin_and_cancel(
     }
 }
 
-pub(crate) fn should_fallback_from_acp_error(error: &str) -> bool {
-    error != ASSISTANT_STREAM_CANCELED_ERROR
+/// One-shot CLI fallback is only for ACP setup failures (adapter missing,
+/// initialize/session-new errors). Never fall back after `session/prompt`
+/// started — the agent may already have streamed text or executed kkterm MCP
+/// tools, and re-running the turn would duplicate both — and never fall back
+/// on user cancellation.
+pub(crate) fn should_fallback_from_acp_error(failure: &AcpRunFailure) -> bool {
+    !failure.prompt_started && failure.error != ASSISTANT_STREAM_CANCELED_ERROR
 }
 
 pub(crate) fn cli_process_invocation(command: &str, args: &[&str]) -> (String, Vec<String>) {

--- a/src-tauri/src/ai/tests.rs
+++ b/src-tauri/src/ai/tests.rs
@@ -230,12 +230,193 @@ fn acp_command_specs_use_registry_adapters() {
 
 #[test]
 fn assistant_cancellation_never_falls_back_to_one_shot_cli() {
-    assert!(!should_fallback_from_acp_error(
-        ASSISTANT_STREAM_CANCELED_ERROR
+    assert!(!should_fallback_from_acp_error(&AcpRunFailure {
+        error: ASSISTANT_STREAM_CANCELED_ERROR.to_string(),
+        prompt_started: false,
+    }));
+    assert!(should_fallback_from_acp_error(&AcpRunFailure {
+        error: "ACP backend returned an error during initialize".to_string(),
+        prompt_started: false,
+    }));
+}
+
+#[test]
+fn started_acp_prompt_never_falls_back_to_one_shot_cli() {
+    // Once session/prompt is dispatched the agent may already have streamed
+    // text or executed kkterm MCP tools; a one-shot re-run would duplicate both.
+    assert!(!should_fallback_from_acp_error(&AcpRunFailure {
+        error: "timed out waiting for ACP response id 3".to_string(),
+        prompt_started: true,
+    }));
+}
+
+#[test]
+fn acp_agent_requests_with_colliding_ids_are_not_responses() {
+    // The agent's own request id namespace can collide numerically with
+    // KKTerm's request ids; `method` marks it as a request, not our response.
+    let agent_request = json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "session/request_permission",
+        "params": {}
+    });
+    assert!(!acp_message_is_response_for(&agent_request, 3));
+
+    let response = json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "result": { "stopReason": "end_turn" }
+    });
+    assert!(acp_message_is_response_for(&response, 3));
+    assert!(!acp_message_is_response_for(&response, 2));
+}
+
+#[test]
+fn acp_thought_chunks_stream_as_reasoning_deltas() {
+    let message = json!({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+            "sessionId": "sess_1",
+            "update": {
+                "sessionUpdate": "agent_thought_chunk",
+                "content": { "type": "text", "text": "Considering options" }
+            }
+        }
+    });
+
+    let event = acp_session_update_stream_event(&message).expect("event");
+    assert_eq!(
+        serde_json::to_value(&event).expect("serialize"),
+        json!({ "type": "reasoningDelta", "delta": "Considering options" })
+    );
+}
+
+#[test]
+fn acp_tool_call_updates_stream_as_tool_chips() {
+    let start = json!({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+            "update": {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "call_1",
+                "title": "Read config file",
+                "status": "in_progress"
+            }
+        }
+    });
+    let event = acp_session_update_stream_event(&start).expect("start event");
+    assert_eq!(
+        serde_json::to_value(&event).expect("serialize"),
+        json!({ "type": "toolCallStart", "toolId": "call_1", "toolName": "Read config file" })
+    );
+
+    let done = json!({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "call_1",
+                "status": "completed"
+            }
+        }
+    });
+    let event = acp_session_update_stream_event(&done).expect("end event");
+    assert_eq!(
+        serde_json::to_value(&event).expect("serialize"),
+        json!({ "type": "toolCallEnd", "toolId": "call_1", "toolName": "", "error": null })
+    );
+
+    let failed = json!({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "call_1",
+                "status": "failed"
+            }
+        }
+    });
+    let event = acp_session_update_stream_event(&failed).expect("failed event");
+    assert_eq!(
+        serde_json::to_value(&event).expect("serialize"),
+        json!({ "type": "toolCallEnd", "toolId": "call_1", "toolName": "", "error": "failed" })
+    );
+
+    // A status-less update changes nothing chip-worthy.
+    let noop = json!({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "call_1"
+            }
+        }
+    });
+    assert!(acp_session_update_stream_event(&noop).is_none());
+}
+
+#[test]
+fn acp_plan_updates_stream_as_work_plan_steps() {
+    let message = json!({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+            "update": {
+                "sessionUpdate": "plan",
+                "entries": [
+                    { "content": "Inspect the host", "priority": "high", "status": "completed" },
+                    { "content": "Apply the fix", "priority": "high", "status": "in_progress" },
+                    { "content": "Verify", "priority": "medium", "status": "pending" }
+                ]
+            }
+        }
+    });
+
+    let event = acp_session_update_stream_event(&message).expect("plan event");
+    assert_eq!(
+        serde_json::to_value(&event).expect("serialize"),
+        json!({
+            "type": "planUpdate",
+            "steps": [
+                { "id": "acp-plan-0", "label": "Inspect the host", "status": "completed" },
+                { "id": "acp-plan-1", "label": "Apply the fix", "status": "running" },
+                { "id": "acp-plan-2", "label": "Verify", "status": "pending" }
+            ]
+        })
+    );
+}
+
+#[test]
+fn acp_agent_message_chunks_are_not_duplicated_as_stream_events() {
+    let message = json!({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "content": { "type": "text", "text": "Hello" }
+            }
+        }
+    });
+    assert!(acp_session_update_stream_event(&message).is_none());
+}
+
+#[test]
+fn claude_auth_status_requires_logged_in_json() {
+    assert!(claude_auth_status_logged_in(
+        "{\n  \"loggedIn\": true,\n  \"authMethod\": \"claude.ai\"\n}"
     ));
-    assert!(should_fallback_from_acp_error(
-        "ACP backend returned an error during initialize"
+    assert!(!claude_auth_status_logged_in(
+        "{\n  \"loggedIn\": false\n}"
     ));
+    // Unknown output shapes degrade to the old exit-code-only behavior.
+    assert!(claude_auth_status_logged_in("Logged in as user@example.com"));
+    assert!(claude_auth_status_logged_in("{\"status\":\"ok\"}"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Audit of the AI Assistant's ACP (Agent Client Protocol) CLI bridge found five protocol/robustness bugs and one functionality gap; this PR fixes them and strengthens the documented harness contract.

**ACP bridge bug fixes (`src-tauri/src/ai/cli_backend.rs`):**

- **JSON-RPC id collision**: agent-initiated requests (e.g. `session/request_permission`) live in the agent's own id namespace, which can collide numerically with KKTerm's request ids 1–3. `wait_for_id` treated any matching numeric id as *our* response, aborting the turn with "response did not include result" and stranding the permission prompt. Messages carrying `method` are now never classified as responses (`acp_message_is_response_for`).
- **String-id requests hung the agent**: unknown agent requests only received a `-32601` reply when the id was a `u64`; Claude's adapter uses string ids (the existing `acp_jsonrpc_id_preserves_string_permission_ids` test proves it). The reply path now uses `acp_jsonrpc_id`.
- **Mid-turn fallback duplicated work**: any ACP error triggered the one-shot `codex exec` / `claude -p` fallback — even after the agent had streamed text or executed kkterm MCP tools — duplicating visible output and re-running side-effecting work. Fallback is now gated to setup failures only (`AcpRunFailure.prompt_started`), matching what `docs/AI_PROVIDERS.md` already claimed ("not available or fails to initialize").
- **Fixed 300s wall-clock timeout**: the `session/prompt` deadline kept ticking while the user was deciding an approval card or the agent was actively streaming. It is now an idle timeout that resets on every received message; only true silence aborts. Cancellation via Stop is unaffected.
- **One stray non-JSON stdout line (npx/npm notice) killed the session**: unparseable lines are now logged to `aiassistant.debug.log` and skipped.

**Functionality gap closed:**

- ACP `agent_thought_chunk`, `tool_call` / `tool_call_update`, and `plan` session updates were silently dropped. They now map onto the existing `reasoningDelta` / `toolCallStart` / `toolCallEnd` / `planUpdate` stream events, so CLI-backed turns render thinking, tool chips, and the work plan in the assistant work panel exactly like native HTTP providers. No frontend changes needed — the UI already supports these events.

**CLI knowledge fix:**

- `claude auth status` exits 0 even when logged out, reporting `"loggedIn": false` in its JSON output (verified against the real CLI). KKTerm only checked the exit code, so Settings could show a logged-out CLI as authenticated. The output is now parsed, degrading to exit-code behavior for unknown output shapes.

Also verified against the installed CLIs and npm: every `codex` / `claude` flag KKTerm uses exists (`--ask-for-approval`, `--ignore-user-config`, `--ephemeral`, `--tools`, `--permission-mode`, `--no-session-persistence`, `claude auth login/status`), and the pinned ACP adapters `@zed-industries/codex-acp@0.15.0` and `@agentclientprotocol/claude-agent-acp@0.40.0` exist. Frontend approval/stream/live-tool paths audited clean; no changes required there.

## Type of change

- [x] Bug fix
- [x] Docs / manual

## Areas touched

- [x] Backend (Rust/Tauri — `src-tauri/`)
- [x] Docs (`docs/`, manual, ADR)

## Domain & docs

- [x] Uses the canonical vocabulary (Connection / Session / Tab / Workspace / Module — not "profile" for a stored Connection)
- [x] New/changed behavior in a manual chapter's scope updates the relevant `docs/manual/` chapter (chapter 13 §Composer and §Built-in tools; `docs/AI_PROVIDERS.md` ACP/CLI contract)

## i18n

- [x] No user-visible strings (new work-panel text is model/CLI-generated tool titles and plan labels; no new UI keys)

## High-risk invariants

- [x] No frontend close hooks / close-confirmation flows added
- [x] No live Session state added to the durable Connection model
- [x] RDP/VNC/WebView2 surface rules respected (not touched)

## Checks

- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 889 passed, 0 failed (8 new regression tests: id-collision classification, no-fallback-after-prompt-start, thought/tool/plan event mapping, no double-emission of message chunks, `loggedIn` parsing)
- `npm run check` / `npm run build` not run: no frontend code changed (docs + Rust only, < 500 LOC)
- Live ACP end-to-end (real Codex/Claude adapter session) not exercised in this change; unit tests cover the message classification and event mapping

## Notes for reviewers

- `should_fallback_from_acp_error` changed signature from `&str` to `&AcpRunFailure`; both `ai.rs` call sites (streaming + non-streaming CLI provider) updated and now log `promptStarted` in the fallback debug records.
- Newer adapter versions exist on npm (codex-acp 0.16.0, claude-agent-acp 0.55.0); pins left as-is deliberately — bumping is a separate, testable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)