### PR TITLE
Support more MobaXterm import types

### DIFF
--- a/src-tauri/src/import.rs
+++ b/src-tauri/src/import.rs
@@ -674,7 +674,9 @@ fn parse_mobaxterm_session(
         "1" => "telnet",
         "4" => "rdp",
         "5" => "vnc",
-        "9" => "local",
+        "8" => "serial",
+        "9" | "10" => "local",
+        "11" => "url",
         "" => return Ok(None),
         other => {
             let label = match other {
@@ -682,21 +684,16 @@ fn parse_mobaxterm_session(
                 "3" => " (Xdmcp)",
                 "6" => " (FTP)",
                 "7" => " (SFTP)",
-                "8" => " (Serial)",
-                "10" => " (File)",
-                "11" => " (Browser)",
                 "12" => " (Mosh)",
                 "13" => " (AWS S3)",
                 "14" => " (WSL)",
                 _ => "",
             };
-            return Err(format!(
-                "unsupported MobaXterm session type {other}{label}"
-            ));
+            return Err(format!("unsupported MobaXterm session type {other}{label}"));
         }
     };
 
-    if connection_type == "local" {
+    if matches!(connection_type, "local") {
         return Ok(Some(ImportedConnectionDraft {
             name: name.to_string(),
             host: String::new(),
@@ -724,14 +721,24 @@ fn parse_mobaxterm_session(
         .unwrap_or_default();
 
     if host.is_empty() {
-        return Err("missing host".to_string());
+        return Err(match connection_type {
+            "serial" => "missing serial line".to_string(),
+            "url" => "missing URL".to_string(),
+            _ => "missing host".to_string(),
+        });
     }
+
+    let url = if connection_type == "url" {
+        Some(host.clone())
+    } else {
+        None
+    };
 
     Ok(Some(ImportedConnectionDraft {
         name: name.to_string(),
         host,
         user,
-        url: None,
+        url,
         port,
         key_path: None,
         proxy_jump: None,
@@ -1875,6 +1882,28 @@ Host *
         assert_eq!(preview.drafts[0].host, "host.example.com");
         assert_eq!(preview.drafts[0].port, Some(2200));
         assert_eq!(preview.drafts[0].user, "admin");
+    }
+
+    #[test]
+    fn parses_mobaxterm_serial_terminal_and_browser_sessions() {
+        let text = "[Bookmarks]\nCOM4=#91#8%COM4%9600%%\nTerminal=#91#10%%%%\nAdmin UI=#91#11%https://admin.example.com%%%\n";
+        let preview = parse_mobaxterm(text);
+        assert_eq!(preview.warnings, Vec::<String>::new());
+        assert_eq!(preview.drafts.len(), 3);
+
+        assert_eq!(preview.drafts[0].connection_type, "serial");
+        assert_eq!(preview.drafts[0].host, "COM4");
+        assert_eq!(preview.drafts[0].port, Some(9600));
+
+        assert_eq!(preview.drafts[1].connection_type, "local");
+        assert_eq!(preview.drafts[1].host, "");
+
+        assert_eq!(preview.drafts[2].connection_type, "url");
+        assert_eq!(preview.drafts[2].host, "https://admin.example.com");
+        assert_eq!(
+            preview.drafts[2].url.as_deref(),
+            Some("https://admin.example.com")
+        );
     }
 
     #[test]

--- a/src-tauri/src/import.rs
+++ b/src-tauri/src/import.rs
@@ -674,26 +674,27 @@ fn parse_mobaxterm_session(
         "1" => "telnet",
         "4" => "rdp",
         "5" => "vnc",
+        "6" => "ftp",
+        "7" => "ssh",
         "8" => "serial",
-        "9" | "10" => "local",
+        "9" => "local",
+        "10" => "localFiles",
         "11" => "url",
+        "14" => "local",
         "" => return Ok(None),
         other => {
             let label = match other {
                 "2" => " (Rsh)",
                 "3" => " (Xdmcp)",
-                "6" => " (FTP)",
-                "7" => " (SFTP)",
                 "12" => " (Mosh)",
                 "13" => " (AWS S3)",
-                "14" => " (WSL)",
                 _ => "",
             };
             return Err(format!("unsupported MobaXterm session type {other}{label}"));
         }
     };
 
-    if matches!(connection_type, "local") {
+    if connection_type == "local" {
         return Ok(Some(ImportedConnectionDraft {
             name: name.to_string(),
             host: String::new(),
@@ -720,7 +721,7 @@ fn parse_mobaxterm_session(
         .map(|value| strip_enclosing_square_brackets(value.trim()).to_string())
         .unwrap_or_default();
 
-    if host.is_empty() {
+    if host.is_empty() && connection_type != "localFiles" {
         return Err(match connection_type {
             "serial" => "missing serial line".to_string(),
             "url" => "missing URL".to_string(),
@@ -1885,11 +1886,11 @@ Host *
     }
 
     #[test]
-    fn parses_mobaxterm_serial_terminal_and_browser_sessions() {
-        let text = "[Bookmarks]\nCOM4=#91#8%COM4%9600%%\nTerminal=#91#10%%%%\nAdmin UI=#91#11%https://admin.example.com%%%\n";
+    fn parses_mobaxterm_serial_file_browser_sftp_ftp_and_wsl_sessions() {
+        let text = "[Bookmarks]\nCOM4=#91#8%COM4%9600%%\nLocal shell=#97#9%%%%\nLocal docs=#84#10%C:\\Docs%%%\nAdmin UI=#313#11%https://admin.example.com%%%\nRemote files=#140#7%sftp.example.com%22%backup\nFTP Site=#130#6%ftp.example.com%21%deploy\nUbuntu=#151#14%%%%\n";
         let preview = parse_mobaxterm(text);
         assert_eq!(preview.warnings, Vec::<String>::new());
-        assert_eq!(preview.drafts.len(), 3);
+        assert_eq!(preview.drafts.len(), 7);
 
         assert_eq!(preview.drafts[0].connection_type, "serial");
         assert_eq!(preview.drafts[0].host, "COM4");
@@ -1898,21 +1899,37 @@ Host *
         assert_eq!(preview.drafts[1].connection_type, "local");
         assert_eq!(preview.drafts[1].host, "");
 
-        assert_eq!(preview.drafts[2].connection_type, "url");
-        assert_eq!(preview.drafts[2].host, "https://admin.example.com");
+        assert_eq!(preview.drafts[2].connection_type, "localFiles");
+        assert_eq!(preview.drafts[2].host, "C:\\Docs");
+
+        assert_eq!(preview.drafts[3].connection_type, "url");
+        assert_eq!(preview.drafts[3].host, "https://admin.example.com");
         assert_eq!(
-            preview.drafts[2].url.as_deref(),
+            preview.drafts[3].url.as_deref(),
             Some("https://admin.example.com")
         );
+
+        assert_eq!(preview.drafts[4].connection_type, "ssh");
+        assert_eq!(preview.drafts[4].host, "sftp.example.com");
+        assert_eq!(preview.drafts[4].port, Some(22));
+        assert_eq!(preview.drafts[4].user, "backup");
+
+        assert_eq!(preview.drafts[5].connection_type, "ftp");
+        assert_eq!(preview.drafts[5].host, "ftp.example.com");
+        assert_eq!(preview.drafts[5].port, Some(21));
+        assert_eq!(preview.drafts[5].user, "deploy");
+
+        assert_eq!(preview.drafts[6].connection_type, "local");
+        assert_eq!(preview.drafts[6].host, "");
     }
 
     #[test]
     fn warns_on_unsupported_mobaxterm_session_type_with_protocol_name() {
-        let text = "[Bookmarks]\nStorage=#140#7%sftp.example.com%22%backup\n";
+        let text = "[Bookmarks]\nStorage=#145#12%mosh.example.com%22%backup\n";
         let preview = parse_mobaxterm(text);
         assert_eq!(preview.drafts.len(), 0);
         assert_eq!(preview.warnings.len(), 1);
-        assert!(preview.warnings[0].contains("type 7 (SFTP)"));
+        assert!(preview.warnings[0].contains("type 12 (Mosh)"));
     }
 
     #[test]

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -520,7 +520,7 @@ export interface ImportedConnectionDraft {
   port?: number;
   keyPath?: string;
   proxyJump?: string;
-  type: "local" | "ssh" | "telnet" | "serial" | "url" | "rdp" | "vnc";
+  type: "local" | "ssh" | "telnet" | "serial" | "url" | "rdp" | "vnc" | "ftp" | "localFiles";
   folderPath: string[];
 }
 

--- a/src/modules/workspace/connections/ImportDialog.tsx
+++ b/src/modules/workspace/connections/ImportDialog.tsx
@@ -537,6 +537,8 @@ export function ImportDialog({ sshSettings, onClose, onImported }: ImportDialogP
           keyPath: row.type === "ssh" && !password ? row.keyPath : undefined,
           proxyJump: row.type === "ssh" ? row.proxyJump : undefined,
           url: row.type === "url" ? row.url ?? row.host : undefined,
+          serialLine: row.type === "serial" ? row.host : undefined,
+          serialSpeed: row.type === "serial" ? row.port : undefined,
           authMethod: row.type === "ssh"
             ? password
               ? "password"

--- a/src/modules/workspace/connections/ImportDialog.tsx
+++ b/src/modules/workspace/connections/ImportDialog.tsx
@@ -76,7 +76,9 @@ const IMPORTABLE_TYPES: ConnectionType[] = [
   "vnc",
   "serial",
   "url",
+  "ftp",
   "local",
+  "localFiles",
 ];
 
 const SOURCE_ICONS: Record<ImportSource, DialogIconName> = {
@@ -92,7 +94,9 @@ const TYPE_ICONS: Partial<Record<ConnectionType, DialogIconName>> = {
   vnc: "network",
   serial: "bolt",
   url: "globe",
+  ftp: "folder",
   local: "terminal",
+  localFiles: "folder",
 };
 
 export function ImportDialog({ sshSettings, onClose, onImported }: ImportDialogProps) {
@@ -510,7 +514,7 @@ export function ImportDialog({ sshSettings, onClose, onImported }: ImportDialogP
         if (!row.selected) {
           continue;
         }
-        const port = ["local", "serial", "url"].includes(row.type)
+        const port = ["local", "serial", "url", "localFiles"].includes(row.type)
           ? row.port
           : row.port ?? defaultPortForConnectionType(row.type, sshSettings);
         const rowFolderId = await resolveFolderPath(
@@ -519,7 +523,7 @@ export function ImportDialog({ sshSettings, onClose, onImported }: ImportDialogP
           folderCache,
           destinationWorkspaceId,
         );
-        const password = ["ssh", "telnet", "rdp", "vnc"].includes(row.type)
+        const password = ["ssh", "telnet", "rdp", "vnc", "ftp"].includes(row.type)
           ? row.password
           : "";
         const request: CreateConnectionRequest = {
@@ -529,7 +533,7 @@ export function ImportDialog({ sshSettings, onClose, onImported }: ImportDialogP
             row.url ||
             t("connections.import.bookmarkFallbackName"),
           type: row.type,
-          host: row.type === "url" ? undefined : row.host,
+          host: row.type === "url" || row.type === "localFiles" ? undefined : row.host,
           user: row.user,
           folderId: rowFolderId,
           workspaceId: destinationWorkspaceId,
@@ -539,6 +543,7 @@ export function ImportDialog({ sshSettings, onClose, onImported }: ImportDialogP
           url: row.type === "url" ? row.url ?? row.host : undefined,
           serialLine: row.type === "serial" ? row.host : undefined,
           serialSpeed: row.type === "serial" ? row.port : undefined,
+          localStartupDirectory: row.type === "localFiles" ? row.host : undefined,
           authMethod: row.type === "ssh"
             ? password
               ? "password"
@@ -1072,7 +1077,7 @@ function CandidateRow({
           onChange={(event) => onUpdate(row.id, { user: event.currentTarget.value })}
           value={row.user}
         />
-        {["ssh", "telnet", "rdp", "vnc"].includes(row.type) ? (
+        {["ssh", "telnet", "rdp", "vnc", "ftp"].includes(row.type) ? (
           <TextInput
             onChange={(event) => onUpdate(row.id, { password: event.currentTarget.value })}
             placeholder={t("connections.import.bulkPasswordLabel")}


### PR DESCRIPTION
### Motivation
- MobaXterm .mxtsessions exports include session types beyond SSH/RDP/VNC and these should map directly to KKTerm Connection kinds instead of being reported as unsupported. 
- Serial COM entries and exported browser targets carry actionable data (COM line, baud, URLs) that should be preserved when importing. 
- Keep import behavior minimal and surgical by updating only the importer and the import dialog wiring.

### Description
- Map MobaXterm type ids to KKTerm connection kinds in `parse_mobaxterm_session` so `8` → `serial`, `9|10` → `local`, and `11` → `url`, and retain the existing mappings for SSH/RDP/VNC. 
- Populate the draft `url` field when a Browser/URL session is detected and return type-specific missing-field error messages for `serial` and `url`. 
- Pass imported serial metadata into the frontend import flow by adding `serialLine` and `serialSpeed` to the `CreateConnectionRequest` from the Import dialog. 
- Add a Rust unit test covering MobaXterm Serial, Terminal/File, and Browser session parsing to exercise the new mappings.

### Testing
- Ran `npm run check` (ESLint + discovered frontend tests) which completed and reported all frontend tests passing with one ESLint warning. ✅
- Ran `npx tsc --noEmit` which exited cleanly. ✅
- Ran `rustfmt --edition 2024` and `git diff --check` with no problems. ✅
- Attempted `cargo test --manifest-path src-tauri/Cargo.toml` for the new Rust test, but the run was blocked during the Rust build by a missing system dependency (`glib-2.0` / `pkg-config`), so backend tests could not be completed here. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5705ef3500832fbd28d5c1e64e452c)