### PR TITLE
fix(itops): keep elevated 2.5D object sprites visually planted on their support

### DIFF
--- a/src/modules/itops/ServerRoomIsoView.tsx
+++ b/src/modules/itops/ServerRoomIsoView.tsx
@@ -262,14 +262,40 @@ export function ServerRoomIsoView({
       floorRows,
     );
   };
+  // An elevated billboard sprite anchored near the camera-far edge of a
+  // cabinet top rises against empty air and reads as floating, because the
+  // artwork is drawn much larger than its physical footprint. Keep the
+  // sprite's base at least this far into its cell span from the two far
+  // edges so it always visually stands on its support surface; the stored
+  // position, footprint, and collision math stay exact.
+  const PLANT_NEAR_FRAC = 0.4;
+  const plantAnchor = (
+    point: { x: number; y: number },
+    cell: IsoCell,
+    span: { w: number; h: number },
+    z: number,
+  ): { x: number; y: number } => {
+    if (z <= 0) return point;
+    const rect = rotateRectForView(
+      { x: cell.x + offX, y: cell.y + offY, w: span.w, d: span.h },
+      angle,
+      floorCols,
+      floorRows,
+    );
+    return {
+      x: Math.max(point.x, rect.x + rect.w * PLANT_NEAR_FRAC),
+      y: Math.max(point.y, rect.y + rect.d * PLANT_NEAR_FRAC),
+    };
+  };
   const objectDisplayAnchor = (object: RoomObject): { x: number; y: number } => {
     const anchor = objectSurfaceAnchor(object.kind, object.rot, object.corner);
-    return rotatePointForView(
+    const point = rotatePointForView(
       { x: object.x + offX + anchor.x, y: object.y + offY + anchor.y },
       angle,
       floorCols,
       floorRows,
     );
+    return plantAnchor(point, object, objectCellSpan(object.kind, object.rot), object.z);
   };
   const planeW = dims.cols * CELL;
   const planeH = dims.rows * CELL;
@@ -658,11 +684,16 @@ export function ServerRoomIsoView({
                           floorCols,
                           floorRows,
                         );
-                        const displayAnchor = rotatePointForView(
-                          { x: hover.x + offX + anchor.x, y: hover.y + offY + anchor.y },
-                          angle,
-                          floorCols,
-                          floorRows,
+                        const displayAnchor = plantAnchor(
+                          rotatePointForView(
+                            { x: hover.x + offX + anchor.x, y: hover.y + offY + anchor.y },
+                            angle,
+                            floorCols,
+                            floorRows,
+                          ),
+                          hover,
+                          span,
+                          z ?? 0,
                         );
                         return (
                           <>


### PR DESCRIPTION
## Summary

Follow-up to #542. The projection math is correct — an object on a cabinet top anchors its billboarded sprite exactly on the projected top face at every view angle (verified with in-page geometry markers). But when a rotation maps the object''s footprint quadrant to the **camera-far edge** of the top face, the deliberately oversized artwork rises against empty air and *reads* as floating beside the rack. That''s why the Kuai Kuai packs looked way off after each view rotation while looking perfect at the default angle.

Fix: clamp an **elevated** sprite''s base into the camera-near portion of its cell span (`PLANT_NEAR_FRAC = 0.4`) so the artwork always visibly stands on its support surface. The armed placement ghost gets the same treatment.

- Grounded (z = 0) objects are untouched.
- Stored position, footprint, selection tile, and collision math stay exact — only where the billboard sprite is drawn shifts, by at most ~0.15 cell.

Verified in a browser harness with the real room data (racks + packs on the rack-5 ceiling corners): the packs now stay on the cabinet top through all four view angles, and the default angle keeps its previous look.

## Type of change

- [x] Bug fix

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)

## i18n

- [x] No user-visible strings

## Checks

- [x] `npm run check` (lint clean, 802/802 tests, tsc clean)

## Notes for reviewers

- Before/after at view angle 1: previously one pack hung fully over the void past the top-left edge of the cabinet; now both packs overlap the top face at every angle.
- The clamp only ever pulls toward the camera (Math.max on both display axes), so two packs sharing a cell remain visually distinct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)