### PR TITLE
Validate all required platforms before publishing release manifest

### DIFF
--- a/scripts/release-mirror-model.mjs
+++ b/scripts/release-mirror-model.mjs
@@ -1,5 +1,16 @@
 const VERSION_TAG = /^v(\d+\.\d+\.\d+)$/;
 
+// Windows, macOS, and Linux assets are built and attached to the same GitHub
+// Release by separate, staggered jobs/scripts. A manifest missing any of
+// these must never replace the public "current" manifest, or updater clients
+// on the platforms that haven't landed yet will find a version bump with no
+// matching platform entry and hard-fail instead of just not updating yet.
+export const REQUIRED_PLATFORMS = ["windows-x64", "windows-arm64", "darwin-aarch64", "darwin-x86_64", "linux-x86_64"];
+
+export function missingRequiredPlatforms(manifest) {
+  return REQUIRED_PLATFORMS.filter((platform) => !manifest.platforms[platform]);
+}
+
 export function versionFromTag(tag) {
   const match = VERSION_TAG.exec(tag ?? "");
   if (!match) throw new Error(`Invalid release tag: ${tag ?? ""}`);

--- a/scripts/sync-cloudflare-release.mjs
+++ b/scripts/sync-cloudflare-release.mjs
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 
 import {
   buildReleaseManifest,
+  missingRequiredPlatforms,
   recognizedReleaseAssets,
   versionFromTag,
 } from "./release-mirror-model.mjs";
@@ -143,6 +144,14 @@ export async function main(argv = process.argv.slice(2)) {
     const assetNames = assets.map((asset) => asset.name);
     await verifyDownloadedChecksums(directory, assetNames);
     const manifest = buildReleaseManifest(release, PUBLIC_BASE_URL);
+    const missing = missingRequiredPlatforms(manifest);
+    if (missing.length > 0) {
+      console.log(
+        `${release.tag_name} is still missing platform assets (${missing.join(", ")}); ` +
+          "leaving the current public manifest untouched until the release finishes staggering in.",
+      );
+      return;
+    }
     await materializeSignatures(manifest, directory);
     const manifestPath = join(directory, "release-manifest.json");
     await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");

--- a/tests/release-mirror-model.test.mjs
+++ b/tests/release-mirror-model.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   buildReleaseManifest,
+  missingRequiredPlatforms,
   recognizedReleaseAssets,
   versionFromTag,
 } from "../scripts/release-mirror-model.mjs";
@@ -90,6 +91,35 @@ test("adds signed staggered macOS and Linux updater entries", () => {
     "https://kkterm.ryantsai.com/releases/v0.1.93/kkterm-0.1.93-macos-universal.app.tar.gz",
   );
   assert.equal(manifest.platforms["linux-x86_64"].signature_asset, "kkterm-0.1.93-linux-x86_64.AppImage.sig");
+});
+
+test("flags a Windows-only manifest as missing macOS and Linux platforms", () => {
+  const manifest = buildReleaseManifest(release, "https://kkterm.ryantsai.com");
+  assert.deepEqual(missingRequiredPlatforms(manifest), [
+    "windows-arm64",
+    "darwin-aarch64",
+    "darwin-x86_64",
+    "linux-x86_64",
+  ]);
+});
+
+test("reports no missing platforms once macOS and Linux stagger in", () => {
+  const manifest = buildReleaseManifest(
+    {
+      ...release,
+      assets: [
+        ...release.assets,
+        { name: "kkterm-0.1.93-windows-arm64-setup.exe" },
+        { name: "kkterm-0.1.93-windows-arm64-setup.exe.sha256" },
+        { name: "kkterm-0.1.93-macos-universal.app.tar.gz" },
+        { name: "kkterm-0.1.93-macos-universal.app.tar.gz.sig" },
+        { name: "kkterm-0.1.93-linux-x86_64.AppImage" },
+        { name: "kkterm-0.1.93-linux-x86_64.AppImage.sig" },
+      ],
+    },
+    "https://kkterm.ryantsai.com",
+  );
+  assert.deepEqual(missingRequiredPlatforms(manifest), []);
 });
 
 test("rejects draft, prerelease, and malformed release tags", () => {


### PR DESCRIPTION
## Summary

Adds validation to prevent incomplete release manifests from being published to the public mirror. When GitHub Release assets are attached by staggered CI jobs (Windows, macOS, Linux), a manifest missing any platform would cause updater clients on unfinished platforms to hard-fail instead of gracefully waiting.

Introduces `missingRequiredPlatforms()` to detect incomplete manifests and gates manifest publication in `sync-cloudflare-release.mjs` until all required platforms (Windows x64/ARM64, macOS ARM64/x86_64, Linux x86_64) are present.

## Type of change

- [x] Feature
- [ ] Bug fix
- [x] Refactor / cleanup
- [ ] Docs / manual
- [ ] Build / CI / tooling

## Areas touched

- [ ] Frontend (React/TypeScript — `src/`)
- [ ] Backend (Rust/Tauri — `src-tauri/`)
- [ ] Docs (`docs/`, manual, ADR)

## Checks

- [x] Added unit tests covering both incomplete and complete manifests
- [x] Existing tests pass
- [x] No user-visible strings or i18n impact

https://claude.ai/code/session_01BPvdg3LTRhTDFChLE9MST4