### PR TITLE
Share portable marker filename constant across app and CLI

### DIFF
--- a/src-tauri/src/app_paths.rs
+++ b/src-tauri/src/app_paths.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager};
 
-pub const PORTABLE_MARKER_FILENAME: &str = "kkterm-portable.marker";
+pub use crate::portable_marker::PORTABLE_MARKER_FILENAME;
 #[cfg(any(debug_assertions, test))]
 const PORTABLE_ENVIRONMENT_VARIABLE: &str = "KKTERM_PORTABLE";
 const PORTABLE_SMOKE_ENVIRONMENT_VARIABLE: &str = "KKTERM_PORTABLE_SMOKE_TEST";

--- a/src-tauri/src/bin/kkterm-cli.rs
+++ b/src-tauri/src/bin/kkterm-cli.rs
@@ -21,8 +21,15 @@ use tokio::time::{Duration, timeout};
 #[path = "../mcp_tool_catalog.rs"]
 mod mcp_tool_catalog;
 
+// Share the portable-mode marker filename with the in-app launcher so the CLI's
+// sibling-bridge lookup can never drift from `app_paths.rs`. Included by path
+// for the same thin-forwarder reason as the tool catalog above; the module has
+// no dependencies. See portable_marker.rs.
+#[path = "../portable_marker.rs"]
+mod portable_marker;
+use portable_marker::PORTABLE_MARKER_FILENAME;
+
 const BRIDGE_INFO_FILENAME: &str = "mcp-bridge.json";
-const PORTABLE_MARKER_FILENAME: &str = "kkterm-portable.marker";
 const BUNDLE_IDENTIFIER: &str = "com.kkterm.app";
 const PROTOCOL_VERSION: &str = "2025-03-26";
 const SERVER_NAME: &str = "kkterm-cli";

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,6 +34,7 @@ mod pc_info;
 mod performance;
 mod power;
 mod portable_creator;
+mod portable_marker;
 #[cfg(target_os = "windows")]
 mod portable_single_instance;
 mod rdp;

--- a/src-tauri/src/portable_marker.rs
+++ b/src-tauri/src/portable_marker.rs
@@ -1,0 +1,19 @@
+// Portable-mode marker filename (single source of truth).
+//
+// An empty `kkterm-portable.marker` beside the executable is THE portable-mode
+// switch (see `docs/PORTABLE.md`). Two independent code paths look for it and
+// must never disagree on the name:
+//
+//   * `app_paths.rs` (inside kkterm.exe) reads it at launch to decide whether
+//     the app runs in portable or installed mode.
+//   * `bin/kkterm-cli.rs` (the stdio forwarder) reads it to bind a portable CLI
+//     to its sibling `data/mcp-bridge.json` instead of the installed instance.
+//
+// The app crate uses it via `crate::portable_marker` (re-exported from
+// `app_paths`); the CLI binary includes this exact source file with
+// `#[path = "../portable_marker.rs"]` so it shares the constant without linking
+// the whole `kkterm_lib` crate (keeping the forwarder thin). It has no
+// dependencies, so it builds on every platform.
+
+/// Empty marker file beside the executable that activates portable mode.
+pub const PORTABLE_MARKER_FILENAME: &str = "kkterm-portable.marker";


### PR DESCRIPTION
The portable-mode marker filename ("kkterm-portable.marker") — the
switch that both the in-app launcher and the CLI forwarder use to detect
portable mode — was defined independently in app_paths.rs and
bin/kkterm-cli.rs. The two detection paths must agree on the name, so a
drift between the copies would silently break portable CLI bridge
discovery.

Move it to a dependency-free portable_marker.rs shared the same way as
mcp_tool_catalog.rs: the app crate re-exports it from app_paths (so
portable_creator.rs's import is unchanged), and the thin CLI binary
includes the file with #[path] instead of linking the whole lib crate.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019EL5zBfANhjBNUbeLSy53r