### PR TITLE
fix(itops): settle room objects against resolved rack cells; drop iso debug telemetry

### DIFF
--- a/src/modules/itops/ServerRoomIsoView.tsx
+++ b/src/modules/itops/ServerRoomIsoView.tsx
@@ -27,10 +27,6 @@ import type { Rack, RackItem, RackItemStatus } from "../../types";
 import { rackFloorMetrics } from "./roomFloorPlan";
 import { RoomObjectIsoArtwork } from "./RoomObjectArtwork";
 import {
-  logUiDebug,
-  isTauriRuntime,
-} from "../../lib/tauri";
-import {
   ISO_ROT_DEG,
   ISO_TILT_COS,
   ISO_TILT_DEG,
@@ -92,23 +88,6 @@ const CELL = 58;
 // Vertical scale: one rack unit in plane px. Linear so stacking is exact —
 // an object with z = rack heightU sits flush on the cabinet top.
 const PX_PER_U = 2.1;
-
-function roundGeom(value: number): number {
-  return Math.round(value * 1000) / 1000;
-}
-
-function roundPoint(point: { x: number; y: number }): { x: number; y: number } {
-  return { x: roundGeom(point.x), y: roundGeom(point.y) };
-}
-
-function roundRect(rect: CellRect): CellRect {
-  return {
-    x: roundGeom(rect.x),
-    y: roundGeom(rect.y),
-    w: roundGeom(rect.w),
-    d: roundGeom(rect.d),
-  };
-}
 
 function cabHeight(heightU: number): number {
   return Math.min(124, Math.max(20, Math.max(1, heightU) * PX_PER_U));
@@ -292,65 +271,6 @@ export function ServerRoomIsoView({
       floorRows,
     );
   };
-  useEffect(() => {
-    if (!isTauriRuntime() || objects.length === 0) return;
-    logUiDebug("itops.iso.objectPlacement", {
-      angle,
-      cellPx: CELL,
-      floor: { cols: floorCols, rows: floorRows, offX, offY },
-      objects: objects.map((object) => {
-        const footprint = objectFootprint(object.kind, object.rot, object.corner);
-        const anchor = objectSurfaceAnchor(object.kind, object.rot, object.corner);
-        const displayRect = rotateRectForView(
-          { x: object.x + offX + footprint.x, y: object.y + offY + footprint.y, w: footprint.w, d: footprint.d },
-          angle,
-          floorCols,
-          floorRows,
-        );
-        const displayAnchor = rotatePointForView(
-          { x: object.x + offX + anchor.x, y: object.y + offY + anchor.y },
-          angle,
-          floorCols,
-          floorRows,
-        );
-        const supportingRack = racks.find((rack) => {
-          const cell = layout.cells[rack.id];
-          if (!cell || cell.x !== object.x || cell.y !== object.y) return false;
-          return object.z === Math.min(ROOM_CEILING_U, Math.max(1, rack.heightU));
-        });
-        return {
-          id: object.id,
-          kind: object.kind,
-          cell: { x: object.x, y: object.y },
-          z: object.z,
-          rot: object.rot,
-          corner: object.corner,
-          footprint: roundRect(footprint),
-          anchor: roundPoint(anchor),
-          displayRect: roundRect(displayRect),
-          displayAnchor: roundPoint(displayAnchor),
-          supportingRack: supportingRack
-            ? {
-                id: supportingRack.id,
-                cell: layout.cells[supportingRack.id],
-                facing: sanitizeFacing(facing[supportingRack.id]),
-                depthFrac: roundGeom(rackDepthFrac(supportingRack.depthMm)),
-                displayCell: rotateCellForView(
-                  {
-                    x: layout.cells[supportingRack.id].x + offX,
-                    y: layout.cells[supportingRack.id].y + offY,
-                  },
-                  angle,
-                  floorCols,
-                  floorRows,
-                ),
-                displayFacing: rotateFacingForView(sanitizeFacing(facing[supportingRack.id]), angle),
-              }
-            : null,
-        };
-      }),
-    });
-  }, [angle, facing, floorCols, floorRows, objects, offX, offY, racks, layout.cells]);
   const planeW = dims.cols * CELL;
   const planeH = dims.rows * CELL;
 
@@ -764,10 +684,10 @@ export function ServerRoomIsoView({
                                     "--tile": OBJECT_ACCENTS[tool],
                                   } as React.CSSProperties
                                 }
-                                >
-                                  <span
-                                    className="rm-iso-obj-model"
-                                    data-kind={tool}
+                              >
+                                <span
+                                  className="rm-iso-obj-model"
+                                  data-kind={tool}
                                   style={{
                                     left: (displayAnchor.x - displayRect.x) * CELL,
                                     top: (displayAnchor.y - displayRect.y) * CELL,

--- a/src/modules/itops/SitesTab.tsx
+++ b/src/modules/itops/SitesTab.tsx
@@ -40,7 +40,7 @@ import {
   topologyGroupKey,
   type DrillPath,
 } from "./rackTopology";
-import { sanitizeFacing } from "./roomIsoLayout";
+import { resolveIsoLayout, sanitizeFacing } from "./roomIsoLayout";
 import { ItOpsBackground } from "./ItOpsBackground";
 import { RackStage } from "./RackStage";
 import { ServerRoomFloorPlan } from "./ServerRoomFloorPlan";
@@ -1135,8 +1135,13 @@ function RackDrill({
   }, [isoPlacementScope, roomName, saveDurableRoomObjects, showStatusBarNotice, site.id, t]);
 
   useEffect(() => {
-    if (!isoPlacementScope || roomObjects.length === 0) return;
-    const settled = settleRoomObjects(roomObjects, roomRacks ?? [], isoPlacements, roomFacing);
+    if (!isoPlacementScope || roomRacks == null || roomObjects.length === 0) return;
+    // Settle against the same resolved cells the room views draw (stored
+    // placements plus derived defaults), not the raw stored map — otherwise
+    // auto-placed racks are invisible to gravity and their rack-top objects
+    // would be yanked to the floor.
+    const rackCells = resolveIsoLayout(roomRacks, isoPlacements).cells;
+    const settled = settleRoomObjects(roomObjects, roomRacks, rackCells, roomFacing);
     if (!sameRoomObjects(roomObjects, settled)) saveRoomObjectsState(settled);
   }, [isoPlacementScope, roomObjects, roomRacks, isoPlacements, roomFacing, saveRoomObjectsState]);
 

--- a/tests/itops-edit-toolbar.test.mjs
+++ b/tests/itops-edit-toolbar.test.mjs
@@ -120,7 +120,8 @@ test("2.5D edit controls are selection-scoped and the room owns its appearance",
   assert.match(isoView, /objectDisplayRect/);
   assert.match(isoView, /objectDisplayAnchor/);
   assert.match(isoView, /rotateRectForView/);
-  assert.match(isoView, /logUiDebug\("itops\.iso\.objectPlacement"/);
+  // The placement pipeline is pure math — no runtime debug telemetry.
+  assert.doesNotMatch(isoView, /logUiDebug/);
   assert.doesNotMatch(isoView, /corner=\{rotateFacingForView\(object\.corner, angle\)\}/);
   assert.match(isoView, /editMode && selected/);
   // Object kind chips no longer float above the artwork — the view stays clean.


### PR DESCRIPTION
## Summary

Follow-up to the 2.5D kuai kuai placement saga. The placement math from `c5ef45ab` is actually correct — verified by mounting `ServerRoomIsoView` in a browser harness with the real room data and measuring the projected geometry at all four view angles (sprite anchors land pixel-exact on the supporting cabinet top; drag/drop and armed click placement store the correct cells). The packs that still looked adrift were **stale persisted coordinates** written back when the older, broken renderer was live: they were dragged until they *looked* right under the wrong projection, which stored compensated-wrong cells.

This PR removes the leftover debugging from the fix attempts and fixes the two real defects that remained, both in the gravity-settle pass:

- **Settle against resolved rack cells.** `settleRoomObjects` was fed the raw stored placement map, while the room views draw `resolveIsoLayout(...).cells` (stored placements plus derived defaults). Racks without a stored grid cell were invisible to gravity, so objects resting on an auto-placed rack would be yanked to the floor.
- **Don't settle before the room's racks load.** The effect could run with objects loaded but racks still pending, which would floor every rack-top object and *persist* that.
- **Remove the `itops.iso.objectPlacement` debug-telemetry effect** (plus its `roundGeom/roundPoint/roundRect` helpers and `lib/tauri` import) from `ServerRoomIsoView` — it re-serialized the whole room geometry on every objects/angle change. Also fixes the mangled JSX indentation the fix commit left in the ghost-preview block. The edit-toolbar test asserted the telemetry existed; it now asserts the opposite.

## Type of change

- [x] Bug fix
- [x] Refactor / cleanup

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)

## i18n

- [x] No user-visible strings

## Checks

- [x] `npm run check` (lint clean, 802/802 tests, tsc clean)

## Notes for reviewers

- No behavior change to the placement/projection pipeline itself — `objectDisplayRect` / `objectDisplayAnchor` / `rotateRectForView` from `c5ef45ab` stay as-is; they were verified correct.
- Existing rooms with packs stored on the wrong cell will still show them there (the data is faithful to what was saved). They can simply be dragged to the right cabinet now — edits at HEAD persist the correct cell.
- The settle pass still only adjusts `z` (never `x`/`y`/`corner`), so it heals floaters without moving anything laterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)