### PR TITLE
Compact screenshot editor chrome

### DIFF
--- a/src/modules/screenshots/screenshots.css
+++ b/src/modules/screenshots/screenshots.css
@@ -492,6 +492,28 @@
   max-height: calc(100vh - 40px) !important;
 }
 
+.screenshots-editor .kk-dlg-head {
+  display: flex;
+  min-height: 36px;
+  align-items: center;
+  padding: 0 44px 0 14px;
+}
+
+.screenshots-editor .kk-dlg-title {
+  overflow: hidden;
+  font-size: 14px;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.screenshots-editor .kk-dlg-close {
+  top: 6px;
+  right: 10px;
+  width: 24px;
+  height: 24px;
+}
+
 .screenshots-editor .kk-dlg-body {
   padding: 0;
   overflow: hidden;
@@ -511,7 +533,7 @@
   flex: 0 0 auto;
   align-items: center;
   gap: 5px;
-  padding: 8px 12px;
+  padding: 5px 10px;
   overflow: visible;
   border-bottom: 1px solid var(--hairline);
   background: var(--surface-muted);
@@ -521,8 +543,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: 26px;
+  height: 26px;
   padding: 0;
   border: 1px solid transparent;
   border-radius: 6px;
@@ -615,7 +637,8 @@
 
 .screenshots-editor .kk-dlg-foot {
   position: relative;
-  min-height: 55px;
+  min-height: 38px;
+  padding: 8px 14px;
 }
 
 .screenshots-editor__divider {


### PR DESCRIPTION
### Motivation
- Make the screenshot editor header shorter and vertically center the file name and close button in the top row so long file names align visually with the close control. 
- Reduce top-row toolbar and bottom footer vertical space to produce a denser, more compact editor chrome.

### Description
- Adjusted screenshot editor chrome in `src/modules/screenshots/screenshots.css` by adding a scoped header rule `.screenshots-editor .kk-dlg-head` with `min-height: 36px`, `align-items: center`, and tighter padding. 
- Constrained the title with `.screenshots-editor .kk-dlg-title` to use a slightly smaller font and ellipsis truncation for long file names. 
- Repositioned and resized the close button via `.screenshots-editor .kk-dlg-close` and reduced toolbar/button sizing and padding (`.screenshots-editor__toolbar` padding to `5px 10px` and toolbar buttons from `28px` to `26px`). 
- Shortened the footer by lowering `.screenshots-editor .kk-dlg-foot` `min-height` from `55px` to `38px` and tightened footer padding.

### Testing
- Ran `npm run lint` which completed successfully with one unrelated pre-existing React Hook warning in `RdpCanvasView.tsx` (no new lint errors). 
- Ran `git diff --check` with no whitespace/merge issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5efbbc7cb0832f8d3ff8767c7c9ea1)