### PR TITLE
Fix first-click activation for Connection toolbar controls

### DIFF
--- a/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
+++ b/src/modules/workspace/connections/terminal/TerminalWorkspace.tsx
@@ -872,10 +872,24 @@ function EmbeddedConnectionPane({
   // panes to avoid a second, misaligned X.
   const showOverlayClose = canClosePane && pane.kind !== "webview";
 
+  function handleEmbeddedPaneMouseDown(event: ReactMouseEvent<HTMLElement>) {
+    if (shouldDeferPaneFocusUntilClick(event.target)) {
+      return;
+    }
+    onFocus();
+  }
+
+  function handleEmbeddedPaneClick(event: ReactMouseEvent<HTMLElement>) {
+    if (shouldDeferPaneFocusUntilClick(event.target)) {
+      onFocus();
+    }
+  }
+
   return (
     <article
       className="embedded-workspace-pane"
-      onMouseDown={onFocus}
+      onClick={handleEmbeddedPaneClick}
+      onMouseDown={handleEmbeddedPaneMouseDown}
     >
       {showOverlayClose ? (
         <button
@@ -1711,6 +1725,20 @@ function TerminalPaneView({
       return;
     }
     focusTerminalRendererFromSurface();
+  }
+
+  function handlePaneMouseDown(event: ReactMouseEvent<HTMLElement>) {
+    if (shouldDeferPaneFocusUntilClick(event.target)) {
+      return;
+    }
+    onFocus();
+    focusTerminalRenderer();
+  }
+
+  function handlePaneClick(event: ReactMouseEvent<HTMLElement>) {
+    if (shouldDeferPaneFocusUntilClick(event.target)) {
+      onFocus();
+    }
   }
 
   const actionsMenuRef = useRef<HTMLDivElement | null>(null);
@@ -3122,10 +3150,8 @@ function TerminalPaneView({
         .filter(Boolean)
         .join(" ")}
       data-tutorial-id="terminal.pane"
-      onMouseDown={() => {
-        onFocus();
-        focusTerminalRenderer();
-      }}
+      onClick={handlePaneClick}
+      onMouseDown={handlePaneMouseDown}
       ref={paneRef}
       style={
         terminalToolbarBackground
@@ -4011,4 +4037,13 @@ function isFocusableElement(element: HTMLElement) {
 
   const tabIndex = element.getAttribute("tabindex");
   return tabIndex !== null && tabIndex !== "-1";
+}
+
+function shouldDeferPaneFocusUntilClick(target: EventTarget | null) {
+  const element = target instanceof Element ? target : null;
+  return Boolean(
+    element?.closest(
+      'button, input, textarea, select, a[href], summary, [role="button"], [role^="menuitem"]',
+    ),
+  );
 }

--- a/tests/connection-toolbar-first-click.test.mjs
+++ b/tests/connection-toolbar-first-click.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const terminalWorkspaceSource = await readFile(
+  new URL("../src/modules/workspace/connections/terminal/TerminalWorkspace.tsx", import.meta.url),
+  "utf8",
+);
+
+test("Panorama Connection toolbar controls defer Pane selection until click", () => {
+  assert.match(
+    terminalWorkspaceSource,
+    /function shouldDeferPaneFocusUntilClick\(/,
+    "terminal and embedded Connection Panes need one shared interactive-target guard",
+  );
+  assert.match(
+    terminalWorkspaceSource,
+    /function handleEmbeddedPaneMouseDown\([\s\S]*shouldDeferPaneFocusUntilClick\(event\.target\)[\s\S]*onFocus\(\)/,
+    "embedded Connection controls must not change focused Pane during mousedown",
+  );
+  assert.match(
+    terminalWorkspaceSource,
+    /function handleEmbeddedPaneClick\([\s\S]*shouldDeferPaneFocusUntilClick\(event\.target\)[\s\S]*onFocus\(\)/,
+    "embedded Connection controls should select their Pane after their click handler runs",
+  );
+  assert.match(
+    terminalWorkspaceSource,
+    /function handlePaneMouseDown\([\s\S]*shouldDeferPaneFocusUntilClick\(event\.target\)[\s\S]*onFocus\(\)[\s\S]*focusTerminalRenderer\(\)/,
+    "terminal controls must not focus or select the Pane before Chromium synthesizes click",
+  );
+  assert.match(
+    terminalWorkspaceSource,
+    /function handlePaneClick\([\s\S]*shouldDeferPaneFocusUntilClick\(event\.target\)[\s\S]*onFocus\(\)/,
+    "terminal controls should select their Pane only after activation",
+  );
+});
+
+test("the deferred Pane-focus guard covers every Connection toolbar control shape", () => {
+  const focusGuard = terminalWorkspaceSource.match(
+    /function shouldDeferPaneFocusUntilClick\([\s\S]*?\n\}/,
+  )?.[0];
+  assert.ok(focusGuard, "the shared Pane-focus guard should remain discoverable");
+  assert.match(
+    focusGuard,
+    /button,\s*input,\s*textarea,\s*select,\s*a\[href\],\s*summary,\s*\[role="button"\],\s*\[role\^="menuitem"\]/,
+    "buttons, address/search fields, selectors, links, and custom toolbar controls all need first-click protection",
+  );
+  assert.doesNotMatch(
+    focusGuard,
+    /tabindex|canvas/,
+    "VNC and canvas-RDP surfaces must retain their immediate pointer-down Pane focus",
+  );
+});


### PR DESCRIPTION
## What

- Defer Pane selection/focus until `click` when the pointer target is an interactive toolbar control.
- Keep immediate `mousedown` focus for terminal, VNC, and canvas-RDP surfaces.
- Apply the same guard to terminal Panes and embedded Panorama/split Panes.
- Add regression coverage for the two focus wrappers and all toolbar control shapes.

## Why

Selecting an inactive Pane during `mousedown` updates React state and can rerender the control before Chromium synthesizes `click`. The first press then only changes the selected Pane; a later press activates the toolbar button or menu.

## Connection-type audit

Verified first-click activation after selecting the content surface for Local, SSH, Telnet, Serial, URL, RDP, VNC, FTP/FTPS, local File Explorer, Document, and SSH-launched SFTP. The non-terminal standalone workspaces do not have another selection-on-`mousedown` wrapper.

## Checks

- 29 focused frontend tests passed
- `npx eslint src/modules/workspace/connections/terminal/TerminalWorkspace.tsx`
- `npx tsc --noEmit`
- `git diff --check origin/main...HEAD`
