### PR TITLE
Remember active tab per workspace

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -1194,11 +1194,25 @@ function firstTabIdForWorkspace(tabs: WorkspaceTab[], workspaceId: string) {
   return tabs.find((tab) => tabWorkspaceId(tab) === workspaceId)?.id ?? "";
 }
 
+function tabIdForWorkspace(
+  tabs: WorkspaceTab[],
+  workspaceId: string,
+  preferredTabId: string | undefined,
+) {
+  const preferredTab = preferredTabId
+    ? tabs.find((tab) => tab.id === preferredTabId)
+    : undefined;
+  return tabWorkspaceId(preferredTab) === workspaceId
+    ? preferredTab?.id ?? ""
+    : firstTabIdForWorkspace(tabs, workspaceId);
+}
+
 interface WorkspaceState {
   query: string;
   tabs: WorkspaceTab[];
   activeTabId: string;
   activeWorkspaceId: string;
+  activeTabIdsByWorkspace: Record<string, string>;
   workspaces: Workspace[];
   generalSettings: GeneralSettings;
   credentialSettings: CredentialSettings;
@@ -1410,6 +1424,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   tabs: initialTabs,
   activeTabId: initialTabs[0]?.id ?? "",
   activeWorkspaceId: loadStoredActiveWorkspaceId(),
+  activeTabIdsByWorkspace: initialTabs[0]
+    ? { [tabWorkspaceId(initialTabs[0])]: initialTabs[0].id }
+    : {},
   workspaces: [],
   generalSettings: defaultGeneralSettings,
   credentialSettings: defaultCredentialSettings,
@@ -1448,7 +1465,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       set({
         workspaces,
         activeWorkspaceId: fallbackId,
-        activeTabId: firstTabIdForWorkspace(get().tabs, fallbackId),
+        activeTabId: tabIdForWorkspace(
+          get().tabs,
+          fallbackId,
+          get().activeTabIdsByWorkspace[fallbackId],
+        ),
       });
       if (typeof window !== "undefined") {
         window.dispatchEvent(new CustomEvent("kkterm:connection-tree-invalidated"));
@@ -1462,12 +1483,19 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       return;
     }
     persistActiveWorkspaceId(workspaceId);
-    const activeTab = get().tabs.find((tab) => tab.id === get().activeTabId);
+    const state = get();
+    const activeTabIdsByWorkspace = {
+      ...state.activeTabIdsByWorkspace,
+      [state.activeWorkspaceId]: state.activeTabId,
+    };
     set({
       activeWorkspaceId: workspaceId,
-      activeTabId: tabWorkspaceId(activeTab) === workspaceId
-        ? activeTab?.id ?? ""
-        : firstTabIdForWorkspace(get().tabs, workspaceId),
+      activeTabId: tabIdForWorkspace(
+        state.tabs,
+        workspaceId,
+        activeTabIdsByWorkspace[workspaceId],
+      ),
+      activeTabIdsByWorkspace,
     });
     // The Connection Tree, rail, and sidebar all re-read the active Workspace's
     // tree off this shared invalidation event.
@@ -1494,7 +1522,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     );
     const nextActiveTabId = activeTabStillOpen
       ? get().activeTabId
-      : firstTabIdForWorkspace(remainingTabs, nextActiveWorkspaceId);
+      : tabIdForWorkspace(
+          remainingTabs,
+          nextActiveWorkspaceId,
+          get().activeTabIdsByWorkspace[nextActiveWorkspaceId],
+        );
 
     if (nextActiveWorkspaceId !== get().activeWorkspaceId) {
       persistActiveWorkspaceId(nextActiveWorkspaceId);
@@ -1671,13 +1703,27 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     // session" over the wrong Workspace.
     if (tab && targetWorkspaceId !== state.activeWorkspaceId) {
       persistActiveWorkspaceId(targetWorkspaceId);
-      set({ activeTabId: tabId, activeWorkspaceId: targetWorkspaceId });
+      set((current) => ({
+        activeTabId: tabId,
+        activeWorkspaceId: targetWorkspaceId,
+        activeTabIdsByWorkspace: {
+          ...current.activeTabIdsByWorkspace,
+          [current.activeWorkspaceId]: current.activeTabId,
+          [targetWorkspaceId]: tabId,
+        },
+      }));
       if (typeof window !== "undefined") {
         window.dispatchEvent(new CustomEvent("kkterm:connection-tree-invalidated"));
       }
       return;
     }
-    set({ activeTabId: tabId });
+    set((current) => ({
+      activeTabId: tabId,
+      activeTabIdsByWorkspace: {
+        ...current.activeTabIdsByWorkspace,
+        [targetWorkspaceId]: tabId,
+      },
+    }));
   },
   renameTab: async (tabId, title) => {
     const displayTitle = title.trim();

--- a/tests/workspace-delete-cleanup.test.mjs
+++ b/tests/workspace-delete-cleanup.test.mjs
@@ -18,7 +18,7 @@ assert.match(
 
 assert.match(
   storeSource,
-  /set\(\{[\s\S]*?workspaces,[\s\S]*?activeWorkspaceId: fallbackId,[\s\S]*?activeTabId: firstTabIdForWorkspace\(get\(\)\.tabs, fallbackId\),[\s\S]*?\}\);[\s\S]*?window\.dispatchEvent\(new CustomEvent\("kkterm:connection-tree-invalidated"\)\);/,
+  /set\(\{[\s\S]*?workspaces,[\s\S]*?activeWorkspaceId: fallbackId,[\s\S]*?activeTabId: tabIdForWorkspace\([\s\S]*?get\(\)\.tabs,[\s\S]*?fallbackId,[\s\S]*?get\(\)\.activeTabIdsByWorkspace\[fallbackId\],[\s\S]*?\),[\s\S]*?\}\);[\s\S]*?window\.dispatchEvent\(new CustomEvent\("kkterm:connection-tree-invalidated"\)\);/,
   "workspace list refresh also invalidates the tree when the active Workspace disappears",
 );
 

--- a/tests/workspace-tab-workspace-scope.test.mjs
+++ b/tests/workspace-tab-workspace-scope.test.mjs
@@ -26,12 +26,17 @@ test("top Tab Strip is scoped to the active Workspace", async () => {
   );
   assert.match(
     storeSource,
-    /activeTabId: tabWorkspaceId\(activeTab\) === workspaceId[\s\S]*?activeTab\?\.id \?\? ""[\s\S]*?firstTabIdForWorkspace\(get\(\)\.tabs,\s*workspaceId\)/,
-    "switching Workspaces should activate a Tab from the destination Workspace or clear the active Tab",
+    /activeTabIdsByWorkspace = \{[\s\S]*?\[state\.activeWorkspaceId\]: state\.activeTabId[\s\S]*?activeTabId: tabIdForWorkspace\([\s\S]*?activeTabIdsByWorkspace\[workspaceId\]/,
+    "switching Workspaces should restore the destination Workspace's last active Tab or clear the active Tab",
   );
   assert.match(
     storeSource,
     /const nextActiveTabId =[\s\S]*?firstTabIdForWorkspace\(remainingTabs,\s*activeWorkspaceId\)/,
     "closing the active Tab should choose the next Tab from the same active Workspace",
+  );
+  assert.match(
+    storeSource,
+    /targetWorkspaceId !== state\.activeWorkspaceId[\s\S]*?\[current\.activeWorkspaceId\]: current\.activeTabId[\s\S]*?\[targetWorkspaceId\]: tabId/,
+    "activating a Tab from another Workspace should remember both the source and target Workspace selections",
   );
 });


### PR DESCRIPTION
### Motivation
- Preserve the user’s last-selected Tab per Workspace so switching Workspaces (via the Activity Rail or programmatically) restores the previously active Tab instead of always falling back to the first opened Tab.
- Ensure activating a Tab that lives in another Workspace records both the source and destination Workspace selections so rail shortcuts and cross-workspace activations behave predictably.

### Description
- Added a runtime-only map `activeTabIdsByWorkspace` to `WorkspaceState` and initialized it from `initialTabs` in `src/store.ts`.
- Introduced helper `tabIdForWorkspace` and replaced fallback calls to `firstTabIdForWorkspace` with `tabIdForWorkspace` in `setWorkspaces`, `setActiveWorkspace`, and `closeWorkspaceTabs` so the remembered Tab is restored when present.
- Updated `activateTab` to persist the source Workspace's current Tab and to store the activated Tab for the destination Workspace when switching Workspaces.
- Updated tests to reflect the remembered-Tab behavior by adjusting `tests/workspace-tab-workspace-scope.test.mjs` and `tests/workspace-delete-cleanup.test.mjs` assertions.

### Testing
- Ran `node --test tests/workspace-tab-workspace-scope.test.mjs` and the test passed.
- Ran `node tests/workspace-delete-cleanup.test.mjs` and the test passed.
- Ran the full frontend check with `npm run check`; the test suite passed and reported one pre-existing ESLint warning in `src/modules/workspace/connections/remote-desktop/RdpCanvasView.tsx` unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56e8c66994832f82d0382d4875d635)