### PR TITLE
Respect Chocolatey default for installer bundles

### DIFF
--- a/installer/catalog.v1.json
+++ b/installer/catalog.v1.json
@@ -432,6 +432,7 @@
         "id": "astral-sh.uv"
       },
       "options": [
+        "provider",
         "version"
       ],
       "descriptionLocales": {
@@ -448,6 +449,10 @@
         "ko": "Astral의 빠른 Python 패키지 및 프로젝트 관리자. 필요에 따라 Python 자체를 설치할 수 있습니다.",
         "id": "Paket Python cepat dan manajer proyek dari Astral. Dapat menginstal Python sendiri sesuai permintaan.",
         "vi": "Trình quản lý dự án và gói Python nhanh từ Astral. Có thể tự cài đặt Python theo yêu cầu."
+      },
+      "chocolateyProvider": {
+        "kind": "chocolatey",
+        "id": "uv"
       }
     },
     {

--- a/src/modules/installer/InstallerToolDialog.tsx
+++ b/src/modules/installer/InstallerToolDialog.tsx
@@ -1612,6 +1612,9 @@ function defaultInstallOptionsForRecipe(
   ) {
     return { provider: "chocolatey" };
   }
+  if (preferredProvider === "chocolatey" && recipe.provider.kind === "bundle") {
+    return { provider: "chocolatey" };
+  }
   return {};
 }
 

--- a/src/modules/installer/dag.ts
+++ b/src/modules/installer/dag.ts
@@ -206,7 +206,7 @@ function estimateUacPromptsFor(
           ? sum +
               estimateUacPromptsFor(
                 stepRecipe,
-                undefined,
+                options,
                 byId,
                 detected,
                 directlyActionableIds,

--- a/tests/installer-chocolatey-provider-ui.test.mjs
+++ b/tests/installer-chocolatey-provider-ui.test.mjs
@@ -22,6 +22,9 @@ const latestVersionSource = await readFile(
   new URL("../src-tauri/src/installer/latest_version.rs", import.meta.url),
   "utf8",
 );
+const catalog = JSON.parse(
+  await readFile(new URL("../installer/catalog.v1.json", import.meta.url), "utf8"),
+);
 
 test("Chocolatey provider selection opens Chocolatey install dialog when missing", () => {
   assert.match(
@@ -114,6 +117,21 @@ test("Chocolatey-backed plans depend on Chocolatey instead of the recipe's winge
     dagSource,
     /id !== targetRecipeId && detected\[id\]\?\.installed[\s\S]*order\.push\(recipe\)/,
     "Already-installed prerequisites should satisfy their own dependency chain.",
+  );
+  assert.match(
+    dagSource,
+    /case "bundle":[\s\S]*estimateUacPromptsFor\(\s*stepRecipe,\s*options,/,
+    "Bundle UAC estimates should honor the selected provider passed to bundle steps.",
+  );
+});
+
+test("uv exposes a Chocolatey provider for Python bundle step installs", () => {
+  const uv = catalog.recipes.find((recipe) => recipe.id === "uv");
+  assert.ok(uv, "catalog should include uv");
+  assert.deepEqual(uv.chocolateyProvider, { kind: "chocolatey", id: "uv" });
+  assert.ok(
+    uv.options.includes("provider"),
+    "uv should show and accept provider selection so the Python bundle can forward Chocolatey.",
   );
 });
 

--- a/tests/installer-default-provider-settings.test.mjs
+++ b/tests/installer-default-provider-settings.test.mjs
@@ -53,4 +53,9 @@ test("new install dialogs only preselect Chocolatey when both package providers 
     /useWorkspaceStore\([\s\S]*state\.generalSettings\.installerDefaultProvider/,
     "InstallerToolDialog should read the persisted default provider from general settings.",
   );
+  assert.match(
+    dialogSource,
+    /preferredProvider === "chocolatey" && recipe\.provider\.kind === "bundle"[\s\S]*return \{ provider: "chocolatey" \}/,
+    "Bundle dialogs should forward the Chocolatey preference to their step recipes.",
+  );
 });


### PR DESCRIPTION
### Motivation

- Bundle step installs (e.g. the Python `python-bundle` which runs `uv`) were still being routed through WinGet even when the global installer default was Chocolatey, causing `nvm`, `got`, `python` step installs to prefer WinGet.
- The intent is to let a user-chosen default package provider (Chocolatey) be forwarded into bundle steps so their step recipes can use `choco` when available.

### Description

- Add a `chocolateyProvider` entry and `provider` option to the `uv` recipe in `installer/catalog.v1.json` so `uv` can be installed/managed via Chocolatey when selected.
- Forward the installer default into bundle installs by returning `{ provider: "chocolatey" }` from `defaultInstallOptionsForRecipe` when the preferred provider is Chocolatey and the recipe is a `bundle` in `src/modules/installer/InstallerToolDialog.tsx`.
- Make bundle UAC estimation honor the selected provider by passing the `options` through to `estimateUacPromptsFor` for bundle step recipes in `src/modules/installer/dag.ts`.
- Add/adjust regression tests to cover the new default-provider forwarding and the `uv` Chocolatey metadata in `tests/installer-default-provider-settings.test.mjs` and `tests/installer-chocolatey-provider-ui.test.mjs`.

### Testing

- Ran the frontend unit tests with `node --test tests/installer-default-provider-settings.test.mjs tests/installer-chocolatey-provider-ui.test.mjs tests/installer-winget-prereq.test.mjs`, and all tests passed (18 tests total).
- Attempted `cargo test --manifest-path src-tauri/Cargo.toml installer::schema::tests::shipped_catalog_parses_and_validates`, but the run was blocked by missing system dependency (`glib-2.0` / `pkg-config`) in the container; the Rust test could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f1c360f78832f93d2ce0844bcf685)