### PR TITLE
fix(linux): resolve conflicting signer private-key args in AppImage build

### DIFF
--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -108,8 +108,11 @@ strip_bundled_wayland_libs() {
   ARCH="${TARGET_TRIPLE%%-*}" "$(prepare_appimagetool)" "$work_dir/squashfs-root" "$appimage" >/dev/null
 
   # tauri build already produced an updater signature over the pre-patch
-  # bytes; regenerate it now that the AppImage contents changed.
-  "./node_modules/.bin/tauri" signer sign "$appimage"
+  # bytes; regenerate it now that the AppImage contents changed. The signer
+  # subcommand rejects --private-key and --private-key-path being set
+  # together, so drop the path env var here since the key content is
+  # already loaded into TAURI_SIGNING_PRIVATE_KEY.
+  env -u TAURI_SIGNING_PRIVATE_KEY_PATH "./node_modules/.bin/tauri" signer sign "$appimage"
 }
 
 "./node_modules/.bin/tauri" build --target "$TARGET_TRIPLE" --bundles appimage "$@"


### PR DESCRIPTION
## Summary
- `scripts/package-linux.sh` resigns the AppImage after stripping bundled libwayland libs, but `tauri signer sign` rejects `--private-key` and `--private-key-path` being present at the same time
- the script always exports both `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PATH`, which broke the resign step with: `error: the argument '--private-key <PRIVATE_KEY>' cannot be used with '--private-key-path <PRIVATE_KEY_PATH>'`
- unset the path env var for that one `signer sign` invocation, since the key content is already resolved into `TAURI_SIGNING_PRIVATE_KEY` earlier in the script

## Test plan
- [x] `bash -n scripts/package-linux.sh` (syntax check)
- [ ] Run `npm run package:linux` end-to-end in CI to confirm the AppImage builds and resigns successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)