### PR TITLE
fix(itops): stop dialog clipping the icon picker popover

### DIFF
--- a/src/app/ui/dialog/dialogs.css
+++ b/src/app/ui/dialog/dialogs.css
@@ -63,6 +63,16 @@
   line-height: 1.45;
 }
 
+/* The shared ConnectionIconPicker floats its mini grid as an absolutely
+   positioned popover. Inside a Sheet the clipping (.kk-dlg overflow:hidden) and
+   the scrolling body (.kk-dlg-body overflow-y:auto) would chop it into a jumbled
+   strip, so let a dialog hosting an open picker escape both while it is open.
+   Mirrors the .connection-dialog override in connections.css. */
+.kk-dlg:has(.connection-icon-popover),
+.kk-dlg:has(.connection-icon-popover) .kk-dlg-body {
+  overflow: visible;
+}
+
 .kk-dlg-head {
   position: relative;
   padding: 20px 22px 0;


### PR DESCRIPTION
## Summary

The IT Ops **Edit Site** / **Edit Server Room** dialogs are built from the shared `Sheet` primitive (`.kk-dlg`), whose `overflow: hidden` and scrolling `.kk-dlg-body` clipped the absolutely-positioned `ConnectionIconPicker` popover into a jumbled strip when opened.

The connections dialog already escapes this with `.connection-dialog:has(.connection-icon-popover) { overflow: visible }`, but that override is scoped to `.connection-dialog` and never reached the shared `.kk-dlg` used by IT Ops. This PR mirrors the override in `src/app/ui/dialog/dialogs.css` so any Sheet-based dialog hosting an open picker lets the grid float out intact. It is keyed on the popover being present in the DOM (it only renders while open), so normal scrolling is unaffected otherwise. Covers both `SiteDialog` and `ServerRoomDialog`.

## Type of change

- [x] Bug fix

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)

## UI / design language

- [x] Dialogs built from `src/app/ui/dialog` primitives; colors read from tokens (no hard-coded hex)

## i18n

- [x] No user-visible strings

## Checks

- [x] Verified live in the Vite dev preview: drove IT Ops -> New Site -> opened the icon picker and measured the DOM. `.kk-dlg` / `.kk-dlg-body` now compute `overflow: visible`; the popover renders at its full 520x422 floating below the dialog body instead of being clipped, with search-on-top and the 12-column icon grid laid out correctly and scrolling internally.

## Notes for reviewers

- CSS-only change (10 lines added).
- Pre-existing behavior unchanged by this fix (and identical in the connections dialog): the popover opens downward only with `max-height: calc(100vh - 140px)` and scrolls internally, so on a very short window it can extend below the fold. Flipping/clamping it to stay fully on-screen would be a separate enhancement to the shared picker.
