### PR TITLE
[codex] Fix IronRDP canvas assistant routing

### DIFF
--- a/src/modules/workspace/connections/remote-desktop/RdpCanvasView.tsx
+++ b/src/modules/workspace/connections/remote-desktop/RdpCanvasView.tsx
@@ -58,10 +58,14 @@ function base64ToBytes(base64: string): Uint8Array {
 export function RdpCanvasView({
   cadSignal = 0,
   connection,
+  onSessionConnected,
+  onSessionDisconnected,
   surfaceRef,
 }: {
   cadSignal?: number;
   connection: Connection;
+  onSessionConnected?: (sessionId: string) => void;
+  onSessionDisconnected?: (sessionId: string) => void;
   surfaceRef?: RefObject<HTMLCanvasElement | null>;
 }) {
   const { t } = useTranslation();
@@ -80,10 +84,27 @@ export function RdpCanvasView({
     }
     let disposed = false;
     let unlisten: (() => void) | undefined;
+    let reportedConnected = false;
     const sessionId = createRdpSessionId();
     sessionIdRef.current = sessionId;
     setStatus("connecting");
     setErrorMessage("");
+
+    const reportConnected = () => {
+      if (reportedConnected) {
+        return;
+      }
+      reportedConnected = true;
+      onSessionConnected?.(sessionId);
+    };
+
+    const reportDisconnected = () => {
+      if (!reportedConnected) {
+        return;
+      }
+      reportedConnected = false;
+      onSessionDisconnected?.(sessionId);
+    };
 
     const draw = (event: RdpCanvasEvent) => {
       const canvas = canvasRef.current;
@@ -123,12 +144,15 @@ export function RdpCanvasView({
       switch (payload.kind) {
         case "connected":
           setStatus("connected");
+          reportConnected();
           break;
         case "error":
           setErrorMessage(payload.message);
+          reportDisconnected();
           break;
         case "disconnected":
           setStatus("disconnected");
+          reportDisconnected();
           break;
         default:
           draw(payload);
@@ -153,11 +177,13 @@ export function RdpCanvasView({
       if (!disposed) {
         setErrorMessage(error instanceof Error ? error.message : String(error));
         setStatus("disconnected");
+        reportDisconnected();
       }
     });
 
     return () => {
       disposed = true;
+      reportDisconnected();
       unlisten?.();
       void invokeCommand("close_rdp_client_session", { request: { sessionId } }).catch(() => undefined);
       sessionIdRef.current = null;

--- a/src/modules/workspace/connections/remote-desktop/RemoteDesktopWorkspace.tsx
+++ b/src/modules/workspace/connections/remote-desktop/RemoteDesktopWorkspace.tsx
@@ -33,6 +33,7 @@ import {
 } from "../../paneRegistry";
 import { usesCanvasRdp } from "../../../../lib/platform";
 import { RdpCanvasView } from "./RdpCanvasView";
+import { scancodeForCode } from "./rdpScancodes";
 
 type VncSessionEvent =
   | { kind: "connected"; sessionId: string; name: string }
@@ -264,6 +265,31 @@ export function RemoteDesktopWorkspace({
     }
     rdpConnectionCountedRef.current = false;
     markConnectionSessionEnded(connection.id);
+  };
+
+  const requireRdpCanvasSessionId = () => {
+    const sessionId = sessionIdRef.current;
+    if (!sessionId || !sessionStartedRef.current) {
+      throw new Error("RDP Session is not connected.");
+    }
+    return sessionId;
+  };
+
+  const handleRdpCanvasConnected = (sessionId: string) => {
+    sessionIdRef.current = sessionId;
+    sessionStartingRef.current = false;
+    sessionStartedRef.current = true;
+    setRdpStatus(t("remoteDesktop.connected"));
+    markRdpConnectionStarted();
+  };
+
+  const handleRdpCanvasDisconnected = (sessionId: string) => {
+    if (sessionIdRef.current === sessionId) {
+      sessionIdRef.current = null;
+    }
+    sessionStartingRef.current = false;
+    sessionStartedRef.current = false;
+    markRdpConnectionEnded();
   };
 
   const handleRdpDisconnectedStatus = (connectionState: number) => {
@@ -498,12 +524,34 @@ export function RemoteDesktopWorkspace({
     if (!paneId || !connection || !isTauriRuntime()) {
       return;
     }
+    const mouseClick: RemoteDesktopController["mouseClick"] = connection.type === "vnc"
+      ? (x, y, button) => sendVncMouseClick(x, y, button)
+      : useRdpCanvas
+        ? (x, y, button) => sendRdpCanvasMouseClick(requireRdpCanvasSessionId(), x, y, button)
+        : async (x, y, button) => {
+            const sessionId = sessionIdRef.current;
+            if (!sessionId || !sessionStartedRef.current) {
+              throw new Error("RDP Session is not connected.");
+            }
+            await invokeCommand("send_rdp_mouse_click", {
+              request: {
+                sessionId,
+                x: Math.max(0, Math.min(65535, Math.trunc(x))),
+                y: Math.max(0, Math.min(65535, Math.trunc(y))),
+                button,
+              },
+            });
+          };
     const controller: RemoteDesktopController = {
       kind: connection.type === "vnc" ? "vnc" : "rdp",
       captureScreenshot: captureRemoteDesktopScreenshot,
       sendText: async (text, pressEnter) => {
         if (connection.type === "vnc") {
           await sendVncText(text, pressEnter);
+          return;
+        }
+        if (useRdpCanvas) {
+          await sendRdpCanvasText(requireRdpCanvasSessionId(), text, pressEnter);
           return;
         }
         const sessionId = sessionIdRef.current;
@@ -519,6 +567,10 @@ export function RemoteDesktopWorkspace({
           await sendVncKeyPress(key);
           return;
         }
+        if (useRdpCanvas) {
+          await sendRdpCanvasKeyPress(requireRdpCanvasSessionId(), key);
+          return;
+        }
         const sessionId = sessionIdRef.current;
         if (!sessionId || !sessionStartedRef.current) {
           throw new Error("RDP Session is not connected.");
@@ -527,28 +579,25 @@ export function RemoteDesktopWorkspace({
           request: { sessionId, key },
         });
       },
-      mouseClick:
-        connection.type === "vnc"
-          ? (x, y, button) => sendVncMouseClick(x, y, button)
-          : async (x, y, button) => {
-              const sessionId = sessionIdRef.current;
-              if (!sessionId || !sessionStartedRef.current) {
-                throw new Error("RDP Session is not connected.");
-              }
-              await invokeCommand("send_rdp_mouse_click", {
-                request: {
-                  sessionId,
-                  x: Math.max(0, Math.min(65535, Math.trunc(x))),
-                  y: Math.max(0, Math.min(65535, Math.trunc(y))),
-                  button,
-                },
-              });
-            },
+      mouseClick,
     };
     registerRemoteDesktopController(paneId, controller);
     return () => unregisterRemoteDesktopController(paneId, controller);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [connection?.type, tab.panes[0]?.id]);
+
+  useEffect(() => {
+    const paneId = tab.panes[0]?.id;
+    if (!useRdpCanvas || !paneId || !isTauriRuntime()) {
+      return;
+    }
+    const sender = async (text: string, pressEnter: boolean) => {
+      await sendRdpCanvasText(requireRdpCanvasSessionId(), text, pressEnter);
+    };
+    registerRdpTextSender(paneId, sender);
+    return () => unregisterRdpTextSender(paneId, sender);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [useRdpCanvas, tab.panes[0]?.id]);
 
   const triggerPreCapture = () => {
     if (!canStartRdp || !isActive || !rdpVisibleRef.current) {
@@ -1606,6 +1655,8 @@ export function RemoteDesktopWorkspace({
             cadSignal={rdpCanvasCadSignal}
             connection={connection}
             key={rdpStartKey}
+            onSessionConnected={handleRdpCanvasConnected}
+            onSessionDisconnected={handleRdpCanvasDisconnected}
             surfaceRef={canvasRef}
           />
         ) : null}
@@ -1781,6 +1832,87 @@ function pointerButtonMask(button: number) {
     return 4;
   }
   return 1;
+}
+
+async function sendRdpCanvasText(sessionId: string, text: string, pressEnter: boolean) {
+  if (text.length > 0) {
+    await invokeCommand("send_rdp_client_text", { request: { sessionId, text } });
+  }
+  if (pressEnter && !text.endsWith("\n") && !text.endsWith("\r")) {
+    await sendRdpCanvasKeyPress(sessionId, "enter");
+  }
+}
+
+async function sendRdpCanvasKeyPress(sessionId: string, key: string) {
+  if (normalizeRemoteDesktopKeyName(key) === "ctrlaltdelete") {
+    await invokeCommand("send_rdp_client_ctrl_alt_delete", { request: { sessionId } });
+    return;
+  }
+  const scancode = rdpCanvasScancodeForName(key);
+  await invokeCommand("send_rdp_client_key_event", {
+    request: { sessionId, scancode, down: true },
+  });
+  await invokeCommand("send_rdp_client_key_event", {
+    request: { sessionId, scancode, down: false },
+  });
+}
+
+async function sendRdpCanvasMouseClick(
+  sessionId: string,
+  x: number,
+  y: number,
+  button: "left" | "right" | "middle",
+) {
+  const request = {
+    sessionId,
+    x: Math.max(0, Math.min(65535, Math.trunc(x))),
+    y: Math.max(0, Math.min(65535, Math.trunc(y))),
+  };
+  const buttonMask = button === "right" ? 4 : button === "middle" ? 2 : 1;
+  await invokeCommand("send_rdp_client_pointer_event", {
+    request: { ...request, buttonMask },
+  });
+  await invokeCommand("send_rdp_client_pointer_event", {
+    request: { ...request, buttonMask: 0 },
+  });
+}
+
+function rdpCanvasScancodeForName(value: string) {
+  const code = rdpCanvasCodeForName(value);
+  const scancode = code ? scancodeForCode(code) : undefined;
+  if (scancode === undefined) {
+    throw new Error(`Unsupported RDP key press: ${value}`);
+  }
+  return scancode;
+}
+
+function rdpCanvasCodeForName(value: string) {
+  const keyCodes: Record<string, string> = {
+    enter: "Enter",
+    return: "Enter",
+    tab: "Tab",
+    escape: "Escape",
+    esc: "Escape",
+    backspace: "Backspace",
+    delete: "Delete",
+    del: "Delete",
+    arrowup: "ArrowUp",
+    up: "ArrowUp",
+    arrowdown: "ArrowDown",
+    down: "ArrowDown",
+    arrowleft: "ArrowLeft",
+    left: "ArrowLeft",
+    arrowright: "ArrowRight",
+    right: "ArrowRight",
+    home: "Home",
+    end: "End",
+    pageup: "PageUp",
+    pgup: "PageUp",
+    pagedown: "PageDown",
+    pgdn: "PageDown",
+    space: "Space",
+  };
+  return keyCodes[normalizeRemoteDesktopKeyName(value)];
 }
 
 function resolveRdpOptions(

--- a/tests/rdp-canvas-controller-routing.test.mjs
+++ b/tests/rdp-canvas-controller-routing.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workspaceSource = await readFile(
+  new URL("../src/modules/workspace/connections/remote-desktop/RemoteDesktopWorkspace.tsx", import.meta.url),
+  "utf8",
+);
+const canvasSource = await readFile(
+  new URL("../src/modules/workspace/connections/remote-desktop/RdpCanvasView.tsx", import.meta.url),
+  "utf8",
+);
+
+test("IronRDP canvas sessions report lifecycle to the workspace controller", () => {
+  assert.match(canvasSource, /onSessionConnected\?: \(sessionId: string\) => void;/);
+  assert.match(canvasSource, /onSessionDisconnected\?: \(sessionId: string\) => void;/);
+  assert.match(canvasSource, /onSessionConnected\?\.\(sessionId\);/);
+  assert.match(canvasSource, /onSessionDisconnected\?\.\(sessionId\);/);
+  assert.match(workspaceSource, /onSessionConnected=\{handleRdpCanvasConnected\}/);
+  assert.match(workspaceSource, /onSessionDisconnected=\{handleRdpCanvasDisconnected\}/);
+});
+
+test("assistant remote-desktop tools use IronRDP client commands for canvas RDP", () => {
+  assert.match(
+    workspaceSource,
+    /if \(useRdpCanvas\) \{\s*await sendRdpCanvasText\(requireRdpCanvasSessionId\(\), text, pressEnter\);/s,
+  );
+  assert.match(
+    workspaceSource,
+    /if \(useRdpCanvas\) \{\s*await sendRdpCanvasKeyPress\(requireRdpCanvasSessionId\(\), key\);/s,
+  );
+  assert.match(workspaceSource, /sendRdpCanvasMouseClick\(requireRdpCanvasSessionId\(\), x, y, button\)/);
+  assert.match(workspaceSource, /invokeCommand\("send_rdp_client_text"/);
+  assert.match(workspaceSource, /invokeCommand\("send_rdp_client_key_event"/);
+  assert.match(workspaceSource, /invokeCommand\("send_rdp_client_pointer_event"/);
+  assert.match(workspaceSource, /invokeCommand\("send_rdp_client_ctrl_alt_delete"/);
+});
+
+test("assistant composer direct-send registers an RDP text sender for canvas RDP", () => {
+  assert.match(
+    workspaceSource,
+    /if \(!useRdpCanvas \|\| !paneId \|\| !isTauriRuntime\(\)\) \{\s*return;\s*\}/s,
+  );
+  assert.match(workspaceSource, /registerRdpTextSender\(paneId, sender\);/);
+  assert.match(workspaceSource, /sendRdpCanvasText\(requireRdpCanvasSessionId\(\), text, pressEnter\)/);
+});


### PR DESCRIPTION
## Summary

Follow-up review fix for #541.

The Linux RDP route added in #541 correctly sends Linux through the existing IronRDP canvas view, but the workspace-level assistant controller still assumed every RDP Session was the Windows ActiveX path. On macOS/Linux canvas RDP, assistant live tools and the composer "send to RDP" shortcut could see a visible RDP canvas while still failing with "RDP Session is not connected" or using the wrong `send_rdp_*` command family.

This PR wires the canvas session lifecycle back to `RemoteDesktopWorkspace`, then routes assistant text, keypress, mouse-click, and direct-send actions through the existing `send_rdp_client_*` commands when `usesCanvasRdp()` is active. Windows ActiveX RDP and VNC keep their existing paths.

## Validation

- `node tests/rdp-canvas-controller-routing.test.mjs`
- `npx tsc --noEmit`
- `npm run lint`
- `node tests/run-all.mjs`