### PR TITLE
fix(linux): stop AppImage env leaking into spawned host processes

### DIFF
--- a/docs/LINUX_PORT.md
+++ b/docs/LINUX_PORT.md
@@ -277,6 +277,21 @@ a clean Ubuntu, and runs the smoke path (open window, open a local terminal).**
 > Both fixes were validated end-to-end on the Fedora VM: extract → strip →
 > repack with `appimagetool` → relaunch showed no crash and a visibly
 > rendered window.
+>
+> **Follow-up (2026-07-05, v0.1.112 on the same Fedora 44 VM):** still blank —
+> a third bug in fix (2) itself. AppImage's AppRun wrapper exports
+> `LD_LIBRARY_PATH` pointing at the bundled libs, and the spawned host
+> `systemd-detect-virt` inherited it, aborting with
+> ``libcrypto.so.3: version `OPENSSL_3.4.0' not found`` (bundled Ubuntu
+> OpenSSL 3.0 vs. Fedora 44's `libsystemd-shared` needing 3.4 symbols) — so
+> VM detection reported "not a VM" and the DMA-BUF workaround never engaged.
+> Fix: `main.rs` scrubs `LD_LIBRARY_PATH` when spawning the detector. The
+> same leak reaches terminal shells and the spawned host `ssh` (which
+> silently loaded the *bundled* libcrypto), so `sessions.rs` now scrubs all
+> AppImage-injected variables (`LD_LIBRARY_PATH`, `GTK_*`, `GDK_*`,
+> `GIO_EXTRA_MODULES`, `GSETTINGS_SCHEMA_DIR`, `XDG_DATA_DIRS` entries under
+> `$APPDIR`, `APPDIR`/`APPIMAGE`/`ARGV0`/`OWD`) from local-shell and ssh
+> children; no-op outside an AppImage.
 
 - [ ] Add `appimage` to a **Linux-only** bundle target. Do NOT add it to the
       shared `tauri.conf.json` `bundle.targets` (which is `nsis`/`app`/`dmg`);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,8 +16,14 @@ fn main() {
 /// Tauri/GTK/WebKit touch the display (see docs/LINUX_PORT.md Phase 5/6).
 #[cfg(target_os = "linux")]
 fn apply_linux_gpu_workarounds() {
+    // When running from an AppImage, AppRun points LD_LIBRARY_PATH at the
+    // bundled libs; host binaries like systemd-detect-virt must not load
+    // those (e.g. bundled libcrypto.so.3 lacks the host's OPENSSL_3.4.0
+    // symbols on Fedora 44, so the loader aborts and detection reports
+    // "not a VM").
     let running_in_vm = std::process::Command::new("systemd-detect-virt")
         .args(["--vm", "--quiet"])
+        .env_remove("LD_LIBRARY_PATH")
         .status()
         .map(|status| status.success())
         .unwrap_or(false);

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -2550,6 +2550,7 @@ fn command_for(request: &StartTerminalSessionRequest) -> Result<CommandBuilder, 
                 CommandBuilder::new(resolved_program.clone())
             };
             sanitize_windows_local_environment(&mut command);
+            sanitize_linux_appimage_environment(&mut command);
             set_terminal_environment(&mut command);
             apply_managed_terminal_environment(&mut command, &request.environment_variables)?;
             if let Some(session_id) = psmux_session_id {
@@ -2588,6 +2589,7 @@ fn command_for(request: &StartTerminalSessionRequest) -> Result<CommandBuilder, 
             }
 
             let mut command = CommandBuilder::new("ssh");
+            sanitize_linux_appimage_environment(&mut command);
             set_terminal_environment(&mut command);
             command.arg("-tt");
             if let Some(port) = request.port {
@@ -2849,6 +2851,74 @@ fn sanitize_windows_local_environment(command: &mut CommandBuilder) {
         // for every mainstream terminal); only explicit overrides are layered on.
         let _ = command;
     }
+}
+
+// When KKTerm runs from an AppImage, the AppRun wrapper and its bundled
+// linuxdeploy GTK hook rewrite the environment so the app loads the bundled
+// GTK/WebKit stack from the transient /tmp/.mount_* directory. Children that
+// execute *host* binaries must not inherit those values: the bundled
+// libraries come from the build host and mismatch the running system (e.g.
+// systemd tools abort with `OPENSSL_3.4.0' not found` on Fedora 44, ssh
+// silently uses the bundled libcrypto instead of the host's patched one).
+// Variables the hook overwrites wholesale are dropped — the pre-AppImage
+// value is unrecoverable and a plain desktop shell would not have them set —
+// while prepended path lists are filtered entry-by-entry so any entries the
+// user had before launch survive. No-op outside an AppImage (no APPDIR).
+fn sanitize_linux_appimage_environment(command: &mut CommandBuilder) {
+    #[cfg(target_os = "linux")]
+    {
+        let Some(appdir) = std::env::var("APPDIR")
+            .ok()
+            .filter(|value| !value.is_empty())
+        else {
+            return;
+        };
+
+        for name in [
+            "APPDIR",
+            "APPIMAGE",
+            "ARGV0",
+            "OWD",
+            "GDK_BACKEND",
+            "GTK_THEME",
+            "GTK_DATA_PREFIX",
+            "GTK_EXE_PREFIX",
+            "GTK_PATH",
+            "GTK_IM_MODULE_FILE",
+            "GDK_PIXBUF_MODULE_FILE",
+            "GSETTINGS_SCHEMA_DIR",
+            "GIO_EXTRA_MODULES",
+        ] {
+            command.env_remove(name);
+        }
+
+        for name in ["LD_LIBRARY_PATH", "XDG_DATA_DIRS"] {
+            let Ok(value) = std::env::var(name) else {
+                continue;
+            };
+            match filter_appimage_path_list(&value, &appdir) {
+                Some(kept) => command.env(name, kept),
+                None => command.env_remove(name),
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = command;
+    }
+}
+
+/// Drops `:`-separated path entries that point into the AppImage mount,
+/// returning `None` when nothing user-provided remains.
+#[cfg(any(target_os = "linux", test))]
+fn filter_appimage_path_list(value: &str, appdir: &str) -> Option<String> {
+    let kept = value
+        .split(':')
+        .filter(|entry| !entry.is_empty() && !entry.starts_with(appdir))
+        .collect::<Vec<_>>()
+        .join(":");
+    (!kept.is_empty()).then_some(kept)
 }
 
 // Compose the current user's environment from the registry exactly as Windows
@@ -3207,6 +3277,32 @@ fn make_session_id(title: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn appimage_path_list_filter_keeps_user_entries_only() {
+        let appdir = "/tmp/.mount_kktermXXXXXX";
+        // AppRun prepends every bundled lib dir; user had one entry of their own.
+        assert_eq!(
+            filter_appimage_path_list(
+                "/tmp/.mount_kktermXXXXXX/usr/lib/:/tmp/.mount_kktermXXXXXX/usr/lib64/:/opt/custom/lib:",
+                appdir
+            ),
+            Some("/opt/custom/lib".to_string())
+        );
+        // Entirely AppImage-injected: nothing left, caller should unset.
+        assert_eq!(
+            filter_appimage_path_list("/tmp/.mount_kktermXXXXXX/usr/lib/:", appdir),
+            None
+        );
+        // The GTK hook prepends to XDG_DATA_DIRS; system entries survive.
+        assert_eq!(
+            filter_appimage_path_list(
+                "/tmp/.mount_kktermXXXXXX/usr/share:/usr/share:/usr/local/share",
+                appdir
+            ),
+            Some("/usr/share:/usr/local/share".to_string())
+        );
+    }
 
     #[cfg(target_os = "windows")]
     #[test]


### PR DESCRIPTION
## Summary

v0.1.112 (with the wayland-lib strip from #537) still showed a blank window on the Fedora 44 VM. Root cause: a third bug, in the VM-detection added by #537 itself.

The AppImage AppRun wrapper exports `LD_LIBRARY_PATH` pointing into the transient `/tmp/.mount_*` bundle, and the linuxdeploy GTK hook exports a dozen more vars (`GTK_*`, `GDK_*`, `GIO_EXTRA_MODULES`, `GSETTINGS_SCHEMA_DIR`, `XDG_DATA_DIRS`, ...). Host binaries spawned by KKTerm inherit all of it:

1. **Blank window on VMs**: `systemd-detect-virt` aborted with ``libcrypto.so.3: version `OPENSSL_3.4.0' not found`` (bundled Ubuntu OpenSSL 3.0 vs. Fedora 44's `libsystemd-shared` needing 3.4 symbols). Detection reported "not a VM", so `WEBKIT_DISABLE_DMABUF_RENDERER` was never set. `main.rs` now scrubs `LD_LIBRARY_PATH` when spawning the detector.
2. **Env leak into terminals and ssh**: host `ssh` silently loaded the *bundled* libcrypto (missing host security updates), `git` warned about libpcre2 mismatches, and systemd-family tools failed outright inside KKTerm terminals. New `sanitize_linux_appimage_environment()` in `sessions.rs`, applied to local-shell and ssh spawns: wholesale-overwritten vars are dropped; prepended path lists (`LD_LIBRARY_PATH`, `XDG_DATA_DIRS`) are filtered entry-by-entry so user-set entries survive. No-op outside an AppImage (no `APPDIR`).

## Test plan

- [x] Reproduced on Fedora 44 VM against the real v0.1.112 AppImage: with bundled `LD_LIBRARY_PATH`, `systemd-detect-virt` exits 1; with it removed it reports `vmware`.
- [x] Forcing `WEBKIT_DISABLE_DMABUF_RENDERER=1` on the v0.1.112 AppImage renders the window correctly (visually confirmed), proving the env-var path is the only remaining blocker.
- [x] Confirmed host `ssh -V` under the bundled `LD_LIBRARY_PATH` reports the bundled OpenSSL 3.0.13 instead of the host's.
- [x] Unit test added for the `:`-separated path-list filtering (`filter_appimage_path_list`).
- [ ] Local `cargo check`/`cargo test` blocked on this VM by a missing `pipewire-devel` system package (environment issue; all other deps compiled cleanly after clearing a corrupted `target/debug`) — relying on CI to build and run tests.
- [ ] End-to-end revalidation on the VM with the next packaged build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141uBJu7wyyxRnaM3Y5AHYH