### PR TITLE
Fix Hero Geometric background animation

### DIFF
--- a/src/modules/dashboard/registry/componentry/hero-geometric.tsx
+++ b/src/modules/dashboard/registry/componentry/hero-geometric.tsx
@@ -132,6 +132,24 @@ function sanitizeHexColor(value: string, fallback: string) {
     return trimmed.startsWith("#") ? trimmed : `#${trimmed}`;
 }
 
+export function applyHeroGeometricFrame(
+    material: THREE.ShaderMaterial,
+    elapsedTime: number,
+    size: { width: number; height: number },
+    color1: string,
+    color2: string,
+    speed: number
+) {
+    material.uniforms.uTime.value = elapsedTime * speed;
+    material.uniforms.uResolution.value.set(size.width, size.height);
+    material.uniforms.uColor1.value.set(
+        sanitizeHexColor(color1, HERO_GEOMETRIC_FALLBACK_COLOR_1)
+    );
+    material.uniforms.uColor2.value.set(
+        sanitizeHexColor(color2, HERO_GEOMETRIC_FALLBACK_COLOR_2)
+    );
+}
+
 const GradientPlane = ({
     color1,
     color2,
@@ -141,7 +159,7 @@ const GradientPlane = ({
     color2: string;
     speed?: number
 }) => {
-    const meshRef = useRef<THREE.Mesh>(null);
+    const materialRef = useRef<THREE.ShaderMaterial>(null);
     const uniforms = useMemo(
         () => ({
             uTime: { value: 0 },
@@ -154,16 +172,22 @@ const GradientPlane = ({
 
     useFrame((state) => {
         const { clock, size } = state;
-        uniforms.uTime.value = clock.getElapsedTime() * speed;
-        uniforms.uResolution.value.set(size.width, size.height);
-        uniforms.uColor1.value.set(sanitizeHexColor(color1, HERO_GEOMETRIC_FALLBACK_COLOR_1));
-        uniforms.uColor2.value.set(sanitizeHexColor(color2, HERO_GEOMETRIC_FALLBACK_COLOR_2));
+        if (!materialRef.current) return;
+        applyHeroGeometricFrame(
+            materialRef.current,
+            clock.getElapsedTime(),
+            size,
+            color1,
+            color2,
+            speed
+        );
     });
 
     return (
-        <mesh ref={meshRef} scale={[2, 2, 1]}>
+        <mesh scale={[2, 2, 1]}>
             <planeGeometry args={[2, 2]} />
             <shaderMaterial
+                ref={materialRef}
                 vertexShader={vertexShader}
                 fragmentShader={fragmentShader}
                 uniforms={uniforms}
@@ -273,4 +297,3 @@ export default function HeroGeometric({
         </div>
     );
 }
-

--- a/tests/hero-geometric-animation.test.ts
+++ b/tests/hero-geometric-animation.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import * as THREE from "three";
+
+import { applyHeroGeometricFrame } from "../src/modules/dashboard/registry/componentry/hero-geometric.tsx";
+
+test("Hero Geometric updates the mounted shader material uniforms", async () => {
+  const material = new THREE.ShaderMaterial({
+    uniforms: {
+      uTime: { value: 0 },
+      uResolution: { value: new THREE.Vector2() },
+      uColor1: { value: new THREE.Color("#000000") },
+      uColor2: { value: new THREE.Color("#000000") },
+    },
+  });
+
+  applyHeroGeometricFrame(
+    material,
+    2.5,
+    { width: 800, height: 600 },
+    "#112233",
+    "#abcdef",
+    2,
+  );
+
+  assert.equal(material.uniforms.uTime.value, 5);
+  assert.deepEqual(material.uniforms.uResolution.value.toArray(), [800, 600]);
+  assert.equal(material.uniforms.uColor1.value.getHexString(), "112233");
+  assert.equal(material.uniforms.uColor2.value.getHexString(), "abcdef");
+
+  const source = await readFile(
+    new URL("../src/modules/dashboard/registry/componentry/hero-geometric.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(source, /ref=\{materialRef\}/);
+  assert.match(source, /applyHeroGeometricFrame\(\s*materialRef\.current/);
+});


### PR DESCRIPTION
## Summary
- update the mounted `ShaderMaterial` uniforms from the React Three Fiber frame loop
- add regression coverage for time, resolution, and color uniform updates

## Root cause
React Three Fiber clones the `uniforms` prop when constructing the mounted shader material. The animation loop was mutating the original memoized object, leaving the material actually rendered by WebGL at `uTime = 0`.

## Validation
- `npm run check` — 1,205 tests passed, ESLint and TypeScript passed
- `npm run build`
- native Tauri/WebView2 smoke test — GPU `uTime` advances and compositor captures differ across frames
- clean-cache IT Ops launch smoke test passed; the observed blank dev window was a stale Vite optimized-dependency response (`504 Outdated Optimize Dep`), not an IT Ops render crash