### PR TITLE
Guard React event reads in state updaters

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -481,6 +481,8 @@ Workspace chrome layout is global state. Connection-specific live context may ch
 
 `src/App.tsx` is intentionally a small shell now. It composes page routing, Settings routing, global Workspace chrome, the app-wide Status Bar, and startup/bootstrap hooks. Workspace surfaces, Connection UI, Activity Rail internals, and app-shell effects live in feature or app-shell source areas so terminal, SFTP, URL, RDP/VNC, assistant, connection-tree, and Activity Rail work can proceed independently without repeatedly touching the root shell.
 
+React form events are handler-scoped. When an input/select/textarea handler feeds a functional state updater, snapshot `event.currentTarget` / `event.target` fields into local constants before calling `setState((prev) => ...)`; never read event fields inside the updater callback. This keeps updates safe under React scheduling and is guarded by `tests/react-event-functional-updater-policy.test.mjs`.
+
 - `src/App.tsx` — root `App` composition, Workspace/Settings routing, Workspace chrome assembly, app-wide Status Bar placement, settings reset handoff, and startup hook wiring.
 - `src/App.css` — global CSS entrypoint and cascade-order manifest. Keep `@import "tailwindcss"` first, then import shared token/base CSS, then per-feature CSS.
 - `src/styles/colorSchemes.css` — global font faces, `:root` design tokens, and `[data-color-scheme="..."]` CSS custom property blocks consumed by feature CSS files.

--- a/src/modules/settings/FileExplorerSettings.tsx
+++ b/src/modules/settings/FileExplorerSettings.tsx
@@ -75,12 +75,13 @@ export function FileExplorerSettings() {
             <span>{t("settings.fileExplorerOpenMode")}</span>
             <select
               value={draft.fileExplorerOpenMode}
-              onChange={(event) =>
+              onChange={(event) => {
+                const fileExplorerOpenMode = event.target.value as SftpSettings["fileExplorerOpenMode"];
                 setDraft((state) => ({
                   ...state,
-                  fileExplorerOpenMode: event.target.value as SftpSettings["fileExplorerOpenMode"],
-                }))
-              }
+                  fileExplorerOpenMode,
+                }));
+              }}
             >
               <option value="external">{t("settings.fileExplorerOpenModeExternal")}</option>
               <option value="inlineEditor">{t("settings.fileExplorerOpenModeInlineEditor")}</option>

--- a/src/modules/settings/GeneralSettings.tsx
+++ b/src/modules/settings/GeneralSettings.tsx
@@ -597,12 +597,13 @@ export function GeneralSettings() {
             <select
               disabled={!draft.statusBarEnabled || !draft.statusBarMonitorEnabled}
               value={draft.statusBarMonitorIntervalSeconds}
-              onChange={(event) =>
+              onChange={(event) => {
+                const statusBarMonitorIntervalSeconds = Number(event.currentTarget.value);
                 setDraft((s) => ({
                   ...s,
-                  statusBarMonitorIntervalSeconds: Number(event.currentTarget.value),
-                }))
-              }
+                  statusBarMonitorIntervalSeconds,
+                }));
+              }}
             >
               {STATUS_BAR_MONITOR_INTERVAL_OPTIONS.map((seconds) => (
                 <option key={seconds} value={seconds}>

--- a/src/modules/settings/InstallerSettings.tsx
+++ b/src/modules/settings/InstallerSettings.tsx
@@ -65,12 +65,13 @@ export function InstallerSettings() {
               value={resolveInstallerCheckIntervalSeconds(
                 draft.installerCheckIntervalSeconds,
               )}
-              onChange={(event) =>
+              onChange={(event) => {
+                const installerCheckIntervalSeconds = Number(event.currentTarget.value);
                 setDraft((state) => ({
                   ...state,
-                  installerCheckIntervalSeconds: Number(event.currentTarget.value),
-                }))
-              }
+                  installerCheckIntervalSeconds,
+                }));
+              }}
             >
               {INSTALLER_CHECK_INTERVAL_OPTIONS.map((seconds) => (
                 <option key={seconds} value={seconds}>
@@ -88,14 +89,15 @@ export function InstallerSettings() {
             <span>{t("settings.installerDefaultProvider")}</span>
             <select
               value={draft.installerDefaultProvider}
-              onChange={(event) =>
+              onChange={(event) => {
+                const installerDefaultProvider = event.currentTarget.value as
+                  | "winget"
+                  | "chocolatey";
                 setDraft((state) => ({
                   ...state,
-                  installerDefaultProvider: event.currentTarget.value as
-                    | "winget"
-                    | "chocolatey",
-                }))
-              }
+                  installerDefaultProvider,
+                }));
+              }}
             >
               <option value="winget">
                 {t("settings.installerDefaultProviderWinget")}

--- a/src/modules/settings/RdpSettings.tsx
+++ b/src/modules/settings/RdpSettings.tsx
@@ -99,12 +99,13 @@ export function RdpSettings() {
             <span>{t("settings.remoteDesktopViewMode")}</span>
             <select
               value={draft.viewMode}
-              onChange={(event) =>
+              onChange={(event) => {
+                const viewMode = event.currentTarget.value as RemoteDesktopViewMode;
                 setDraft((settings) => ({
                   ...settings,
-                  viewMode: event.currentTarget.value as RemoteDesktopViewMode,
-                }))
-              }
+                  viewMode,
+                }));
+              }}
             >
               <option value="fit">{t("settings.remoteDesktopViewModeFit")}</option>
               <option value="stretch">{t("settings.remoteDesktopViewModeStretch")}</option>

--- a/src/modules/settings/SavedCredentialEditDialog.tsx
+++ b/src/modules/settings/SavedCredentialEditDialog.tsx
@@ -117,14 +117,20 @@ export function SavedCredentialEditDialog({
           <TextInput
             autoFocus
             value={draft.label}
-            onChange={(event) => setDraft((current) => ({ ...current, label: event.currentTarget.value }))}
+            onChange={(event) => {
+              const label = event.currentTarget.value;
+              setDraft((current) => ({ ...current, label }));
+            }}
             placeholder={t("settings.savedCredentialNamePlaceholder")}
           />
         </Field>
         <Field label={t("settings.savedCredentialUsername")}>
           <TextInput
             value={draft.username}
-            onChange={(event) => setDraft((current) => ({ ...current, username: event.currentTarget.value }))}
+            onChange={(event) => {
+              const username = event.currentTarget.value;
+              setDraft((current) => ({ ...current, username }));
+            }}
           />
         </Field>
         <Field
@@ -136,7 +142,10 @@ export function SavedCredentialEditDialog({
             type="password"
             autoComplete="new-password"
             value={draft.password}
-            onChange={(event) => setDraft((current) => ({ ...current, password: event.currentTarget.value }))}
+            onChange={(event) => {
+              const password = event.currentTarget.value;
+              setDraft((current) => ({ ...current, password }));
+            }}
           />
         </Field>
       </Sheet>

--- a/src/modules/settings/SelectiveImportDialog.tsx
+++ b/src/modules/settings/SelectiveImportDialog.tsx
@@ -236,9 +236,10 @@ export function SelectiveImportDialog({
                     <Select
                       options={actionOptions}
                       value={actions.credentials ?? "add"}
-                      onChange={(event) =>
-                        setActions((prev) => ({ ...prev, credentials: event.currentTarget.value as SegmentAction }))
-                      }
+                      onChange={(event) => {
+                        const credentials = event.currentTarget.value as SegmentAction;
+                        setActions((prev) => ({ ...prev, credentials }));
+                      }}
                     />
                   }
                 />

--- a/src/modules/settings/UrlCredentialManager.tsx
+++ b/src/modules/settings/UrlCredentialManager.tsx
@@ -420,15 +420,16 @@ export function UrlCredentialManager({
                         placeholder={t("settings.urlCredentialPasswordPlaceholder")}
                         type={passwordVisible ? "text" : "password"}
                         value={editDraft.password}
-                        onChange={(event) =>
+                        onChange={(event) => {
+                          const password = event.currentTarget.value;
                           setEditDraft((current) => current
                             ? {
                                 ...current,
-                                password: event.currentTarget.value,
+                                password,
                                 passwordDirty: true,
                               }
-                            : current)
-                        }
+                            : current);
+                        }}
                       />
                       <button
                         aria-label={t(

--- a/src/modules/settings/UrlSettings.tsx
+++ b/src/modules/settings/UrlSettings.tsx
@@ -129,9 +129,10 @@ export function UrlSettings() {
             <input
               {...technicalInputProps}
               list="url-user-agent-presets"
-              onChange={(event) =>
-                setDraft((settings) => ({ ...settings, defaultUserAgent: event.currentTarget.value }))
-              }
+              onChange={(event) => {
+                const defaultUserAgent = event.currentTarget.value;
+                setDraft((settings) => ({ ...settings, defaultUserAgent }));
+              }}
               placeholder={t("settings.urlUserAgentDefaultPlaceholder")}
               value={draft.defaultUserAgent ?? ""}
             />
@@ -162,9 +163,10 @@ export function UrlSettings() {
             <span>{t("connections.dataPartition")}</span>
             <input
               {...technicalInputProps}
-              onChange={(event) =>
-                setDraft((settings) => ({ ...settings, defaultDataPartition: event.currentTarget.value }))
-              }
+              onChange={(event) => {
+                const defaultDataPartition = event.currentTarget.value;
+                setDraft((settings) => ({ ...settings, defaultDataPartition }));
+              }}
               placeholder={t("connections.default")}
               value={draft.defaultDataPartition ?? ""}
             />

--- a/src/modules/settings/VncSettings.tsx
+++ b/src/modules/settings/VncSettings.tsx
@@ -48,12 +48,13 @@ export function VncSettings() {
             <span>{t("settings.preferredEncoding")}</span>
             <select
               value={draft.preferredEncoding}
-              onChange={(event) =>
+              onChange={(event) => {
+                const preferredEncoding = event.currentTarget.value as VncPreferredEncoding;
                 setDraft((settings) => ({
                   ...settings,
-                  preferredEncoding: event.currentTarget.value as VncPreferredEncoding,
-                }))
-              }
+                  preferredEncoding,
+                }));
+              }}
             >
               <option value="tight">{t("settings.vncEncodingTight")}</option>
               <option value="zrle">{t("settings.vncEncodingZrle")}</option>
@@ -64,12 +65,13 @@ export function VncSettings() {
             <span>{t("settings.colorLevel")}</span>
             <select
               value={draft.colorLevel}
-              onChange={(event) =>
+              onChange={(event) => {
+                const colorLevel = event.currentTarget.value as VncColorLevel;
                 setDraft((settings) => ({
                   ...settings,
-                  colorLevel: event.currentTarget.value as VncColorLevel,
-                }))
-              }
+                  colorLevel,
+                }));
+              }}
             >
               <option value="full">{t("settings.vncColorFull")}</option>
               <option value="256">{t("settings.vncColor256")}</option>
@@ -86,12 +88,13 @@ export function VncSettings() {
             <span>{t("settings.remoteDesktopViewMode")}</span>
             <select
               value={draft.viewMode}
-              onChange={(event) =>
+              onChange={(event) => {
+                const viewMode = event.currentTarget.value as RemoteDesktopViewMode;
                 setDraft((settings) => ({
                   ...settings,
-                  viewMode: event.currentTarget.value as RemoteDesktopViewMode,
-                }))
-              }
+                  viewMode,
+                }));
+              }}
             >
               <option value="fit">{t("settings.remoteDesktopViewModeFit")}</option>
               <option value="stretch">{t("settings.remoteDesktopViewModeStretch")}</option>

--- a/tests/react-event-functional-updater-policy.test.mjs
+++ b/tests/react-event-functional-updater-policy.test.mjs
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import ts from "typescript";
+
+const files = execFileSync("rg", ["--files", "src", "-g", "*.tsx", "-g", "*.ts"], { encoding: "utf8" })
+  .trim()
+  .split("\n")
+  .filter(Boolean);
+
+const eventFieldReadPattern = /\bevent\.(?:currentTarget|target)\.(?:value|checked|files)\b/;
+
+function isFunctionalStateSetterCall(node) {
+  return ts.isCallExpression(node)
+    && ts.isIdentifier(node.expression)
+    && /^set[A-Z]/.test(node.expression.text)
+    && node.arguments.length > 0
+    && ts.isArrowFunction(node.arguments[0]);
+}
+
+test("React event fields are captured before functional state updaters", () => {
+  const violations = [];
+
+  for (const file of files) {
+    const source = readFileSync(file, "utf8");
+    const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+
+    function visit(node) {
+      if (isFunctionalStateSetterCall(node)) {
+        const updaterSource = node.arguments[0].getText(sourceFile);
+        if (eventFieldReadPattern.test(updaterSource)) {
+          const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+          violations.push(`${file}:${line + 1}`);
+        }
+      }
+      ts.forEachChild(node, visit);
+    }
+
+    visit(sourceFile);
+  }
+
+  assert.deepEqual(
+    violations,
+    [],
+    "Snapshot event.currentTarget/event.target fields in the onChange handler before using a functional state updater.",
+  );
+});


### PR DESCRIPTION
### Motivation
- Follow up on the saved-credential typing crash by auditing other form handlers that used event fields inside functional state updaters.  
- Prevent reading `event.currentTarget` / `event.target` inside scheduled functional `setState` callbacks, which can observe a released React event and crash.  
- Make the convention explicit in docs and enforce it with an automated policy test so the mistake doesn't reappear.

### Description
- Snapshot input/select/textarea event fields into local `const` variables in multiple Settings handlers before calling functional updaters (`setDraft`, `setEditDraft`, `setActions`), including `UrlSettings.tsx`, `UrlCredentialManager.tsx`, `VncSettings.tsx`, `RdpSettings.tsx`, `InstallerSettings.tsx`, `FileExplorerSettings.tsx`, `GeneralSettings.tsx`, and `SelectiveImportDialog.tsx`.  
- Tightened `SavedCredentialEditDialog.tsx` to capture `label`, `username`, and `password` into locals before calling the functional updater.  
- Replaced the narrow saved-credential-only test with a new TypeScript AST policy test `tests/react-event-functional-updater-policy.test.mjs` that scans frontend sources for event-field reads inside functional state-updater callbacks.  
- Documented the convention in `docs/ARCHITECTURE.md` under the Frontend Source Map so future contributors know to snapshot `event` fields before scheduled updates.

### Testing
- Ran the new policy test with `node tests/react-event-functional-updater-policy.test.mjs`, which passed.  
- Ran the full frontend checks with `npm run check` (includes `eslint`, the frontend test suite, and `tsc --noEmit`), which completed successfully (one pre-existing ESLint `react-hooks/exhaustive-deps` warning was reported but did not fail the check).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ebdb6a070832fbaf44f0ba7bde112)