### PR TITLE
Add GitHub Sponsors links to README files

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [ryantsai]

--- a/README.de.md
+++ b/README.de.md
@@ -36,6 +36,9 @@
   <a href="https://github.com/ryantsai/KKTerm/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/ryantsai/KKTerm?style=for-the-badge&color=blue" alt="MIT License" />
   </a>
+  <a href="https://github.com/sponsors/ryantsai">
+    <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="KKTerm auf GitHub unterstützen" />
+  </a>
   <br />
   <img src="https://img.shields.io/badge/cross%E2%80%91platform-desktop-0078D6?style=flat-square" alt="Cross-platform desktop" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
@@ -233,6 +236,14 @@ Aus dem Quellcode bauen oder mitmachen? Alles, was du brauchst, steht in [`CONTR
 - Mehr IT-Ops-Automatisierungsfunktionen
 
 Vollständige, häufig aktualisierte Version: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+---
+
+## Sponsoring
+
+KKTerm wird von einer einzigen Person entwickelt und betreut. Wenn es dir nützlich ist, ist jede Unterstützung willkommen und hilft mir, es weiter zu verbessern.
+
+[![KKTerm auf GitHub unterstützen](https://img.shields.io/badge/Sponsor%20on%20GitHub-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/ryantsai)
 
 ---
 

--- a/README.es-MX.md
+++ b/README.es-MX.md
@@ -36,6 +36,9 @@
   <a href="https://github.com/ryantsai/KKTerm/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/ryantsai/KKTerm?style=for-the-badge&color=blue" alt="MIT License" />
   </a>
+  <a href="https://github.com/sponsors/ryantsai">
+    <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="Patrocina KKTerm en GitHub" />
+  </a>
   <br />
   <img src="https://img.shields.io/badge/cross%E2%80%91platform-desktop-0078D6?style=flat-square" alt="Cross-platform desktop" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
@@ -233,6 +236,14 @@ Si alguno de esos puntos *era* un factor decisivo — está bien, nos vemos en l
 - Más funcionalidad de automatización de IT Ops
 
 Versión completa y actualizada seguido: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+---
+
+## Patrocinio
+
+KKTerm es desarrollado y mantenido por una sola persona. Si te resulta útil, cualquier apoyo es bienvenido y me ayuda a seguir mejorándolo.
+
+[![Patrocina KKTerm en GitHub](https://img.shields.io/badge/Sponsor%20on%20GitHub-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/ryantsai)
 
 ---
 

--- a/README.es.md
+++ b/README.es.md
@@ -36,6 +36,9 @@
   <a href="https://github.com/ryantsai/KKTerm/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/ryantsai/KKTerm?style=for-the-badge&color=blue" alt="MIT License" />
   </a>
+  <a href="https://github.com/sponsors/ryantsai">
+    <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="Patrocina KKTerm en GitHub" />
+  </a>
   <br />
   <img src="https://img.shields.io/badge/cross%E2%80%91platform-desktop-0078D6?style=flat-square" alt="Cross-platform desktop" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
@@ -233,6 +236,14 @@ Si alguno de esos puntos *era* un factor decisivo — justo, nos vemos en la v2.
 - Más funcionalidad de automatización de IT Ops
 
 Versión completa y actualizada con frecuencia: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+---
+
+## Patrocinio
+
+KKTerm es desarrollado y mantenido por una sola persona. Si te resulta útil, cualquier apoyo es bienvenido y me ayuda a seguir mejorándolo.
+
+[![Patrocina KKTerm en GitHub](https://img.shields.io/badge/Sponsor%20on%20GitHub-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/ryantsai)
 
 ---
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -36,6 +36,9 @@
   <a href="https://github.com/ryantsai/KKTerm/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/ryantsai/KKTerm?style=for-the-badge&color=blue" alt="MIT License" />
   </a>
+  <a href="https://github.com/sponsors/ryantsai">
+    <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="Soutenir KKTerm sur GitHub" />
+  </a>
   <br />
   <img src="https://img.shields.io/badge/cross%E2%80%91platform-desktop-0078D6?style=flat-square" alt="Cross-platform desktop" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
@@ -233,6 +236,14 @@ Envie de compiler depuis les sources ou de contribuer ? Tout ce qu'il vous faut 
 - Plus de fonctions d'automatisation IT Ops
 
 Version complète et fréquemment mise à jour : [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+---
+
+## Soutien financier
+
+KKTerm est développé et maintenu par une seule personne. Si vous le trouvez utile, tout soutien est bienvenu et m’aide à continuer de l’améliorer.
+
+[![Soutenir KKTerm sur GitHub](https://img.shields.io/badge/Sponsor%20on%20GitHub-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/ryantsai)
 
 ---
 

--- a/README.id.md
+++ b/README.id.md
@@ -36,6 +36,9 @@
   <a href="https://github.com/ryantsai/KKTerm/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/ryantsai/KKTerm?style=for-the-badge&color=blue" alt="MIT License" />
   </a>
+  <a href="https://github.com/sponsors/ryantsai">
+    <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="Dukung KKTerm di GitHub" />
+  </a>
   <br />
   <img src="https://img.shields.io/badge/cross%E2%80%91platform-desktop-0078D6?style=flat-square" alt="Cross-platform desktop" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
@@ -233,6 +236,14 @@ Mau build dari sumber atau berkontribusi? Semua yang kamu butuhkan ada di [`CONT
 - Lebih banyak fungsi otomatisasi IT Ops
 
 Versi lengkap dan sering diperbarui: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+---
+
+## Dukungan
+
+KKTerm dikembangkan dan dipelihara oleh satu orang. Jika bermanfaat bagimu, dukungan apa pun sangat berarti dan membantu saya terus mengembangkannya.
+
+[![Dukung KKTerm di GitHub](https://img.shields.io/badge/Sponsor%20on%20GitHub-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/ryantsai)
 
 ---
 

--- a/README.it.md
+++ b/README.it.md
@@ -36,6 +36,9 @@
   <a href="https://github.com/ryantsai/KKTerm/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/ryantsai/KKTerm?style=for-the-badge&color=blue" alt="MIT License" />
   </a>
+  <a href="https://github.com/sponsors/ryantsai">
+    <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="Sostieni KKTerm su GitHub" />
+  </a>
   <br />
   <img src="https://img.shields.io/badge/cross%E2%80%91platform-desktop-0078D6?style=flat-square" alt="Cross-platform desktop" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
@@ -233,6 +236,14 @@ Vuoi compilare dai sorgenti o contribuire? Tutto ciò che serve è in [`CONTRIBU
 - Più funzionalità di automazione IT Ops
 
 Versione completa e aggiornata di frequente: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+---
+
+## Sponsorizzazioni
+
+KKTerm è sviluppato e mantenuto da una sola persona. Se lo trovi utile, qualsiasi supporto è benvenuto e mi aiuta a continuare a migliorarlo.
+
+[![Sostieni KKTerm su GitHub](https://img.shields.io/badge/Sponsor%20on%20GitHub-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/ryantsai)
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -36,6 +36,9 @@
   <a href="https://github.com/ryantsai/KKTerm/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/ryantsai/KKTerm?style=for-the-badge&color=blue" alt="MIT License" />
   </a>
+  <a href="https://github.com/sponsors/ryantsai">
+    <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="GitHub で KKTerm を支援" />
+  </a>
   <br />
   <img src="https://img.shields.io/badge/cross%E2%80%91platform-desktop-0078D6?style=flat-square" alt="Cross-platform desktop" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
@@ -233,6 +236,14 @@ Dashboard View では、KKTerm 内蔵のアニメーション背景を45種類�
 - IT Ops 自動化機能の追加
 
 完全で頻繁に更新される版：[`docs/ROADMAP.md`](docs/ROADMAP.md)。
+
+---
+
+## スポンサー支援
+
+KKTerm は一人で開発・保守しています。役に立ったと感じていただけたら、どのような支援も歓迎です。今後の改善を続ける力になります。
+
+[![GitHub で KKTerm を支援](https://img.shields.io/badge/Sponsor%20on%20GitHub-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/ryantsai)
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -36,6 +36,9 @@
   <a href="https://github.com/ryantsai/KKTerm/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/ryantsai/KKTerm?style=for-the-badge&color=blue" alt="MIT License" />
   </a>
+  <a href="https://github.com/sponsors/ryantsai">
+    <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="GitHub에서 KKTerm 후원하기" />
+  </a>
   <br />
   <img src="https://img.shields.io/badge/cross%E2%80%91platform-desktop-0078D6?style=flat-square" alt="Cross-platform desktop" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
@@ -233,6 +236,14 @@ Dashboard View에서는 KKTerm에 내장된 애니메이션 배경 45종을 사�
 - 더 많은 IT Ops 자동화 기능
 
 전체이며 자주 갱신되는 버전: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+---
+
+## 후원
+
+KKTerm은 한 사람이 개발하고 유지 관리합니다. 유용하게 사용하고 계시다면 어떤 지원이든 환영하며, 계속 개선하는 데 큰 도움이 됩니다.
+
+[![GitHub에서 KKTerm 후원하기](https://img.shields.io/badge/Sponsor%20on%20GitHub-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/ryantsai)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@
   <a href="https://github.com/ryantsai/KKTerm/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/ryantsai/KKTerm?style=for-the-badge&color=blue" alt="MIT License" />
   </a>
+  <a href="https://github.com/sponsors/ryantsai">
+    <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="Sponsor KKTerm on GitHub" />
+  </a>
   <br />
   <img src="https://img.shields.io/badge/cross%E2%80%91platform-desktop-0078D6?style=flat-square" alt="Cross-platform desktop" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
@@ -235,6 +238,14 @@ Want to build from source or contribute? Everything you need is in [`CONTRIBUTIN
 - More IT Ops automation functionality
 
 Full and frequently-updated version: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+---
+
+## Sponsorship
+
+KKTerm is developed and maintained by one person. If you find it useful, any support is welcome and helps me keep improving it.
+
+[![Sponsor KKTerm on GitHub](https://img.shields.io/badge/Sponsor%20on%20GitHub-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/ryantsai)
 
 ---
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -36,6 +36,9 @@
   <a href="https://github.com/ryantsai/KKTerm/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/ryantsai/KKTerm?style=for-the-badge&color=blue" alt="MIT License" />
   </a>
+  <a href="https://github.com/sponsors/ryantsai">
+    <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="Apoie o KKTerm no GitHub" />
+  </a>
   <br />
   <img src="https://img.shields.io/badge/cross%E2%80%91platform-desktop-0078D6?style=flat-square" alt="Cross-platform desktop" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
@@ -233,6 +236,14 @@ Quer compilar do código-fonte ou contribuir? Tudo que você precisa está em [`
 - Mais funcionalidade de automação de IT Ops
 
 Versão completa e atualizada com frequência: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+---
+
+## Apoio
+
+O KKTerm é desenvolvido e mantido por uma única pessoa. Se ele for útil para você, qualquer apoio é bem-vindo e me ajuda a continuar melhorando o projeto.
+
+[![Apoie o KKTerm no GitHub](https://img.shields.io/badge/Sponsor%20on%20GitHub-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/ryantsai)
 
 ---
 

--- a/README.th.md
+++ b/README.th.md
@@ -36,6 +36,9 @@
   <a href="https://github.com/ryantsai/KKTerm/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/ryantsai/KKTerm?style=for-the-badge&color=blue" alt="MIT License" />
   </a>
+  <a href="https://github.com/sponsors/ryantsai">
+    <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="สนับสนุน KKTerm บน GitHub" />
+  </a>
   <br />
   <img src="https://img.shields.io/badge/cross%E2%80%91platform-desktop-0078D6?style=flat-square" alt="Cross-platform desktop" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
@@ -233,6 +236,14 @@ Module **Screenshots** จับภาพพื้นที่ที่เลื
 - ฟังก์ชันอัตโนมัติของ IT Ops เพิ่มขึ้น
 
 ฉบับเต็มและอัปเดตบ่อย: [`docs/ROADMAP.md`](docs/ROADMAP.md)
+
+---
+
+## การสนับสนุน
+
+KKTerm พัฒนาและดูแลโดยคนเพียงคนเดียว หากคุณเห็นว่าเป็นประโยชน์ การสนับสนุนทุกรูปแบบยินดีอย่างยิ่งและช่วยให้ผมพัฒนาต่อไปได้
+
+[![สนับสนุน KKTerm บน GitHub](https://img.shields.io/badge/Sponsor%20on%20GitHub-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/ryantsai)
 
 ---
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -36,6 +36,9 @@
   <a href="https://github.com/ryantsai/KKTerm/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/ryantsai/KKTerm?style=for-the-badge&color=blue" alt="MIT License" />
   </a>
+  <a href="https://github.com/sponsors/ryantsai">
+    <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="Tài trợ KKTerm trên GitHub" />
+  </a>
   <br />
   <img src="https://img.shields.io/badge/cross%E2%80%91platform-desktop-0078D6?style=flat-square" alt="Cross-platform desktop" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
@@ -233,6 +236,14 @@ Muốn build từ mã nguồn hay đóng góp? Mọi thứ bạn cần đều n�
 - Thêm chức năng tự động hóa IT Ops
 
 Bản đầy đủ và cập nhật thường xuyên: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+---
+
+## Tài trợ
+
+KKTerm do một người phát triển và duy trì. Nếu bạn thấy ứng dụng hữu ích, mọi sự hỗ trợ đều được trân trọng và giúp tôi tiếp tục cải thiện nó.
+
+[![Tài trợ KKTerm trên GitHub](https://img.shields.io/badge/Sponsor%20on%20GitHub-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/ryantsai)
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,6 +36,9 @@
   <a href="https://github.com/ryantsai/KKTerm/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/ryantsai/KKTerm?style=for-the-badge&color=blue" alt="MIT License" />
   </a>
+  <a href="https://github.com/sponsors/ryantsai">
+    <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="在 GitHub 上赞助 KKTerm" />
+  </a>
   <br />
   <img src="https://img.shields.io/badge/cross%E2%80%91platform-desktop-0078D6?style=flat-square" alt="Cross-platform desktop" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
@@ -233,6 +236,14 @@ homelab、正职工作、还有那个客户的服务器，本来就不该挤在�
 - 更多 IT Ops 自动化功能
 
 完整且经常更新的版本：[`docs/ROADMAP.md`](docs/ROADMAP.md)。
+
+---
+
+## 赞助
+
+KKTerm 由我独自开发和维护。如果它对你有所帮助，欢迎任何形式的支持，这将帮助我继续改进它。
+
+[![在 GitHub 上赞助 KKTerm](https://img.shields.io/badge/Sponsor%20on%20GitHub-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/ryantsai)
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -36,6 +36,9 @@
   <a href="https://github.com/ryantsai/KKTerm/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/ryantsai/KKTerm?style=for-the-badge&color=blue" alt="MIT License" />
   </a>
+  <a href="https://github.com/sponsors/ryantsai">
+    <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="在 GitHub 上贊助 KKTerm" />
+  </a>
   <br />
   <img src="https://img.shields.io/badge/cross%E2%80%91platform-desktop-0078D6?style=flat-square" alt="Cross-platform desktop" />
   <img src="https://img.shields.io/badge/local--first-no%20telemetry-success?style=flat-square" alt="Local-first" />
@@ -233,6 +236,14 @@ homelab、正職工作、還有那個客戶的伺服器，本來就不該擠在�
 - 更多 IT Ops 自動化功能
 
 完整且時常更新的版本：[`docs/ROADMAP.md`](docs/ROADMAP.md)。
+
+---
+
+## 贊助
+
+KKTerm 由我獨自開發與維護。如果它對你有所幫助，歡迎任何形式的支持，這會協助我持續改進它。
+
+[![在 GitHub 上贊助 KKTerm](https://img.shields.io/badge/Sponsor%20on%20GitHub-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/ryantsai)
 
 ---
 


### PR DESCRIPTION
## Summary

- opt in to GitHub Sponsors through `.github/FUNDING.yml`
- add a GitHub Sponsors badge to the primary and localized README headers
- add translated sponsorship sections explaining that KKTerm is maintained by one person and welcoming support

## Impact

Visitors can discover and use the project’s GitHub Sponsors page from every supported README language, and GitHub can surface the repository’s Sponsor button.

## Validation

- `git diff --check`
- verified all 14 README files contain both GitHub Sponsors links

Documentation and repository metadata only; no application tests were run.