### PR TITLE
fix(itops): bottom-align 2.5D object artwork inside its sprite box

### DIFF
--- a/src/modules/itops/RoomObjectArtwork.tsx
+++ b/src/modules/itops/RoomObjectArtwork.tsx
@@ -99,8 +99,18 @@ export function RoomObjectPlanArtwork({ kind }: { kind: RoomObjectKind }) {
 }
 
 export function RoomObjectIsoArtwork({ kind }: { kind: RoomObjectKind }) {
+  // The 2.5D sprite box is bottom-anchored on the object's surface point, but
+  // the square viewBox letterboxes inside the per-kind portrait boxes; keep
+  // the artwork flush with the box bottom so bags/cabinets stand on their
+  // anchor instead of hovering above it.
   return (
-    <svg className="rm-object-art rm-object-art-iso" data-kind={kind} viewBox="0 0 100 100" aria-hidden="true">
+    <svg
+      className="rm-object-art rm-object-art-iso"
+      data-kind={kind}
+      viewBox="0 0 100 100"
+      preserveAspectRatio="xMidYMax meet"
+      aria-hidden="true"
+    >
       {kind === "aircon" ? (
         <>
           <path className="rm-art-iso-top" d="m25 20 39-12 17 12-39 13Z" />


### PR DESCRIPTION
## Summary

Follow-up to #543. The Kuai Kuai packs sat *near* the rack ceiling but hovered a few pixels above it — and the offset was exactly what it looked like: an artwork-centering issue.

The 2.5D sprite box is bottom-anchored on the object''s surface point, but `RoomObjectIsoArtwork` draws into a square `0 0 100 100` viewBox while the per-kind sprite boxes are portrait (Kuai Kuai 42x56, UPS 48x58, extinguisher 38x54, crash cart 58x66, aircon 62x96). SVG''s default `preserveAspectRatio="xMidYMid"` letterboxes the square content **vertically centred**, leaving ~7px of dead space *below* the drawing — so every portrait sprite stood slightly above its anchor.

Fix: `preserveAspectRatio="xMidYMax meet"` on the iso artwork, keeping the drawing flush with the box bottom. Landscape boxes (camera, sensor, smoke detector, cable tray) letterbox horizontally and are unaffected; the top-down floor-plan artwork stays centred as before.

Verified in a browser harness with the real room data at 200% zoom across all four view angles: the packs now stand directly on the cabinet top, and the floor-standing extinguisher''s shadow meets the floor.

## Type of change

- [x] Bug fix

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)

## i18n

- [x] No user-visible strings

## Checks

- [x] `npm run check` (lint clean, 803/803 tests, tsc clean)

## Notes for reviewers

- One-attribute change plus a comment; benefits every portrait, surface-standing sprite, not just Kuai Kuai.
- Object picker thumbnails share this SVG and will show the artwork resting on the thumb''s bottom edge — visually consistent with "standing" fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)