### PR TITLE
Hide AI shell command windows

### DIFF
--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -6389,17 +6389,16 @@ fn shell_command_tool(root: &Path, args: Value) -> String {
         })
         .to_string();
     }
-    let output = if shell.eq_ignore_ascii_case("batch") {
-        Command::new("cmd")
-            .args(["/C", &command])
-            .current_dir(root)
-            .output()
+    let mut process = if shell.eq_ignore_ascii_case("batch") {
+        let mut process = Command::new("cmd");
+        process.args(["/C", &command]);
+        process
     } else {
-        Command::new("powershell")
-            .args(["-NoProfile", "-NonInteractive", "-Command", &command])
-            .current_dir(root)
-            .output()
+        let mut process = Command::new("powershell");
+        process.args(["-NoProfile", "-NonInteractive", "-Command", &command]);
+        process
     };
+    let output = crate::installer::proc::no_window(process.current_dir(root)).output();
     match output {
         Ok(output) => {
             let mut text = String::new();


### PR DESCRIPTION
### Motivation
- Prevent the AI assistant's `shell_command` tool from spawning visible console windows on Windows by routing the child `cmd`/PowerShell process through the repo's existing no-window helper before spawning.

### Description
- Change in `src-tauri/src/ai.rs`: build the `Command` for `cmd` or `powershell` first and call `crate::installer::proc::no_window(...)` before `.output()` so the external console is suppressed when the assistant runs shell commands.

### Testing
- Ran `rustfmt --edition 2024 src-tauri/src/ai.rs` and `git diff --check` which passed, and attempted `cargo check --manifest-path src-tauri/Cargo.toml` which failed in this environment due to a missing system dependency (`glib-2.0.pc` / `glib-2.0` pkg-config) and therefore could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58a6964cec832fa8db8757cc92c531)