### PR TITLE
Fix AI CLI detection with refreshed PATH

### DIFF
--- a/src-tauri/src/ai/cli_backend.rs
+++ b/src-tauri/src/ai/cli_backend.rs
@@ -698,13 +698,16 @@ pub(crate) fn common_user_bin_candidates(names: &[&str]) -> Vec<PathBuf> {
 }
 
 pub(crate) fn path_cli_backend_candidates(provider: AiCliBackendKind) -> Vec<PathBuf> {
-    let Some(path) = std::env::var_os("PATH") else {
-        return Vec::new();
-    };
-    bin_candidates_from_roots(
-        std::env::split_paths(&path).collect(),
-        cli_backend_command_names(provider),
-    )
+    let paths = [
+        std::env::var_os("PATH"),
+        crate::installer::install::refreshed_path_public().map(Into::into),
+    ];
+    let roots = paths
+        .into_iter()
+        .flatten()
+        .flat_map(|path| std::env::split_paths(&path).collect::<Vec<_>>())
+        .collect();
+    bin_candidates_from_roots(roots, cli_backend_command_names(provider))
 }
 
 pub(crate) fn bin_candidates_from_roots(roots: Vec<PathBuf>, names: &[&str]) -> Vec<PathBuf> {


### PR DESCRIPTION
### Motivation
- Ensure AI CLI backend discovery resolves freshly installed npm-backed CLIs (e.g. Codex CLI) even when the running KKTerm process has a stale `PATH` by including the Install Helper's refreshed persisted PATH in the candidate search.

### Description
- Update `src-tauri/src/ai/cli_backend.rs` so `path_cli_backend_candidates` merges the current process `PATH` with `crate::installer::install::refreshed_path_public()` and then expands candidate roots with `std::env::split_paths` before calling `bin_candidates_from_roots`.

### Testing
- Attempted to run `cargo test --manifest-path src-tauri/Cargo.toml bin_candidates_expand_roots_in_name_order -- --nocapture`, but the run failed to complete due to a missing system dependency (`glib-2.0`/pkg-config) in this environment, so the unit test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ad8491788832f87c676102f76f6b2)