### PR TITLE
Fix selective workspace replace default

### DIFF
--- a/src-tauri/src/selective_export.rs
+++ b/src-tauri/src/selective_export.rs
@@ -648,7 +648,7 @@ fn apply_segment(
                 continue;
             }
             let mut rewritten = row_obj.clone();
-            rewrite_row(tx, table, &mut rewritten, remap)?;
+            rewrite_row(tx, table, &mut rewritten, action, remap)?;
             // On "add", a built-in Task the importer already has (same
             // deterministic id / built_in_key) is kept as-is rather than
             // duplicated; one the importer lacks is inserted.
@@ -675,6 +675,7 @@ fn rewrite_row(
     tx: &rusqlite::Transaction<'_>,
     table: &TableSpec,
     row: &mut Map<String, Value>,
+    action: &str,
     remap: &HashMap<(String, String), String>,
 ) -> Result<(), String> {
     // Primary key.
@@ -691,7 +692,7 @@ fn rewrite_row(
 
     // Workspaces gain a default flag conflict if two rows claim default; on add
     // we keep only the importer's existing default.
-    if table.name == "workspaces" && row.contains_key("is_default") {
+    if action == "add" && table.name == "workspaces" && row.contains_key("is_default") {
         row.insert("is_default".to_string(), Value::from(0));
     }
 
@@ -2179,7 +2180,7 @@ mod tests {
         let src = SqliteConnection::open_in_memory().unwrap();
         connections_schema(&src);
         src.execute(
-            "INSERT INTO workspaces (id, name, is_default, sort_order) VALUES ('ws-src','Imported',0,0)",
+            "INSERT INTO workspaces (id, name, is_default, sort_order) VALUES ('ws-src','Imported',1,0)",
             [],
         )
         .unwrap();
@@ -2209,19 +2210,19 @@ mod tests {
             .unwrap();
             tx.commit().unwrap();
         }
-        let ids: Vec<String> = {
+        let rows: Vec<(String, i64)> = {
             let mut stmt = dst
-                .prepare("SELECT id FROM workspaces ORDER BY id")
+                .prepare("SELECT id, is_default FROM workspaces ORDER BY id")
                 .unwrap();
-            stmt.query_map([], |row| row.get(0))
+            stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
                 .unwrap()
                 .collect::<Result<_, _>>()
                 .unwrap()
         };
         assert_eq!(
-            ids,
-            vec!["ws-src".to_string()],
-            "replace wipes old rows and keeps bundle ids"
+            rows,
+            vec![("ws-src".to_string(), 1)],
+            "replace wipes old rows and keeps bundle ids plus the imported default"
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Importing a selective backup with the `replace` action cleared workspace `is_default` flags, which could leave the app with no default workspace after a restore.
- The intent is for `replace` imports to preserve the backup's default workspace flag while `add`/merge should avoid causing duplicate defaults.

### Description
- Pass the segment `action` into `rewrite_row` so row rewrites can behave differently for `add` vs `replace` by changing the call to `rewrite_row(tx, table, &mut rewritten, action, remap)`.
- Change workspace default handling to only clear `is_default` for `add` imports by using `if action == "add" && table.name == "workspaces" && row.contains_key("is_default") { ... }`.
- Update the selective-import regression test `replace_clears_then_inserts_preserving_ids` to insert an imported workspace with `is_default = 1` and assert the imported default survives the `replace` flow.

### Testing
- Ran formatting with `rustfmt --edition 2024 src-tauri/src/selective_export.rs` and `git diff --check`; both passed locally.
- Attempted to run the specific selective-export test with `cargo test --manifest-path src-tauri/Cargo.toml selective_export::tests::replace_clears_then_inserts_preserving_ids`, but the test run was blocked by a missing system dependency (`glib-2.0` / `glib-2.0.pc`) required by the build environment, so the full test could not complete here.
- The change is covered by the updated unit test that asserts the `replace` path preserves the imported default workspace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5828a8c0f4832fb32a13d908cc4643)