### PR TITLE
feat(itops): full-width Object Picker preview cards; fix off-screen placement cursor ghost

### DIFF
--- a/src/modules/itops/itops.css
+++ b/src/modules/itops/itops.css
@@ -12,10 +12,11 @@
 
 /* fills the workspace content area, mirroring the Installer/Dashboard modules.
    `.itops-page` also rides on portaled dialog backdrops (Sheet `zClassName`)
-   so the module tokens below reach IT Ops dialogs — the page-root layout half
-   must not apply there or it demotes the backdrop's fixed overlay positioning
-   and pushes the dialog below the viewport. */
-.itops-page:not(.kk-dlg-backdrop) {
+   and the armed-placement cursor ghost (`.rk-cursor-ghost`) so the module
+   tokens below reach those body-portaled elements — the page-root layout half
+   must not apply there or it demotes their fixed overlay positioning and
+   pushes them below the viewport. */
+.itops-page:not(.kk-dlg-backdrop):not(.rk-cursor-ghost) {
   position: relative;
   grid-column: 2 / 5;
   grid-row: 1;
@@ -4781,23 +4782,21 @@
   height: 100%;
 }
 .itops-page .rm-picker-thumb.device {
-  width: 82px;
-  height: 28px;
+  width: 100%;
+  height: 40px;
   flex: 0 0 auto;
 }
-/* Rack View device picker: a single-column list, one device type per row,
-   with the faceplate thumb beside a left-aligned name. */
+/* Rack View device picker: a single-column list of preview cards — the
+   faceplate thumb spans the card's full width with the name underneath. */
 .itops-page .rm-picker-devices .rm-picker-grid {
   grid-template-columns: minmax(0, 1fr);
 }
 .itops-page .rm-picker-devices .rm-picker-card {
-  flex-direction: row;
-  justify-content: flex-start;
-  gap: 8px;
-  padding: 5px 8px;
+  align-items: stretch;
+  gap: 6px;
+  padding: 8px 8px 6px;
 }
 .itops-page .rm-picker-devices .rm-picker-name {
-  text-align: left;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/tests/itops-edit-toolbar.test.mjs
+++ b/tests/itops-edit-toolbar.test.mjs
@@ -153,10 +153,10 @@ test("Rack device picker arms a configure-then-place flow with a cursor-snapped 
 test("IT Ops page-root layout stays off dialog backdrops and edit-mode dot grids", async () => {
   const css = await read("src/modules/itops/itops.css");
 
-  // `.itops-page` rides on Sheet backdrops (zClassName) for module tokens;
-  // the page-root positioning must not demote the fixed overlay or the
-  // dialog renders below the viewport.
-  assert.match(css, /\.itops-page:not\(\.kk-dlg-backdrop\) \{/);
+  // `.itops-page` rides on Sheet backdrops (zClassName) and the armed
+  // placement cursor ghost for module tokens; the page-root positioning must
+  // not demote those fixed overlays or they render below the viewport.
+  assert.match(css, /\.itops-page:not\(\.kk-dlg-backdrop\):not\(\.rk-cursor-ghost\) \{/);
   // The Site View dot grid is an edit-mode affordance even over a custom
   // background (the `.has-bg` rule is more specific than the generic reset).
   assert.match(


### PR DESCRIPTION
## Summary

Two changes to the Rack View (single-rack edit mode) Object Picker:

1. **Full-width preview cards** — each picker card now shows the device faceplate preview spanning the card's entire width (40px tall) with the name centered underneath, replacing the previous 82x28 thumbnail beside the label. The room/site pickers share the base card styles and are unchanged.
2. **Fix: armed-placement preview never floated under the cursor** — after configuring a device and arming placement, the cursor-tracked ghost was rendered on every mouse move but off-screen. The body-portaled `.rk-cursor-ghost` rides the `itops-page` class for module tokens, so the page-root rule `.itops-page:not(.kk-dlg-backdrop)` (specificity 0-2-0) overrode the ghost's `position: fixed; z-index: 120` (0-1-0) with `position: relative; z-index: 75`, leaving it in-flow at the end of `<body>` below the viewport. This is the same failure mode already documented for Sheet dialog backdrops; the fix extends that exclusion to `.itops-page:not(.kk-dlg-backdrop):not(.rk-cursor-ghost)`. Not a VS Code debugging limitation — placement uses plain `pointermove`, not HTML5 drag-and-drop.

## Type of change

- [x] Feature
- [x] Bug fix

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)

## i18n

- [x] No user-visible strings

## Checks

- Ran `node --test tests/itops-edit-toolbar.test.mjs` — all 14 pass (includes the guard test pinning the page-root selector, updated in this PR).
- Verified in the Vite browser preview with seeded store data: picker cards render full-width previews; arming a Server and moving the mouse shows the faceplate ghost centered under the cursor (`position: fixed`, z-index 120) away from the rack, and it still snaps into the rack grid as the dashed U-slot ghost near it.
- CSS-only + one test assertion (< 500 LOC), so the full check suite was skipped per AGENTS.md.

## Notes for reviewers

The ghost only appears once the mouse moves after the configure dialog closes — that part is by design (the pointer position is unknown until the first `pointermove`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)