### PR TITLE
fix(rail): return to cross-Workspace session instead of spawning a new one

### DIFF
--- a/src/app/ActivityRail.tsx
+++ b/src/app/ActivityRail.tsx
@@ -21,7 +21,7 @@ import { showNativeContextMenu, type NativeContextMenuItem } from "../lib/native
 import { supportsInstallerHelper } from "../lib/platform";
 import { activityRailModuleOrder } from "./activityRailOrder";
 import { invokeCommand, isTauriRuntime } from "../lib/tauri";
-import { useWorkspaceStore } from "../store";
+import { DEFAULT_WORKSPACE_ID, useWorkspaceStore } from "../store";
 import type { Connection, Workspace } from "../types";
 import { NewWorkspaceDialog } from "../modules/workspace/NewWorkspaceDialog";
 import { DeleteWorkspaceDialog } from "../modules/workspace/WorkspaceRailDialogs";
@@ -307,9 +307,24 @@ export function ActivityRail({
 
   function handleRailConnectionClick(item: ConnectedRailItem) {
     onNavigate("workspace");
+    const existingTab = item.tabId
+      ? tabs.find((tab) => tab.id === item.tabId)
+      : undefined;
+    // A connected session can live in another Workspace; jump back to it
+    // (activateTab switches Workspaces) instead of assembling a child
+    // layout — and brand-new sessions — in the current Workspace.
+    if (
+      existingTab &&
+      (existingTab.workspaceId ?? DEFAULT_WORKSPACE_ID) !== activeWorkspaceId
+    ) {
+      activateTab(existingTab.id);
+      return;
+    }
     if (generalSettings.hideTopTabButtons) {
       const childConnections = loadStoredChildConnections().filter(
-        (child) => child.parentConnectionId === item.connection.id,
+        (child) =>
+          child.parentConnectionId === item.connection.id &&
+          (child.workspaceId ?? DEFAULT_WORKSPACE_ID) === activeWorkspaceId,
       );
       if (childConnections.length > 0) {
         openChildConnectionLayout(item.connection, childConnections);

--- a/tests/activity-rail-child-shortcut.test.mjs
+++ b/tests/activity-rail-child-shortcut.test.mjs
@@ -35,6 +35,19 @@ test("Activity Rail opens Child Connection Tab layouts like the Connection Tree"
   );
 });
 
+test("Activity Rail returns to sessions living in another Workspace", () => {
+  assert.match(
+    activityRailSource,
+    /\(existingTab\.workspaceId \?\? DEFAULT_WORKSPACE_ID\) !== activeWorkspaceId[\s\S]*activateTab\(existingTab\.id\);[\s\S]*return;[\s\S]*generalSettings\.hideTopTabButtons/,
+    "a rail click on a session from another Workspace must activate its Tab (switching Workspaces) before the child-layout branch can spawn new sessions in the current Workspace",
+  );
+  assert.match(
+    activityRailSource,
+    /child\.parentConnectionId === item\.connection\.id &&[\s\S]*\(child\.workspaceId \?\? DEFAULT_WORKSPACE_ID\) === activeWorkspaceId/,
+    "rail shortcuts must only assemble child layouts from the active Workspace's Child Connections",
+  );
+});
+
 test("Activity Rail CSS tooltip stays hidden while native rail tooltip is active", () => {
   assert.match(
     appCss,


### PR DESCRIPTION
## Summary

Fixes the Activity Rail bug where clicking a connected Connection whose Session lives in another Workspace spawned brand-new sessions in the current Workspace instead of returning to the existing one.

Repro (with Child Connections enabled and top Tab buttons hidden): open a terminal session in workspace2, switch to workspace1, click that session's rail item → new session spawns in workspace1.

Root cause: `handleRailConnectionClick` ran the Child Connection layout branch before the Tab-activation fallback, and `openChildConnectionLayout` is scoped to the active Workspace — it found no existing group Tab/Panes to reuse (they live in the other Workspace) and built fresh Panes. The `activateTab` path that correctly switches Workspaces was never reached. The stored Child Connection lookup also ignored `workspaceId`, unlike every equivalent filter in the store.

Fix (in `src/app/ActivityRail.tsx`):
- If the rail item's Tab lives in a different Workspace than the active one, activate that Tab immediately (`activateTab` already switches to its parent Workspace) and return.
- Scope the `loadStoredChildConnections()` filter to the active Workspace (`child.workspaceId ?? DEFAULT_WORKSPACE_ID`), matching the store's existing semantics.

Same-Workspace behavior is unchanged; the existing contract test enforcing "child layout before generic tab activation" still passes. Added assertions to `tests/activity-rail-child-shortcut.test.mjs` locking in the cross-Workspace early return and the Workspace-scoped child filter.

## Type of change

- [x] Bug fix

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)

## Domain & docs

- [x] Uses the canonical vocabulary (Connection / Session / Tab / Workspace / Module — not "profile" for a stored Connection)
- [x] Source placement follows `docs/ARCHITECTURE.md` → Frontend Source Map; reused typed wrappers in `src/lib/tauri.ts` where applicable

## i18n

- [x] No user-visible strings

## High-risk invariants

- [x] No frontend close hooks / close-confirmation flows added
- [x] No live Session state added to the durable Connection model

## Checks

- [x] `npm run check`

## Notes for reviewers

Not validated in the real Tauri desktop runtime — the fix is pure frontend Tab-routing logic, but a quick manual pass of the repro above is worthwhile: rail click should now jump back to the workspace2 session, and clicking a rail item whose session is in the current Workspace should still assemble the child panorama as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)