### PR TITLE
fix: left-align connection hint links in empty workspace

### DIFF
--- a/src/modules/workspace/WorkspaceCanvas.tsx
+++ b/src/modules/workspace/WorkspaceCanvas.tsx
@@ -90,7 +90,7 @@ function WorkspaceEmptyState() {
           </button>
         ))}
         <button
-          className="empty-workspace-connection-link"
+          className="empty-workspace-connection-link empty-workspace-connection-link--import"
           onClick={requestImportConnections}
           type="button"
         >

--- a/src/modules/workspace/workspace.css
+++ b/src/modules/workspace/workspace.css
@@ -249,10 +249,15 @@
 .empty-workspace-connection-links {
   display: grid;
   grid-template-columns: repeat(2, minmax(132px, 1fr));
-  justify-items: center;
+  justify-items: start;
   gap: 3px 18px;
   width: min(320px, calc(100vw - 48px));
   margin-top: 4px;
+}
+
+.empty-workspace-connection-link--import {
+  grid-column: 1 / -1;
+  justify-self: center;
 }
 
 .empty-workspace-connection-link {


### PR DESCRIPTION
## What changed

In the "No active session" empty workspace state, the connection creation links (Local terminal, SSH, Telnet, Serial, URL, RDP, VNC, FTP, File Explorer, Document) are now left-aligned within their two columns instead of center-aligned. The **Import connections** link remains centered below them.

## Why

Center-aligning each link within its grid cell made the labels drift toward the middle and read as ragged. Left-aligning within each column gives the list a cleaner, more scannable layout, while keeping Import connections visually distinct as a centered action.

## How

- `workspace.css`: changed the connection links grid from `justify-items: center` to `justify-items: start`, and added `.empty-workspace-connection-link--import` which spans both columns (`grid-column: 1 / -1`) and centers itself (`justify-self: center`).
- `WorkspaceCanvas.tsx`: added the `--import` modifier class to the Import connections button.

## Notes for reviewer

Pure static layout change — no behavior or logic affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)