### PR TITLE
fix(settings): stop AI assistant skill list overflowing horizontally

### DIFF
--- a/src/modules/settings/AssistantSkills.tsx
+++ b/src/modules/settings/AssistantSkills.tsx
@@ -240,7 +240,6 @@ function AssistantSkillRow({
         <div className="assistant-skill-row-description">
           {skill.invalidReason || skill.description}
         </div>
-        <div className="assistant-skill-row-path">{skill.folderPath}</div>
       </div>
       <div className="assistant-skill-row-actions">
         <label className="assistant-skill-toggle">

--- a/src/modules/settings/settings.css
+++ b/src/modules/settings/settings.css
@@ -2431,22 +2431,22 @@
 }
 
 .assistant-skill-row-name {
-  font-weight: 650;
+  color: var(--text);
+  font-weight: 530;
   font-size: 13px;
+  line-height: 1.3;
 }
 
-.assistant-skill-row-description,
-.assistant-skill-row-path {
+.assistant-skill-row-description {
   font-size: 12px;
-  color: var(--muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  font-weight: 450;
+  color: var(--text-muted);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
 }
 
 .assistant-skill-row[data-invalid="true"] .assistant-skill-row-description {
   color: #b91c1c;
-  white-space: normal;
 }
 
 .assistant-skill-row-actions {


### PR DESCRIPTION
## Summary

The **Settings → AI Assistant** skill list required horizontal scrolling because each row rendered the full skill folder path (`C:\Users\...\assistant-skills\...`) with `white-space: nowrap`, forcing rows wider than the settings panel.

This PR:

1. **Matches the title/description layout to the AI tools section** — the skill name and description now use the same font weights, colors (`var(--text)` / `var(--text-muted)`), and line-heights as the `.settings-toggle-row` `strong`/`small` used by the AI tools list.
2. **Removes the full folder path text** from each row — the per-row open-folder button already provides that navigation.
3. **Eliminates horizontal scrolling** — descriptions now wrap naturally (`overflow-wrap: anywhere` guards long unbreakable tokens) and the widest element (the path) is gone, so rows stay within the panel width.

## Changes

- `src/modules/settings/AssistantSkills.tsx` — removed the `.assistant-skill-row-path` div (`folderPath` is still used as the React `key`).
- `src/modules/settings/settings.css` — restyled name/description to match AI tools and removed the nowrap/ellipsis path rule.

## Verification

This list only renders under the Tauri runtime (gated by `isTauriRuntime()` and populated by Tauri commands), so the browser-only dev preview cannot exercise it. The changes are CSS/markup-only and self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)