### PR TITLE
feat(itops): expose IT Ops topology tools to the AI assistant and built-in MCP server

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -27,6 +27,8 @@ Namespaces in this build:
   browser.
 - `kkterm.dashboard.*` — Dashboard Module: views, widget instances,
   AI-Created Widgets.
+- `kkterm.itops.*` — IT Ops Module: Sites, Server Rooms, Racks, Rack
+  Devices, and the Host inventory list.
 - `kkterm.network.*` — Network capability: read-only diagnostics (ping,
   DNS, TCP check, port scan, interfaces, Wake-on-LAN, WHOIS).
 - `kkterm.watchdog.*` — Watchdog capability: background monitors that poll
@@ -229,6 +231,31 @@ same protection without any per-Module gate code.
 | `kkterm.dashboard.dangerous.update_custom_widget` | Edit an existing AI-Created Widget body/title/etc. |
 | `kkterm.dashboard.dangerous.remove_custom_widget` | Delete an AI-Created Widget definition (use `forceDeleteInstances` to also remove placements). |
 | `kkterm.dashboard.dangerous.reset` | Wipe the entire Dashboard. Irreversible. |
+
+### IT Ops Module (`kkterm.itops.*`)
+
+Site topology and Rack Device placement for the IT Ops Module (docs/ITOPS.md).
+Backed by `crate::ai::itops_tool`, the same implementation the in-app
+assistant's `itops_*` tools use, so MCP and the assistant share one storage
+path. Mutations emit `itops-changed` so the IT Ops UI reloads. All tools are
+safe (durable data reads/writes, no executable code and no secrets); in the
+in-app assistant the mutating tools still go through the per-call approval
+prompt unless the tool permission mode is Allow-all. The topology invariant
+is Site → Server Room → Rack → Rack Device: create the parent first.
+
+| Name | Description |
+|---|---|
+| `kkterm.itops.sites.list` | List IT Ops Sites (id, name, memberIds, filter, transport). Presentation-heavy fields (backgrounds, icon images) are omitted. |
+| `kkterm.itops.sites.create` | Create a Site. Optional `memberIds` reference saved Connection ids; `transport` defaults to `auto`. |
+| `kkterm.itops.server_rooms.list` | List one Site's Server Rooms by `siteId`. |
+| `kkterm.itops.server_rooms.create` | Create a Server Room in a Site. `floorColor` defaults to `default`. |
+| `kkterm.itops.racks.list` | List one Site's Racks by `siteId`, each with its placed Rack Devices in U order. |
+| `kkterm.itops.racks.create` | Create a Rack in a Site. `serverRoom` names an existing Server Room in the same Site; `heightU` defaults to 42, `depthMm` to 1000. |
+| `kkterm.itops.rack_items.place` | Place one Rack Device at a contiguous U span (`startU` is the lowest occupied U, 1 = bottom). Placement is validated against rack bounds and overlaps. Kind `connection` requires `connectionId`. |
+| `kkterm.itops.rack_items.update` | Update one Rack Device's kind, label, Connection binding, or metadata by id. Full-value semantics: omitted metadata clears stored metadata. |
+| `kkterm.itops.rack_items.move` | Move and/or resize one Rack Device by id, possibly into a different Rack; the new span is re-validated. |
+| `kkterm.itops.rack_items.remove` | Remove one Rack Device placement by id. Bound saved Connections are untouched. |
+| `kkterm.itops.hosts.list` | List one Site's Hosts by `siteId`: hostname, kind, parent Host, bound Connection ids, and last connectivity-scan snapshot. |
 
 ### Network capability (`kkterm.network.*`)
 

--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -2793,6 +2793,99 @@ fn ai_tool_definitions_with_skills(
             json!({"type":"object","properties":{}}),
         ));
     }
+    if settings.itops() {
+        tools.push(tool_definition(
+            "itops_list_sites",
+            "List IT Ops Sites (id, name, memberIds, filter, transport). A Site is a durable named selection of saved Connections and the top-level parent of Server Rooms, Racks, and Hosts; the topology is Site → Server Room → Rack → Rack Device. Presentation-heavy fields (backgrounds, icon images) are omitted.",
+            json!({"type":"object","properties":{}}),
+        ));
+        tools.push(tool_definition(
+            "itops_create_site",
+            "Create an IT Ops Site. Optional memberIds reference existing saved Connection ids (call connection_list to discover them); transport picks the default Batch Run transport and defaults to auto.",
+            json!({"type":"object","properties":{
+                "name":{"type":"string","minLength":1},
+                "memberIds":{"type":"array","items":{"type":"string"}},
+                "transport":{"type":"string","enum":["ssh","winrm","psexec","auto"]}
+            },"required":["name"]}),
+        ));
+        tools.push(tool_definition(
+            "itops_list_server_rooms",
+            "List the Server Rooms of one IT Ops Site by siteId. Every Rack must belong to a Server Room in the same Site, so check or create the room before creating a Rack.",
+            json!({"type":"object","properties":{"siteId":{"type":"string"}},"required":["siteId"]}),
+        ));
+        tools.push(tool_definition(
+            "itops_create_server_room",
+            "Create a Server Room in an IT Ops Site. floorColor is optional and defaults to \"default\".",
+            json!({"type":"object","properties":{
+                "siteId":{"type":"string"},
+                "name":{"type":"string","minLength":1},
+                "floorColor":{"type":"string","enum":["default","concrete","graphite","green","blue"]}
+            },"required":["siteId","name"]}),
+        ));
+        tools.push(tool_definition(
+            "itops_list_racks",
+            "List the Racks of one IT Ops Site by siteId, each with its placed Rack Devices (items) in U order. Use this to inspect the current topology and find free U spans before placing a device.",
+            json!({"type":"object","properties":{"siteId":{"type":"string"}},"required":["siteId"]}),
+        ));
+        tools.push(tool_definition(
+            "itops_create_rack",
+            "Create a Rack in an IT Ops Site. serverRoom is the name of an existing Server Room in the same Site (create it first with itops_create_server_room). heightU defaults to 42 and depthMm to 1000; rackGroup is an optional grouping tag within the room.",
+            json!({"type":"object","properties":{
+                "siteId":{"type":"string"},
+                "name":{"type":"string","minLength":1},
+                "serverRoom":{"type":"string","minLength":1},
+                "rackGroup":{"type":"string"},
+                "shell":{"type":"string","enum":["black","white","grey"]},
+                "heightU":{"type":"integer","minimum":1,"maximum":100},
+                "depthMm":{"type":"integer","minimum":1,"maximum":5000},
+                "powerCapacityW":{"type":"integer","minimum":0}
+            },"required":["siteId","name","serverRoom"]}),
+        ));
+        tools.push(tool_definition(
+            "itops_place_rack_item",
+            "Place one Rack Device into a Rack at a contiguous U span. startU is the device's lowest occupied U (1 = bottom of the rack); the span startU..startU+heightU-1 must fit inside the rack and must not overlap existing devices, so call itops_list_racks first to find free space. kind \"connection\" makes the device openable and requires connectionId (a saved Connection id); the other kinds are passive inventory/visual devices. Optional metadata carries presentation fields such as status (\"online\"|\"warning\"|\"offline\"), accent, notes, ports, disks, battery, load, and powerW — never secrets.",
+            json!({"type":"object","properties":{
+                "rackId":{"type":"string"},
+                "kind":{"type":"string","enum":["connection","server","storage","switch","router","firewall","pdu","ups","kvm","patchPanel","genericDevice"]},
+                "label":{"type":"string"},
+                "startU":{"type":"integer","minimum":1},
+                "heightU":{"type":"integer","minimum":1},
+                "connectionId":{"type":"string"},
+                "metadata":{"type":"object"}
+            },"required":["rackId","kind","label","startU","heightU"]}),
+        ));
+        tools.push(tool_definition(
+            "itops_update_rack_item",
+            "Update one Rack Device's kind, label, Connection binding, or metadata by id (position changes go through itops_move_rack_item). Submit full new values: omitted metadata clears previously stored metadata, so read the device from itops_list_racks first and resend the fields you want to keep.",
+            json!({"type":"object","properties":{
+                "id":{"type":"string"},
+                "kind":{"type":"string","enum":["connection","server","storage","switch","router","firewall","pdu","ups","kvm","patchPanel","genericDevice"]},
+                "label":{"type":"string"},
+                "connectionId":{"type":"string"},
+                "metadata":{"type":"object"}
+            },"required":["id","kind","label"]}),
+        ));
+        tools.push(tool_definition(
+            "itops_move_rack_item",
+            "Move and/or resize one Rack Device by id — possibly into a different Rack. The new U span is validated against the target rack (bounds and overlaps).",
+            json!({"type":"object","properties":{
+                "id":{"type":"string"},
+                "rackId":{"type":"string"},
+                "startU":{"type":"integer","minimum":1},
+                "heightU":{"type":"integer","minimum":1}
+            },"required":["id","rackId","startU","heightU"]}),
+        ));
+        tools.push(tool_definition(
+            "itops_remove_rack_item",
+            "Remove one Rack Device from its Rack by id. This deletes the placement only; any bound saved Connection is untouched.",
+            json!({"type":"object","properties":{"id":{"type":"string"}},"required":["id"]}),
+        ));
+        tools.push(tool_definition(
+            "itops_list_hosts",
+            "List the Hosts of one IT Ops Site by siteId: durable inventory entries addressed by hostname, with kind (physical|vm|container|other), optional parentHostId (the device Host carrying a VM/container), bound Connection ids, and the last connectivity-scan snapshot.",
+            json!({"type":"object","properties":{"siteId":{"type":"string"}},"required":["siteId"]}),
+        ));
+    }
     if settings.connections() {
         tools.push(tool_definition(
             "connection_list",
@@ -3632,6 +3725,7 @@ async fn run_ai_tool(
         name if tool_settings.dashboard() && name.starts_with("dashboard_") => {
             dashboard_tool(app, name, args)
         }
+        name if tool_settings.itops() && name.starts_with("itops_") => itops_tool(app, name, args),
         name if tool_settings.connections() && name.starts_with("connection_") => {
             connection_tool(app, name, args)
         }
@@ -3731,6 +3825,7 @@ fn tool_requires_allow_all(tool_name: &str) -> bool {
                     | "dashboard_read_widget_source"
                     | "dashboard_check_widget_health"
             ))
+        || (tool_name.starts_with("itops_") && !tool_name.starts_with("itops_list"))
         || matches!(
             tool_name,
             "connection_create"
@@ -3964,6 +4059,235 @@ pub(crate) fn connection_tool(app: &tauri::AppHandle, name: &str, args: Value) -
                     "connection-tree-changed",
                     json!({ "source": "aiTool", "tool": name }),
                 );
+            }
+            value.to_string()
+        }
+        Err(error) => json!({ "ok": false, "error": error }).to_string(),
+    }
+}
+
+/// Strip presentation-heavy IT Ops fields (backgrounds, room background/icon
+/// maps, icon image data URLs) before returning Sites/Racks to the model, so
+/// embedded images never bloat the context.
+fn compact_itops_value(mut value: Value) -> Value {
+    fn strip(object: &mut serde_json::Map<String, Value>) {
+        for key in ["background", "roomBackgrounds", "roomIcons", "iconDataUrl"] {
+            object.remove(key);
+        }
+    }
+    match &mut value {
+        Value::Array(items) => {
+            for item in items {
+                if let Some(object) = item.as_object_mut() {
+                    strip(object);
+                }
+            }
+        }
+        Value::Object(object) => strip(object),
+        _ => {}
+    }
+    value
+}
+
+/// IT Ops Module tools shared by the in-app assistant and the built-in MCP
+/// bridge (`kkterm.itops.*`): Site/Server Room/Rack topology reads and
+/// creation, Rack Device placement, and the Host inventory list. Mutations
+/// emit `itops-changed` so the IT Ops Module reloads when a change arrives
+/// from outside its own UI.
+pub(crate) fn itops_tool(app: &tauri::AppHandle, name: &str, args: Value) -> String {
+    use crate::itops::host_storage as itops_hosts;
+    use crate::itops::ids::new_itops_id;
+    use crate::itops::site_storage as itops_topo;
+    use crate::itops::storage as itops_sites;
+    use crate::itops::types::{RackItemKind, RackItemMetadata, Transport};
+
+    fn to_value<T: serde::Serialize>(value: T) -> Value {
+        serde_json::to_value(value).unwrap_or(Value::Null)
+    }
+    fn required_string(args: &Value, key: &str) -> Result<String, String> {
+        let value = arg_string(args, key);
+        if value.trim().is_empty() {
+            Err(format!("{key} is required"))
+        } else {
+            Ok(value)
+        }
+    }
+    fn optional_u32(args: &Value, key: &str) -> Option<u32> {
+        args.get(key)
+            .and_then(Value::as_u64)
+            .and_then(|value| u32::try_from(value).ok())
+    }
+    fn required_u32(args: &Value, key: &str) -> Result<u32, String> {
+        optional_u32(args, key).ok_or_else(|| format!("{key} is required and must be a positive integer"))
+    }
+    fn item_kind(args: &Value) -> Result<RackItemKind, String> {
+        serde_json::from_value(args.get("kind").cloned().unwrap_or(Value::Null))
+            .map_err(|_| "kind must be a valid rack device kind".to_string())
+    }
+    fn item_metadata(args: &Value) -> Result<RackItemMetadata, String> {
+        match args.get("metadata") {
+            None | Some(Value::Null) => Ok(RackItemMetadata::default()),
+            Some(value) => serde_json::from_value(value.clone())
+                .map_err(|error| format!("invalid metadata: {error}")),
+        }
+    }
+    fn optional_connection_id(args: &Value) -> Option<String> {
+        args.get("connectionId")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    }
+
+    let storage = app.state::<Storage>();
+    let result: Result<Value, String> = storage.with_connection_infallible(|conn| match name {
+        "itops_list_sites" => itops_sites::list_sites(conn)
+            .map(|sites| compact_itops_value(to_value(sites)))
+            .map_err(|e| e.to_string()),
+        "itops_create_site" => {
+            let site_name = required_string(&args, "name")?;
+            let member_ids: Vec<String> = args
+                .get("memberIds")
+                .and_then(Value::as_array)
+                .map(|values| {
+                    values
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .map(str::to_string)
+                        .collect()
+                })
+                .unwrap_or_default();
+            let transport: Transport = match args.get("transport") {
+                None | Some(Value::Null) => Transport::Auto,
+                Some(value) => serde_json::from_value(value.clone())
+                    .map_err(|_| "transport must be ssh, winrm, psexec, or auto".to_string())?,
+            };
+            let id = new_itops_id("hg");
+            itops_sites::create_site(
+                conn, &id, &site_name, member_ids, None, transport, None, None, None,
+            )
+            .map(|site| compact_itops_value(to_value(site)))
+            .map_err(|e| e.to_string())
+        }
+        "itops_list_server_rooms" => {
+            let site_id = required_string(&args, "siteId")?;
+            itops_topo::list_server_rooms(conn, &site_id)
+                .map(to_value)
+                .map_err(|e| e.to_string())
+        }
+        "itops_create_server_room" => {
+            let site_id = required_string(&args, "siteId")?;
+            let room_name = required_string(&args, "name")?;
+            let floor_color = arg_string(&args, "floorColor");
+            let floor_color = if floor_color.trim().is_empty() {
+                "default".to_string()
+            } else {
+                floor_color
+            };
+            let id = new_itops_id("room");
+            itops_topo::create_server_room(conn, &id, &site_id, &room_name, &floor_color)
+                .map(to_value)
+                .map_err(|e| e.to_string())
+        }
+        "itops_list_racks" => {
+            let site_id = required_string(&args, "siteId")?;
+            itops_topo::list_racks(conn, &site_id)
+                .map(|racks| compact_itops_value(to_value(racks)))
+                .map_err(|e| e.to_string())
+        }
+        "itops_create_rack" => {
+            let site_id = required_string(&args, "siteId")?;
+            let rack_name = required_string(&args, "name")?;
+            let server_room = required_string(&args, "serverRoom")?;
+            let rack_group = arg_string(&args, "rackGroup");
+            let shell = args
+                .get("shell")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let height_u = optional_u32(&args, "heightU").unwrap_or(42);
+            let depth_mm = optional_u32(&args, "depthMm").unwrap_or(1000);
+            let power_capacity_w = optional_u32(&args, "powerCapacityW");
+            let id = new_itops_id("rack");
+            itops_topo::create_rack(
+                conn,
+                &id,
+                &site_id,
+                &rack_name,
+                &server_room,
+                &rack_group,
+                shell.as_deref(),
+                height_u,
+                depth_mm,
+                power_capacity_w,
+            )
+            .map(|rack| compact_itops_value(to_value(rack)))
+            .map_err(|e| e.to_string())
+        }
+        "itops_place_rack_item" => {
+            let rack_id = required_string(&args, "rackId")?;
+            let kind = item_kind(&args)?;
+            let label = arg_string(&args, "label");
+            let start_u = required_u32(&args, "startU")?;
+            let height_u = required_u32(&args, "heightU")?;
+            let metadata = item_metadata(&args)?;
+            let id = new_itops_id("ri");
+            itops_topo::place_rack_item(
+                conn,
+                &id,
+                &rack_id,
+                optional_connection_id(&args),
+                kind,
+                &label,
+                start_u,
+                height_u,
+                metadata,
+            )
+            .map(to_value)
+            .map_err(|e| e.to_string())
+        }
+        "itops_update_rack_item" => {
+            let id = required_string(&args, "id")?;
+            let kind = item_kind(&args)?;
+            let label = arg_string(&args, "label");
+            let metadata = item_metadata(&args)?;
+            itops_topo::update_rack_item(
+                conn,
+                &id,
+                kind,
+                optional_connection_id(&args),
+                &label,
+                metadata,
+            )
+            .map(to_value)
+            .map_err(|e| e.to_string())
+        }
+        "itops_move_rack_item" => {
+            let id = required_string(&args, "id")?;
+            let rack_id = required_string(&args, "rackId")?;
+            let start_u = required_u32(&args, "startU")?;
+            let height_u = required_u32(&args, "heightU")?;
+            itops_topo::move_rack_item(conn, &id, &rack_id, start_u, height_u)
+                .map(to_value)
+                .map_err(|e| e.to_string())
+        }
+        "itops_remove_rack_item" => {
+            let id = required_string(&args, "id")?;
+            itops_topo::remove_rack_item(conn, &id)
+                .map(|_| json!({"ok": true}))
+                .map_err(|e| e.to_string())
+        }
+        "itops_list_hosts" => {
+            let site_id = required_string(&args, "siteId")?;
+            itops_hosts::list_hosts(conn, &site_id)
+                .map(to_value)
+                .map_err(|e| e.to_string())
+        }
+        _ => Err(format!("unknown IT Ops tool: {name}")),
+    });
+    match result {
+        Ok(value) => {
+            if !name.starts_with("itops_list") {
+                let _ = app.emit("itops-changed", json!({ "source": "aiTool", "tool": name }));
             }
             value.to_string()
         }

--- a/src-tauri/src/itops/mod.rs
+++ b/src-tauri/src/itops/mod.rs
@@ -8,7 +8,7 @@ pub mod automation_commands;
 pub mod automation_storage;
 pub mod commands;
 pub mod host_storage;
-mod ids;
+pub(crate) mod ids;
 pub mod inventory;
 pub mod run_storage;
 pub mod runner;

--- a/src-tauri/src/mcp_bridge.rs
+++ b/src-tauri/src/mcp_bridge.rs
@@ -1108,6 +1108,43 @@ async fn dispatch_tool(app: &AppHandle, name: &str, args: Value) -> Result<Value
             let raw = crate::ai::dashboard_tool(app, "dashboard_reset", json!({}));
             parse_dashboard_json(&raw)
         }
+        // -- IT Ops: Site topology + Rack Devices ---------------------------
+        // itops_tool reads the same camelCase argument keys the catalog
+        // publishes, validates required fields itself, and reports failures
+        // as {"ok": false, "error": …}, so forward arguments unchanged.
+        "kkterm.itops.sites.list" => {
+            parse_tool_json(&crate::ai::itops_tool(app, "itops_list_sites", json!({})))
+        }
+        "kkterm.itops.sites.create" => {
+            parse_tool_json(&crate::ai::itops_tool(app, "itops_create_site", args))
+        }
+        "kkterm.itops.server_rooms.list" => {
+            parse_tool_json(&crate::ai::itops_tool(app, "itops_list_server_rooms", args))
+        }
+        "kkterm.itops.server_rooms.create" => {
+            parse_tool_json(&crate::ai::itops_tool(app, "itops_create_server_room", args))
+        }
+        "kkterm.itops.racks.list" => {
+            parse_tool_json(&crate::ai::itops_tool(app, "itops_list_racks", args))
+        }
+        "kkterm.itops.racks.create" => {
+            parse_tool_json(&crate::ai::itops_tool(app, "itops_create_rack", args))
+        }
+        "kkterm.itops.rack_items.place" => {
+            parse_tool_json(&crate::ai::itops_tool(app, "itops_place_rack_item", args))
+        }
+        "kkterm.itops.rack_items.update" => {
+            parse_tool_json(&crate::ai::itops_tool(app, "itops_update_rack_item", args))
+        }
+        "kkterm.itops.rack_items.move" => {
+            parse_tool_json(&crate::ai::itops_tool(app, "itops_move_rack_item", args))
+        }
+        "kkterm.itops.rack_items.remove" => {
+            parse_tool_json(&crate::ai::itops_tool(app, "itops_remove_rack_item", args))
+        }
+        "kkterm.itops.hosts.list" => {
+            parse_tool_json(&crate::ai::itops_tool(app, "itops_list_hosts", args))
+        }
         // -- Workspace: SFTP/FTP file browser ------------------------------
         "kkterm.workspace.file_browser.list" => {
             let raw = crate::ai::live_session_tool(
@@ -1594,6 +1631,18 @@ mod tests {
         assert!(names.contains(&"kkterm.workspace.sessions.remote_desktop_screenshot".to_string()));
         assert!(names.contains(&"kkterm.workspace.dangerous.remote_desktop_send_text".to_string()));
         assert!(names.contains(&"kkterm.workspace.dangerous.remote_desktop_keypress".to_string()));
+        // IT Ops surface
+        assert!(names.contains(&"kkterm.itops.sites.list".to_string()));
+        assert!(names.contains(&"kkterm.itops.sites.create".to_string()));
+        assert!(names.contains(&"kkterm.itops.server_rooms.list".to_string()));
+        assert!(names.contains(&"kkterm.itops.server_rooms.create".to_string()));
+        assert!(names.contains(&"kkterm.itops.racks.list".to_string()));
+        assert!(names.contains(&"kkterm.itops.racks.create".to_string()));
+        assert!(names.contains(&"kkterm.itops.rack_items.place".to_string()));
+        assert!(names.contains(&"kkterm.itops.rack_items.update".to_string()));
+        assert!(names.contains(&"kkterm.itops.rack_items.move".to_string()));
+        assert!(names.contains(&"kkterm.itops.rack_items.remove".to_string()));
+        assert!(names.contains(&"kkterm.itops.hosts.list".to_string()));
         // Network surface
         assert!(names.contains(&"kkterm.network.ping".to_string()));
         assert!(names.contains(&"kkterm.network.dns".to_string()));

--- a/src-tauri/src/mcp_tool_catalog.rs
+++ b/src-tauri/src/mcp_tool_catalog.rs
@@ -519,6 +519,128 @@ pub fn tool_descriptors() -> Vec<Value> {
             "description": "DANGEROUS: wipe the entire Dashboard — all views, instances, and AI-Created Widgets. Irreversible. Requires Allow-all.",
             "inputSchema": {"type": "object", "properties": {}, "additionalProperties": false},
         }),
+        // -- IT Ops: Site topology + Rack Devices (kkterm.itops.*) ---------
+        json!({
+            "name": "kkterm.itops.sites.list",
+            "description": "List IT Ops Sites (id, name, memberIds, filter, transport). A Site is a durable named selection of saved Connections and the top-level parent of Server Rooms, Racks, and Hosts; the topology is Site → Server Room → Rack → Rack Device. Presentation-heavy fields (backgrounds, icon images) are omitted.",
+            "inputSchema": {"type": "object", "properties": {}, "additionalProperties": false},
+        }),
+        json!({
+            "name": "kkterm.itops.sites.create",
+            "description": "Create an IT Ops Site. Optional memberIds reference existing saved Connection ids (see kkterm.workspace.connections.list); transport picks the default Batch Run transport and defaults to auto.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "minLength": 1},
+                    "memberIds": {"type": "array", "items": {"type": "string"}},
+                    "transport": {"type": "string", "enum": ["ssh", "winrm", "psexec", "auto"]},
+                },
+                "required": ["name"],
+                "additionalProperties": false,
+            },
+        }),
+        json!({
+            "name": "kkterm.itops.server_rooms.list",
+            "description": "List the Server Rooms of one IT Ops Site by siteId. Every Rack must belong to a Server Room in the same Site.",
+            "inputSchema": site_id_input_schema(),
+        }),
+        json!({
+            "name": "kkterm.itops.server_rooms.create",
+            "description": "Create a Server Room in an IT Ops Site. floorColor is optional and defaults to 'default'.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "siteId": {"type": "string"},
+                    "name": {"type": "string", "minLength": 1},
+                    "floorColor": {"type": "string", "enum": ["default", "concrete", "graphite", "green", "blue"]},
+                },
+                "required": ["siteId", "name"],
+                "additionalProperties": false,
+            },
+        }),
+        json!({
+            "name": "kkterm.itops.racks.list",
+            "description": "List the Racks of one IT Ops Site by siteId, each with its placed Rack Devices (items) in U order. Use this to inspect the topology and find free U spans before placing a device.",
+            "inputSchema": site_id_input_schema(),
+        }),
+        json!({
+            "name": "kkterm.itops.racks.create",
+            "description": "Create a Rack in an IT Ops Site. serverRoom is the name of an existing Server Room in the same Site (create it first with kkterm.itops.server_rooms.create). heightU defaults to 42 and depthMm to 1000; rackGroup is an optional grouping tag within the room.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "siteId": {"type": "string"},
+                    "name": {"type": "string", "minLength": 1},
+                    "serverRoom": {"type": "string", "minLength": 1},
+                    "rackGroup": {"type": "string"},
+                    "shell": {"type": "string", "enum": ["black", "white", "grey"]},
+                    "heightU": {"type": "integer", "minimum": 1, "maximum": 100},
+                    "depthMm": {"type": "integer", "minimum": 1, "maximum": 5000},
+                    "powerCapacityW": {"type": "integer", "minimum": 0},
+                },
+                "required": ["siteId", "name", "serverRoom"],
+                "additionalProperties": false,
+            },
+        }),
+        json!({
+            "name": "kkterm.itops.rack_items.place",
+            "description": "Place one Rack Device into a Rack at a contiguous U span. startU is the device's lowest occupied U (1 = bottom of the rack); the span startU..startU+heightU-1 must fit inside the rack and must not overlap existing devices — call kkterm.itops.racks.list first to find free space. kind 'connection' makes the device openable and requires connectionId (a saved Connection id); the other kinds are passive inventory/visual devices. Optional metadata carries presentation fields such as status ('online'|'warning'|'offline'), accent, notes, ports, disks, battery, load, and powerW — never secrets.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "rackId": {"type": "string"},
+                    "kind": {"type": "string", "enum": ["connection", "server", "storage", "switch", "router", "firewall", "pdu", "ups", "kvm", "patchPanel", "genericDevice"]},
+                    "label": {"type": "string"},
+                    "startU": {"type": "integer", "minimum": 1},
+                    "heightU": {"type": "integer", "minimum": 1},
+                    "connectionId": {"type": "string"},
+                    "metadata": {"type": "object"},
+                },
+                "required": ["rackId", "kind", "label", "startU", "heightU"],
+                "additionalProperties": false,
+            },
+        }),
+        json!({
+            "name": "kkterm.itops.rack_items.update",
+            "description": "Update one Rack Device's kind, label, Connection binding, or metadata by id (position changes go through kkterm.itops.rack_items.move). Submit full new values: omitted metadata clears previously stored metadata, so read the device from kkterm.itops.racks.list first and resend the fields you want to keep.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "kind": {"type": "string", "enum": ["connection", "server", "storage", "switch", "router", "firewall", "pdu", "ups", "kvm", "patchPanel", "genericDevice"]},
+                    "label": {"type": "string"},
+                    "connectionId": {"type": "string"},
+                    "metadata": {"type": "object"},
+                },
+                "required": ["id", "kind", "label"],
+                "additionalProperties": false,
+            },
+        }),
+        json!({
+            "name": "kkterm.itops.rack_items.move",
+            "description": "Move and/or resize one Rack Device by id — possibly into a different Rack. The new U span is validated against the target rack (bounds and overlaps).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "rackId": {"type": "string"},
+                    "startU": {"type": "integer", "minimum": 1},
+                    "heightU": {"type": "integer", "minimum": 1},
+                },
+                "required": ["id", "rackId", "startU", "heightU"],
+                "additionalProperties": false,
+            },
+        }),
+        json!({
+            "name": "kkterm.itops.rack_items.remove",
+            "description": "Remove one Rack Device from its Rack by id. This deletes the placement only; any bound saved Connection is untouched.",
+            "inputSchema": id_input_schema("id"),
+        }),
+        json!({
+            "name": "kkterm.itops.hosts.list",
+            "description": "List the Hosts of one IT Ops Site by siteId: durable inventory entries addressed by hostname, with kind (physical|vm|container|other), optional parentHostId (the device Host carrying a VM/container), bound Connection ids, and the last connectivity-scan snapshot.",
+            "inputSchema": site_id_input_schema(),
+        }),
         // -- Network: read-only diagnostics (kkterm.network.*) -------------
         json!({
             "name": "kkterm.network.ping",
@@ -718,6 +840,15 @@ fn connection_update_input_schema() -> Value {
         required.insert(0, json!("connectionId"));
     }
     schema
+}
+
+fn site_id_input_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {"siteId": {"type": "string"}},
+        "required": ["siteId"],
+        "additionalProperties": false,
+    })
 }
 
 fn id_input_schema(id_name: &str) -> Value {

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -899,6 +899,8 @@ pub struct AiAssistantToolSettings {
     performance_counters: bool,
     #[serde(default = "default_ai_dashboard_tool_enabled")]
     dashboard: bool,
+    #[serde(default = "default_ai_itops_tool_enabled")]
+    itops: bool,
     #[serde(default = "default_ai_connections_tool_enabled")]
     connections: bool,
     #[serde(default = "default_ai_sessions_tool_enabled")]
@@ -942,6 +944,9 @@ impl AiAssistantToolSettings {
     pub(crate) fn dashboard(&self) -> bool {
         self.dashboard
     }
+    pub(crate) fn itops(&self) -> bool {
+        self.itops
+    }
     pub(crate) fn connections(&self) -> bool {
         self.connections
     }
@@ -975,6 +980,7 @@ impl AiAssistantToolSettings {
             || self.current_time
             || self.performance_counters
             || self.dashboard
+            || self.itops
             || self.connections
             || self.sessions
             || self.tutorial
@@ -5238,6 +5244,7 @@ fn default_ai_assistant_tool_settings() -> AiAssistantToolSettings {
         current_time: default_ai_current_time_tool_enabled(),
         performance_counters: default_ai_performance_counters_tool_enabled(),
         dashboard: default_ai_dashboard_tool_enabled(),
+        itops: default_ai_itops_tool_enabled(),
         connections: default_ai_connections_tool_enabled(),
         sessions: default_ai_sessions_tool_enabled(),
         tutorial: default_ai_tutorial_tool_enabled(),
@@ -5270,6 +5277,10 @@ fn default_ai_performance_counters_tool_enabled() -> bool {
 }
 
 fn default_ai_dashboard_tool_enabled() -> bool {
+    true
+}
+
+fn default_ai_itops_tool_enabled() -> bool {
     true
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import {
 import { ConnectionSidebar } from "./modules/workspace/connections/ConnectionSidebar";
 import { useDashboardStore } from "./modules/dashboard/state/dashboardStore";
 import { useDashboardBackendInvalidation } from "./modules/dashboard/state/invalidation";
+import { useItOpsBackendInvalidation } from "./modules/itops/invalidation";
 import {
   loadSiteTreeCollapsed,
   saveSiteTreeCollapsed,
@@ -218,6 +219,7 @@ function App() {
 
   const { generalSettingsReady } = useBootstrapSettings();
   useDashboardBackendInvalidation();
+  useItOpsBackendInvalidation();
   useDebugFrontendHeartbeat();
   useFrontendLaunchTimestamp();
   useHostUsagePolling();

--- a/src/ai/providers.ts
+++ b/src/ai/providers.ts
@@ -27,6 +27,7 @@ export const DEFAULT_AI_ASSISTANT_TOOLS: AiAssistantToolSettings = {
   performanceCounters: true,
   email: false,
   dashboard: true,
+  itops: true,
   connections: true,
   sessions: true,
   tutorial: true,

--- a/src/app-defaults.ts
+++ b/src/app-defaults.ts
@@ -164,6 +164,7 @@ export const defaultAiAssistantToolSettings = {
   performanceCounters: true,
   email: false,
   dashboard: true,
+  itops: true,
   connections: true,
   sessions: true,
   tutorial: true,

--- a/src/modules/itops/invalidation.ts
+++ b/src/modules/itops/invalidation.ts
@@ -1,0 +1,46 @@
+import { useEffect } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { isTauriRuntime } from "../../lib/tauri";
+import { useItOpsStore } from "./state";
+
+const ITOPS_CHANGED_EVENT = "itops-changed";
+
+// Reload IT Ops data when the backend reports a mutation from outside this
+// UI (the AI assistant's itops_* tools or the built-in MCP kkterm.itops.*
+// bridge). Mirrors the Dashboard's dashboard-changed invalidation.
+export function useItOpsBackendInvalidation() {
+  useEffect(() => {
+    if (!isTauriRuntime()) return;
+
+    let disposed = false;
+    let unlisten: (() => void) | null = null;
+
+    void listen(ITOPS_CHANGED_EVENT, () => {
+      const store = useItOpsStore.getState();
+      if (store.loaded) {
+        void store.loadSites();
+      }
+      for (const siteId of Object.keys(store.serverRoomsBySite)) {
+        void store.loadServerRooms(siteId);
+      }
+      for (const siteId of Object.keys(store.racksBySite)) {
+        void store.loadRacks(siteId);
+      }
+    })
+      .then((cleanup) => {
+        if (disposed) {
+          cleanup();
+        } else {
+          unlisten = cleanup;
+        }
+      })
+      .catch(() => {
+        // IT Ops pages still reload on navigation when the listener fails.
+      });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1138,6 +1138,7 @@ export type AiAssistantToolId =
   | "performanceCounters"
   | "email"
   | "dashboard"
+  | "itops"
   | "connections"
   | "sessions"
   | "tutorial"


### PR DESCRIPTION
## Summary

Makes the AI Assistant and the built-in MCP server (`kkterm-cli`) fully able to work with the IT Ops Module's topology: they can now list and create **Sites**, **Server Rooms**, and **Racks**, place/update/move/remove **Rack Devices**, and read a Site's **Host** inventory.

The core is one shared implementation — a new `itops_tool` in `src-tauri/src/ai.rs` — called by both the in-app assistant (`itops_*` tools) and the MCP bridge (`kkterm.itops.*`), reusing the existing `itops` storage layer so all domain validation (rack must belong to a Server Room in the same Site, U-span bounds and overlap rejection, `connection`-kind devices require a `connectionId`) applies identically on both surfaces. Tool descriptions teach the model the domain rules from `CONTEXT.md` (Site → Server Room → Rack → Rack Device, U1 = bottom of the rack).

Plumbing details:

- New backend `itops` assistant tool gate (default on, backend-only like the existing `watchdog` gate — no Settings UI toggle). Mutating tools go through the per-call approval prompt unless permission mode is Allow-all; list tools are approval-free.
- 11 `kkterm.itops.*` descriptors added to the shared MCP tool catalog (published by both the live bridge and offline `kkterm-cli` discovery) plus matching `dispatch_tool` arms; all in the safe namespace — durable-data mutations like the Dashboard view tools, no executable code, no secrets.
- Mutations emit a new `itops-changed` event; a new `src/modules/itops/invalidation.ts` hook (registered in `App.tsx`, mirroring the Dashboard's `dashboard-changed` pattern) reloads the IT Ops store so external MCP edits appear in the UI immediately.
- Site/Rack payloads returned to the model are compacted: backgrounds, room background/icon maps, and icon data URLs are stripped so embedded images never bloat the context.
- `src-tauri/src/itops/mod.rs`: `ids` module made `pub(crate)` so the shared tool can mint ids with the standard generator.

## Type of change

- [x] Feature

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)
- [x] Backend (Rust/Tauri — `src-tauri/`)
- [x] Docs (`docs/`, manual, ADR)

## Domain & docs

- [x] Uses the canonical vocabulary (Site / Server Room / Rack / Rack Device / Host / Connection)
- [x] Built-in MCP tool changes update `docs/MCP.md` (new `kkterm.itops.*` namespace section + tool table); Settings AI safety text unchanged, so `docs/manual/15-settings.md` untouched

## i18n

- [x] No user-visible strings (tool descriptions are AI-facing English, matching the existing tool surface; no UI strings added)

## High-risk invariants

- [x] No frontend close hooks / close-confirmation flows added
- [x] No live Session state added to the durable Connection model

## Checks

- [x] `npm run check` — lint and `tsc` pass; frontend tests 900/903, the 3 failures (`connection-add-notification`, `empty-workspace-connection-actions`, `workspace-empty-connection-links`) are pre-existing on this branch (verified identical failures on the clean tree before this change)
- [ ] `npm run build` — not run
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 926 passed, 0 failed (includes the extended MCP published-surface test)
- [ ] Not yet validated in the real Tauri desktop runtime — recommend one manual pass: call a `kkterm.itops.*` tool from an external MCP client and confirm the IT Ops UI live-reloads via `itops-changed`

## Notes for reviewers

- Tool scope is deliberately creation + placement (per the request); Site/Room/Rack deletion is not exposed to the assistant or MCP. `rack_items.remove` is exposed since it only deletes a placement.
- `itops_update_rack_item` has full-value semantics (omitted metadata clears stored metadata), matching the underlying storage function; the tool descriptions warn the model to read-then-resend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)