### PR TITLE
Use disk icon for URL credential save

### DIFF
--- a/src/lib/reicon.tsx
+++ b/src/lib/reicon.tsx
@@ -16,7 +16,7 @@ import {
   Database as ReDatabase, DocumentCode2 as ReDocumentCode2, DocumentText2 as ReDocumentText2, Download as ReDownload,
   Edit2 as ReEdit2, Envelope as ReEnvelope, Eye as ReEye, EyeOff as ReEyeOff,
   File as ReFile, FilePlus as ReFilePlus, FileText as ReFileText, FileUp as ReFileUp,
-  Fingerprint as ReFingerprint, Flag as ReFlag, Folder as ReFolder, FolderOpen as ReFolderOpen,
+  Fingerprint as ReFingerprint, Flag as ReFlag, Floppy as ReFloppy, Folder as ReFolder, FolderOpen as ReFolderOpen,
   FolderPlus as ReFolderPlus, Gauge3 as ReGauge3, Gear as ReGear, Globe as ReGlobe,
   Globe2 as ReGlobe2, Grid as ReGrid, Hand as ReHand, HardDrive as ReHardDrive,
   Hashtag as ReHashtag, HeartPulse as ReHeartPulse, HelpCircle as ReHelpCircle, Home as ReHome,
@@ -77,7 +77,7 @@ const reiconIconComponents = {
   "Eye": ReEye, "EyeOff": ReEyeOff, "File": ReFile, "FileCode": ReDocumentCode2,
   "FileImage": ReImage, "FileJson": ReDocumentCode2, "FilePlus": ReFilePlus, "FileTerminal": ReTerminalSquare,
   "FileText": ReFileText, "FileUp": ReFileUp, "Fingerprint": ReFingerprint, "Flag": ReFlag,
-  "Folder": ReFolder, "FolderOpen": ReFolderOpen, "FolderPlus": ReFolderPlus, "Gauge": ReGauge3,
+  "Floppy": ReFloppy, "Folder": ReFolder, "FolderOpen": ReFolderOpen, "FolderPlus": ReFolderPlus, "Gauge": ReGauge3,
   "GitBranch": ReBranchUp, "Globe": ReGlobe, "Globe2": ReGlobe2, "Grid": ReGrid,
   "Grid2x2": ReGrid, "Hammer": ReSledgehammer, "Hand": ReHand, "HardDrive": ReHardDrive,
   "Hash": ReHashtag, "HeartPulse": ReHeartPulse, "Home": ReHome, "ImagePlus": ReImagePlus,
@@ -209,6 +209,7 @@ export const FileText = ReFileText;
 export const FileUp = ReFileUp;
 export const Fingerprint = ReFingerprint;
 export const Flag = ReFlag;
+export const Floppy = ReFloppy;
 export const Folder = ReFolder;
 export const FolderOpen = ReFolderOpen;
 export const FolderPlus = ReFolderPlus;

--- a/src/modules/workspace/connections/webview/WebViewWorkspace.tsx
+++ b/src/modules/workspace/connections/webview/WebViewWorkspace.tsx
@@ -1,7 +1,7 @@
 import { ScreenshotMenu } from "../../ScreenshotMenu";
 import { documentHasWebviewBlockingOverlay } from "../../nativeOverlay";
 
-import { ArrowLeft, ArrowRight, Bot, ExternalLink, Globe2, KeyRound, Lock, RefreshCw, Save, Unlock, X } from "../../../../lib/reicon";
+import { ArrowLeft, ArrowRight, Bot, ExternalLink, Floppy, Globe2, KeyRound, Lock, RefreshCw, Unlock, X } from "../../../../lib/reicon";
 import { listen } from "@tauri-apps/api/event";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -1200,7 +1200,7 @@ export function WebViewWorkspace({
                   title={t("webview.savePasswordTitle")}
                   type="button"
                 >
-                  <Save size={15} />
+                  <Floppy size={15} />
                 </button>
                 <button
                   className="terminal-pane-action"


### PR DESCRIPTION
### Motivation
- The URL Connection "save credentials" toolbar icon resembled a bookmark; switch to a disk/floppy glyph to clearly indicate a save-to-storage action.

### Description
- Exported the `Floppy` (disk) glyph from the shared icon wrapper in `src/lib/reicon.tsx` and added it to the compat map.
- Replaced the toolbar button icon in `src/modules/workspace/connections/webview/WebViewWorkspace.tsx` from `<Save />` to `<Floppy />` for the URL credential save action.

### Testing
- Ran `npm run lint -- --quiet` which completed successfully. 
- Verified no whitespace or diff issues with `git diff --check` (no errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56e7e409f8832f807d649d9347120f)