### PR TITLE
Stop sudo playbook leaking password and skipping later nodes

### DIFF
--- a/src-tauri/src/itops/runner.rs
+++ b/src-tauri/src/itops/runner.rs
@@ -43,6 +43,27 @@ pub fn cap_output(mut output: String) -> String {
     output
 }
 
+/// Placeholder substituted for any sudo secret that surfaces in playbook output.
+const REDACTED_SECRET: &str = "••••••";
+
+/// Scrub every `secret` occurrence out of `text`. A PTY with echo enabled reflects
+/// the password we push for a `sudo -S` prompt, so this is the last line of defense
+/// enforcing the ITOPS invariant that plaintext never reaches the live stream or a
+/// persisted Run History row (docs/ITOPS.md). Empty secrets are ignored so an
+/// unset credential can never blank the whole transcript.
+pub fn redact_secrets(text: &str, secrets: &[String]) -> String {
+    let mut redacted = text.to_string();
+    for secret in secrets {
+        if secret.is_empty() {
+            continue;
+        }
+        if redacted.contains(secret.as_str()) {
+            redacted = redacted.replace(secret.as_str(), REDACTED_SECRET);
+        }
+    }
+    redacted
+}
+
 /// Runs a Batch Task on one host. Blocking; called from worker threads.
 /// `on_chunk` is invoked for each output frame as it arrives so the runner can
 /// stream live per-host output; the final combined output is still returned in
@@ -265,12 +286,21 @@ impl BatchTransport for SshTransport {
             socks_proxy: spec.socks_proxy.clone(),
             compression: spec.compression,
         };
+        // Every sudo credential in play, so we can scrub it from anything the
+        // remote PTY echoes back before it reaches the live stream or storage.
+        let redactions: Vec<String> = self
+            .task_secrets
+            .values()
+            .filter(|secret| !secret.is_empty())
+            .cloned()
+            .collect();
         let streamed_output = Mutex::new(String::new());
         let capture_chunk = |chunk: &str| {
-            streamed_output.lock().unwrap().push_str(chunk);
-            on_chunk(chunk);
+            let safe = redact_secrets(chunk, &redactions);
+            streamed_output.lock().unwrap().push_str(&safe);
+            on_chunk(&safe);
         };
-        match task {
+        let mut exec_outcome = match task {
             BatchTask::Script { .. } => {
                 let result = ssh::run_remote_command_capture_streaming(request, &capture_chunk);
                 outcome_from_streaming_result(result, streamed_output.into_inner().unwrap())
@@ -296,8 +326,14 @@ impl BatchTransport for SshTransport {
                                 .unwrap_or("KKTerm sudo password: ");
                             let quoted_prompt = prompt.replace('\'', "'\"'\"'");
                             step_specs.push(ssh::PlaybookStepSpec {
+                                // The `''` splits the ready marker across two adjacent
+                                // shell-quoted literals: the shell concatenates them so
+                                // printf still emits `__KKTERM_SUDO_READY__`, but the
+                                // command echoed back by the PTY reads `SUDO''_READY`,
+                                // so the next step's `expect` cannot match this echo and
+                                // must wait for sudo to actually succeed.
                                 send: format!(
-                                    "sudo -S -p '{quoted_prompt}' -v && printf '\\n__KKTERM_SUDO_READY__\\n'"
+                                    "sudo -S -p '{quoted_prompt}' -v && printf '\\n__KKTERM_SUDO''_READY__\\n'"
                                 ),
                                 expect: Some(prompt.to_string()),
                                 timeout_seconds: step.timeout_seconds,
@@ -378,7 +414,11 @@ impl BatchTransport for SshTransport {
                     },
                 }
             }
-        }
+        };
+        // ssh accumulates its own transcript for the returned outcome, so scrub the
+        // credential out of the persisted copy too, not just the streamed chunks.
+        exec_outcome.output = redact_secrets(&exec_outcome.output, &redactions);
+        exec_outcome
     }
 }
 
@@ -677,6 +717,24 @@ mod tests {
         });
         assert_eq!(chunks.load(Ordering::SeqCst), 2); // one "done" frame per host
         assert!(report.hosts.iter().all(|host| host.output == "done"));
+    }
+
+    #[test]
+    fn redact_secrets_scrubs_every_occurrence() {
+        let secrets = vec!["tsai0529".to_string()];
+        let transcript = "sudo -S ...\ntsai0529\n__KKTERM_SUDO_READY__\ntsai0529 again\n";
+        let redacted = redact_secrets(transcript, &secrets);
+        assert!(!redacted.contains("tsai0529"));
+        assert_eq!(redacted.matches("••••••").count(), 2);
+        assert!(redacted.contains("__KKTERM_SUDO_READY__")); // non-secret output survives
+    }
+
+    #[test]
+    fn redact_secrets_ignores_empty_secret() {
+        // An unset credential must never turn into a blanket match that blanks output.
+        let secrets = vec![String::new()];
+        let transcript = "nothing secret here";
+        assert_eq!(redact_secrets(transcript, &secrets), transcript);
     }
 
     #[test]

--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -2929,8 +2929,20 @@ async fn run_playbook_on_session(
         .channel_open_session()
         .await
         .map_err(|error| format!("failed to open SSH playbook channel: {error}"))?;
+    // Disable terminal echo on the playbook PTY. A sudo node pushes the password
+    // for `sudo -S`, which reads from stdin and therefore never suppresses echo the
+    // way it does for a real TTY prompt; without this the line discipline reflects
+    // the plaintext straight into the captured transcript (docs/ITOPS.md).
     channel
-        .request_pty(false, "xterm-256color", 120, 40, 0, 0, &[])
+        .request_pty(
+            false,
+            "xterm-256color",
+            120,
+            40,
+            0,
+            0,
+            &[(russh::Pty::ECHO, 0), (russh::Pty::ECHONL, 0)],
+        )
         .await
         .map_err(|error| format!("failed to allocate SSH PTY: {error}"))?;
     channel


### PR DESCRIPTION
## Summary

A Playbook **sudo node** drives an interactive PTY that echoes what it is fed. Two bugs fell out of that, both reported from a `testplay` playbook (Acquire sudo → `sudo apt update`):

1. **Password leaked into Run History.** `sudo -S` reads the password from stdin, so sudo never suppresses terminal echo the way it does for a real TTY prompt. The line discipline reflected the plaintext password straight into the captured transcript — which is streamed live *and* persisted to a Run History row. This violates the documented invariant in `docs/ITOPS.md`: *"plaintext … is never copied into SQLite or Run History."*
2. **`apt update` never ran.** Both wait-markers (`KKTerm sudo password:` and `__KKTERM_SUDO_READY__`) were literal substrings of the command being typed, so `wait_for_substring` matched instantly on the shell's *echo* of the command. The playbook declared success on an echo and closed the channel before the following Command node executed.

## Fixes

- **`runner.rs` — redaction backstop:** add `redact_secrets()` and scrub every sudo secret from both the live stream (`capture_chunk`) and the final persisted transcript (`exec_outcome.output`). Guarantees the ITOPS invariant regardless of PTY behavior.
- **`ssh.rs` — stop the echo at the source:** allocate the playbook PTY with `Pty::ECHO`/`Pty::ECHONL` disabled, so the pushed password is not reflected in the first place.
- **`runner.rs` — fix expect-on-echo:** emit the ready marker split across two shell-quoted literals (`'…SUDO''_READY…'`). The shell still prints `__KKTERM_SUDO_READY__`, but the echoed command reads `SUDO''_READY`, so `expect` can no longer match its own echo and must wait for sudo to actually succeed.

Added unit tests for the redaction helper.

## Type of change

- [x] Bug fix

## Areas touched

- [x] Backend (Rust/Tauri — `src-tauri/`)

## i18n

- [x] No user-visible strings

## High-risk invariants

- [x] No live Session state added to the durable Connection model
- [x] No frontend close hooks / close-confirmation flows added

## Checks

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` (ran `cargo test --lib itops::runner`: 10 passed, incl. new redaction tests; compiles clean)
- [ ] Validated in the real Tauri desktop runtime

## Notes for reviewers

- **End-to-end still needs a live host.** The runner's own tests note the real PTY/expect behavior "needs a live host to exercise"; I could not run this against a real SSH target. Please re-run the playbook and confirm (a) the password no longer appears in run output and (b) `apt update` output shows.
- **Config caveat:** if a Command node has no `expect` value, the run may still close the channel right after sending it, cutting off its output. Setting the Command node's expect to something in the command's output avoids this — orthogonal to the bugs fixed here.
