### PR TITLE
Repair RDP ActiveX focus repair and add RDP canvas focus diagnostics

### DIFF
--- a/src-tauri/src/rdp.rs
+++ b/src-tauri/src/rdp.rs
@@ -29,6 +29,7 @@ mod platform {
                 LibraryLoader::{GetModuleHandleW, GetProcAddress, LoadLibraryW},
                 Memory::{GMEM_MOVEABLE, GlobalAlloc, GlobalLock, GlobalUnlock},
                 Ole::{CF_UNICODETEXT, DISPID_PROPERTYPUT, IOleInPlaceObject, OleInitialize},
+                Threading::{AttachThreadInput, GetCurrentThreadId},
                 Variant::{
                     VARIANT, VT_BOOL, VT_BSTR, VT_DISPATCH, VT_I2, VT_I4, VT_UI4, VariantClear,
                 },
@@ -40,9 +41,10 @@ mod platform {
                     VIRTUAL_KEY, VkKeyScanW,
                 },
                 WindowsAndMessaging::{
-                    CallNextHookEx, CreateWindowExW, DestroyWindow, GetClientRect, GetWindowRect,
-                    HC_ACTION, HHOOK, HMENU, IsChild, MSLLHOOKSTRUCT, SW_SHOWNOACTIVATE,
-                    SWP_NOACTIVATE, SWP_NOZORDER, SendMessageW, SetForegroundWindow, SetWindowPos,
+                    CallNextHookEx, CreateWindowExW, DestroyWindow, GetClientRect,
+                    GetForegroundWindow, GetWindowRect, GetWindowThreadProcessId, HC_ACTION, HHOOK,
+                    HMENU, IsChild, MSLLHOOKSTRUCT, SW_SHOWNOACTIVATE, SWP_NOACTIVATE,
+                    SWP_NOZORDER, SendMessageW, SetForegroundWindow, SetWindowPos,
                     SetWindowsHookExW, ShowWindow, UnhookWindowsHookEx, WH_MOUSE_LL,
                     WM_LBUTTONDOWN, WM_MBUTTONDOWN, WM_RBUTTONDOWN, WM_XBUTTONDOWN,
                     WS_CLIPCHILDREN, WS_CLIPSIBLINGS, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_POPUP,
@@ -1393,12 +1395,7 @@ mod platform {
                 let module = GetModuleHandleW(PCWSTR::null())
                     .ok()
                     .map(|handle| HINSTANCE(handle.0));
-                match SetWindowsHookExW(
-                        WH_MOUSE_LL,
-                        Some(rdp_overlay_focus_hook_proc),
-                        module,
-                        0,
-                    ) {
+                match SetWindowsHookExW(WH_MOUSE_LL, Some(rdp_overlay_focus_hook_proc), module, 0) {
                     Ok(hook) => {
                         state.hook = Some(hook);
                     }
@@ -1932,9 +1929,77 @@ mod platform {
         // raise in some paths, but best-effort focus still keeps programmatic input
         // routed to the in-process control when Windows permits it.
         unsafe {
-            let _ = SetForegroundWindow(owner);
-            let _ = SetForegroundWindow(active);
-            let _ = SetFocus(Some(focus));
+            let current_thread = GetCurrentThreadId();
+            let owner_thread = GetWindowThreadProcessId(owner, None);
+            let active_thread = GetWindowThreadProcessId(active, None);
+            let focus_thread = GetWindowThreadProcessId(focus, None);
+            let foreground = GetForegroundWindow();
+            let foreground_thread = if foreground.0.is_null() {
+                0
+            } else {
+                GetWindowThreadProcessId(foreground, None)
+            };
+            let attached_owner = owner_thread != 0
+                && owner_thread != current_thread
+                && AttachThreadInput(current_thread, owner_thread, true).as_bool();
+            let attached_active = active_thread != 0
+                && active_thread != current_thread
+                && active_thread != owner_thread
+                && AttachThreadInput(current_thread, active_thread, true).as_bool();
+            let attached_focus = focus_thread != 0
+                && focus_thread != current_thread
+                && focus_thread != owner_thread
+                && focus_thread != active_thread
+                && AttachThreadInput(current_thread, focus_thread, true).as_bool();
+            let attached_foreground = foreground_thread != 0
+                && foreground_thread != current_thread
+                && foreground_thread != owner_thread
+                && foreground_thread != active_thread
+                && foreground_thread != focus_thread
+                && AttachThreadInput(current_thread, foreground_thread, true).as_bool();
+
+            let foreground_owner = SetForegroundWindow(owner).as_bool();
+            let foreground_active = SetForegroundWindow(active).as_bool();
+            let previous_focus = SetFocus(Some(focus));
+            let (set_focus_succeeded, previous_focus_hwnd) = match previous_focus {
+                Ok(previous) => (true, format_hwnd(previous)),
+                Err(error) => (false, error.to_string()),
+            };
+            rdp_debug(
+                "focus.apply",
+                &json!({
+                    "ownerHwnd": format_hwnd(owner),
+                    "activeHwnd": format_hwnd(active),
+                    "focusHwnd": format_hwnd(focus),
+                    "foregroundHwnd": format_hwnd(foreground),
+                    "currentThread": current_thread,
+                    "ownerThread": owner_thread,
+                    "activeThread": active_thread,
+                    "focusThread": focus_thread,
+                    "foregroundThread": foreground_thread,
+                    "attachedOwnerThread": attached_owner,
+                    "attachedActiveThread": attached_active,
+                    "attachedFocusThread": attached_focus,
+                    "attachedForegroundThread": attached_foreground,
+                    "setForegroundOwner": foreground_owner,
+                    "setForegroundActive": foreground_active,
+                    "setFocusSucceeded": set_focus_succeeded,
+                    "previousFocusHwnd": previous_focus_hwnd,
+                }),
+            );
+
+            if attached_foreground {
+                let _ = AttachThreadInput(current_thread, foreground_thread, false);
+            }
+            if attached_focus {
+                let _ = AttachThreadInput(current_thread, focus_thread, false);
+            }
+            if attached_active {
+                let _ = AttachThreadInput(current_thread, active_thread, false);
+            }
+            if attached_owner {
+                let _ = AttachThreadInput(current_thread, owner_thread, false);
+            }
         }
     }
 

--- a/src/modules/workspace/connections/remote-desktop/RdpCanvasView.tsx
+++ b/src/modules/workspace/connections/remote-desktop/RdpCanvasView.tsx
@@ -14,7 +14,7 @@ import { useEffect, useRef, useState } from "react";
 import type { RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { readFromClipboard, writeToClipboard } from "../../../../lib/clipboard";
-import { invokeCommand, isTauriRuntime } from "../../../../lib/tauri";
+import { invokeCommand, isTauriRuntime, logUiDebug } from "../../../../lib/tauri";
 import type { Connection } from "../../../../types";
 import { connectionPasswordOwnerId } from "../utils";
 import { isCharacterCode, scancodeForCode } from "./rdpScancodes";
@@ -82,6 +82,21 @@ export function RdpCanvasView({
   const composingRef = useRef(false);
   const [status, setStatus] = useState<"connecting" | "connected" | "disconnected">("connecting");
   const [errorMessage, setErrorMessage] = useState("");
+
+  const focusInput = (reason: string) => {
+    const input = inputRef.current;
+    if (!input) {
+      return;
+    }
+    input.focus({ preventScroll: true });
+    logUiDebug("rdp.canvas.focus", {
+      reason,
+      sessionId: sessionIdRef.current,
+      documentHasFocus: document.hasFocus(),
+      activeElement: document.activeElement?.tagName.toLowerCase() ?? null,
+      inputFocused: document.activeElement === input,
+    });
+  };
 
   // Session lifecycle + framebuffer rendering.
   useEffect(() => {
@@ -230,7 +245,7 @@ export function RdpCanvasView({
     sendPointer(e.clientX, e.clientY, buttonMaskRef.current);
   };
   const onPointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
-    inputRef.current?.focus();
+    focusInput("pointerdown");
     const bit = e.button === 1 ? 1 : e.button === 2 ? 2 : e.button === 0 ? 0 : -1;
     if (bit >= 0) {
       buttonMaskRef.current |= 1 << bit;
@@ -311,7 +326,7 @@ export function RdpCanvasView({
       return;
     }
     void invokeCommand("send_rdp_client_ctrl_alt_delete", { request: { sessionId } }).catch(() => undefined);
-    inputRef.current?.focus();
+    focusInput("ctrl-alt-delete");
   };
 
   useEffect(() => {
@@ -322,6 +337,13 @@ export function RdpCanvasView({
   }, [cadSignal]);
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    logUiDebug("rdp.canvas.key", {
+      sessionId: sessionIdRef.current,
+      code: e.code,
+      key: e.key,
+      composing: composingRef.current,
+      documentHasFocus: document.hasFocus(),
+    });
     if (composingRef.current || e.key === "Process") {
       return; // IME is composing — let composition events handle it.
     }
@@ -405,7 +427,7 @@ export function RdpCanvasView({
         : "";
 
   return (
-    <div className="rdp-canvas-view" onPointerDown={() => inputRef.current?.focus()}>
+    <div className="rdp-canvas-view" onPointerDown={() => focusInput("surface-pointerdown")}>
       <canvas
         ref={setCanvasRef}
         className="rdp-canvas-surface"

--- a/tests/rdp-canvas-focus-diagnostics.test.mjs
+++ b/tests/rdp-canvas-focus-diagnostics.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("IronRDP canvas records focus and first key diagnostics", async () => {
+  const source = await readFile(
+    new URL("../src/modules/workspace/connections/remote-desktop/RdpCanvasView.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(source, /function RdpCanvasView/);
+  assert.match(source, /const focusInput = \(reason: string\) => \{/);
+  assert.match(source, /input\.focus\(\{ preventScroll: true \}\)/);
+  assert.match(source, /logUiDebug\("rdp\.canvas\.focus"/);
+  assert.match(source, /inputFocused: document\.activeElement === input/);
+  assert.match(source, /focusInput\("pointerdown"\)/);
+  assert.match(source, /logUiDebug\("rdp\.canvas\.key"/);
+});

--- a/tests/rdp-overlay-focus-policy.test.mjs
+++ b/tests/rdp-overlay-focus-policy.test.mjs
@@ -27,7 +27,7 @@ test("RDP overlay keyboard focus uses a low-level click hook, not WM_MOUSEACTIVA
   );
   assert.match(
     shim,
-    /SetWindowsHookExW\([\s\S]*WH_MOUSE_LL[\s\S]*,\s*0,\s*\)/,
+    /SetWindowsHookExW\([\s\S]*WH_MOUSE_LL[\s\S]*,\s*0\s*\)/,
     "RDP focus hook should be global low-level (dwThreadId = 0) so it is not tied to a recreated ActiveX child thread",
   );
   assert.match(
@@ -42,8 +42,13 @@ test("RDP overlay keyboard focus uses a low-level click hook, not WM_MOUSEACTIVA
   );
   assert.match(
     source,
-    /fn focus_rdp_window\([\s\S]*SetForegroundWindow\(owner\)[\s\S]*SetForegroundWindow\(active\)[\s\S]*SetFocus\(Some\(focus\)\)/,
-    "RDP focus should foreground KKTerm, foreground the no-activate overlay, and focus the clicked or hosted ActiveX HWND",
+    /fn focus_rdp_window\([\s\S]*AttachThreadInput\(current_thread, foreground_thread, true\)[\s\S]*SetForegroundWindow\(owner\)[\s\S]*SetForegroundWindow\(active\)[\s\S]*SetFocus\(Some\(focus\)\)/,
+    "RDP focus should attach input queues before foregrounding KKTerm/the overlay and focusing the clicked or hosted ActiveX HWND",
+  );
+  assert.match(
+    source,
+    /rdp_debug\(\s*"focus\.apply"[\s\S]*"setFocusSucceeded"/,
+    "RDP focus repair should log whether focus calls actually succeeded",
   );
   assert.match(
     shim,


### PR DESCRIPTION
### Motivation
- Address intermittent loss of keyboard input to embedded RDP ActiveX after app/window switching or multi-monitor focus changes by fixing cross-thread focus routing. 
- Make RDP focus-repair behavior observable so environment-specific failures can be diagnosed from logs. 
- Improve diagnostics for the macOS/Linux IronRDP canvas path so the “no input” reports can be distinguished between DOM-focus vs. transport issues.

### Description
- Win32: update `focus_rdp_window` in `src-tauri/src/rdp.rs` to temporarily call `AttachThreadInput` for the current thread and the overlay/owner/active/foreground threads before calling `SetForegroundWindow`/`SetFocus`, and detach afterward; add structured `rdp_debug("focus.apply", ...)` logging with HWNDs, thread ids, which `AttachThreadInput` calls succeeded, `SetForegroundWindow` results, and whether `SetFocus` succeeded. 
- Frontend: add `focusInput` helper and diagnostic logging (`logUiDebug("rdp.canvas.focus")` and `logUiDebug("rdp.canvas.key")`) to `src/modules/workspace/connections/remote-desktop/RdpCanvasView.tsx` so pointer-focus attempts and first-key handling are recorded for IronRDP canvas sessions. 
- Tests: tighten `tests/rdp-overlay-focus-policy.test.mjs` to require the input-queue attachment + focus-result logging and add `tests/rdp-canvas-focus-diagnostics.test.mjs` to assert the new diagnostic hooks exist. 
- Hygiene: minor call-site updates to use the diagnostic helper and small formatting adjustments around the `SetWindowsHookExW` install path.

### Testing
- Ran `node --test tests/rdp-overlay-focus-policy.test.mjs tests/rdp-canvas-focus-diagnostics.test.mjs` and both tests passed. 
- Ran `npm run lint -- --quiet` and ESLint completed successfully. 
- Attempted `cargo check --manifest-path src-tauri/Cargo.toml` but it failed in this container due to missing system dependency `glib-2.0.pc` (GLib dev package); this is an environment limitation, not a code regression. 
- Attempted `cargo check --manifest-path src-tauri/Cargo.toml --target x86_64-pc-windows-gnu` but the Windows Rust target was not installed in this environment; cross-target check is blocked here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54cc2a6568832f8d1a821c8f09b5bd)