### PR TITLE
chore(ssh): upgrade russh 0.61.2 -> 0.62.4 on the stabilized RustCrypto line

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1474,15 +1474,16 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-rc.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto",
+ "rand_core 0.10.1",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1932,9 +1933,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.18"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54fb064faabbee66e1fc8e5c5a9458d4269dc2d8b638fe86a425adb2510d1a96"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
  "der 0.8.1",
  "digest 0.11.3",
@@ -1957,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-rc.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1985,9 +1986,9 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.33"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102d3643d30dd8b559613c5cced68317199597fffb278cdc88daa2ef7fafc935"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1997,7 +1998,6 @@ dependencies = [
  "group",
  "hkdf",
  "hybrid-array",
- "once_cell",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.10.1",
@@ -5682,9 +5682,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.10"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41adc63effe99d48837a8cc0e6d7a77e32ae6a07f6000df466178dbc2193093e"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -5695,9 +5695,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.10"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd5333afa5ae0347f39e6a0f2c9c155da431583fd71fe5555bd0521b4ccaf02"
+checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -5709,9 +5709,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.10"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a5297f53dc16d35909060ba3032cff7867e8809f01e273ff325579d5f0ceae"
+checksum = "4ad64cc32c2dc466317c12ee5853e61f159f9eab1fe7efade0395dc2e7b43449"
 dependencies = [
  "base16ct",
  "ecdsa",
@@ -6390,9 +6390,9 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.10"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f845ec3240cd5ed5e1e31cf3ff633a5bf47c698dc4092ba9e767415b3d393406"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
 dependencies = [
  "crypto-bigint",
  "crypto-common 0.2.2",
@@ -6404,11 +6404,15 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.10"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2793f22b9b6fd11ef3ac1d59bf003c2573593e4968702341605c2748fd90bf"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -7000,12 +7004,12 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5236ce872cac07e0fb3969b0cbf468c7d2f37d432f1b627dcb7b8d34563fb0c3"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
+ "crypto-bigint",
  "hmac",
- "subtle",
 ]
 
 [[package]]
@@ -7098,9 +7102,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.61.2"
+version = "0.62.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf893f64684e58da8a68d56a5e84d1cf0440226274c515770fe267707a7d0b0"
+checksum = "b8b67b5a0d8068c89dcbe9d95df986af7a851d1f3c604525274c37468e60464f"
 dependencies = [
  "aes 0.9.1",
  "bitflags 2.13.0",
@@ -7156,7 +7160,7 @@ dependencies = [
  "sec1",
  "sha1 0.11.0",
  "sha2 0.11.0",
- "sha3 0.11.0",
+ "sha3 0.12.0",
  "signature",
  "spki 0.8.0",
  "ssh-encoding",
@@ -7171,9 +7175,9 @@ dependencies = [
 
 [[package]]
 name = "russh-cryptovec"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443f6bbcfacb34a1aab2b12b99bf08e0c63abdc5a0db261901365df9d57fff51"
+checksum = "3aec6cb630dbe85d72ffd7bcd95f07e1bd69f9f270ee8adfa1afe443a6331438"
 dependencies = [
  "log",
  "nix 0.31.3",
@@ -8087,17 +8091,15 @@ dependencies = [
 
 [[package]]
 name = "ssh-cipher"
-version = "0.3.0-rc.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10db6f219196a8528f9ec904d9d45cdad692d65b0e57e72be4dedd1c5fddce36"
+checksum = "d801accda99469cde6d73da741422610fdf6508a72d9a69d1b55cb241c720597"
 dependencies = [
  "aead",
  "aes 0.9.1",
  "aes-gcm",
- "cbc",
  "chacha20",
  "cipher 0.5.2",
- "ctr",
  "ctutils",
  "des",
  "poly1305",
@@ -8107,9 +8109,9 @@ dependencies = [
 
 [[package]]
 name = "ssh-encoding"
-version = "0.3.0-rc.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abf34aa716da5d5b4c496936d042ea282ab392092cd68a72ef6a8863ff8c96a"
+checksum = "7b54d0ed0498daf3f78d82e00e28c8eec9d75a067c4cfbcc7a0f7d0f4077749e"
 dependencies = [
  "base64ct",
  "bytes",
@@ -8122,9 +8124,9 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.7.0-rc.10"
+version = "0.7.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45735ce3dea95690e4a9e414c4cfde7f79835063c3dcd35881df85a84118e74b"
+checksum = "f9a32fae177b74a22aa9c5b01bf7e68b33545be32d9e381e248058d2adc15ce3"
 dependencies = [
  "argon2 0.6.0-rc.8",
  "bcrypt-pbkdf",
@@ -10696,6 +10698,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff",
+ "group",
+ "hybrid-array",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10794,9 +10807,9 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "x25519-dalek"
-version = "3.0.0-rc.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17b575e04fcdb37e5509a85a14ff08116678a1c9724befb8b571db742dbdbb0"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.10.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,7 +51,11 @@ portable-pty = "0.9.0"
 keyring-core = "1.0.0"
 # Keep pinned until russh and IronRDP both release stable dependency lines that
 # no longer need the local RustCrypto/Dalek compatibility patches below.
-russh = { version = "=0.61.2", default-features = false, features = ["des", "flate2", "ring", "rsa"] }
+# 0.62.4 moves most of the RustCrypto/Dalek line to stable (the vendored picky/
+# sspi pins were relaxed to match) and adds upstream panic/security fixes. It
+# does NOT fix the compression.rs compress_into truncation that corrupts the
+# stream when zlib output exceeds input+10 bytes (incompressible SFTP uploads).
+russh = { version = "=0.62.4", default-features = false, features = ["des", "flate2", "ring", "rsa"] }
 russh-sftp = "2.3.0"
 suppaftp = { version = "10.0.0", default-features = false, features = ["tokio", "tokio-async-native-tls", "deprecated"] }
 async-native-tls = { version = "0.6", default-features = false, features = ["runtime-tokio"] }
@@ -217,8 +221,9 @@ opt-level = "s"
 opt-level = 1
 
 [patch.crates-io]
-# Temporary downstream application of Devolutions/IronRDP#1363 so russh 0.61.2
-# and the macOS/Linux IronRDP client share one RustCrypto/Dalek prerelease line.
+# Temporary downstream application of Devolutions/IronRDP#1363 so russh 0.62.4
+# and the macOS/Linux IronRDP client share one RustCrypto/Dalek line (now mostly
+# the stabilized releases; rsa/pkcs1/ssh-key/ff/group are still upstream rc pins).
 # Remove these patches when IronRDP/picky-rs/sspi-rs publish the aligned stack.
 picky = { path = "vendor/picky-rs-russh-061/picky" }
 picky-asn1 = { path = "vendor/picky-rs-russh-061/picky-asn1" }

--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -429,12 +429,15 @@ impl client::Handler for VerifyingClient {
         channel: Channel<Msg>,
         _originator_address: &str,
         _originator_port: u32,
+        reply: client::ChannelOpenHandle,
         _session: &mut Session,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send {
         let x11_forwarding = self.x11_forwarding.clone();
         let bridge_tasks = self.bridge_tasks.clone();
         async move {
+            // Dropping `reply` without accepting rejects the channel open.
             if let Some(x11_forwarding) = x11_forwarding {
+                reply.accept().await;
                 spawn_bridge_task(&bridge_tasks, async move {
                     if let Err(error) = bridge_x11_channel(channel, x11_forwarding.display).await {
                         ssh_debug("bridge.x11.error", json!({ "error": error }));
@@ -452,6 +455,7 @@ impl client::Handler for VerifyingClient {
         connected_port: u32,
         _originator_address: &str,
         _originator_port: u32,
+        reply: client::ChannelOpenHandle,
         _session: &mut Session,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send {
         let target = self.remote_forward_targets.as_ref().and_then(|targets| {
@@ -469,7 +473,9 @@ impl client::Handler for VerifyingClient {
         });
         let bridge_tasks = self.bridge_tasks.clone();
         async move {
+            // Dropping `reply` without accepting rejects the channel open.
             if let Some((dest_host, dest_port)) = target {
+                reply.accept().await;
                 spawn_bridge_task(&bridge_tasks, async move {
                     if let Err(error) =
                         bridge_remote_forward_channel(channel, dest_host, dest_port).await

--- a/src-tauri/vendor/picky-rs-russh-061/picky/Cargo.toml
+++ b/src-tauri/vendor/picky-rs-russh-061/picky/Cargo.toml
@@ -49,12 +49,12 @@ rand = "0.10"
 rand_core = "0.10"
 crypto-bigint = "0.7"
 
-ed25519-dalek = { version = "=3.0.0-rc.0", features = ["hazmat", "rand_core"] }
-x25519-dalek = { version = "=3.0.0-rc.0", features = ["static_secrets"] }
+ed25519-dalek = { version = "3", features = ["hazmat", "rand_core"] }
+x25519-dalek = { version = "3", features = ["static_secrets"] }
 
-p256 = { version = "=0.14.0-rc.10", features = ["ecdh"] }
-p384 = { version = "=0.14.0-rc.10", features = ["ecdh"] }
-p521 = { version = "=0.14.0-rc.10", features = ["ecdh"] }
+p256 = { version = "0.14", features = ["ecdh"] }
+p384 = { version = "0.14", features = ["ecdh"] }
+p521 = { version = "0.14", features = ["ecdh"] }
 
 rsa = { version = "=0.10.0-rc.18", features = ["std"] }
 
@@ -64,7 +64,7 @@ sha1 = { version = "0.11", features = ["oid"] }
 sha2 = { version = "0.11", features = ["oid"] }
 sha3 = { version = "0.12", features = ["oid"] }
 
-aes-gcm = { version = "=0.11.0-rc.4", optional = true }
+aes-gcm = { version = "0.11", optional = true }
 aes = { version = "0.9", optional = true }
 aes-kw = { version = "0.3", optional = true }
 argon2 = { version = "=0.6.0-rc.8", optional = true }
@@ -80,20 +80,20 @@ inout = "0.2.2"
 
 # Pin transitive dependencies versions.
 # TODO: Remove when stable versions will be released.
-aead = { version = "=0.6.0-rc.10", optional = true }
+aead = { version = "0.6", optional = true }
 blake2 = { version = "=0.11.0-rc.6", optional = true }
 ed25519 = "=3.0.0"
-ecdsa = "=0.17.0-rc.18"
-elliptic-curve = "=0.14.0-rc.33"
+ecdsa = "0.17"
+elliptic-curve = "0.14"
 pkcs1 = "=0.8.0-rc.4"
-primefield = "=0.14.0-rc.10"
-primeorder = "=0.14.0-rc.10"
+primefield = "0.14"
+primeorder = "0.14"
 ff = { version = "=0.14.0", default-features = false }
 group = "=0.14.0"
 rustcrypto-ff = "=0.14.0-rc.1"
 rustcrypto-ff_derive = "=0.14.0-rc.0"
 rustcrypto-group = "=0.14.0-rc.1"
-curve25519-dalek = "=5.0.0-rc.0"
+curve25519-dalek = "5"
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/src-tauri/vendor/sspi-rs-russh-061/Cargo.toml
+++ b/src-tauri/vendor/sspi-rs-russh-061/Cargo.toml
@@ -196,11 +196,11 @@ tokio = { workspace = true, features = ["time", "rt", "rt-multi-thread"] }
 pkcs1 = "=0.8.0-rc.4"
 pkcs8 = "=0.11.0"
 signature = "=3.0.0"
-p256 = "=0.14.0-rc.10"
-primefield = "=0.14.0-rc.10"
-primeorder = "=0.14.0-rc.10"
-p384 = "=0.14.0-rc.10"
-p521 = "=0.14.0-rc.10"
+p256 = "0.14"
+primefield = "0.14"
+primeorder = "0.14"
+p384 = "0.14"
+p521 = "0.14"
 
 # "Zero-knowledge Cryptography in Rust" crates
 ff = { version = "=0.14.0", default-features = false }
@@ -210,8 +210,8 @@ rustcrypto-ff_derive = "=0.14.0-rc.0"
 rustcrypto-group = "=0.14.0-rc.1"
 
 # "dalek cryptography" crates
-ed25519-dalek = "=3.0.0-rc.0"
-curve25519-dalek = "=5.0.0-rc.0"
+ed25519-dalek = "3"
+curve25519-dalek = "5"
 
 [dev-dependencies]
 base64.workspace = true


### PR DESCRIPTION
## Summary

Upgrades `russh` from the pinned `=0.61.2` to `=0.62.4`, pulling in upstream security fixes (three client-triggerable session-handler panics in PTY / Curve25519 packet handling — GHSA-cqjc-rmpq-xprq, GHSA-g9hv-x236-4qp3, GHSA-5xvq-cp9x-6p6r), an RFC 4254 channel-close compliance fix, and a kex guess handling fix.

russh 0.62.3+ moved most of its RustCrypto/Dalek dependency line from prerelease pins to the stabilized releases, so the vendored picky/sspi compatibility patches are relaxed to match (curve25519/ed25519/x25519-dalek 5.0.0/3.0.0, p256/p384/p521/primefield/primeorder 0.14.0, ecdsa 0.17.0, elliptic-curve 0.14.1, aes-gcm 0.11.0, aead 0.6.1). `rsa`/`pkcs1`/`ssh-key`/`rustcrypto-ff`/`rustcrypto-group` stay on the same rc pins russh itself still uses. The resulting lockfile resolves to a single unified version of every crypto crate (the pkcs1 0.7.5/0.8.0-rc.4 pair pre-existed).

**Code change**: russh 0.62.0 changed the client `Handler` contract for server-initiated channel opens — handlers now receive a `ChannelOpenHandle` that must be explicitly accepted; dropping it rejects the open. `server_channel_open_x11` and `server_channel_open_forwarded_tcpip` in `src-tauri/src/ssh.rs` now accept only when a bridge target (X11 display / remote-forward target) exists; unmatched opens are rejected instead of the previous accept-then-drop, which is more RFC-correct.

**What this does NOT fix**: the diagnosed SFTP upload failure for incompressible files (e.g. a ~900KB PNG stalling at ~56% then timing out with SSH compression on). Root cause is `compress_into` in russh's `compression.rs`: it reserves `input + 10` output bytes and breaks the deflate loop on `Status::Ok` even when the buffer filled exactly, silently dropping pending compressed bytes and corrupting the stream for payloads that expand under zlib. Verified byte-identical in 0.61.2, 0.62.4, and current `main` — needs a separate vendored patch or upstream fix, plus consideration of defaulting SFTP sessions to no compression in the meantime.

## Type of change

- [x] Build / CI / tooling
- [x] Bug fix (upstream security fixes; stricter channel-open handling)

## Areas touched

- [x] Backend (Rust/Tauri — `src-tauri/`)

## i18n

- [x] No user-visible strings

## High-risk invariants

- [x] No frontend close hooks / close-confirmation flows added
- [x] No live Session state added to the durable Connection model
- [x] RDP/VNC/WebView2 surface rules respected (vendored IronRDP patch set unchanged apart from dependency pins)

## Checks

- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 1087 passed, 0 failed
- [ ] `npm run check` / `npm run build` — not run; no frontend changes
- [ ] Validated in the real Tauri desktop runtime — pending; see reviewer notes

## Notes for reviewers

- The vendored `picky` compiles standalone against the stable crypto line, and `sspi` compiled as its dependency. `ironrdp-connector` could not be fully compile-verified from this Windows machine (cross-target check needs a C toolchain); its own code and the vendored picky/sspi versions are unchanged, so risk is low — but please let macOS/Linux CI or a local build confirm before merge.
- Runtime smoke tests worth doing: SSH terminal connect, SFTP browse/transfer, remote port forward, X11 forward, and RDP on macOS/Linux.
- Rejecting unmatched forwarded-tcpip/X11 channel opens is a deliberate behavior change from silently accepting and dropping them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)