### PR TITLE
Share bundle identifier constant across app and CLI

### DIFF
--- a/src-tauri/src/bin/kkterm-cli.rs
+++ b/src-tauri/src/bin/kkterm-cli.rs
@@ -29,8 +29,15 @@ mod mcp_tool_catalog;
 mod portable_marker;
 use portable_marker::PORTABLE_MARKER_FILENAME;
 
+// Share the bundle identifier with the app crate so the CLI's installed-mode
+// app-data path can never drift from the folder Tauri actually uses. Included
+// by path for the same thin-forwarder reason as the modules above; it has no
+// dependencies. See bundle_identifier.rs.
+#[path = "../bundle_identifier.rs"]
+mod bundle_identifier;
+use bundle_identifier::BUNDLE_IDENTIFIER;
+
 const BRIDGE_INFO_FILENAME: &str = "mcp-bridge.json";
-const BUNDLE_IDENTIFIER: &str = "com.kkterm.app";
 const PROTOCOL_VERSION: &str = "2025-03-26";
 const SERVER_NAME: &str = "kkterm-cli";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src-tauri/src/bundle_identifier.rs
+++ b/src-tauri/src/bundle_identifier.rs
@@ -1,0 +1,25 @@
+// Bundle identifier (single source of truth for the installed app-data folder).
+//
+// This is the Tauri bundle identifier from `tauri.conf.json`. Tauri names the
+// installed app-data directory after it (`%APPDATA%\com.kkterm.app`,
+// `$XDG_DATA_HOME/com.kkterm.app`, ...), so any code that reconstructs that
+// installed path by hand must use the exact same string:
+//
+//   * `bin/kkterm-cli.rs` (the stdio forwarder) builds the installed
+//     `mcp-bridge.json` path when it is not running beside a portable marker.
+//     It cannot ask Tauri to resolve the app-data dir, so it needs this value.
+//   * `ssh.rs` tests pin the expected installed `ssh_known_hosts` path against
+//     this identifier (production resolves the dir through Tauri).
+//
+// The app crate uses it via `crate::bundle_identifier`; the CLI binary includes
+// this exact source file with `#[path = "../bundle_identifier.rs"]` so it
+// shares the constant without linking the whole `kkterm_lib` crate (keeping the
+// forwarder thin). It has no dependencies, so it builds on every platform.
+//
+// NOTE: this is intentionally NOT the OS keychain service name. That value
+// lives separately in `secrets.rs` and must stay stable on its own — it happens
+// to equal this identifier today, but pinning stored secrets to the app-data
+// folder name would risk losing access if the identifier ever changed.
+
+/// Tauri bundle identifier; the folder name of the installed app-data directory.
+pub const BUNDLE_IDENTIFIER: &str = "com.kkterm.app";

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod app_tray;
 mod app_updates;
 mod assistant_skills;
 mod auto_start;
+mod bundle_identifier;
 mod currency_rates;
 mod dashboard_commands;
 mod dashboard_ids;

--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -3982,14 +3982,15 @@ mod tests {
     }
 
     fn default_app_known_hosts_path() -> Option<PathBuf> {
+        use crate::bundle_identifier::BUNDLE_IDENTIFIER;
         if cfg!(target_os = "windows") {
             env::var_os("APPDATA")
                 .map(PathBuf::from)
-                .map(|path| path.join("com.kkterm.app").join("ssh_known_hosts"))
+                .map(|path| path.join(BUNDLE_IDENTIFIER).join("ssh_known_hosts"))
         } else if let Some(data_home) = env::var_os("XDG_DATA_HOME") {
             Some(
                 PathBuf::from(data_home)
-                    .join("com.kkterm.app")
+                    .join(BUNDLE_IDENTIFIER)
                     .join("ssh_known_hosts"),
             )
         } else {
@@ -3997,7 +3998,7 @@ mod tests {
                 PathBuf::from(home)
                     .join(".local")
                     .join("share")
-                    .join("com.kkterm.app")
+                    .join(BUNDLE_IDENTIFIER)
                     .join("ssh_known_hosts")
             })
         }


### PR DESCRIPTION
## Summary

The bundle identifier (`com.kkterm.app`) — the folder Tauri names the installed app-data directory after — was hard-coded independently in two Rust locations:

- `bin/kkterm-cli.rs` as `BUNDLE_IDENTIFIER`, used to locate the installed `mcp-bridge.json` when the CLI is not running beside a portable marker.
- `ssh.rs` test helpers that pin the expected installed `ssh_known_hosts` path.

The thin CLI forwarder cannot ask Tauri to resolve the app-data dir, so it genuinely needs the literal; a drift between the copies would silently break its installed-mode bridge lookup. This moves the value into a dependency-free `bundle_identifier.rs`, shared the same way as `portable_marker.rs` (#653): the app crate references `crate::bundle_identifier`, and the CLI binary includes the file with `#[path]` instead of linking the whole `kkterm_lib` crate (keeping the forwarder thin).

The OS keychain service name in `secrets.rs` (`SERVICE_NAME`) is **intentionally left separate**. It equals this identifier today, but stored secrets must stay addressable even if the app-data folder identifier ever changed, so coupling them would be a correctness hazard.

Follow-up to #653, which applied the same shared-constant pattern to the portable marker filename.

## Type of change

- [x] Refactor / cleanup

## Areas touched

- [x] Backend (Rust/Tauri — `src-tauri/`)

## Domain & docs

- [x] Uses the canonical vocabulary
- [x] Source placement follows `docs/ARCHITECTURE.md`; mirrors the existing `#[path]` shared-module pattern (`mcp_tool_catalog.rs`, `portable_marker.rs`)

## i18n

- [x] No user-visible strings

## High-risk invariants

- [x] None violated. Keychain service name deliberately kept decoupled from the app-data identifier.

## Checks

- [ ] `cargo check` / `cargo test` — could not run in this environment: the Tauri build requires GTK system libraries (`gdk-3.0`) that aren't installed, so `gdk-sys`'s build script fails before compiling any project code. The change is a value-preserving constant relocation that mirrors an already-merged pattern; CI on a real build host is the actual confirmation.

## Notes for reviewers

Value is byte-identical to the previous literals, so behavior is unchanged. The `ssh.rs` usage is test-only (`#[cfg(test)]`), which also gives the app crate a real consumer of the shared const so it doesn't warn as dead code — and that test still guards the value against `tauri.conf.json`'s identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019EL5zBfANhjBNUbeLSy53r)_