### PR TITLE
Reuse the live SSH Session for port-forwarding loopback-port discovery

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2325,11 +2325,12 @@ async fn detect_ssh_remote_os(
 async fn list_remote_loopback_ports(
     app: tauri::AppHandle,
     request: sessions::TmuxConnectionRequest,
+    session_id: Option<String>,
 ) -> Result<Vec<sessions::RemoteLoopbackPort>, String> {
     run_blocking_command("SSH loopback port discovery", move || {
         let sessions = app.state::<sessions::SessionManager>();
         let secrets = app.state::<secrets::Secrets>();
-        sessions.list_remote_loopback_ports(app.clone(), &secrets, request, false)
+        sessions.list_remote_loopback_ports(app.clone(), &secrets, request, session_id, false)
     })
     .await
 }

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -1276,14 +1276,16 @@ impl SessionManager {
         app: AppHandle,
         secrets: &secrets::Secrets,
         request: TmuxConnectionRequest,
+        session_id: Option<String>,
         hide_common_ports: bool,
     ) -> Result<Vec<RemoteLoopbackPort>, String> {
-        let output = run_ssh_command(
+        let output = self.run_ssh_probe_command(
             app,
             secrets,
             &request,
+            session_id.as_deref(),
             remote_loopback_port_command(),
-            Some(Duration::from_secs(5)),
+            Duration::from_secs(5),
         )?;
         Ok(filter_remote_loopback_ports(
             parse_remote_loopback_ports(&output),

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -2254,6 +2254,7 @@ type CommandMap = {
         secretOwnerId?: string;
         passphraseOwnerId?: string;
       };
+      sessionId?: string;
     };
     result: RemoteLoopbackPort[];
   };

--- a/src/modules/workspace/connections/terminal/SshPortForwardingDialog.tsx
+++ b/src/modules/workspace/connections/terminal/SshPortForwardingDialog.tsx
@@ -316,6 +316,7 @@ export function SshPortForwardingDialog({
       .catch(() => undefined);
     void invokeCommand("list_remote_loopback_ports", {
       request: sshConnectionRequest(connection),
+      sessionId: sessionId ?? undefined,
     })
       .then((ports) => {
         if (!cancelled) {


### PR DESCRIPTION
# Summary

Closes #551 ("使用ssh連接埠重新導向,原本terminal會被重新登入").

Opening the SSH Port Forwarding dialog always spawned a **separate one-shot SSH login** to enumerate remote loopback ports for the destination-port suggestions: `list_remote_loopback_ports` never accepted a session id and went straight to `run_ssh_command`, which opens a brand-new SSH connection. On hosts that limit concurrent logins per user (common on network appliances), that extra login kicks or resets the user's original terminal Session — matching the reported "original terminal gets logged in again."

This routes the loopback-port probe through `run_ssh_probe_command`, the same live-Session path OS detection and `list_remote_network_addresses` already use, and passes the live session id from `SshPortForwardingDialog`. When a live native SSH Session exists, the probe now runs as a channel on that Session and no second login is made; the previous fresh-connection behavior remains only as the fallback when no live Session is available.

Note on the issue's framing: port forwards themselves already run as channels multiplexed on the same native SSH connection as the terminal, so no reordering of tunnel-vs-connection establishment is needed — the stray login came from this discovery probe, not from the forwards.

## Type of change

- [x] Bug fix

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)
- [x] Backend (Rust/Tauri — `src-tauri/`)

## Domain & docs

- [x] Uses the canonical vocabulary (Connection / Session / Tab / Workspace / Module — not "profile" for a stored Connection)
- [x] Source placement follows `docs/ARCHITECTURE.md` → Frontend Source Map; reused typed wrappers in `src/lib/tauri.ts` where applicable

## i18n

- [x] No user-visible strings

## High-risk invariants

- [x] No frontend close hooks / close-confirmation flows added
- [x] No live Session state added to the durable Connection model

## Checks

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` (plus `cargo check --tests`)
- `npx tsc --noEmit` and ESLint on the touched frontend files pass. Full `npm run check` / `npm run build` / `cargo test` skipped per AGENTS.md (8-line change, well under the 500-LOC threshold).
- [ ] Validated in the real Tauri desktop runtime — not possible in this environment; worth a quick manual check against a host that limits concurrent SSH logins.

## Notes for reviewers

- The dialog's `sessionId` is null when no live pane Session exists; the backend then falls back to the old fresh-connection probe, so suggestion behavior is unchanged in that case.
- If the reporter's re-login turns out to happen at a different moment than dialog-open (e.g. on connect), that would point at the remaining fallback paths (system-ssh transport, where forwards can't attach at all) and deserves a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmXrK1xJTVu3PpyknZ8ELt

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmXrK1xJTVu3PpyknZ8ELt)_