### PR TITLE
feat(itops): show IT Ops Module on Activity Rail by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to KKTerm are documented here.
 
 ## New
 
+- **IT Ops:** The IT Ops Module is now officially released and shows on the Activity Rail by default. Fresh installs and upgrades reveal it automatically; anyone who prefers it hidden can still turn it off in **Settings → IT Ops**. (by @ryantsai)
 - **IT Ops:** Exposed IT Ops topology tools to the AI assistant and the built-in MCP server. (PR #573 by @ryantsai)
 
 ## Improved

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -13,7 +13,7 @@ use std::{
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use zip::{ZipArchive, ZipWriter, write::SimpleFileOptions};
 
-const SCHEMA_USER_VERSION: i32 = 46;
+const SCHEMA_USER_VERSION: i32 = 47;
 
 const DEFAULT_TERMINAL_OPACITY: u8 = 50;
 
@@ -511,8 +511,10 @@ pub struct GeneralSettings {
     separate_split_terminal_backgrounds: bool,
     #[serde(default = "default_show_installer_on_rail")]
     show_installer_on_rail: bool,
-    // IT Ops Module rail visibility. Defaults off while the Module is in
-    // development; users opt in via Settings → IT Ops.
+    // IT Ops Module rail visibility. Now that the Module is officially released
+    // it defaults on; users can still hide it via Settings → IT Ops. Installs
+    // that persisted the former dev-era `false` are flipped once by the v47
+    // migration (see `reveal_it_ops_on_release`).
     #[serde(default = "default_show_it_ops")]
     show_it_ops: bool,
     #[serde(default = "default_show_dont_sleep_on_rail")]
@@ -2592,6 +2594,19 @@ impl Storage {
         )?;
         // Cell quadrant of quarter-block room fixtures (NULL = pre-corner row).
         ensure_column(&connection, "itops_room_objects", "corner", "INTEGER")?;
+        // v47: IT Ops graduated from a dev-only, hidden-by-default Module to an
+        // officially released one. Existing installs persisted `showItOps: false`
+        // (the former dev default, baked into the 'general' settings blob by any
+        // settings save — including the periodic auto-backup timestamp update), so
+        // flipping the default alone only reaches fresh installs. Reveal the Module
+        // once for upgrading installs. Nothing distinguishes "never touched" from
+        // "explicitly hidden while in dev", and the Module was never officially
+        // visible to be hidden, so treat every upgrading install as opting in;
+        // users can hide it again afterwards and that choice persists (this
+        // one-time migration never runs again).
+        if stored_version < 47 {
+            reveal_it_ops_on_release(&connection)?;
+        }
         connection
             .execute_batch(&format!("PRAGMA user_version = {SCHEMA_USER_VERSION}"))
             .map_err(to_storage_error)?;
@@ -2816,6 +2831,41 @@ fn ensure_column(
         .execute(
             &format!("ALTER TABLE {table} ADD COLUMN {column} {definition}"),
             [],
+        )
+        .map_err(to_storage_error)?;
+    Ok(())
+}
+
+/// One-time v47 migration: reveal the IT Ops Module on the Activity Rail for
+/// upgrading installs by flipping the stored `showItOps` flag to `true` in the
+/// 'general' settings blob. Fresh installs have no 'general' row yet and pick up
+/// the new default instead, so this only touches already-persisted settings. A
+/// missing or unparseable blob is left untouched.
+fn reveal_it_ops_on_release(connection: &SqliteConnection) -> Result<(), String> {
+    let stored: Option<String> = connection
+        .query_row(
+            "SELECT value FROM settings WHERE key = 'general'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(to_storage_error)?;
+    let Some(stored) = stored else {
+        return Ok(());
+    };
+    let Ok(serde_json::Value::Object(mut object)) =
+        serde_json::from_str::<serde_json::Value>(&stored)
+    else {
+        return Ok(());
+    };
+    object.insert("showItOps".to_string(), serde_json::Value::Bool(true));
+    let serialized = serde_json::to_string(&serde_json::Value::Object(object))
+        .map_err(|error| format!("failed to serialize general settings: {error}"))?;
+    connection
+        .execute(
+            "UPDATE settings SET value = ?1, updated_at = CURRENT_TIMESTAMP \
+             WHERE key = 'general'",
+            params![serialized],
         )
         .map_err(to_storage_error)?;
     Ok(())
@@ -4865,7 +4915,7 @@ fn default_show_dashboard_on_rail() -> bool {
 }
 
 fn default_show_it_ops() -> bool {
-    false
+    true
 }
 
 fn default_show_dont_sleep_on_rail() -> bool {

--- a/src-tauri/src/storage/tests.rs
+++ b/src-tauri/src/storage/tests.rs
@@ -2182,7 +2182,7 @@ fn general_settings_round_trip_through_settings_table() {
     assert!(defaults.submit_ai_attachments_directly);
     assert!(!defaults.separate_split_terminal_backgrounds);
     assert!(defaults.show_installer_on_rail);
-    assert!(!defaults.show_it_ops);
+    assert!(defaults.show_it_ops);
     assert!(defaults.show_dont_sleep_on_rail);
     assert_eq!(
         defaults.activity_rail_order,
@@ -2301,6 +2301,32 @@ fn general_settings_round_trip_through_settings_table() {
     assert!(reloaded.advanced_debugging_enabled);
     assert!(reloaded.rdp_webview_stability);
     assert!(reloaded.last_backup_at.is_none());
+}
+
+#[test]
+fn it_ops_visibility_revealed_for_upgrading_installs() {
+    let db_path = temp_db_path("itops-reveal-migration");
+    // Simulate a pre-release install: persist the former dev-era hidden value,
+    // then roll the schema version back to before the reveal migration.
+    {
+        let storage = Storage::open(db_path.clone()).expect("storage opens");
+        let mut settings = storage.general_settings().expect("load defaults");
+        settings.show_it_ops = false;
+        storage
+            .update_general_settings(settings)
+            .expect("persist hidden IT Ops");
+    }
+    {
+        let connection = rusqlite::Connection::open(&db_path).expect("raw open");
+        connection
+            .execute_batch("PRAGMA user_version = 46;")
+            .expect("downgrade schema version");
+    }
+
+    // Reopening runs initialize_schema, whose v47 migration flips the flag on.
+    let storage = Storage::open(db_path).expect("storage reopens");
+    let migrated = storage.general_settings().expect("load migrated settings");
+    assert!(migrated.show_it_ops);
 }
 
 #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -325,7 +325,7 @@ function App() {
     return { ok: true };
   }
 
-  // The IT Ops Module is hidden by default while under development. If it gets
+  // The IT Ops Module shows by default, but users can hide it. If it gets
   // turned off while it is the active (or last-active) page, fall back to the
   // Workspace so the user is never stranded on a Module they can't navigate to.
   useEffect(() => {

--- a/src/app-defaults.ts
+++ b/src/app-defaults.ts
@@ -35,7 +35,7 @@ export const defaultGeneralSettings: GeneralSettings = {
   submitAiAttachmentsDirectly: true,
   separateSplitTerminalBackgrounds: false,
   showInstallerOnRail: true,
-  showItOps: false,
+  showItOps: true,
   showDontSleepOnRail: true,
   activityRailOrder: [...DEFAULT_ACTIVITY_RAIL_ORDER],
   installerCheckIntervalSeconds: 86400,

--- a/tests/activity-rail-visibility-settings.test.mjs
+++ b/tests/activity-rail-visibility-settings.test.mjs
@@ -58,7 +58,7 @@ test("Activity Rail visibility defaults and rendering match the unified controls
   assert.match(defaults, /showWorkspaceOnRail:\s*true/);
   assert.match(defaults, /showDashboardOnRail:\s*true/);
   assert.match(defaults, /showInstallerOnRail:\s*true/);
-  assert.match(defaults, /showItOps:\s*false/);
+  assert.match(defaults, /showItOps:\s*true/);
   assert.match(defaults, /showDontSleepOnRail:\s*true/);
   assert.match(defaults, /activityRailOrder:\s*\[\.\.\.DEFAULT_ACTIVITY_RAIL_ORDER\]/);
 


### PR DESCRIPTION
## Summary

The IT Ops Module was hidden by default (`showItOps: false`) while under development. Now that it is officially released, this defaults it **on** for fresh installs and reveals it for existing installs that have not otherwise configured it.

**Why a migration is needed, not just a default flip:** General settings persist as a single JSON blob under key `'general'`, and that blob is rewritten by any settings save — including the periodic auto-backup timestamp update. So nearly every existing install already has `showItOps: false` baked into its stored blob. Flipping the default alone would only reach brand-new installs, so a one-time migration is required to reach upgrading users.

**On "not explicitly hidden":** The stored data is a single bool that was `false` for everyone during development — there is no stored signal distinguishing "never touched" from "explicitly hidden while in dev." Since the Module was never officially visible to be hidden, the migration treats every upgrading install as opting in. Users can hide it again via **Settings → IT Ops**, and because the migration is schema-version-guarded it never re-runs, so that choice persists.

## Type of change

- [x] Feature

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)
- [x] Backend (Rust/Tauri — `src-tauri/`)

## What changed

- **`src-tauri/src/storage.rs`**: `default_show_it_ops()` → `true`; bumped `SCHEMA_USER_VERSION` 46 → 47; added `reveal_it_ops_on_release()`, a one-time v47 migration (guarded by `stored_version < 47`) that flips the persisted `showItOps` to `true` in the `'general'` blob. Missing/unparseable blobs are left untouched; fresh installs have no `'general'` row and pick up the new default.
- **`src/app-defaults.ts`**: `showItOps: true`.
- **`src/App.tsx`**: refreshed the stale "hidden by default while under development" comment (behavior unchanged — the fallback-navigation effect only acts when the Module is hidden).
- **Tests**: updated the JS + Rust defaults assertions; added `it_ops_visibility_revealed_for_upgrading_installs`, which simulates a pre-v47 install and asserts the migration reveals the Module.
- **`CHANGELOG.md`**: added a "New" entry.

## i18n

- [x] No user-visible strings (default/behavior change only; the existing Settings → IT Ops toggle copy is unchanged)

## Checks

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — storage suite 139/139 pass, including the new migration test
- [x] Relevant JS tests (`activity-rail-visibility-settings`, `activity-rail-order`) pass via the `tsx` runner
- [ ] Validated in the real Tauri desktop runtime

## Notes for reviewers

Verified via unit tests rather than the browser preview — the settings default + SQLite migration are backend concerns not exercisable in the vite preview. Worth an extra look at the migration's one-time semantics (it runs for any `stored_version < 47`, which includes fresh installs at version 0, but no-ops there because there is no `'general'` row yet).
