### PR TITLE
Expose IT Ops Rack layout controls to the AI assistant

### DIFF
--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -3257,6 +3257,36 @@ fn ai_tool_definitions_with_skills(
             },"required":["id","name","serverRoom","heightU","depthMm"]}),
         ));
         tools.push(tool_definition(
+            "itops_reorder_racks",
+            "Reorder all Racks in one Site. Read itops_list_racks first, then supply every Rack id exactly once in the desired sortOrder.",
+            json!({"type":"object","properties":{
+                "siteId":{"type":"string"},
+                "orderedIds":{"type":"array","items":{"type":"string"}}
+            },"required":["siteId","orderedIds"]}),
+        ));
+        tools.push(tool_definition(
+            "itops_set_rack_placements",
+            "Batch-set Rack positions in Server Room View. Use kind floor for top-down pixel coordinates or grid for 2.5D grid cells; each entry's x/y values update the corresponding floorX/floorY or gridX/gridY fields.",
+            json!({"type":"object","properties":{
+                "kind":{"type":"string","enum":["floor","grid"]},
+                "entries":{"type":"array","items":{"type":"object","properties":{
+                    "id":{"type":"string"},
+                    "x":{"type":"number"},
+                    "y":{"type":"number"}
+                },"required":["id","x","y"]}}
+            },"required":["kind","entries"]}),
+        ));
+        tools.push(tool_definition(
+            "itops_set_rack_facings",
+            "Batch-set Rack quarter-turn facings in Server Room View. facing is 0 through 3, where 0 faces toward positive y.",
+            json!({"type":"object","properties":{
+                "entries":{"type":"array","items":{"type":"object","properties":{
+                    "id":{"type":"string"},
+                    "facing":{"type":"integer","minimum":0,"maximum":3}
+                },"required":["id","facing"]}}
+            },"required":["entries"]}),
+        ));
+        tools.push(tool_definition(
             "itops_delete_rack",
             "Delete one Rack by id, including its Rack Device placements. Bound saved Connections are untouched.",
             json!({"type":"object","properties":{"id":{"type":"string"}},"required":["id"]}),

--- a/src-tauri/src/ai/tests.rs
+++ b/src-tauri/src/ai/tests.rs
@@ -2692,6 +2692,50 @@ fn itops_rack_item_tools_expose_mounting_face_and_rack_top_contracts() {
 }
 
 #[test]
+fn itops_rack_layout_and_ordering_tools_are_published_with_bounded_schemas() {
+    let settings: AiAssistantToolSettings = serde_json::from_value(json!({
+        "itops": true
+    }))
+    .expect("tool settings deserialize");
+    let tools = ai_tool_definitions(&settings);
+
+    for name in [
+        "itops_reorder_racks",
+        "itops_set_rack_placements",
+        "itops_set_rack_facings",
+    ] {
+        assert!(
+            tools.iter().any(|tool| tool.function.name == name),
+            "IT Ops tool {name} must be published"
+        );
+    }
+
+    let placements = tools
+        .iter()
+        .find(|tool| tool.function.name == "itops_set_rack_placements")
+        .expect("Rack placement tool exists");
+    assert_eq!(
+        placements
+            .function
+            .parameters
+            .pointer("/properties/kind/enum"),
+        Some(&json!(["floor", "grid"]))
+    );
+
+    let facings = tools
+        .iter()
+        .find(|tool| tool.function.name == "itops_set_rack_facings")
+        .expect("Rack facing tool exists");
+    assert_eq!(
+        facings
+            .function
+            .parameters
+            .pointer("/properties/entries/items/properties/facing/maximum"),
+        Some(&json!(3))
+    );
+}
+
+#[test]
 fn itops_ipam_tools_cover_crud_bulk_import_and_sensitive_inputs() {
     let settings: AiAssistantToolSettings = serde_json::from_value(json!({
         "itops": true

--- a/tests/major-module-ai-mcp-coverage.test.mjs
+++ b/tests/major-module-ai-mcp-coverage.test.mjs
@@ -82,6 +82,21 @@ test("native assistant exposes every major Module and all persisted tool groups"
   }
 });
 
+test("native assistant publishes IT Ops Rack layout and ordering tools", async () => {
+  const ai = await read("src-tauri/src/ai.rs");
+
+  for (const tool of [
+    "itops_reorder_racks",
+    "itops_set_rack_placements",
+    "itops_set_rack_facings",
+  ]) {
+    assert.ok(
+      ai.includes(`tool_definition(\n            "${tool}"`),
+      `assistant must publish ${tool}, not only dispatch it`,
+    );
+  }
+});
+
 test("Tutorial navigation accepts the advertised Screenshots Module page", async () => {
   const ai = await read("src-tauri/src/ai.rs");
   assert.match(


### PR DESCRIPTION
### Motivation

- Make the IT Ops rack layout and ordering operations available to the built-in AI assistant and MCP clients so assistant-authored workflows can reorder racks and apply batch placements/facings programmatically.

### Description

- Publish three assistant tools in `src-tauri/src/ai.rs`: `itops_reorder_racks`, `itops_set_rack_placements`, and `itops_set_rack_facings`, each with a bounded JSON `inputSchema` describing required fields and valid ranges.
- Document `kind` semantics for placements (`floor` vs `grid`) and validate `facing` as an integer in `0..=3` in the tool schemas.
- Add a Rust unit test in `src-tauri/src/ai/tests.rs` to assert the three IT Ops tools are published and that placement/facing schema constraints exist.
- Add a frontend test `tests/major-module-ai-mcp-coverage.test.mjs` that ensures `src-tauri/src/ai.rs` actually contains the `tool_definition` entries (prevents dispatcher-only regressions).

### Testing

- Ran the new JS coverage test with `node --test tests/major-module-ai-mcp-coverage.test.mjs`, which passed.
- Ran `git diff --check` and `rustfmt` formatting steps to ensure diffs and formatting are clean, which produced no issues.
- Attempted the Rust unit test `cargo test --manifest-path src-tauri/Cargo.toml itops_rack_layout_and_ordering_tools_are_published_with_bounded_schemas`, but the build failed during native dependency compilation due to a missing system package (`glib-2.0` development files / `glib-2.0.pc`) in the container, so the Cargo test could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77f8caba30832fbc6f5fe1bd2efb1e)