### PR TITLE
Fix Server Room floor plan / 2.5D view not taking full pane height

### DIFF
--- a/src/modules/itops/itops.css
+++ b/src/modules/itops/itops.css
@@ -3292,10 +3292,13 @@
   background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--accent) 40%, transparent));
 }
 
-/* Drill-down detail. */
+/* Drill-down detail. Grows to fill the .hg-detail pane so the spatial room
+   views can take its full height; taller content keeps its natural height
+   (flex basis stays content-sized) and scrolls the pane as before. */
 .itops-page .ft-drill {
   display: flex;
   flex-direction: column;
+  flex: 1 0 auto;
   gap: 14px;
   min-height: 0;
   overflow: auto;


### PR DESCRIPTION
## Summary

Follow-up to #526: the window-filling Server Room views measured and stretched inside `.ft-drill`, but `.ft-drill` is a flex child of the `.hg-detail` pane with **no flex-grow**, so it stayed content-height and the floor plan / 2.5D grids never received the pane's height (they rendered at their minimum size with empty space below). The #526 verification harness had forced `height:100%` on `.ft-drill`, which masked this.

Fix: `.ft-drill` gets `flex: 1 0 auto`, so it grows to fill the pane. Taller content (rack elevations) keeps its natural height through the content-sized flex basis and scrolls the pane exactly as before.

## Type of change

- [x] Bug fix

## Areas touched

- [x] Frontend (React/TypeScript — `src/`) — CSS only, 4 lines in `src/modules/itops/itops.css`

## i18n

- [x] No user-visible strings

## Checks

Cosmetic CSS-only change, full suite skipped per AGENTS.md. Verified in a browser harness replicating the real DOM chain (`.hg.ft` → `.hg-detail` → `.ft-drill`) with no forced heights:
- Floor plan: drill 688px of a 720px pane (pane padding accounts for the rest), grid 1009×590 filling the scroll area, no stray pane scrollbars.
- 2.5D: viewport 1014×595 filling the pane.
- Tall-content regression check: a 2000px block inside the drill grows it naturally and the pane scrolls (elevation mode unaffected).

## Notes for reviewers

Worth one glance in the real desktop app since the pane sizing was exactly what the previous harness got wrong — this time the harness reproduced the bug before the fix and the fill after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)