### PR TITLE
Fix RDP overlay handling for connection import dialog

### DIFF
--- a/src/modules/workspace/connections/ImportDialog.tsx
+++ b/src/modules/workspace/connections/ImportDialog.tsx
@@ -572,7 +572,7 @@ export function ImportDialog({ sshSettings, onClose, onImported }: ImportDialogP
   );
 
   return (
-    <DialogShell>
+    <DialogShell zClassName="connection-dialog-backdrop">
       <Sheet
         ariaLabel={t("connections.import.title")}
         className="import-dialog import-dialog-redesign"

--- a/tests/dialog-portal-policy.test.mjs
+++ b/tests/dialog-portal-policy.test.mjs
@@ -225,3 +225,23 @@ test("Assistant image preview escapes the AI Assistant Panel and remains RDP-blo
     "RDP native overlay parking should treat the Assistant image preview as a blocking overlay",
   );
 });
+
+
+test("Connection import dialog participates in RDP overlay parking", async () => {
+  const importDialogSource = await readFile(
+    new URL("../src/modules/workspace/connections/ImportDialog.tsx", import.meta.url),
+    "utf8",
+  );
+  const nativeOverlaySource = await readFile(new URL("../src/modules/workspace/nativeOverlay.ts", import.meta.url), "utf8");
+
+  assert.match(
+    importDialogSource,
+    /<DialogShell\s+zClassName="connection-dialog-backdrop">/,
+    "Connection import dialog should mark its portal backdrop as RDP-blocking",
+  );
+  assert.match(
+    nativeOverlaySource,
+    /"\.connection-dialog-backdrop"/,
+    "RDP native overlay parking should treat Connection dialogs as blocking overlays",
+  );
+});


### PR DESCRIPTION
### Motivation
- The Connection Import dialog was not marked as an RDP-blocking overlay, so it could be hidden behind an active RDP native surface instead of triggering the screenshot/parking workaround used by other connection dialogs.

### Description
- Add `zClassName="connection-dialog-backdrop"` to the `DialogShell` in `src/modules/workspace/connections/ImportDialog.tsx` so the import dialog portal backdrop participates in RDP overlay parking.
- Add a regression test in `tests/dialog-portal-policy.test.mjs` that verifies the Import dialog marks its portal backdrop and that `src/modules/workspace/nativeOverlay.ts` treats `.connection-dialog-backdrop` as a blocking overlay.

### Testing
- Ran `node --test tests/dialog-portal-policy.test.mjs` and the test passed (all assertions succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54b0cfa1f8832fb1fe919178f2f021)