### PR TITLE
fix(itops): room elevations device picker rendered empty

### DIFF
--- a/src/modules/itops/itops.css
+++ b/src/modules/itops/itops.css
@@ -3994,7 +3994,10 @@
 }
 /* Server Room elevation rows with the shared device picker column riding on
    the right. The rows can grow far taller than the drill viewport, so the
-   picker sticks to the scrollport top instead of stretching with them. */
+   picker sticks to the scrollport top instead of stretching with them. The
+   content-sized (flex-start) column would collapse the grid's stretch-only
+   `flex: 1 1 0` height to zero, so here the grid sizes to its cards and the
+   viewport-capped picker scrolls them internally. */
 .itops-page .rk-room-layout {
   display: flex;
   align-items: flex-start;
@@ -4007,8 +4010,19 @@
   min-width: 0;
 }
 .itops-page .rk-room-layout > .rm-picker {
+  /* Pins below the sticky drill toolbar while the elevation rows scroll. */
   position: sticky;
-  top: 8px;
+  top: 40px;
+  max-height: calc(100vh - 164px);
+}
+.itops-page .rk-room-layout > .rm-picker .rm-picker-grid {
+  flex: 0 1 auto;
+}
+/* The drill column's overflow:auto never actually scrolls (it grows with its
+   content while .hg-detail does the scrolling), but it would still capture
+   the picker's sticky scrollport. Release it while hosting the room rows. */
+.itops-page .ft-drill:has(.rk-room-layout) {
+  overflow: visible;
 }
 .itops-page .it-free-surface {
   position: relative;


### PR DESCRIPTION
## Summary

Follow-up to #571, which was merged with a layout bug: in Server Room elevations edit mode the device picker column rendered as an empty frame (header + search only). The shared `.rm-picker-grid` gets its height from `flex: 1 1 0`, which only works when the picker column is **stretched** to the row height (as in Rack View); the room layout's content-sized `align-items: flex-start` column collapsed the grid to zero height. The cards were in the DOM — my pre-merge verification counted them but never measured height, so it slipped through.

- Size the grid to its cards inside `.rk-room-layout` (`flex: 0 1 auto`), with the picker capped to the viewport (`max-height: calc(100vh - 164px)`) so the card list scrolls internally.
- The sticky pinning also never engaged: `.ft-drill`'s vestigial `overflow: auto` (it grows with its content while `.hg-detail` does the real scrolling) captured the sticky scrollport. Released via `.ft-drill:has(.rk-room-layout) { overflow: visible; }` — scoped so Rack View / Site View / spatial views keep their current overflow.
- Pin at `top: 40px` so the picker sits below the sticky drill toolbar instead of sliding under it.

## Type of change

- [x] Bug fix

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)

## i18n

- [x] No user-visible strings

## Checks

CSS-only change (16 insertions). Ran the IT Ops test files (20/20 pass) and verified in the browser preview with seeded data:

- Picker shows all 11 device cards; grid scrolls to the last card.
- Picker stays pinned below the toolbar while the tall elevation rows scroll (screenshot-verified at scrolled and unscrolled positions).
- Rack View regression-checked: picker/grid heights unchanged and `.ft-drill` keeps `overflow: auto` there.

## Notes for reviewers

`:has()` is already used elsewhere in the codebase (connections.css), so no compatibility change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)