### PR TITLE
Fix shortcut event routing regressions

### DIFF
--- a/src/modules/workspace/WorkspaceCanvas.tsx
+++ b/src/modules/workspace/WorkspaceCanvas.tsx
@@ -403,9 +403,13 @@ export function WorkspaceCanvas({
     // surfaces; stopPropagation keeps the handled key out of the terminal.
     const handleShortcutKeyDown = (event: globalThis.KeyboardEvent) => {
       const target = event.target instanceof Element ? event.target : null;
-      // Remote Desktop surfaces forward raw keys to the remote host, and the
-      // Settings overlay hosts the shortcut recorder; leave their input alone.
-      if (target?.closest(".rdp-canvas-view, .vnc-display, .settings-backdrop, .dialog-backdrop")) {
+      // Remote Desktop surfaces forward raw keys to the remote host. Block
+      // shortcuts whenever a Settings or dialog backdrop is mounted as focus
+      // can still be parked on a Workspace control behind a modal.
+      if (target?.closest(".rdp-canvas-view, .vnc-display")) {
+        return;
+      }
+      if (document.querySelector(".settings-backdrop, .dialog-backdrop, .kk-dlg-backdrop")) {
         return;
       }
       const state = useWorkspaceStore.getState();

--- a/src/modules/workspace/connections/ConnectionSidebar.tsx
+++ b/src/modules/workspace/connections/ConnectionSidebar.tsx
@@ -2262,6 +2262,10 @@ export function ConnectionSidebar({
     if (!isRename && !isDelete) {
       return;
     }
+    if (event.repeat) {
+      event.preventDefault();
+      return;
+    }
     const target = event.target as HTMLElement;
     // Never hijack typing in the rename input, search field, or any editable.
     if (target.closest("input, textarea, [contenteditable='true']")) {

--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -25,7 +25,10 @@ import { useGitRepoDetection } from "../../../git/useGitRepoDetection";
 import { createTerminalRenderer, logTerminalFontAtlasState, scheduleTerminalFontAtlasRefresh, type TerminalDimensions, type TerminalRenderer } from "./renderer";
 import { resolveTerminalColorScheme, TERMINAL_COLOR_SCHEMES } from "./colorSchemes";
 import { findQuickSelectMatches, labelQuickSelectMatches, quickSelectPointerAction, type LabeledQuickSelectMatch } from "./quickSelect";
-import { workspaceShortcutFromKeyboardEvent } from "../../keymap";
+import {
+  fixedTerminalShortcutFromKeyboardEvent,
+  workspaceShortcutFromKeyboardEvent,
+} from "../../keymap";
 import { ensureLayout } from "../../layout";
 import {
   broadcastInputToOtherPanes,
@@ -1955,11 +1958,12 @@ function TerminalPaneView({
       // Terminal-scope Workspace shortcuts, rebindable in Settings →
       // Shortcuts. Workspace-scope shortcuts (Tab management) are handled by
       // the window capture listener before xterm ever sees the key.
-      const action = workspaceShortcutFromKeyboardEvent(
-        event,
-        useWorkspaceStore.getState().generalSettings.workspaceShortcuts,
-        "terminal",
-      );
+      const action = fixedTerminalShortcutFromKeyboardEvent(event)
+        ?? workspaceShortcutFromKeyboardEvent(
+          event,
+          useWorkspaceStore.getState().generalSettings.workspaceShortcuts,
+          "terminal",
+        );
       switch (action) {
         case "copy": {
           const selection = terminal.getSelection();
@@ -2019,24 +2023,6 @@ function TerminalPaneView({
         }
         default:
           break;
-      }
-
-      // Fixed conventional aliases kept alongside the rebindable bindings:
-      // Ctrl+Insert copies and Ctrl+Shift+V pastes in most terminals.
-      if (event.ctrlKey && event.key === "Insert") {
-        const selection = terminal.getSelection();
-        if (selection) {
-          void writeToClipboard(selection);
-          setSelectedTerminalText(selection);
-          setContextMenu(null);
-          return false;
-        }
-        return true;
-      }
-      if (event.ctrlKey && event.shiftKey && event.key.toLowerCase() === "v") {
-        event.preventDefault();
-        void handlePasteIntoTerminal();
-        return false;
       }
 
       return true;

--- a/src/modules/workspace/keymap.ts
+++ b/src/modules/workspace/keymap.ts
@@ -58,6 +58,14 @@ export const WORKSPACE_SHORTCUT_ACTIONS: readonly WorkspaceShortcutAction[] = [
   { id: "splitUp", scope: "terminal", labelKey: "terminal.splitUp", defaultBinding: null },
 ];
 
+const FIXED_TERMINAL_SHORTCUT_ALIASES: ReadonlyArray<{
+  actionId: WorkspaceShortcutActionId;
+  binding: string;
+}> = [
+  { actionId: "copy", binding: "Ctrl+Insert" },
+  { actionId: "paste", binding: "Ctrl+Shift+V" },
+];
+
 const MODIFIER_KEYS = new Set(["Control", "Shift", "Alt", "Meta"]);
 
 /**
@@ -141,6 +149,20 @@ export function workspaceShortcutFromKeyboardEvent(
 }
 
 /**
+ * Resolve conventional terminal aliases that remain active independently of
+ * the user's configurable primary bindings.
+ */
+export function fixedTerminalShortcutFromKeyboardEvent(
+  event: KeyboardEvent,
+): WorkspaceShortcutActionId | null {
+  const binding = bindingFromKeyboardEvent(event);
+  if (!binding) {
+    return null;
+  }
+  return FIXED_TERMINAL_SHORTCUT_ALIASES.find((alias) => alias.binding === binding)?.actionId ?? null;
+}
+
+/**
  * Find the other action already using `binding`, for conflict rejection in
  * the Settings recorder. Shortcuts share one namespace across both scopes
  * because terminal-focused keys reach the window listener too.
@@ -150,6 +172,12 @@ export function conflictingWorkspaceShortcutAction(
   overrides: WorkspaceShortcutOverrides | undefined,
   exceptActionId: WorkspaceShortcutActionId,
 ): WorkspaceShortcutAction | null {
+  const fixedAlias = FIXED_TERMINAL_SHORTCUT_ALIASES.find(
+    (alias) => alias.actionId !== exceptActionId && alias.binding === binding,
+  );
+  if (fixedAlias) {
+    return WORKSPACE_SHORTCUT_ACTIONS.find((action) => action.id === fixedAlias.actionId) ?? null;
+  }
   const bindings = effectiveWorkspaceShortcutBindings(overrides);
   for (const action of WORKSPACE_SHORTCUT_ACTIONS) {
     if (action.id !== exceptActionId && bindings.get(action.id) === binding) {

--- a/tests/connection-tree-keyboard-shortcuts.test.mjs
+++ b/tests/connection-tree-keyboard-shortcuts.test.mjs
@@ -12,6 +12,7 @@ test("Connection Tree handles F2 rename and Delete on the focused connection row
   // (not a terminal or text field) has keyboard focus.
   assert.match(source, /className=\{`tree-list [\s\S]*?onKeyDown=\{handleTreeKeyDown\}/);
   assert.match(source, /function handleTreeKeyDown\(event: ReactKeyboardEvent<HTMLDivElement>\)/);
+  assert.match(source, /if \(event\.repeat\) \{\s*event\.preventDefault\(\);\s*return;/);
   // F2 renames on every platform; delete is the Delete key everywhere plus
   // Backspace / Cmd+Backspace on macOS (Finder convention).
   assert.match(source, /const isRename = event\.key === "F2";/);

--- a/tests/shortcuts-settings.test.mjs
+++ b/tests/shortcuts-settings.test.mjs
@@ -13,6 +13,10 @@ const keymapSource = await readFile(
   new URL("../src/modules/workspace/keymap.ts", import.meta.url),
   "utf8",
 );
+const workspaceCanvasSource = await readFile(
+  new URL("../src/modules/workspace/WorkspaceCanvas.tsx", import.meta.url),
+  "utf8",
+);
 
 test("Shortcuts settings section is wired and listed above Proxy", () => {
   assert.equal(localeEn.settings.sectionShortcuts, "Shortcuts");
@@ -46,4 +50,11 @@ test("keymap ships predefined defaults for common actions and leaves splits unbo
       new RegExp(`id: "${unbound}"[\\s\\S]*?defaultBinding: null`),
     );
   }
+});
+
+test("workspace shortcuts stay inactive behind both legacy and shared dialogs", () => {
+  assert.match(
+    workspaceCanvasSource,
+    /document\.querySelector\("\.settings-backdrop, \.dialog-backdrop, \.kk-dlg-backdrop"\)/,
+  );
 });

--- a/tests/workspace-shortcut-keymap.test.ts
+++ b/tests/workspace-shortcut-keymap.test.ts
@@ -5,6 +5,7 @@ import {
   bindingFromKeyboardEvent,
   conflictingWorkspaceShortcutAction,
   effectiveWorkspaceShortcutBindings,
+  fixedTerminalShortcutFromKeyboardEvent,
   workspaceShortcutFromKeyboardEvent,
 } from "../src/modules/workspace/keymap";
 
@@ -88,6 +89,21 @@ test("conflict detection finds the action already using a binding", () => {
   assert.equal(conflict?.id, "copy");
   // No conflict against an unused combination.
   assert.equal(conflictingWorkspaceShortcutAction("Ctrl+Shift+J", {}, "find"), null);
+});
+
+test("fixed terminal aliases cannot be stolen by other configurable actions", () => {
+  assert.equal(
+    fixedTerminalShortcutFromKeyboardEvent(keyEvent("Insert", { ctrlKey: true })),
+    "copy",
+  );
+  assert.equal(
+    fixedTerminalShortcutFromKeyboardEvent(keyEvent("v", { ctrlKey: true, shiftKey: true })),
+    "paste",
+  );
+  assert.equal(conflictingWorkspaceShortcutAction("Ctrl+Insert", {}, "find")?.id, "copy");
+  assert.equal(conflictingWorkspaceShortcutAction("Ctrl+Shift+V", {}, "find")?.id, "paste");
+  assert.equal(conflictingWorkspaceShortcutAction("Ctrl+Insert", {}, "copy"), null);
+  assert.equal(conflictingWorkspaceShortcutAction("Ctrl+Shift+V", {}, "paste"), null);
 });
 
 test("every action has a unique default binding or is unbound", () => {


### PR DESCRIPTION
## Summary

- block Workspace shortcuts while either legacy or shared app dialogs are mounted
- preserve the fixed Ctrl+Insert copy and Ctrl+Shift+V paste aliases when bindings are customized
- suppress repeated Connection Tree rename/delete keydown events
- add focused regression coverage for all three paths

This follow-up targets the head branch of #574 so the PR contains only review fixes.

## Verification

- npm run check
- npm run build
- npm run i18n:check
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml
- git diff --check