### PR TITLE
Optimize SQLite access and encrypted secret store performance

### DIFF
--- a/src-tauri/src/dashboard_commands.rs
+++ b/src-tauri/src/dashboard_commands.rs
@@ -89,8 +89,12 @@ fn storage(app: &AppHandle) -> State<'_, crate::storage::Storage> {
 }
 
 #[tauri::command]
-pub fn dashboard_load_state(app: AppHandle) -> Result<DashboardLoadState, DashboardCommandError> {
-    storage(&app).with_connection_infallible(|conn| ds::load_state(conn).map_err(Into::into))
+pub async fn dashboard_load_state(
+    app: AppHandle,
+) -> Result<DashboardLoadState, DashboardCommandError> {
+    crate::storage::run_blocking_db(|| {
+        storage(&app).with_connection_infallible(|conn| ds::load_state(conn).map_err(Into::into))
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/dashboard_storage.rs
+++ b/src-tauri/src/dashboard_storage.rs
@@ -524,12 +524,13 @@ pub fn reorder_views(
     conn: &SqliteConnection,
     ordered_ids: &[String],
 ) -> Result<(), DashboardStorageError> {
+    let tx = conn.unchecked_transaction()?;
+    let mut statement = tx.prepare("UPDATE dashboard_views SET sort_order = ? WHERE id = ?")?;
     for (idx, id) in ordered_ids.iter().enumerate() {
-        conn.execute(
-            "UPDATE dashboard_views SET sort_order = ? WHERE id = ?",
-            params![idx as i64, id],
-        )?;
+        statement.execute(params![idx as i64, id])?;
     }
+    drop(statement);
+    tx.commit()?;
     Ok(())
 }
 
@@ -783,22 +784,23 @@ pub fn apply_layout(
         validate_grid_bounds(entry.grid_x, entry.grid_y, entry.grid_w, entry.grid_h)?;
     }
     let tx_savepoint = conn.unchecked_transaction()?;
+    let mut statement = tx_savepoint.prepare(
+        "UPDATE dashboard_widget_instances
+            SET grid_x = ?, grid_y = ?, grid_w = ?, grid_h = ?, sort_order = ?
+            WHERE id = ? AND view_id = ?",
+    )?;
     for (idx, entry) in layout.iter().enumerate() {
-        tx_savepoint.execute(
-            "UPDATE dashboard_widget_instances
-                SET grid_x = ?, grid_y = ?, grid_w = ?, grid_h = ?, sort_order = ?
-                WHERE id = ? AND view_id = ?",
-            params![
-                entry.grid_x,
-                entry.grid_y,
-                entry.grid_w,
-                entry.grid_h,
-                idx as i64,
-                entry.id,
-                view_id
-            ],
-        )?;
+        statement.execute(params![
+            entry.grid_x,
+            entry.grid_y,
+            entry.grid_w,
+            entry.grid_h,
+            idx as i64,
+            entry.id,
+            view_id
+        ])?;
     }
+    drop(statement);
     tx_savepoint.commit()?;
     Ok(())
 }
@@ -983,12 +985,10 @@ pub fn remove_custom_widget(
     }
     let tx = conn.unchecked_transaction()?;
     if !instance_ids.is_empty() {
-        for inst_id in &instance_ids {
-            tx.execute(
-                "DELETE FROM dashboard_widget_instances WHERE id = ?",
-                params![inst_id],
-            )?;
-        }
+        tx.execute(
+            "DELETE FROM dashboard_widget_instances WHERE source_id = ? AND kind = 'script'",
+            params![id],
+        )?;
     }
     tx.execute(
         "DELETE FROM dashboard_custom_widgets WHERE id = ?",
@@ -1096,9 +1096,12 @@ pub fn widget_secret_owner_id_for_instance(
 }
 
 pub fn seed_default(conn: &SqliteConnection) -> Result<(), DashboardStorageError> {
-    let view_exists: i64 =
-        conn.query_row("SELECT COUNT(*) FROM dashboard_views", [], |row| row.get(0))?;
-    if view_exists > 0 {
+    let view_exists: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM dashboard_views LIMIT 1)",
+        [],
+        |row| row.get(0),
+    )?;
+    if view_exists {
         return Ok(());
     }
     create_view(conn, "default", "Default", Some("default"))?;

--- a/src-tauri/src/itops/site_storage.rs
+++ b/src-tauri/src/itops/site_storage.rs
@@ -1071,12 +1071,14 @@ pub fn duplicate_rack(
 }
 
 pub fn reorder_racks(conn: &SqliteConnection, site_id: &str, ordered_ids: &[String]) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    let mut statement =
+        tx.prepare("UPDATE itops_site_racks SET sort_order = ? WHERE id = ? AND site_id = ?")?;
     for (index, id) in ordered_ids.iter().enumerate() {
-        conn.execute(
-            "UPDATE itops_site_racks SET sort_order = ? WHERE id = ? AND site_id = ?",
-            params![index as i64, id, site_id],
-        )?;
+        statement.execute(params![index as i64, id, site_id])?;
     }
+    drop(statement);
+    tx.commit()?;
     Ok(())
 }
 
@@ -1115,29 +1117,35 @@ pub fn set_rack_placements(
                 "rack placement coordinates must be finite".to_string(),
             ));
         }
-        match kind {
-            RackPlacementKind::Floor => {
-                conn.execute(
-                    "UPDATE itops_site_racks
-                     SET floor_x = ?, floor_y = ?, updated_at = CURRENT_TIMESTAMP
-                     WHERE id = ?",
-                    params![entry.x.max(0.0), entry.y.max(0.0), entry.id],
-                )?;
+    }
+    let tx = conn.unchecked_transaction()?;
+    match kind {
+        RackPlacementKind::Floor => {
+            let mut statement = tx.prepare(
+                "UPDATE itops_site_racks
+                 SET floor_x = ?, floor_y = ?, updated_at = CURRENT_TIMESTAMP
+                 WHERE id = ?",
+            )?;
+            for entry in entries {
+                statement.execute(params![entry.x.max(0.0), entry.y.max(0.0), entry.id])?;
             }
-            RackPlacementKind::Grid => {
-                conn.execute(
-                    "UPDATE itops_site_racks
-                     SET grid_x = ?, grid_y = ?, updated_at = CURRENT_TIMESTAMP
-                     WHERE id = ?",
-                    params![
-                        entry.x.round().max(0.0) as i64,
-                        entry.y.round().max(0.0) as i64,
-                        entry.id
-                    ],
-                )?;
+        }
+        RackPlacementKind::Grid => {
+            let mut statement = tx.prepare(
+                "UPDATE itops_site_racks
+                 SET grid_x = ?, grid_y = ?, updated_at = CURRENT_TIMESTAMP
+                 WHERE id = ?",
+            )?;
+            for entry in entries {
+                statement.execute(params![
+                    entry.x.round().max(0.0) as i64,
+                    entry.y.round().max(0.0) as i64,
+                    entry.id
+                ])?;
             }
         }
     }
+    tx.commit()?;
     Ok(())
 }
 
@@ -1152,13 +1160,18 @@ pub fn set_rack_facings(conn: &SqliteConnection, entries: &[RackFacingEntry]) ->
                 entry.facing
             )));
         }
-        conn.execute(
-            "UPDATE itops_site_racks
-             SET facing = ?, updated_at = CURRENT_TIMESTAMP
-             WHERE id = ?",
-            params![entry.facing, entry.id],
-        )?;
     }
+    let tx = conn.unchecked_transaction()?;
+    let mut statement = tx.prepare(
+        "UPDATE itops_site_racks
+         SET facing = ?, updated_at = CURRENT_TIMESTAMP
+         WHERE id = ?",
+    )?;
+    for entry in entries {
+        statement.execute(params![entry.facing, entry.id])?;
+    }
+    drop(statement);
+    tx.commit()?;
     Ok(())
 }
 
@@ -1272,23 +1285,24 @@ pub fn set_room_objects(
         "DELETE FROM itops_room_objects WHERE site_id = ? AND server_room = ?",
         params![site_id, server_room],
     )?;
+    let mut statement = tx.prepare(
+        "INSERT INTO itops_room_objects (id, site_id, server_room, kind, x, y, z, rot, corner)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )?;
     for object in objects {
-        tx.execute(
-            "INSERT INTO itops_room_objects (id, site_id, server_room, kind, x, y, z, rot, corner)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            params![
-                object.id,
-                site_id,
-                server_room,
-                object.kind,
-                object.x,
-                object.y,
-                object.z,
-                object.rot,
-                object.corner
-            ],
-        )?;
+        statement.execute(params![
+            object.id,
+            site_id,
+            server_room,
+            object.kind,
+            object.x,
+            object.y,
+            object.z,
+            object.rot,
+            object.corner
+        ])?;
     }
+    drop(statement);
     tx.commit()?;
     Ok(())
 }

--- a/src-tauri/src/itops/storage.rs
+++ b/src-tauri/src/itops/storage.rs
@@ -331,12 +331,13 @@ pub fn remove_site(conn: &SqliteConnection, id: &str) -> Result<()> {
 }
 
 pub fn reorder_sites(conn: &SqliteConnection, ordered_ids: &[String]) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    let mut statement = tx.prepare("UPDATE itops_sites SET sort_order = ? WHERE id = ?")?;
     for (index, id) in ordered_ids.iter().enumerate() {
-        conn.execute(
-            "UPDATE itops_sites SET sort_order = ? WHERE id = ?",
-            params![index as i64, id],
-        )?;
+        statement.execute(params![index as i64, id])?;
     }
+    drop(statement);
+    tx.commit()?;
     Ok(())
 }
 

--- a/src-tauri/src/itops/task_storage.rs
+++ b/src-tauri/src/itops/task_storage.rs
@@ -490,6 +490,25 @@ const BUILTIN_TASKS: &[BuiltinTaskSpec] = &[
 
 pub fn sync_builtin_catalog(conn: &SqliteConnection) -> Result<()> {
     let tx = conn.unchecked_transaction()?;
+    let mut upsert = tx.prepare(
+        "INSERT INTO itops_tasks
+            (id, name, description, sort_order, applicable_os_json, built_in_key, task_json)
+         VALUES (?, ?, '', ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+            name = excluded.name,
+            description = excluded.description,
+            sort_order = excluded.sort_order,
+            applicable_os_json = excluded.applicable_os_json,
+            built_in_key = excluded.built_in_key,
+            task_json = excluded.task_json,
+            updated_at = CURRENT_TIMESTAMP
+         WHERE itops_tasks.name IS NOT excluded.name
+            OR itops_tasks.description IS NOT excluded.description
+            OR itops_tasks.sort_order IS NOT excluded.sort_order
+            OR itops_tasks.applicable_os_json IS NOT excluded.applicable_os_json
+            OR itops_tasks.built_in_key IS NOT excluded.built_in_key
+            OR itops_tasks.task_json IS NOT excluded.task_json",
+    )?;
     for (index, spec) in BUILTIN_TASKS.iter().enumerate() {
         let id = format!("builtin-task-{}", spec.key);
         let task = BatchTask::Script {
@@ -498,34 +517,16 @@ pub fn sync_builtin_catalog(conn: &SqliteConnection) -> Result<()> {
         };
         let task_json = task_to_json(&task)?;
         let (_, applicable_os_json) = os_to_json(&[spec.os])?;
-        tx.execute(
-            "INSERT INTO itops_tasks
-                (id, name, description, sort_order, applicable_os_json, built_in_key, task_json)
-             VALUES (?, ?, '', ?, ?, ?, ?)
-             ON CONFLICT(id) DO UPDATE SET
-                name = excluded.name,
-                description = excluded.description,
-                sort_order = excluded.sort_order,
-                applicable_os_json = excluded.applicable_os_json,
-                built_in_key = excluded.built_in_key,
-                task_json = excluded.task_json,
-                updated_at = CURRENT_TIMESTAMP
-             WHERE itops_tasks.name IS NOT excluded.name
-                OR itops_tasks.description IS NOT excluded.description
-                OR itops_tasks.sort_order IS NOT excluded.sort_order
-                OR itops_tasks.applicable_os_json IS NOT excluded.applicable_os_json
-                OR itops_tasks.built_in_key IS NOT excluded.built_in_key
-                OR itops_tasks.task_json IS NOT excluded.task_json",
-            params![
-                id,
-                spec.name,
-                -10_000_i64 + index as i64,
-                applicable_os_json,
-                spec.key,
-                task_json
-            ],
-        )?;
+        upsert.execute(params![
+            id,
+            spec.name,
+            -10_000_i64 + index as i64,
+            applicable_os_json,
+            spec.key,
+            task_json
+        ])?;
     }
+    drop(upsert);
     tx.commit()?;
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -536,14 +536,14 @@ fn load_background_image_from_folder(
 }
 
 #[tauri::command]
-fn list_connection_tree(
+async fn list_connection_tree(
     storage: tauri::State<'_, storage::Storage>,
     workspace_id: Option<String>,
 ) -> Result<storage::ConnectionTree, String> {
-    match workspace_id {
+    storage::run_blocking_db(|| match workspace_id {
         Some(workspace_id) => storage.list_connection_tree_for_workspace(workspace_id),
         None => storage.list_connection_tree(),
-    }
+    })
 }
 
 #[tauri::command]
@@ -1000,6 +1000,7 @@ async fn import_settings_database(
     let power = app.state::<power::DontSleepManager>();
     let webviews = app.state::<webview::WebviewSessionManager>();
     secrets.set_secret_store(credential_settings.secret_store())?;
+    secrets.refresh_selected_store()?;
     logging::set_advanced_debugging_enabled(general_settings.advanced_debugging_enabled());
     debug_heartbeat::start(app.clone());
     tray_state.set_minimize_to_tray(general_settings.minimize_to_tray());

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -255,6 +255,9 @@ trait SecretStore: Send + Sync {
     fn write(&self, reference: &SecretReference, secret: &str) -> Result<(), String>;
     fn read(&self, reference: &SecretReference) -> Result<Option<String>, String>;
     fn delete(&self, reference: &SecretReference) -> Result<(), String>;
+    fn refresh(&self) -> Result<(), String> {
+        Ok(())
+    }
     fn exists(&self, reference: &SecretReference) -> Result<bool, String> {
         self.read(reference).map(|secret| secret.is_some())
     }
@@ -437,6 +440,21 @@ impl Secrets {
         };
         drop(state);
         Ok(self.status())
+    }
+
+    /// Revalidate the selected store after the settings database file has been
+    /// replaced. A locked encrypted store has no live backend to refresh and
+    /// intentionally stays locked.
+    pub(crate) fn refresh_selected_store(&self) -> Result<(), String> {
+        let _guard = self.lock()?;
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| "secret store state lock is poisoned".to_string())?;
+        match state.store.as_ref() {
+            Some(store) => store.refresh(),
+            None => Ok(()),
+        }
     }
 
     pub fn configure_encrypted_file_store(
@@ -1050,6 +1068,36 @@ mod tests {
             .read(&reference)
             .expect_err("wrong password should not decrypt sqlite secret");
         assert!(error.contains("could not decrypt"));
+    }
+
+    #[test]
+    fn encrypted_sqlite_store_caches_unlock_and_refresh_revalidates_replaced_data() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let path = temp_dir.path().join("kkterm.sqlite3");
+        crate::storage::Storage::open(path.clone()).expect("storage opens");
+        let store =
+            super::sqlite_store::SqliteSecretStore::new(path.clone(), "test-password".to_string())
+                .expect("sqlite store");
+        store
+            .initialize_or_verify(true)
+            .expect("store sentinel is created");
+
+        let connection = rusqlite::Connection::open(path).expect("raw database opens");
+        connection
+            .execute(
+                "UPDATE encrypted_secret_store_entries SET ciphertext = 'invalid-base64'",
+                [],
+            )
+            .expect("sentinel is replaced");
+        drop(connection);
+
+        // Ordinary operations reuse the unlock verification; the explicit
+        // refresh used after full database replacement must inspect the new
+        // sentinel again.
+        store
+            .initialize_or_verify(false)
+            .expect("cached verification avoids a second password KDF");
+        assert!(store.refresh().is_err());
     }
 
     #[test]

--- a/src-tauri/src/secrets/sqlite_store.rs
+++ b/src-tauri/src/secrets/sqlite_store.rs
@@ -6,7 +6,11 @@ use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::path::PathBuf;
+use std::{
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
 
 const PASSWORD_ENV: &str = "KKTERM_SECRET_STORE_PASSWORD";
 const STORE_VERSION: u8 = 1;
@@ -17,6 +21,7 @@ const SENTINEL_PLAINTEXT: &str = "kkterm-sqlite-secret-store-v1";
 pub(super) struct SqliteSecretStore {
     db_path: PathBuf,
     password: String,
+    verified: AtomicBool,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -38,7 +43,11 @@ impl SqliteSecretStore {
             ));
         }
 
-        Ok(Self { db_path, password })
+        Ok(Self {
+            db_path,
+            password,
+            verified: AtomicBool::new(false),
+        })
     }
 
     pub(super) fn from_environment(db_path: PathBuf) -> Result<Self, String> {
@@ -59,12 +68,7 @@ impl SqliteSecretStore {
     }
 
     pub(super) fn store_exists(db_path: &std::path::Path) -> Result<bool, String> {
-        let connection = Connection::open(db_path).map_err(|error| {
-            format!(
-                "Could not open encrypted SQLite secret store {}: {error}",
-                db_path.display()
-            )
-        })?;
+        let connection = open_connection(db_path)?;
         let sentinel_key = storage_key(SENTINEL_KEY);
         let count: i64 = connection
             .query_row(
@@ -82,12 +86,7 @@ impl SqliteSecretStore {
         db_path: &std::path::Path,
         reference: &SecretReference,
     ) -> Result<bool, String> {
-        let connection = Connection::open(db_path).map_err(|error| {
-            format!(
-                "Could not open encrypted SQLite secret store {}: {error}",
-                db_path.display()
-            )
-        })?;
+        let connection = open_connection(db_path)?;
         let count: i64 = connection
             .query_row(
                 "SELECT COUNT(1) FROM encrypted_secret_store_entries WHERE secret_key = ?1",
@@ -101,31 +100,40 @@ impl SqliteSecretStore {
     }
 
     pub(super) fn initialize_or_verify(&self, create_if_missing: bool) -> Result<(), String> {
+        if self.verified.load(Ordering::Relaxed) {
+            return Ok(());
+        }
         let sentinel_key = storage_key(SENTINEL_KEY);
         if self.exists_by_key(&sentinel_key)? {
             let plaintext = self.read_by_key(&sentinel_key)?.ok_or_else(|| {
                 "Encrypted SQLite secret store verification record is missing".to_string()
             })?;
             if plaintext == SENTINEL_PLAINTEXT {
+                self.verified.store(true, Ordering::Relaxed);
                 return Ok(());
             }
             return Err("Encrypted SQLite secret store verification failed".to_string());
         }
 
         if create_if_missing {
-            return self.write_by_key(&sentinel_key, SENTINEL_PLAINTEXT);
+            self.write_by_key(&sentinel_key, SENTINEL_PLAINTEXT)?;
+            self.verified.store(true, Ordering::Relaxed);
+            return Ok(());
         }
 
         Err("Encrypted SQLite secret store has not been set up".to_string())
     }
 
     pub(super) fn reset(&self) -> Result<(), String> {
+        self.verified.store(false, Ordering::Relaxed);
         let connection = self.open()?;
         connection
             .execute("DELETE FROM encrypted_secret_store_entries", [])
             .map_err(|error| format!("Could not clear encrypted SQLite secrets: {error}"))?;
         drop(connection);
-        self.write_by_key(&storage_key(SENTINEL_KEY), SENTINEL_PLAINTEXT)
+        self.write_by_key(&storage_key(SENTINEL_KEY), SENTINEL_PLAINTEXT)?;
+        self.verified.store(true, Ordering::Relaxed);
+        Ok(())
     }
 
     pub(super) fn rotate_password(&self, new_password: String) -> Result<Self, String> {
@@ -190,16 +198,12 @@ impl SqliteSecretStore {
         transaction.commit().map_err(|error| {
             format!("Could not commit encrypted SQLite secret rotation: {error}")
         })?;
+        replacement.verified.store(true, Ordering::Relaxed);
         Ok(replacement)
     }
 
     fn open(&self) -> Result<Connection, String> {
-        Connection::open(&self.db_path).map_err(|error| {
-            format!(
-                "Could not open encrypted SQLite secret store {}: {error}",
-                self.db_path.display()
-            )
-        })
+        open_connection(&self.db_path)
     }
 
     fn write_by_key(&self, key: &str, secret: &str) -> Result<(), String> {
@@ -299,9 +303,30 @@ impl SecretStore for SqliteSecretStore {
         self.delete_by_key(&storage_key(&reference.key()))
     }
 
+    fn refresh(&self) -> Result<(), String> {
+        self.verified.store(false, Ordering::Relaxed);
+        self.initialize_or_verify(false)
+    }
+
     fn exists(&self, reference: &SecretReference) -> Result<bool, String> {
         self.exists_by_key(&storage_key(&reference.key()))
     }
+}
+
+fn open_connection(db_path: &Path) -> Result<Connection, String> {
+    let connection = Connection::open(db_path).map_err(|error| {
+        format!(
+            "Could not open encrypted SQLite secret store {}: {error}",
+            db_path.display()
+        )
+    })?;
+    connection
+        .busy_timeout(Duration::from_secs(5))
+        .map_err(|error| format!("Could not configure encrypted SQLite secret store: {error}"))?;
+    connection
+        .pragma_update(None, "synchronous", "NORMAL")
+        .map_err(|error| format!("Could not configure encrypted SQLite secret store: {error}"))?;
+    Ok(connection)
 }
 
 fn storage_key(secret_key: &str) -> String {

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -2,7 +2,7 @@ use crate::window_state::{MainWindowSettings, validate_main_window_settings};
 use rusqlite::{Connection as SqliteConnection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     fs,
     fs::{File, OpenOptions},
     io::{Read, Write, copy},
@@ -13,7 +13,7 @@ use std::{
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use zip::{ZipArchive, ZipWriter, write::SimpleFileOptions};
 
-const SCHEMA_USER_VERSION: i32 = 60;
+const SCHEMA_USER_VERSION: i32 = 61;
 
 const DEFAULT_TERMINAL_OPACITY: u8 = 50;
 
@@ -3367,6 +3367,33 @@ impl Storage {
             ensure_column(&connection, "itops_automations", "obsolete_at", "TEXT")?;
             mark_legacy_monitors_obsolete(&connection)?;
         }
+        // v61: cover the workspace-scoped Connection Tree hot path, Saved
+        // Credential usage joins, URL credential recency lookup, Dashboard
+        // custom-widget lookup, and global IT Ops run-history ordering. Keep
+        // this after every older table rebuild so fresh databases retain the
+        // indexes created by CURRENT_SCHEMA. Current-version startup stays on
+        // the reconciliation-only fast path above.
+        if stored_version < 61 {
+            connection
+                .execute_batch(
+                    r#"
+                    CREATE INDEX IF NOT EXISTS idx_connections_workspace_folder_sort
+                        ON connections(workspace_id, folder_id, sort_order);
+                    CREATE INDEX IF NOT EXISTS idx_connections_password_credential
+                        ON connections(password_credential_id);
+                    CREATE INDEX IF NOT EXISTS idx_connection_folders_workspace_parent_sort
+                        ON connection_folders(workspace_id, parent_folder_id, sort_order);
+                    DROP INDEX IF EXISTS idx_url_credentials_connection;
+                    CREATE INDEX idx_url_credentials_connection
+                        ON url_credentials(connection_id, updated_at DESC);
+                    CREATE INDEX IF NOT EXISTS idx_dashboard_widget_instances_source
+                        ON dashboard_widget_instances(source_id, kind);
+                    CREATE INDEX IF NOT EXISTS idx_itops_run_history_started
+                        ON itops_run_history(started_at DESC, id DESC);
+                    "#,
+                )
+                .map_err(to_storage_error)?;
+        }
         connection
             .execute_batch(&format!("PRAGMA user_version = {SCHEMA_USER_VERSION}"))
             .map_err(to_storage_error)?;
@@ -4271,17 +4298,12 @@ fn list_root_connections_for_workspace(
              ORDER BY sort_order, name",
         )
         .map_err(to_storage_error)?;
-    let rows = statement
+    let mut connections = statement
         .query_map(params![workspace_id], saved_connection_from_row)
         .map_err(to_storage_error)?
         .collect::<Result<Vec<_>, _>>()
         .map_err(to_storage_error)?;
-    let mut connections = Vec::new();
-    for row in rows {
-        let mut saved_connection = row;
-        saved_connection.tags = list_tags(connection, &saved_connection.id)?;
-        connections.push(saved_connection);
-    }
+    populate_connection_tags(connection, &mut connections)?;
     Ok(connections)
 }
 
@@ -4334,7 +4356,7 @@ fn list_connections_for_folder(
         ))
         .map_err(to_storage_error)?;
 
-    let rows = if let Some(folder_id) = folder_id {
+    let mut connections = if let Some(folder_id) = folder_id {
         statement
             .query_map(params![folder_id], saved_connection_from_row)
             .map_err(to_storage_error)?
@@ -4347,14 +4369,7 @@ fn list_connections_for_folder(
             .collect::<Result<Vec<_>, _>>()
             .map_err(to_storage_error)?
     };
-
-    let mut connections = Vec::new();
-    for row in rows {
-        let mut saved_connection = row;
-        saved_connection.tags = list_tags(connection, &saved_connection.id)?;
-        connections.push(saved_connection);
-    }
-
+    populate_connection_tags(connection, &mut connections)?;
     Ok(connections)
 }
 
@@ -4362,19 +4377,47 @@ fn list_folders_for_parent(
     connection: &SqliteConnection,
     parent_folder_id: Option<&str>,
 ) -> Result<Vec<ConnectionFolder>, String> {
-    let folder_ids = list_folder_ids_for_parent(connection, parent_folder_id)?;
-    folder_ids
+    let where_clause = if parent_folder_id.is_some() {
+        "parent_folder_id = ?1"
+    } else {
+        "parent_folder_id IS NULL"
+    };
+    let mut statement = connection
+        .prepare(&format!(
+            "SELECT id, name, icon_data_url
+             FROM connection_folders
+             WHERE {where_clause}
+             ORDER BY sort_order, name",
+        ))
+        .map_err(to_storage_error)?;
+    let folders = if let Some(parent_folder_id) = parent_folder_id {
+        statement
+            .query_map(params![parent_folder_id], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                ))
+            })
+            .map_err(to_storage_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(to_storage_error)?
+    } else {
+        statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                ))
+            })
+            .map_err(to_storage_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(to_storage_error)?
+    };
+    folders
         .into_iter()
-        .map(|folder_id| {
-            let (name, icon_data_url) = connection
-                .query_row(
-                    "SELECT name, icon_data_url FROM connection_folders WHERE id = ?1",
-                    params![folder_id],
-                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?)),
-                )
-                .map_err(to_storage_error)?;
-            get_folder_by_id(connection, &folder_id, name, icon_data_url)
-        })
+        .map(|(id, name, icon_data_url)| get_folder_by_id(connection, &id, name, icon_data_url))
         .collect()
 }
 
@@ -4540,12 +4583,12 @@ fn reorder_folder_ids(
         folder_ids.insert(target_index, folder_id.to_string());
     }
 
+    let mut statement = connection
+        .prepare("UPDATE connection_folders SET sort_order = ?1 WHERE id = ?2")
+        .map_err(to_storage_error)?;
     for (index, folder_id) in folder_ids.iter().enumerate() {
-        connection
-            .execute(
-                "UPDATE connection_folders SET sort_order = ?1 WHERE id = ?2",
-                params![index as i64, folder_id],
-            )
+        statement
+            .execute(params![index as i64, folder_id])
             .map_err(to_storage_error)?;
     }
 
@@ -4564,12 +4607,12 @@ fn reorder_root_folder_ids_for_workspace(
         folder_ids.insert(target_index, folder_id.to_string());
     }
 
+    let mut statement = connection
+        .prepare("UPDATE connection_folders SET sort_order = ?1 WHERE id = ?2")
+        .map_err(to_storage_error)?;
     for (index, folder_id) in folder_ids.iter().enumerate() {
-        connection
-            .execute(
-                "UPDATE connection_folders SET sort_order = ?1 WHERE id = ?2",
-                params![index as i64, folder_id],
-            )
+        statement
+            .execute(params![index as i64, folder_id])
             .map_err(to_storage_error)?;
     }
 
@@ -4588,12 +4631,12 @@ fn reorder_connection_ids(
         connection_ids.insert(target_index, connection_id.to_string());
     }
 
+    let mut statement = connection
+        .prepare("UPDATE connections SET sort_order = ?1 WHERE id = ?2")
+        .map_err(to_storage_error)?;
     for (index, connection_id) in connection_ids.iter().enumerate() {
-        connection
-            .execute(
-                "UPDATE connections SET sort_order = ?1 WHERE id = ?2",
-                params![index as i64, connection_id],
-            )
+        statement
+            .execute(params![index as i64, connection_id])
             .map_err(to_storage_error)?;
     }
 
@@ -4612,12 +4655,12 @@ fn reorder_root_connection_ids_for_workspace(
         connection_ids.insert(target_index, connection_id.to_string());
     }
 
+    let mut statement = connection
+        .prepare("UPDATE connections SET sort_order = ?1 WHERE id = ?2")
+        .map_err(to_storage_error)?;
     for (index, connection_id) in connection_ids.iter().enumerate() {
-        connection
-            .execute(
-                "UPDATE connections SET sort_order = ?1 WHERE id = ?2",
-                params![index as i64, connection_id],
-            )
+        statement
+            .execute(params![index as i64, connection_id])
             .map_err(to_storage_error)?;
     }
 
@@ -5097,6 +5140,59 @@ fn list_tags(connection: &SqliteConnection, connection_id: &str) -> Result<Vec<S
 
     rows.collect::<Result<Vec<_>, _>>()
         .map_err(to_storage_error)
+}
+
+/// Populate a group of Connection tag lists in bounded batches. The tree
+/// loader used to prepare and run one tag query per Connection while holding
+/// the shared SQLite mutex; a flat tree with hundreds of Connections therefore
+/// spent most of its time in repeated SQL setup. SQLite's default variable
+/// limit is safely above this deliberately conservative batch size.
+fn populate_connection_tags(
+    connection: &SqliteConnection,
+    connections: &mut [SavedConnection],
+) -> Result<(), String> {
+    const TAG_QUERY_BATCH_SIZE: usize = 500;
+    if connections.is_empty() {
+        return Ok(());
+    }
+
+    let ids = connections
+        .iter()
+        .map(|saved_connection| saved_connection.id.clone())
+        .collect::<Vec<_>>();
+    let mut tags_by_connection = HashMap::<String, Vec<String>>::new();
+    for batch in ids.chunks(TAG_QUERY_BATCH_SIZE) {
+        let placeholders = std::iter::repeat_n("?", batch.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let mut statement = connection
+            .prepare(&format!(
+                "SELECT connection_id, tag
+                 FROM connection_tags
+                 WHERE connection_id IN ({placeholders})
+                 ORDER BY connection_id, sort_order, tag",
+            ))
+            .map_err(to_storage_error)?;
+        let rows = statement
+            .query_map(rusqlite::params_from_iter(batch.iter()), |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(to_storage_error)?;
+        for row in rows {
+            let (connection_id, tag) = row.map_err(to_storage_error)?;
+            tags_by_connection
+                .entry(connection_id)
+                .or_default()
+                .push(tag);
+        }
+    }
+
+    for saved_connection in connections {
+        saved_connection.tags = tags_by_connection
+            .remove(&saved_connection.id)
+            .unwrap_or_default();
+    }
+    Ok(())
 }
 
 fn insert_folder(

--- a/src-tauri/src/storage/connections.rs
+++ b/src-tauri/src/storage/connections.rs
@@ -1885,44 +1885,50 @@ impl Storage {
         // independent copies that keep the shared, non-secret
         // `password_credential_id` reference.
         if let Some(connection_ids) = request.import_connection_ids.as_ref() {
+            let mut next_connection_sort_order =
+                next_root_connection_sort_order_for_workspace(&transaction, &id)?;
+            let mut insert = transaction
+                .prepare(
+                    "INSERT INTO connections (
+                        id, folder_id, workspace_id, name, tab_title, host, username, port,
+                        key_path, proxy_jump, ssh_socks_proxy, ssh_socks_proxy_username, ssh_socks_proxy_inherit_defaults, ssh_compression,
+                        auth_method, local_shell, local_startup_directory,
+                        local_startup_script, url, data_partition, use_tmux_sessions, use_psmux_sessions,
+                        tmux_connection_id, serial_line, serial_speed, rdp_options, vnc_options,
+                        ftp_options, password_credential_id, icon_color, icon_data_url, icon_background_color,
+                        terminal_opacity, terminal_background_json, terminal_color_scheme, terminal_syntax_highlight_profile_id, file_view_open_external,
+                        connection_type, status, sort_order
+                    )
+                    SELECT
+                        ?1, NULL, ?2, name, tab_title, host, username, port,
+                        key_path, proxy_jump, ssh_socks_proxy, ssh_socks_proxy_username, ssh_socks_proxy_inherit_defaults, ssh_compression,
+                        auth_method, local_shell, local_startup_directory,
+                        local_startup_script, url, data_partition, use_tmux_sessions, use_psmux_sessions,
+                        ?3, serial_line, serial_speed, rdp_options, vnc_options,
+                        ftp_options, password_credential_id, icon_color, icon_data_url, icon_background_color,
+                        terminal_opacity, terminal_background_json, terminal_color_scheme, terminal_syntax_highlight_profile_id, file_view_open_external,
+                        connection_type, 'idle', ?4
+                    FROM connections
+                    WHERE id = ?5",
+                )
+                .map_err(to_storage_error)?;
             for source_id in connection_ids {
                 let new_id = make_connection_id(source_id);
                 let tmux_connection_id = make_tmux_connection_id(&new_id);
-                let next_connection_sort_order =
-                    next_root_connection_sort_order_for_workspace(&transaction, &id)?;
-                transaction
-                    .execute(
-                        "INSERT INTO connections (
-                            id, folder_id, workspace_id, name, tab_title, host, username, port,
-                            key_path, proxy_jump, ssh_socks_proxy, ssh_socks_proxy_username, ssh_socks_proxy_inherit_defaults, ssh_compression,
-                            auth_method, local_shell, local_startup_directory,
-                            local_startup_script, url, data_partition, use_tmux_sessions, use_psmux_sessions,
-                            tmux_connection_id, serial_line, serial_speed, rdp_options, vnc_options,
-                            ftp_options, password_credential_id, icon_color, icon_data_url, icon_background_color,
-                            terminal_opacity, terminal_background_json, terminal_color_scheme, terminal_syntax_highlight_profile_id, file_view_open_external,
-                            connection_type, status, sort_order
-                        )
-                        SELECT
-                            ?1, NULL, ?2, name, tab_title, host, username, port,
-                            key_path, proxy_jump, ssh_socks_proxy, ssh_socks_proxy_username, ssh_socks_proxy_inherit_defaults, ssh_compression,
-                            auth_method, local_shell, local_startup_directory,
-                            local_startup_script, url, data_partition, use_tmux_sessions, use_psmux_sessions,
-                            ?3, serial_line, serial_speed, rdp_options, vnc_options,
-                            ftp_options, password_credential_id, icon_color, icon_data_url, icon_background_color,
-                            terminal_opacity, terminal_background_json, terminal_color_scheme, terminal_syntax_highlight_profile_id, file_view_open_external,
-                            connection_type, 'idle', ?4
-                        FROM connections
-                        WHERE id = ?5",
-                        params![
-                            new_id,
-                            id,
-                            tmux_connection_id,
-                            next_connection_sort_order,
-                            source_id
-                        ],
-                    )
+                let inserted = insert
+                    .execute(params![
+                        new_id,
+                        id,
+                        tmux_connection_id,
+                        next_connection_sort_order,
+                        source_id
+                    ])
                     .map_err(to_storage_error)?;
+                if inserted > 0 {
+                    next_connection_sort_order += 1;
+                }
             }
+            drop(insert);
         }
 
         transaction.commit().map_err(to_storage_error)?;
@@ -2009,14 +2015,15 @@ impl Storage {
     ) -> Result<Vec<Workspace>, String> {
         let mut connection = self.lock()?;
         let transaction = connection.transaction().map_err(to_storage_error)?;
+        let mut statement = transaction
+            .prepare("UPDATE workspaces SET sort_order = ?1 WHERE id = ?2")
+            .map_err(to_storage_error)?;
         for (index, workspace_id) in request.ordered_ids.iter().enumerate() {
-            transaction
-                .execute(
-                    "UPDATE workspaces SET sort_order = ?1 WHERE id = ?2",
-                    params![index as i64, workspace_id],
-                )
+            statement
+                .execute(params![index as i64, workspace_id])
                 .map_err(to_storage_error)?;
         }
+        drop(statement);
         transaction.commit().map_err(to_storage_error)?;
         drop(connection);
         self.list_workspaces()

--- a/src-tauri/src/storage/tests.rs
+++ b/src-tauri/src/storage/tests.rs
@@ -2,6 +2,135 @@ use super::*;
 use rusqlite::params;
 
 #[test]
+fn v61_query_indexes_upgrade_and_current_reopen_preserve_schema_fast_path() {
+    let db_path = temp_db_path("query-indexes-v61");
+    {
+        let storage = Storage::open(db_path.clone()).expect("fixture storage opens");
+        storage
+            .with_connection(|connection| {
+                connection
+                    .execute_batch(
+                        "DROP INDEX idx_connections_workspace_folder_sort;
+                         DROP INDEX idx_connections_password_credential;
+                         DROP INDEX idx_connection_folders_workspace_parent_sort;
+                         DROP INDEX idx_url_credentials_connection;
+                         CREATE INDEX idx_url_credentials_connection
+                            ON url_credentials(connection_id);
+                         DROP INDEX idx_dashboard_widget_instances_source;
+                         DROP INDEX idx_itops_run_history_started;
+                         PRAGMA user_version = 60;",
+                    )
+                    .map_err(to_storage_error)
+            })
+            .expect("v60 fixture indexes are prepared");
+    }
+
+    let upgraded = Storage::open(db_path.clone()).expect("v60 storage upgrades");
+    let schema_version: i64 = upgraded
+        .with_connection(|connection| {
+            for (index, columns) in [
+                (
+                    "idx_connections_workspace_folder_sort",
+                    "workspace_id, folder_id, sort_order",
+                ),
+                (
+                    "idx_connections_password_credential",
+                    "password_credential_id",
+                ),
+                (
+                    "idx_connection_folders_workspace_parent_sort",
+                    "workspace_id, parent_folder_id, sort_order",
+                ),
+                (
+                    "idx_url_credentials_connection",
+                    "connection_id, updated_at DESC",
+                ),
+                ("idx_dashboard_widget_instances_source", "source_id, kind"),
+                ("idx_itops_run_history_started", "started_at DESC, id DESC"),
+            ] {
+                let sql: String = connection
+                    .query_row(
+                        "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?1",
+                        params![index],
+                        |row| row.get(0),
+                    )
+                    .map_err(to_storage_error)?;
+                assert!(
+                    sql.contains(columns),
+                    "{index} should cover {columns}: {sql}"
+                );
+            }
+            for (sql, index) in [
+                (
+                    "SELECT id FROM connections
+                     WHERE folder_id IS NULL AND workspace_id = 'default'
+                     ORDER BY sort_order, name",
+                    "idx_connections_workspace_folder_sort",
+                ),
+                (
+                    "SELECT id FROM connection_folders
+                     WHERE parent_folder_id IS NULL AND workspace_id = 'default'
+                     ORDER BY sort_order, name",
+                    "idx_connection_folders_workspace_parent_sort",
+                ),
+                (
+                    "SELECT id FROM connections WHERE password_credential_id = 'credential'",
+                    "idx_connections_password_credential",
+                ),
+                (
+                    "SELECT username FROM url_credentials
+                     WHERE connection_id = 'connection'
+                     ORDER BY updated_at DESC LIMIT 1",
+                    "idx_url_credentials_connection",
+                ),
+                (
+                    "SELECT id FROM dashboard_widget_instances
+                     WHERE source_id = 'widget' AND kind = 'script'",
+                    "idx_dashboard_widget_instances_source",
+                ),
+                (
+                    "SELECT id FROM itops_run_history
+                     ORDER BY started_at DESC, id DESC LIMIT 50",
+                    "idx_itops_run_history_started",
+                ),
+            ] {
+                let mut statement = connection
+                    .prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
+                    .map_err(to_storage_error)?;
+                let plan = statement
+                    .query_map([], |row| row.get::<_, String>(3))
+                    .map_err(to_storage_error)?
+                    .collect::<rusqlite::Result<Vec<_>>>()
+                    .map_err(to_storage_error)?
+                    .join("\n");
+                assert!(plan.contains(index), "query should use {index}: {plan}");
+            }
+            let version: i32 = connection
+                .pragma_query_value(None, "user_version", |row| row.get(0))
+                .map_err(to_storage_error)?;
+            assert_eq!(version, SCHEMA_USER_VERSION);
+            connection
+                .pragma_query_value(None, "schema_version", |row| row.get(0))
+                .map_err(to_storage_error)
+        })
+        .expect("v61 indexes are present");
+    drop(upgraded);
+
+    let reopened = Storage::open(db_path.clone()).expect("current v61 storage reopens");
+    reopened
+        .with_connection(|connection| {
+            let reopened_schema_version: i64 = connection
+                .pragma_query_value(None, "schema_version", |row| row.get(0))
+                .map_err(to_storage_error)?;
+            assert_eq!(reopened_schema_version, schema_version);
+            Ok(())
+        })
+        .expect("current-version reopen leaves the schema unchanged");
+    drop(reopened);
+    let _ = fs::remove_file(db_path);
+}
+
+#[test]
 fn v60_custom_module_document_metadata_upgrade_and_current_reopen_preserve_data() {
     let db_path = temp_db_path("custom-module-documents-v60");
     {
@@ -5383,6 +5512,35 @@ fn default_workspace_is_seeded_and_scopes_the_connection_tree() {
         .list_connection_tree_for_workspace(other.id.clone())
         .expect("other tree loads");
     assert!(other_tree.connections.is_empty());
+}
+
+#[test]
+fn workspace_connection_tree_loads_batched_tags_in_sort_order() {
+    let storage = Storage::open(temp_db_path("workspace-batched-tags")).expect("storage opens");
+    let saved = create_test_ssh_connection_in_workspace(
+        &storage,
+        "Tagged",
+        "tagged.internal",
+        DEFAULT_WORKSPACE_ID.to_string(),
+    );
+    storage
+        .with_connection(|connection| {
+            connection
+                .execute(
+                    "INSERT INTO connection_tags (connection_id, tag, sort_order)
+                     VALUES (?1, 'later', 2), (?1, 'first', 0), (?1, 'middle', 1)",
+                    params![saved.id],
+                )
+                .map_err(to_storage_error)?;
+            Ok(())
+        })
+        .expect("tags are inserted");
+
+    let tree = storage
+        .list_connection_tree_for_workspace(DEFAULT_WORKSPACE_ID.to_string())
+        .expect("workspace tree loads");
+    assert_eq!(tree.connections.len(), 1);
+    assert_eq!(tree.connections[0].tags, ["first", "middle", "later"]);
 }
 
 #[test]

--- a/tests/itops-ipam-device-identity.test.mjs
+++ b/tests/itops-ipam-device-identity.test.mjs
@@ -38,7 +38,7 @@ test("IPAM Address Records persist and import discovered device identity", async
   assert.match(panel, /deviceType: entry\.deviceType/);
   assert.match(panel, /deviceModel: entry\.deviceModel/);
 
-  assert.match(storage, /const SCHEMA_USER_VERSION: i32 = 60;/);
+  assert.match(storage, /const SCHEMA_USER_VERSION: i32 = 61;/);
   assert.match(storage, /device_type\s+TEXT NOT NULL DEFAULT ''/);
   assert.match(storage, /device_model\s+TEXT NOT NULL DEFAULT ''/);
   assert.match(storage, /if stored_version < 53/);

--- a/tests/itops-ipam-site-binding.test.mjs
+++ b/tests/itops-ipam-site-binding.test.mjs
@@ -33,7 +33,7 @@ test("IP Address editor supports direct, Host-implied, and segment-inherited Sit
 
   // The v52 repair stays in place under later bumps; only the current version
   // moves, so this guard tracks the constant rather than pinning it to 52.
-  assert.match(storage, /const SCHEMA_USER_VERSION: i32 = 60;/);
+  assert.match(storage, /const SCHEMA_USER_VERSION: i32 = 61;/);
   assert.match(storage, /if stored_version < 52/);
   assert.match(storage, /"itops_ip_address_records",\s*"site_id"/s);
   assert.match(ipamStorage, /fn apply_prefix_site_bindings/);

--- a/tests/native-performance-command-boundary.test.mjs
+++ b/tests/native-performance-command-boundary.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 
 const [
   source,
+  dashboardCommandsSource,
   itOpsCommandsSource,
   selectiveExportSource,
   xServerSource,
@@ -11,6 +12,7 @@ const [
   remoteFullscreenSource,
 ] = await Promise.all([
   readFile(new URL("../src-tauri/src/lib.rs", import.meta.url), "utf8"),
+  readFile(new URL("../src-tauri/src/dashboard_commands.rs", import.meta.url), "utf8"),
   readFile(new URL("../src-tauri/src/itops/commands.rs", import.meta.url), "utf8"),
   readFile(new URL("../src-tauri/src/selective_export.rs", import.meta.url), "utf8"),
   readFile(new URL("../src-tauri/src/x_server.rs", import.meta.url), "utf8"),
@@ -50,6 +52,14 @@ test("system counter collection runs outside Tauri's native main thread", () => 
   const command = commandSource("get_system_performance_counters", "pc_info_get");
   assert.match(command, /tauri::async_runtime::spawn_blocking/);
   assert.match(command, /system_performance_counters_snapshot\(\)/);
+});
+
+test("unbounded SQLite UI reads run from async commands outside Tokio workers", () => {
+  assert.match(asyncCommandSource(source, "list_connection_tree"), /run_blocking_db\(/);
+  assert.match(
+    asyncCommandSource(dashboardCommandsSource, "dashboard_load_state"),
+    /run_blocking_db\(/,
+  );
 });
 
 test("detached remote full-screen creation leaves the WebView2 IPC callback", () => {


### PR DESCRIPTION
## Summary

- batch Connection Tree tag loading and folder metadata reads to remove N+1 SQLite queries
- add schema-v61 indexes for workspace trees, credential usage, URL credential recency, Dashboard widgets, and IT Ops history
- make bulk reorder/layout writes atomic and reuse prepared statements across Workspace, Dashboard, and IT Ops paths
- cache encrypted SQLite store unlock verification, explicitly refresh it after database replacement, and add a busy timeout
- move large Connection Tree and Dashboard reads through the blocking-aware async command boundary
- add migration, query-plan, batching, secret refresh, and command-boundary regressions

## Root cause

Several hot paths repeatedly prepared and executed small SQLite statements while holding the app's shared connection mutex. Connection Tree loading also issued one tag query per Connection, and bulk layout/reorder operations could commit once per row. The encrypted SQLite secret backend re-decrypted its Argon2 sentinel before each secret operation, adding a second password KDF to normal reads and writes.

## Impact

The changes reduce query count, SQL preparation, transaction overhead, mutex hold time, and password KDF work without introducing a higher-risk connection pool or changing durable behavior. Schema migration remains compatible with legacy databases and preserves the write-free current-version startup fast path.

## Validation

- `npm run check` — lint, TypeScript, and 1,413 frontend tests passed
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml` — 1,207 library tests and 10 CLI tests passed; 2 intentionally ignored
- `git diff --check`
