### PR TITLE
Preserve SSH forwards after tmux pane changes

### DIFF
--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -597,6 +597,7 @@ export function TerminalWorkspace({
           onClose={closeSshPortForwardingDialog}
           onConnectionUpdated={(updatedConnection) => {
             refreshOpenConnectionMetadata(updatedConnection);
+            notifyConnectionTreeInvalidated();
             setSshPortForwardingDialogConnection(updatedConnection);
           }}
         />,

--- a/tests/ssh-port-forwarding-model.test.mjs
+++ b/tests/ssh-port-forwarding-model.test.mjs
@@ -200,6 +200,7 @@ test("SSH forwarding starts through the Pane's live Session", async () => {
 
   assert.match(workspaceSource, /onOpenSshPortForwarding\(pane\.connection, pane\.id, sessionIdRef\.current\)/);
   assert.match(workspaceSource, /startEnabledSshPortForwardings\(\s*connection\.sshPortForwardings \?\? \[\]/);
+  assert.match(workspaceSource, /onConnectionUpdated=\{\(updatedConnection\) => \{[\s\S]*?refreshOpenConnectionMetadata\(updatedConnection\);[\s\S]*?notifyConnectionTreeInvalidated\(\);[\s\S]*?setSshPortForwardingDialogConnection\(updatedConnection\);/);
   assert.match(workspaceSource, /terminal\.sshPortForwardStartupFailed/);
   assert.match(dialogSource, /remotePort:[\s\S]*\bsessionId,/);
   assert.match(tauriSource, /start_ssh_port_forward:[\s\S]*sessionId:\s*string/);


### PR DESCRIPTION
### Motivation
- When port forwards are added/updated from the SSH Port Forwarding dialog, the connection tree was not invalidated so later tmux child/window creation could load stale Connection metadata and lose the saved forwards.

### Description
- Call `notifyConnectionTreeInvalidated()` after `refreshOpenConnectionMetadata(updatedConnection)` when the `SshPortForwardingDialog` reports `onConnectionUpdated` in `src/modules/workspace/connections/terminal/TerminalWorkspace.tsx` so the sidebar reloads the updated Connection metadata.
- Strengthen the unit test in `tests/ssh-port-forwarding-model.test.mjs` to assert the metadata-refresh + tree-invalidation path is present.
- Modified files: `src/modules/workspace/connections/terminal/TerminalWorkspace.tsx`, `tests/ssh-port-forwarding-model.test.mjs`.

### Testing
- Ran `node --test tests/ssh-port-forwarding-model.test.mjs tests/ssh-port-forwarding-dialog.test.mjs`, which completed with all tests passing.
- Ran `git diff --check` to ensure no accidental whitespace or diff errors were introduced and found no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a547540d060832fbd30db2366cc5213)