### PR TITLE
fix: normalize Tauri updater signing key to standard base64

### DIFF
--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -20,19 +20,26 @@ TARGET_TRIPLE="${LINUX_TARGET_TRIPLE:-x86_64-unknown-linux-gnu}"
 KEY_PATH="${TAURI_SIGNING_PRIVATE_KEY_PATH:-$HOME/.tauri/kkterm-updater.key}"
 
 normalize_tauri_signing_key() {
-  local key_content first_line
+  local key_content first_line normalized
 
   key_content="$1"
   first_line="${key_content%%$'\n'*}"
 
   # Tauri expects base64 of the full minisign key box (untrusted comment +
-  # payload). Wrap a raw box if given one; otherwise pass through verbatim.
+  # payload). Wrap a raw box if given one; otherwise treat the value as the
+  # already-base64 box.
   if [[ "$first_line" == "untrusted comment:"* ]]; then
-    printf '%s' "$key_content" | base64 -w 0
-    return
+    normalized="$(printf '%s' "$key_content" | base64 -w 0)"
+  else
+    normalized="$key_content"
   fi
 
-  printf '%s' "$key_content"
+  # Tauri's minisign decoder only accepts single-line standard base64. Strip any
+  # whitespace a secret store or base64 line-wrapping introduced, and map the
+  # URL-safe alphabet (-/_) back to standard (+//) so a URL-safe-encoded secret
+  # still decodes. Valid standard base64 contains none of these, so this is a
+  # no-op on correct keys and only repairs a malformed one.
+  printf '%s' "$normalized" | tr -d '[:space:]' | tr -- '-_' '+/'
 }
 
 extract_tauri_signing_key() {

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -4,19 +4,26 @@ set -euo pipefail
 KEY_PATH=${TAURI_SIGNING_PRIVATE_KEY_PATH:-$HOME/.tauri/kkterm-updater.key}
 
 normalize_tauri_signing_key() {
-  local key_content first_line
+  local key_content first_line normalized
 
   key_content="$1"
   first_line="${key_content%%$'\n'*}"
 
   # Tauri expects base64 of the full minisign key box (untrusted comment +
-  # payload). Wrap a raw box if given one; otherwise pass through verbatim.
+  # payload). Wrap a raw box if given one; otherwise treat the value as the
+  # already-base64 box.
   if [[ "$first_line" == "untrusted comment:"* ]]; then
-    printf '%s' "$key_content" | base64
-    return
+    normalized="$(printf '%s' "$key_content" | base64)"
+  else
+    normalized="$key_content"
   fi
 
-  print -r -- "$key_content"
+  # Tauri's minisign decoder only accepts single-line standard base64. Strip any
+  # whitespace a secret store or base64 line-wrapping introduced, and map the
+  # URL-safe alphabet (-/_) back to standard (+//) so a URL-safe-encoded secret
+  # still decodes. Valid standard base64 contains none of these, so this is a
+  # no-op on correct keys and only repairs a malformed one.
+  printf '%s' "$normalized" | tr -d '[:space:]' | tr -- '-_' '+/'
 }
 
 extract_tauri_signing_key() {


### PR DESCRIPTION
The macOS release job built, signed, and notarized the app but failed at
the final Tauri updater-signing step with:

  failed to decode secret key: failed to decode base64 secret key:
  failed to decode base64 key: Invalid symbol 45, offset 256.

Symbol 45 is '-', which never appears in the standard base64 alphabet that
Tauri's minisign decoder requires; it only appears in URL-safe base64
(where - <-> + and _ <-> /). The signing key was passed through verbatim,
so a URL-safe-encoded (or whitespace-wrapped) secret reached Tauri unchanged
and failed to decode.

Normalize the key after wrapping: strip whitespace introduced by a secret
store or base64 line-wrapping, and map the URL-safe alphabet back to
standard. Valid standard base64 contains none of these characters, so the
transform is a verified no-op on correct keys and only repairs a malformed
one. Apply the same fix to the Linux packaging script, which shares the
identical helper and the same secret.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012j3c18cAzj7cMswg8HnpQe