### PR TITLE
Restore terminal focus after the multiline paste confirmation closes

### DIFF
--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -1728,6 +1728,12 @@ function TerminalPaneView({
     multilinePasteConfirmationResolverRef.current?.(confirmed);
     multilinePasteConfirmationResolverRef.current = null;
     setMultilinePasteConfirmationOpen(false);
+    // The confirm sheet's button holds DOM focus when it is clicked, so once
+    // the dialog unmounts focus falls to <body>. Return it to the terminal
+    // after the unmount commits, on both confirm and cancel.
+    const focus = () => terminalRendererRef.current?.focus();
+    queueMicrotask(focus);
+    window.requestAnimationFrame(focus);
   }
 
   async function writeWithPasteConfirmation(data: string, writeInput: (input: string) => void) {

--- a/tests/terminal-paste-normalization.test.mjs
+++ b/tests/terminal-paste-normalization.test.mjs
@@ -44,6 +44,22 @@ test("terminal copy-on-select reads the live setting so toggling applies to open
   assert.match(selectionHandler, /useWorkspaceStore\.getState\(\)\.terminalSettings\.copyOnSelect/);
 });
 
+test("multiline paste confirmation returns focus to the terminal after the dialog closes", async () => {
+  const workspaceSource = await readFile(
+    new URL("../src/modules/workspace/connections/terminal/TerminalWorkspace.tsx", import.meta.url),
+    "utf8",
+  );
+
+  const resolver =
+    workspaceSource.match(
+      /function resolveMultilinePasteConfirmation\(confirmed: boolean\) \{([\s\S]*?)\n  \}/,
+    )?.[1] ?? "";
+  assert.match(resolver, /setMultilinePasteConfirmationOpen\(false\)/);
+  assert.match(resolver, /terminalRendererRef\.current\?\.focus\(\)/);
+  assert.match(resolver, /queueMicrotask\(focus\)/);
+  assert.match(resolver, /window\.requestAnimationFrame\(focus\)/);
+});
+
 test("clipboard execCommand fallback restores focus after copying", async () => {
   const clipboardSource = await readFile(new URL("../src/lib/clipboard.ts", import.meta.url), "utf8");
 


### PR DESCRIPTION
Confirming or cancelling the multiline paste dialog left DOM focus on the
dismissed sheet's button, which falls back to <body> when the dialog
unmounts, so the terminal stopped receiving keystrokes until clicked
(#525). Refocus the pane's renderer from resolveMultilinePasteConfirmation
using the same queueMicrotask + requestAnimationFrame scheduling as
focusTerminalPaneAfterDialogClose, and add a source-shape regression test.

Fixes #525

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018QBhj9g5AtGU66rdf3vLmj