### PR TITLE
Fix URL overlay visibility after reload

### DIFF
--- a/src/modules/workspace/connections/webview/WebViewWorkspace.tsx
+++ b/src/modules/workspace/connections/webview/WebViewWorkspace.tsx
@@ -782,12 +782,14 @@ export function WebViewWorkspace({
           subtitle: formatWebviewSubtitle(event.payload.url),
           url: event.payload.url,
         });
+        scheduleBoundsPush();
       }),
       listen<WebviewPageLoadEvent>("webview-page-load", (event) => {
         if (event.payload.sessionId !== sessionIdRef.current) {
           return;
         }
         setAddressInput(event.payload.url);
+        scheduleBoundsPush();
         if (event.payload.status === "finished") {
           setFillStatus("");
           void maybeUpdateConnectionIcon(event.payload.url);


### PR DESCRIPTION
### Motivation
- Address issue #617 where URL WebView overlays could remain incorrectly visible or mis-clipped after the embedded browser navigates or is reloaded (for example via F5) because the native overlay bounds/visibility were not re-pushed.

### Description
- Call `scheduleBoundsPush()` from the `webview-navigation` and `webview-page-load` listeners so the frontend re-sends updated overlay bounds/visibility to the backend when the embedded browser navigates or finishes loading.

### Testing
- Ran `npm run lint` and `npm run check` (which runs the frontend tests and `tsc --noEmit`) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5863a67780832f85b0091101003a84)