### PR TITLE
Fix serial port dropdown clipping on macOS

### DIFF
--- a/src/modules/workspace/connections/connections.css
+++ b/src/modules/workspace/connections/connections.css
@@ -719,7 +719,8 @@
   overflow: visible;
 }
 
-.connection-dialog-backdrop .connection-dialog:has(.connection-icon-popover) {
+.connection-dialog-backdrop .connection-dialog:has(.connection-icon-popover),
+.connection-dialog-backdrop .connection-dialog:has(.serial-line-combobox.open) {
   overflow: visible;
 }
 


### PR DESCRIPTION
### Motivation
- On macOS the serial port combobox list could be visually clipped by the connection dialog (showing only the first couple of ports) because the dialog container hid overflow while the dropdown was rendered inside it; the change makes the dialog allow overflow when the serial combobox is open so the full detected `/dev/tty*`/`/dev/cu*` list can be seen.

### Description
- Allow `.connection-dialog` to overflow when the serial combobox is open by adding `.connection-dialog-backdrop .connection-dialog:has(.serial-line-combobox.open)` to the existing overflow rule in `src/modules/workspace/connections/connections.css`, matching the behavior already used for the icon popover.

### Testing
- Ran `npm run lint` which completed successfully (there is a pre-existing `react-hooks/exhaustive-deps` warning unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55c337aa64832fb70c6b81a0b5ae4e)