### PR TITLE
feat: export a Connection Note to Markdown

### DIFF
--- a/docs/localization_todo/notes.export.dialogTitle.md
+++ b/docs/localization_todo/notes.export.dialogTitle.md
@@ -1,0 +1,16 @@
+# notes.export.dialogTitle
+
+- **English value**: `Export note to Markdown`
+- **Namespace**: `notes`
+- **File/component**: `src/modules/notes/NoteEditorSheet.tsx`
+- **UI role**: `heading`
+- **User flow**: The title of the operating system's save-file dialog opened by the note editor's `notes.toolbar.exportMarkdown` control.
+- **Tone**: concise/neutral; it names the action the dialog completes.
+- **Placeholders**: none
+- **Context/meaning**: Title of a native save dialog, so it is a full action phrase ("Export note to Markdown"), not a bare noun. Same sense of "export" as `notes.toolbar.exportMarkdown`.
+- **Domain notes**: "note" is the Connection Note; keep the same word the locale uses in `notes.editor.delete`. Markdown stays English. zh-TW must use 匯出 and 筆記, never 导出 / 笔记.
+
+<!--
+Filename: notes.export.dialogTitle.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/notes.export.filterName.md
+++ b/docs/localization_todo/notes.export.filterName.md
@@ -1,0 +1,16 @@
+# notes.export.filterName
+
+- **English value**: `Markdown file`
+- **Namespace**: `notes`
+- **File/component**: `src/modules/notes/NoteEditorSheet.tsx`
+- **UI role**: `label`
+- **User flow**: The file-type filter label shown in the operating system's save dialog when exporting a Connection Note, alongside the `.md` extension.
+- **Tone**: short noun phrase, matching how the locale names other file-type filters (see `terminal.logFiles`, `terminal.textFiles`).
+- **Placeholders**: none
+- **Context/meaning**: Names a file type in a file picker filter, not an action. Singular "file" is intentional; follow the locale convention for filter labels even if that is plural.
+- **Domain notes**: Markdown stays English as a format name. zh-TW must use 檔案 for "file", never 文件.
+
+<!--
+Filename: notes.export.filterName.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/notes.notice.exportFailed.md
+++ b/docs/localization_todo/notes.notice.exportFailed.md
@@ -1,0 +1,16 @@
+# notes.notice.exportFailed
+
+- **English value**: `The note could not be exported. {{error}}`
+- **Namespace**: `notes`
+- **File/component**: `src/modules/notes/NoteEditorSheet.tsx`
+- **UI role**: `error`
+- **User flow**: An error notice in the bottom Status Bar popup when writing the exported Markdown file fails, for example on a read-only destination. `{{error}}` carries the underlying message.
+- **Tone**: factual failure report, matching `notes.notice.saveFailed` and `notes.notice.deleteFailed` in the same locale.
+- **Placeholders**: `{{error}}` — the raw underlying error text, appended after the sentence. Exactly one occurrence; it must survive verbatim.
+- **Context/meaning**: Failure of the file-export action, not of saving the note into the database (`notes.notice.saveFailed`). The two must read differently.
+- **Domain notes**: "Note" is the Connection Note. Reuse the locale's phrasing pattern from `notes.notice.saveFailed` so the two errors stay consistent. zh-TW must use 匯出 and 筆記.
+
+<!--
+Filename: notes.notice.exportFailed.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/notes.notice.exported.md
+++ b/docs/localization_todo/notes.notice.exported.md
@@ -1,0 +1,16 @@
+# notes.notice.exported
+
+- **English value**: `Note exported to {{path}}.`
+- **Namespace**: `notes`
+- **File/component**: `src/modules/notes/NoteEditorSheet.tsx`
+- **UI role**: `status`
+- **User flow**: A success notice in the bottom Status Bar popup right after the user picks a destination and the note is written to disk. `{{path}}` is the full file path the user chose.
+- **Tone**: short confirmation, matching the sibling `notes.notice.saved` and `notes.notice.deleted`.
+- **Placeholders**: `{{path}}` — the absolute file path the note was written to. Exactly one occurrence; it must survive verbatim.
+- **Context/meaning**: Reports a completed write to a file the user chose. Not the settings backup/export, and not an in-app save (that is `notes.notice.saved`).
+- **Domain notes**: "Note" is the Connection Note. Keep one full sentence around the placeholder rather than concatenating fragments. zh-TW must use 匯出 and 筆記.
+
+<!--
+Filename: notes.notice.exported.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/localization_todo/notes.toolbar.exportMarkdown.md
+++ b/docs/localization_todo/notes.toolbar.exportMarkdown.md
@@ -1,0 +1,16 @@
+# notes.toolbar.exportMarkdown
+
+- **English value**: `Export to Markdown`
+- **Namespace**: `notes`
+- **File/component**: `src/modules/notes/NoteToolbar.tsx`
+- **UI role**: `tooltip`
+- **User flow**: The tooltip and accessible label of the download control at the right end of the Connection Note editor's formatting toolbar, next to find/replace. Pressing it opens a native save dialog and writes the note to a .md file.
+- **Tone**: concise/neutral, matching the sibling toolbar control labels such as `notes.toolbar.insertImage` and `notes.toolbar.search`.
+- **Placeholders**: none
+- **Context/meaning**: "Export" here means writing the note out to a file on disk that the user chooses — not copying to the clipboard, not sharing, and not the settings backup/export flow. "Markdown" is the file format and stays English in every locale.
+- **Domain notes**: A Connection Note is one rich-text note bound to a Connection; use the locale's existing word for a note (the same one used in `notes.editor.delete`). Markdown stays English. Match the locale's established word for export, e.g. the one used in `dashboard.exportWidget` / `itops.actions.export`; zh-TW must use 匯出, never 导出/導出.
+
+<!--
+Filename: notes.toolbar.exportMarkdown.md
+Delete this file once every non-English locale under src/i18n/locales/ has the key translated.
+-->

--- a/docs/manual/21-connection-notes.md
+++ b/docs/manual/21-connection-notes.md
@@ -2,10 +2,10 @@
 
 ## AI grep hints
 
-- Keys: `notes.*` (full namespace), `notes.deepLink.menuLabel`, `notes.deepLink.triggerHint`, `notes.toolbarButton.open`, `notes.toolbarButton.create`, `notes.toolbar.label`, `notes.toolbar.insertImage`, `notes.toolbar.insertLink`, `notes.toolbar.insertDeepLink`, `notes.toolbar.search`, `notes.search.placeholder`, `notes.search.replace`, `notes.search.replaceAll`, `notes.editor.title`, `notes.editor.eyebrow`, `notes.editor.delete`, `notes.editor.resizeDialog`, `notes.editor.sendCodeToTerminal`, `notes.deepLink.title`, `notes.deepLink.searchPlaceholder`, `notes.confirmDelete.title`, `notes.confirmDiscard.title`, `notes.notice.saved`, `notes.notice.deleted`, `notes.notice.deepLinkUnavailable`, `notes.notice.sendToTerminalUnavailable`, `dashboard.notesAddTableRow`, `dashboard.notesDeleteTableRow`, `dashboard.notesAddTableColumn`, `dashboard.notesDeleteTableColumn`, `dashboard.notesDeleteTable`
+- Keys: `notes.*` (full namespace), `notes.deepLink.menuLabel`, `notes.deepLink.triggerHint`, `notes.toolbarButton.open`, `notes.toolbarButton.create`, `notes.toolbar.label`, `notes.toolbar.insertImage`, `notes.toolbar.insertLink`, `notes.toolbar.insertDeepLink`, `notes.toolbar.exportMarkdown`, `notes.toolbar.search`, `notes.search.placeholder`, `notes.search.replace`, `notes.search.replaceAll`, `notes.editor.title`, `notes.editor.eyebrow`, `notes.editor.delete`, `notes.editor.resizeDialog`, `notes.editor.sendCodeToTerminal`, `notes.deepLink.title`, `notes.deepLink.searchPlaceholder`, `notes.confirmDelete.title`, `notes.confirmDiscard.title`, `notes.export.dialogTitle`, `notes.export.filterName`, `notes.notice.saved`, `notes.notice.deleted`, `notes.notice.exported`, `notes.notice.deepLinkUnavailable`, `notes.notice.sendToTerminalUnavailable`, `dashboard.notesAddTableRow`, `dashboard.notesDeleteTableRow`, `dashboard.notesAddTableColumn`, `dashboard.notesDeleteTableColumn`, `dashboard.notesDeleteTable`
 - Files: `src/modules/notes/` (editor, toolbar, search, Deep Link picker, asset handling), `src-tauri/src/storage/notes.rs` (backend), entry points in `src/modules/workspace/connections/terminal/TerminalWorkspace.tsx`, `src/modules/workspace/connections/sftp/SftpWorkspace.tsx`, `src/modules/workspace/connections/webview/WebViewWorkspace.tsx`, and `src/modules/workspace/connections/remote-desktop/RemoteDesktopWorkspace.tsx`
-- Topics: per-Connection notes, rich text, WYSIWYG, HTML notes, note images, note search, find and replace in a note, Deep Links from a note, @ mention trigger, note deletion
-- Synonyms: "sticky note on a connection", "server notes", "document a host", "remember the restart command", "where is the VM directory", "annotate a connection", "at mention", "link to another connection from a note"
+- Topics: per-Connection notes, rich text, WYSIWYG, HTML notes, note images, note search, find and replace in a note, Deep Links from a note, @ mention trigger, note deletion, exporting a note to Markdown
+- Synonyms: "sticky note on a connection", "server notes", "document a host", "remember the restart command", "where is the VM directory", "annotate a connection", "at mention", "link to another connection from a note", "save a note as a .md file", "share a note with someone outside KKTerm"
 - Tutorial targets: `notes.openNote`
 
 ## What a Connection Note is
@@ -75,6 +75,14 @@ Hovering an image reveals a drag handle at its bottom-right corner; dragging it 
 Because they are ordinary files in the app data directory, note images are included in the settings export (`.kkbackup`) and in the startup backup ZIP snapshots, and they are restored with them — see [17-data-backup-secrets.md](17-data-backup-secrets.md). Deleting a note or its Connection deletes that Connection's image directory.
 
 > Selective export bundles carry the note **text** with the Connection, but not its images: the selective bundle format is a database extract and does not include app-data files. Use the full settings export to move notes with their images.
+
+## Exporting a note to Markdown
+
+`notes.toolbar.exportMarkdown`, at the right end of the toolbar next to the search control, writes the note to a `.md` file of your choosing (`notes.export.dialogTitle`, `notes.export.filterName`). It exports **what is currently in the editor**, saved or not, so a note you are still drafting can be handed off; the export changes nothing about the note itself and never binds an unsaved note to its Connection. The default file name is the Connection's name. On success `notes.notice.exported` reports the path in the Status Bar; a failed write reports `notes.notice.exportFailed`. The control is unavailable while the note is loading and on an empty note.
+
+Headings, bold/italic, inline code, code blocks, quotes, dividers, bulleted and numbered lists, checklists (as `- [x]` / `- [ ]`), strikethrough, web links, and tables (as GitHub-flavored Markdown tables) all carry over. Underline and `notes.toolbar.highlight` have no Markdown equivalent and export as plain text. A Deep Link chip exports as the label it displays, because the link only resolves inside KKTerm.
+
+**Images are not exported.** They stay where they live — files under `note-images/` in the app data directory — and the Markdown keeps a reference to each one in that directory instead, in the form `![alt](note-images/<connection id>/<file>.png)`. The exported file therefore records which image was where without copying the bytes; to move notes together with their images, use the full settings export described in [17-data-backup-secrets.md](17-data-backup-secrets.md).
 
 ## Links
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -5788,7 +5788,12 @@
       "insertImage": "Bild einfügen",
       "insertLink": "Weblink einfügen",
       "insertDeepLink": "Mit einem KKTerm-Element verknüpfen",
+      "exportMarkdown": "Als Markdown exportieren",
       "search": "Suchen und ersetzen"
+    },
+    "export": {
+      "dialogTitle": "Notiz als Markdown exportieren",
+      "filterName": "Markdown-Datei"
     },
     "search": {
       "placeholder": "In Notiz suchen",
@@ -5839,7 +5844,9 @@
       "deepLinkUnavailable": "Das verknüpfte Element existiert nicht mehr.",
       "selectTextForLink": "Markieren Sie den Text, der zu einem Link werden soll.",
       "selectUrlForLink": "Markieren Sie eine Webadresse, die mit http:// oder https:// beginnt, um sie zu verlinken.",
-      "sendToTerminalUnavailable": "Kein aktiver Terminal-Bereich für diese Verbindung."
+      "sendToTerminalUnavailable": "Kein aktiver Terminal-Bereich für diese Verbindung.",
+      "exported": "Notiz nach {{path}} exportiert.",
+      "exportFailed": "Die Notiz konnte nicht exportiert werden. {{error}}"
     }
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -5788,7 +5788,12 @@
       "insertImage": "Insert image",
       "insertLink": "Insert web link",
       "insertDeepLink": "Link to a KKTerm item",
+      "exportMarkdown": "Export to Markdown",
       "search": "Find and replace"
+    },
+    "export": {
+      "dialogTitle": "Export note to Markdown",
+      "filterName": "Markdown file"
     },
     "search": {
       "placeholder": "Find in note",
@@ -5839,7 +5844,9 @@
       "deepLinkUnavailable": "That linked item no longer exists.",
       "selectTextForLink": "Select the text you want to turn into a link.",
       "selectUrlForLink": "Select a web address starting with http:// or https:// to link it.",
-      "sendToTerminalUnavailable": "No active terminal Pane for this Connection."
+      "sendToTerminalUnavailable": "No active terminal Pane for this Connection.",
+      "exported": "Note exported to {{path}}.",
+      "exportFailed": "The note could not be exported. {{error}}"
     }
   }
 }

--- a/src/i18n/locales/es-MX.json
+++ b/src/i18n/locales/es-MX.json
@@ -5788,7 +5788,12 @@
       "insertImage": "Insertar imagen",
       "insertLink": "Insertar enlace web",
       "insertDeepLink": "Vincular a un elemento de KKTerm",
+      "exportMarkdown": "Exportar a Markdown",
       "search": "Buscar y reemplazar"
+    },
+    "export": {
+      "dialogTitle": "Exportar la nota a Markdown",
+      "filterName": "Archivo de Markdown"
     },
     "search": {
       "placeholder": "Buscar en la nota",
@@ -5839,7 +5844,9 @@
       "deepLinkUnavailable": "El elemento vinculado ya no existe.",
       "selectTextForLink": "Seleccione el texto que quiere convertir en enlace.",
       "selectUrlForLink": "Seleccione una dirección web que empiece por http:// o https:// para vincularla.",
-      "sendToTerminalUnavailable": "No hay panel de terminal activo para esta conexión."
+      "sendToTerminalUnavailable": "No hay panel de terminal activo para esta conexión.",
+      "exported": "Se exportó la nota a {{path}}.",
+      "exportFailed": "No se pudo exportar la nota. {{error}}"
     }
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -5788,7 +5788,12 @@
       "insertImage": "Insertar imagen",
       "insertLink": "Insertar enlace web",
       "insertDeepLink": "Enlazar a un elemento de KKTerm",
+      "exportMarkdown": "Exportar a Markdown",
       "search": "Buscar y reemplazar"
+    },
+    "export": {
+      "dialogTitle": "Exportar nota a Markdown",
+      "filterName": "Archivo Markdown"
     },
     "search": {
       "placeholder": "Buscar en la nota",
@@ -5839,7 +5844,9 @@
       "deepLinkUnavailable": "El elemento enlazado ya no existe.",
       "selectTextForLink": "Seleccione el texto que quiere convertir en enlace.",
       "selectUrlForLink": "Seleccione una dirección web que empiece por http:// o https:// para enlazarla.",
-      "sendToTerminalUnavailable": "No hay panel de terminal activo para esta conexión."
+      "sendToTerminalUnavailable": "No hay panel de terminal activo para esta conexión.",
+      "exported": "Nota exportada a {{path}}.",
+      "exportFailed": "No se pudo exportar la nota. {{error}}"
     }
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -5788,7 +5788,12 @@
       "insertImage": "Insérer une image",
       "insertLink": "Insérer un lien web",
       "insertDeepLink": "Lier à un élément KKTerm",
+      "exportMarkdown": "Exporter en Markdown",
       "search": "Rechercher et remplacer"
+    },
+    "export": {
+      "dialogTitle": "Exporter la note en Markdown",
+      "filterName": "Fichier Markdown"
     },
     "search": {
       "placeholder": "Rechercher dans la note",
@@ -5839,7 +5844,9 @@
       "deepLinkUnavailable": "L'élément lié n'existe plus.",
       "selectTextForLink": "Sélectionnez le texte à transformer en lien.",
       "selectUrlForLink": "Sélectionnez une adresse web commençant par http:// ou https:// pour la lier.",
-      "sendToTerminalUnavailable": "Aucun volet terminal actif pour cette connexion."
+      "sendToTerminalUnavailable": "Aucun volet terminal actif pour cette connexion.",
+      "exported": "Note exportée vers {{path}}.",
+      "exportFailed": "La note n'a pas pu être exportée. {{error}}"
     }
   }
 }

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -5788,7 +5788,12 @@
       "insertImage": "Sisipkan gambar",
       "insertLink": "Sisipkan tautan web",
       "insertDeepLink": "Tautkan ke item KKTerm",
+      "exportMarkdown": "Ekspor ke Markdown",
       "search": "Cari dan ganti"
+    },
+    "export": {
+      "dialogTitle": "Ekspor catatan ke Markdown",
+      "filterName": "Berkas Markdown"
     },
     "search": {
       "placeholder": "Cari dalam catatan",
@@ -5839,7 +5844,9 @@
       "deepLinkUnavailable": "Item yang ditautkan sudah tidak ada.",
       "selectTextForLink": "Pilih teks yang ingin dijadikan tautan.",
       "selectUrlForLink": "Pilih alamat web yang diawali http:// atau https:// untuk menautkannya.",
-      "sendToTerminalUnavailable": "Tidak ada panel terminal aktif untuk koneksi ini."
+      "sendToTerminalUnavailable": "Tidak ada panel terminal aktif untuk koneksi ini.",
+      "exported": "Catatan diekspor ke {{path}}.",
+      "exportFailed": "Catatan tidak dapat diekspor. {{error}}"
     }
   }
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -5788,7 +5788,12 @@
       "insertImage": "Inserisci immagine",
       "insertLink": "Inserisci link web",
       "insertDeepLink": "Collega a un elemento KKTerm",
+      "exportMarkdown": "Esporta in Markdown",
       "search": "Trova e sostituisci"
+    },
+    "export": {
+      "dialogTitle": "Esporta la nota in Markdown",
+      "filterName": "File Markdown"
     },
     "search": {
       "placeholder": "Cerca nella nota",
@@ -5839,7 +5844,9 @@
       "deepLinkUnavailable": "L'elemento collegato non esiste più.",
       "selectTextForLink": "Seleziona il testo da trasformare in link.",
       "selectUrlForLink": "Seleziona un indirizzo web che inizia con http:// o https:// per collegarlo.",
-      "sendToTerminalUnavailable": "Nessun riquadro terminale attivo per questa connessione."
+      "sendToTerminalUnavailable": "Nessun riquadro terminale attivo per questa connessione.",
+      "exported": "Nota esportata in {{path}}.",
+      "exportFailed": "Impossibile esportare la nota. {{error}}"
     }
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -5788,7 +5788,12 @@
       "insertImage": "画像を挿入",
       "insertLink": "Web リンクを挿入",
       "insertDeepLink": "KKTerm の項目にリンク",
+      "exportMarkdown": "Markdown にエクスポート",
       "search": "検索と置換"
+    },
+    "export": {
+      "dialogTitle": "メモを Markdown にエクスポート",
+      "filterName": "Markdown ファイル"
     },
     "search": {
       "placeholder": "メモ内を検索",
@@ -5839,7 +5844,9 @@
       "deepLinkUnavailable": "リンク先の項目は存在しません。",
       "selectTextForLink": "リンクにするテキストを選択してください。",
       "selectUrlForLink": "http:// または https:// で始まる Web アドレスを選択するとリンクにできます。",
-      "sendToTerminalUnavailable": "この接続に対するアクティブなターミナルペインがありません。"
+      "sendToTerminalUnavailable": "この接続に対するアクティブなターミナルペインがありません。",
+      "exported": "メモを {{path}} にエクスポートしました。",
+      "exportFailed": "メモをエクスポートできませんでした。{{error}}"
     }
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -5788,7 +5788,12 @@
       "insertImage": "이미지 삽입",
       "insertLink": "웹 링크 삽입",
       "insertDeepLink": "KKTerm 항목에 연결",
+      "exportMarkdown": "Markdown으로 내보내기",
       "search": "찾기 및 바꾸기"
+    },
+    "export": {
+      "dialogTitle": "메모를 Markdown으로 내보내기",
+      "filterName": "Markdown 파일"
     },
     "search": {
       "placeholder": "메모에서 찾기",
@@ -5839,7 +5844,9 @@
       "deepLinkUnavailable": "연결된 항목이 더 이상 존재하지 않습니다.",
       "selectTextForLink": "링크로 만들 텍스트를 선택하세요.",
       "selectUrlForLink": "http:// 또는 https://로 시작하는 웹 주소를 선택하면 링크로 만들 수 있습니다.",
-      "sendToTerminalUnavailable": "이 연결에 대한 활성 터미널 창이 없습니다."
+      "sendToTerminalUnavailable": "이 연결에 대한 활성 터미널 창이 없습니다.",
+      "exported": "{{path}}에 메모를 내보냈습니다.",
+      "exportFailed": "메모를 내보내지 못했습니다. {{error}}"
     }
   }
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -5788,7 +5788,12 @@
       "insertImage": "Inserir imagem",
       "insertLink": "Inserir link da web",
       "insertDeepLink": "Vincular a um item do KKTerm",
+      "exportMarkdown": "Exportar para Markdown",
       "search": "Localizar e substituir"
+    },
+    "export": {
+      "dialogTitle": "Exportar nota para Markdown",
+      "filterName": "Arquivo Markdown"
     },
     "search": {
       "placeholder": "Localizar na nota",
@@ -5839,7 +5844,9 @@
       "deepLinkUnavailable": "O item vinculado não existe mais.",
       "selectTextForLink": "Selecione o texto que deseja transformar em link.",
       "selectUrlForLink": "Selecione um endereço da web começando com http:// ou https:// para vinculá-lo.",
-      "sendToTerminalUnavailable": "Nenhum painel de terminal ativo para esta conexão."
+      "sendToTerminalUnavailable": "Nenhum painel de terminal ativo para esta conexão.",
+      "exported": "Nota exportada para {{path}}.",
+      "exportFailed": "Não foi possível exportar a nota. {{error}}"
     }
   }
 }

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -5788,7 +5788,12 @@
       "insertImage": "แทรกรูปภาพ",
       "insertLink": "แทรกลิงก์เว็บ",
       "insertDeepLink": "ลิงก์ไปยังรายการใน KKTerm",
+      "exportMarkdown": "ส่งออกเป็น Markdown",
       "search": "ค้นหาและแทนที่"
+    },
+    "export": {
+      "dialogTitle": "ส่งออกบันทึกเป็น Markdown",
+      "filterName": "ไฟล์ Markdown"
     },
     "search": {
       "placeholder": "ค้นหาในบันทึก",
@@ -5839,7 +5844,9 @@
       "deepLinkUnavailable": "รายการที่ลิงก์ไว้ไม่มีอยู่แล้ว",
       "selectTextForLink": "เลือกข้อความที่ต้องการทำเป็นลิงก์",
       "selectUrlForLink": "เลือกที่อยู่เว็บที่ขึ้นต้นด้วย http:// หรือ https:// เพื่อทำเป็นลิงก์",
-      "sendToTerminalUnavailable": "ไม่มีแผงเทอร์มินัลที่ใช้งานอยู่สำหรับการเชื่อมต่อนี้"
+      "sendToTerminalUnavailable": "ไม่มีแผงเทอร์มินัลที่ใช้งานอยู่สำหรับการเชื่อมต่อนี้",
+      "exported": "ส่งออกบันทึกไปที่ {{path}} แล้ว",
+      "exportFailed": "ไม่สามารถส่งออกบันทึกได้ {{error}}"
     }
   }
 }

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -5788,7 +5788,12 @@
       "insertImage": "Chèn hình ảnh",
       "insertLink": "Chèn liên kết web",
       "insertDeepLink": "Liên kết tới một mục KKTerm",
+      "exportMarkdown": "Xuất sang Markdown",
       "search": "Tìm và thay thế"
+    },
+    "export": {
+      "dialogTitle": "Xuất ghi chú sang Markdown",
+      "filterName": "Tệp Markdown"
     },
     "search": {
       "placeholder": "Tìm trong ghi chú",
@@ -5839,7 +5844,9 @@
       "deepLinkUnavailable": "Mục được liên kết không còn tồn tại.",
       "selectTextForLink": "Hãy chọn đoạn văn bản bạn muốn biến thành liên kết.",
       "selectUrlForLink": "Hãy chọn một địa chỉ web bắt đầu bằng http:// hoặc https:// để tạo liên kết.",
-      "sendToTerminalUnavailable": "Không có bảng terminal đang hoạt động cho kết nối này."
+      "sendToTerminalUnavailable": "Không có bảng terminal đang hoạt động cho kết nối này.",
+      "exported": "Đã xuất ghi chú sang {{path}}.",
+      "exportFailed": "Không thể xuất ghi chú. {{error}}"
     }
   }
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -5788,7 +5788,12 @@
       "insertImage": "插入图片",
       "insertLink": "插入网页链接",
       "insertDeepLink": "链接到 KKTerm 项目",
+      "exportMarkdown": "导出为 Markdown",
       "search": "查找和替换"
+    },
+    "export": {
+      "dialogTitle": "将笔记导出为 Markdown",
+      "filterName": "Markdown 文件"
     },
     "search": {
       "placeholder": "在笔记中查找",
@@ -5839,7 +5844,9 @@
       "deepLinkUnavailable": "链接的项目已不存在。",
       "selectTextForLink": "请选择要转换为链接的文字。",
       "selectUrlForLink": "请选择以 http:// 或 https:// 开头的网址以创建链接。",
-      "sendToTerminalUnavailable": "没有此连接的活动终端窗格。"
+      "sendToTerminalUnavailable": "没有此连接的活动终端窗格。",
+      "exported": "笔记已导出到 {{path}}。",
+      "exportFailed": "无法导出笔记。{{error}}"
     }
   }
 }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -5788,7 +5788,12 @@
       "insertImage": "插入影像",
       "insertLink": "插入網頁連結",
       "insertDeepLink": "連結至 KKTerm 項目",
+      "exportMarkdown": "匯出為 Markdown",
       "search": "尋找與取代"
+    },
+    "export": {
+      "dialogTitle": "將筆記匯出為 Markdown",
+      "filterName": "Markdown 檔案"
     },
     "search": {
       "placeholder": "在筆記中尋找",
@@ -5839,7 +5844,9 @@
       "deepLinkUnavailable": "連結的項目已不存在。",
       "selectTextForLink": "請選取要轉換為連結的文字。",
       "selectUrlForLink": "請選取以 http:// 或 https:// 開頭的網址以建立連結。",
-      "sendToTerminalUnavailable": "此連線沒有作用中的終端機窗格。"
+      "sendToTerminalUnavailable": "此連線沒有作用中的終端機窗格。",
+      "exported": "筆記已匯出至 {{path}}。",
+      "exportFailed": "無法匯出筆記。{{error}}"
     }
   }
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -4948,6 +4948,28 @@ export async function pickAndSaveFile(
   return path;
 }
 
+/**
+ * Show a native save dialog for a Markdown file and write the text to the
+ * chosen path. Returns the chosen path, or null when the user cancels.
+ */
+export async function saveMarkdownFile(
+  defaultFilename: string,
+  contents: string,
+  options: { title: string; filterName: string },
+): Promise<string | null> {
+  if (!isTauriRuntime()) {
+    return null;
+  }
+  const path = await saveDialog({
+    defaultPath: defaultFilename,
+    filters: [{ name: options.filterName, extensions: ["md"] }],
+    title: options.title,
+  });
+  if (typeof path !== "string" || !path) return null;
+  await writeTextFile(path, contents);
+  return path;
+}
+
 export async function selectPngSavePath(defaultFilename: string, title: string) {
   if (!isTauriRuntime()) {
     return null;

--- a/src/modules/notes/NoteEditorSheet.tsx
+++ b/src/modules/notes/NoteEditorSheet.tsx
@@ -22,7 +22,7 @@ import { useWorkspaceStore } from "../../store";
 import { ConnectionGlyph } from "../workspace/connections/ConnectionGlyph";
 import { getPaneRenderer, writeInputToPane } from "../workspace/paneRegistry";
 import type { Connection, ConnectionType } from "../../types";
-import { invokeCommand } from "../../lib/tauri";
+import { invokeCommand, saveMarkdownFile } from "../../lib/tauri";
 import { NoteToolbar } from "./NoteToolbar";
 import { NoteSearchBar } from "./NoteSearchBar";
 import { NoteDeepLinkPicker } from "./NoteDeepLinkPicker";
@@ -38,6 +38,7 @@ import { deleteConnectionNote, getConnectionNote, pruneNoteAssets, putNoteAsset,
 import { navigateNoteDeepLink, parseNoteDeepLink } from "./noteDeepLink";
 import type { NoteDeepLink } from "./noteDeepLink";
 import { downscaleImageFile } from "./noteImages";
+import { noteHtmlToMarkdown, noteMarkdownFilename } from "./noteMarkdown";
 import { showNativeContextMenu } from "../../lib/nativeContextMenu";
 import type { NativeContextMenuItem } from "../../lib/nativeContextMenu";
 
@@ -483,6 +484,26 @@ export function NoteEditorSheet({
     }
   }
 
+  // Export writes what is currently in the editor, saved or not, so an
+  // operator can hand off a note they are still drafting. Images stay in the
+  // app data directory; the Markdown carries their path as a reference.
+  async function handleExportMarkdown() {
+    if (!editor) return;
+    try {
+      const markdown = noteHtmlToMarkdown(sanitizeNoteHtml(dehydrateNoteAssets(editor.getHTML())));
+      const path = await saveMarkdownFile(noteMarkdownFilename(connectionName), markdown, {
+        title: t("notes.export.dialogTitle"),
+        filterName: t("notes.export.filterName"),
+      });
+      if (!path) return;
+      showStatusBarNotice(t("notes.notice.exported", { path }), { tone: "success" });
+    } catch (error) {
+      showStatusBarNotice(t("notes.notice.exportFailed", { error: String(error) }), {
+        tone: "error",
+      });
+    }
+  }
+
   async function handleDelete() {
     setConfirmDelete(false);
     try {
@@ -694,6 +715,8 @@ export function NoteEditorSheet({
                 onInsertImage={() => fileInputRef.current?.click()}
                 onInsertLink={insertLink}
                 onInsertDeepLink={() => setPickerOpen(true)}
+                onExportMarkdown={() => void handleExportMarkdown()}
+                canExport={!loading && !empty}
               />
               {searchOpen ? (
                 <NoteSearchBar

--- a/src/modules/notes/NoteToolbar.tsx
+++ b/src/modules/notes/NoteToolbar.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from "react-i18next";
 import { useEditorState } from "@tiptap/react";
 import type { Editor } from "@tiptap/react";
 import {
-  Code, ImagePlus, Link, List, ListChecks, Minus, Palette, RotateCcw, RotateCw,
-  Search, TableProperties, Waypoints,
+  Code, Download, ImagePlus, Link, List, ListChecks, Minus, Palette, RotateCcw,
+  RotateCw, Search, TableProperties, Waypoints,
 } from "../../lib/reicon";
 
 interface NoteToolbarProps {
@@ -14,6 +14,9 @@ interface NoteToolbarProps {
   onInsertImage: () => void;
   onInsertLink: () => void;
   onInsertDeepLink: () => void;
+  onExportMarkdown: () => void;
+  /** False while the note is loading or has nothing worth writing to a file. */
+  canExport: boolean;
   readOnly: boolean;
 }
 
@@ -63,6 +66,8 @@ export function NoteToolbar({
   onInsertImage,
   onInsertLink,
   onInsertDeepLink,
+  onExportMarkdown,
+  canExport,
   readOnly,
 }: NoteToolbarProps) {
   const { t } = useTranslation();
@@ -259,6 +264,13 @@ export function NoteToolbar({
 
       <span className="note-tool-spacer" />
 
+      <ToolButton
+        disabled={!canExport}
+        label={t("notes.toolbar.exportMarkdown")}
+        onClick={onExportMarkdown}
+      >
+        <Download size={size} />
+      </ToolButton>
       <ToolButton
         active={searchOpen}
         label={t("notes.toolbar.search")}

--- a/src/modules/notes/noteMarkdown.ts
+++ b/src/modules/notes/noteMarkdown.ts
@@ -1,0 +1,114 @@
+import TurndownService from "turndown";
+import { NOTE_ASSET_ATTRIBUTE } from "./noteHtml";
+
+/** Directory, relative to the app data directory, that holds note images. An
+ *  exported note keeps this path as the image's reference instead of copying
+ *  or inlining the bytes, so a reader can still find the original file. */
+const NOTE_IMAGE_DIRECTORY = "note-images";
+
+/** Build the serializer used for note export. Notes carry a few structures
+ *  Turndown does not model on its own — GFM tables, Tiptap checklists, and
+ *  out-of-line images — so each gets an explicit rule. */
+function createNoteMarkdownSerializer() {
+  const serializer = new TurndownService({
+    bulletListMarker: "-",
+    codeBlockStyle: "fenced",
+    headingStyle: "atx",
+    hr: "---",
+  });
+
+  // Images are stored as files beside the database and are deliberately not
+  // exported. The Markdown keeps a reference to the asset's on-disk path so
+  // the image is still identifiable from the exported file alone.
+  serializer.addRule("noteImage", {
+    filter: "img",
+    replacement: (_content, node) => {
+      const assetId = (node as HTMLElement).getAttribute(NOTE_ASSET_ATTRIBUTE);
+      if (!assetId) return "";
+      const alt = (node as HTMLElement).getAttribute("alt")?.trim();
+      return `![${alt || assetId.split("/").pop()}](${NOTE_IMAGE_DIRECTORY}/${assetId})`;
+    },
+  });
+
+  // Tiptap checklist items keep their state in `data-checked`; the generic
+  // list-item rule would drop it and export every item as a plain bullet.
+  serializer.addRule("noteTaskItem", {
+    filter: (node) =>
+      node.nodeName === "LI" && (node as HTMLElement).getAttribute("data-type") === "taskItem",
+    replacement: (content, node) => {
+      const body = content
+        .replace(/^\n+/, "")
+        .replace(/\n+$/, "")
+        // Continuation lines align under the checkbox, so a multi-paragraph
+        // item stays part of that item rather than closing the list.
+        .replace(/\n/gm, "\n      ");
+      const checked = (node as HTMLElement).getAttribute("data-checked") === "true";
+      return `- [${checked ? "x" : " "}] ${body}${node.nextSibling ? "\n" : ""}`;
+    },
+  });
+
+  // GFM strikethrough. Turndown's core rules cover bold, italic, links, and
+  // code, but not the `s` element the note toolbar produces.
+  serializer.addRule("noteStrikethrough", {
+    filter: ["del", "s"],
+    replacement: (content) => (content.trim() ? `~~${content}~~` : content),
+  });
+
+  // Turndown has no table support, so a note's tables would otherwise collapse
+  // into one run-on line. Mirrors the Dashboard Notes widget's GFM output.
+  serializer.addRule("noteTable", {
+    filter: "table",
+    replacement: (_content, node) => {
+      const rows = Array.from((node as HTMLTableElement).rows);
+      if (rows.length === 0) return "";
+      const columnCount = Math.max(...rows.map((row) => row.cells.length), 1);
+      const serializeCell = (cell: HTMLTableCellElement | undefined) =>
+        (cell
+          ? serializer
+              .turndown(cell.innerHTML)
+              .replace(/\|/g, "\\|")
+              .replace(/\r?\n+/g, "<br>")
+              .trim()
+          : "") || " ";
+      const serializeRow = (row: HTMLTableRowElement | undefined) =>
+        `| ${Array.from({ length: columnCount }, (_, index) =>
+          serializeCell(row?.cells[index]),
+        ).join(" | ")} |`;
+      return [
+        "\n\n",
+        [
+          serializeRow(rows[0]),
+          `| ${Array.from({ length: columnCount }, () => "---").join(" | ")} |`,
+          ...rows.slice(1).map(serializeRow),
+        ].join("\n"),
+        "\n\n",
+      ].join("");
+    },
+  });
+
+  return serializer;
+}
+
+const noteMarkdownSerializer = createNoteMarkdownSerializer();
+
+/** Convert a saved note body to Markdown. The input is the same sanitized,
+ *  dehydrated HTML the note is stored as, so images arrive as asset ids and
+ *  Deep Link chips as their captured labels. */
+export function noteHtmlToMarkdown(html: string): string {
+  return `${noteMarkdownSerializer.turndown(html).trim()}\n`;
+}
+
+/** A Connection name is free text, so it cannot be handed to a file picker as
+ *  a default file name unchanged. Keeps the name recognizable while dropping
+ *  the characters Windows, macOS, and Linux reject in a path segment. */
+export function noteMarkdownFilename(connectionName: string): string {
+  const base = connectionName
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f<>:"/\\|?*]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\.+$/, "")
+    .slice(0, 80)
+    .trim();
+  return `${base || "note"}.md`;
+}

--- a/tests/connection-note-markdown-export.test.ts
+++ b/tests/connection-note-markdown-export.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { noteHtmlToMarkdown, noteMarkdownFilename } from "../src/modules/notes/noteMarkdown.ts";
+
+test("note export keeps an image reference instead of the image", () => {
+  // Note images are files in the app data directory, not part of the exported
+  // document. The reference is the asset's path under that directory, so the
+  // original file is still identifiable from the exported Markdown alone.
+  const markdown = noteHtmlToMarkdown(
+    '<p><img data-note-asset="conn-1/abc.png" alt="rack label" width="320"></p>',
+  );
+  assert.equal(markdown.trim(), "![rack label](note-images/conn-1/abc.png)");
+
+  // An image inserted without alt text still names the file it refers to.
+  assert.equal(
+    noteHtmlToMarkdown('<p><img data-note-asset="conn-1/abc.png"></p>').trim(),
+    "![abc.png](note-images/conn-1/abc.png)",
+  );
+
+  // Sanitization strips images that carry no asset id; an exported note must
+  // not smuggle a stray remote source back in either.
+  assert.equal(noteHtmlToMarkdown('<p><img src="https://example.com/x.png"></p>').trim(), "");
+});
+
+test("note export preserves the structures the note toolbar can produce", () => {
+  const markdown = noteHtmlToMarkdown(
+    "<h2>Restart</h2>" +
+      "<ul data-type=\"taskList\">" +
+      '<li data-type="taskItem" data-checked="true"><div><p>backup verified</p></div></li>' +
+      '<li data-type="taskItem" data-checked="false"><div><p>rotate keys</p></div></li>' +
+      "</ul>" +
+      "<pre><code>uptime</code></pre>" +
+      "<p><s>retired</s></p>" +
+      "<table><tbody><tr><th><p>Host</p></th><th><p>Role</p></th></tr>" +
+      "<tr><td><p>db-1</p></td><td><p>primary</p></td></tr></tbody></table>",
+  );
+
+  assert.match(markdown, /^## Restart$/m);
+  // Checklist state is carried by `data-checked`; a plain bullet would lose it.
+  assert.match(markdown, /^- \[x\] backup verified$/m);
+  assert.match(markdown, /^- \[ \] rotate keys$/m);
+  assert.match(markdown, /```\nuptime\n```/);
+  assert.match(markdown, /~~retired~~/);
+  // Turndown has no table rule of its own, so without ours a table would
+  // collapse into one run-on line.
+  assert.match(markdown, /^\| Host \| Role \|$/m);
+  assert.match(markdown, /^\| --- \| --- \|$/m);
+  assert.match(markdown, /^\| db-1 \| primary \|$/m);
+});
+
+test("note export flattens a Deep Link chip to its captured label", () => {
+  // A Deep Link only resolves inside KKTerm, so an exported note keeps the
+  // label the chip displays rather than an unusable target.
+  const markdown = noteHtmlToMarkdown(
+    '<p>See <span data-note-deep-link="connection:abc" data-note-label="edge-01">edge-01</span>.</p>',
+  );
+  assert.equal(markdown.trim(), "See edge-01.");
+});
+
+test("the export file name survives a Connection name that is not a file name", () => {
+  assert.equal(noteMarkdownFilename("prod/db: main*"), "prod db main.md");
+  // Non-ASCII names stay readable rather than collapsing to placeholders.
+  assert.equal(noteMarkdownFilename("正式資料庫"), "正式資料庫.md");
+  assert.equal(noteMarkdownFilename("///"), "note.md");
+});

--- a/tests/connection-notes-wiring.test.mjs
+++ b/tests/connection-notes-wiring.test.mjs
@@ -147,6 +147,23 @@ test("note commands are granted to the main window permission set", () => {
   }
 });
 
+test("Markdown export writes the same body shape the database stores", () => {
+  const editor = read("src/modules/notes/NoteEditorSheet.tsx");
+  // Export must not be a second, looser serialization path: it reuses the save
+  // path's sanitize + dehydrate pair, so an exported file can no more carry
+  // image bytes or unsanitized pasted markup than a saved note can.
+  assert.match(
+    editor,
+    /noteHtmlToMarkdown\(sanitizeNoteHtml\(dehydrateNoteAssets\(editor\.getHTML\(\)\)\)\)/,
+  );
+
+  const markdown = read("src/modules/notes/noteMarkdown.ts");
+  assert.match(markdown, /NOTE_IMAGE_DIRECTORY = "note-images"/);
+
+  const toolbar = read("src/modules/notes/NoteToolbar.tsx");
+  assert.match(toolbar, /notes\.toolbar\.exportMarkdown/);
+});
+
 test("the @ trigger and the toolbar picker share one Deep Link source", () => {
   // Two surfaces offering different targets would be a silent inconsistency,
   // so both must read the same choice list and the same ranking.


### PR DESCRIPTION
## Summary

Adds an export control to the Connection Note editor's toolbar that writes the note to a Markdown file. Images are not exported — the Markdown keeps a reference to each image's path instead.

The control sits at the right end of the toolbar next to find/replace, and opens a native save dialog defaulting to the Connection's name. It is disabled while the note is loading and on an empty note.

Export serializes **what is currently in the editor**, saved or not, so a note still being drafted can be handed off; it does not bind, save, or otherwise modify the note.

### Not a second serialization path

`handleExportMarkdown` runs the body through the same `sanitizeNoteHtml(dehydrateNoteAssets(editor.getHTML()))` pair the save path uses, rather than serializing raw editor HTML. An exported file therefore can no more carry image bytes or unsanitized pasted markup than a saved note row can. `tests/connection-notes-wiring.test.mjs` guards that invariant.

### Images

Images stay where they live — files under `note-images/` in the app data directory — and the Markdown carries a reference in the form `![alt](note-images/<connection id>/<file>.png)`. That is the asset's real relative path under the app data directory, so the exported file records which image was where without copying bytes. An image with no alt text uses its file name as the label. Moving notes *with* their images remains the full settings export.

### Conversion

Reuses the existing `turndown` dependency (already used by the Dashboard Notes widget) with rules for the structures notes hold that turndown does not model: GFM tables, Tiptap checklists (`- [x]` / `- [ ]`), and asset-backed images. Deep Link chips flatten to their captured label, since a Deep Link only resolves inside KKTerm. Underline and `notes.toolbar.highlight` have no Markdown equivalent and export as plain text — deliberately not emitting non-standard `==highlight==` syntax that renders as literal noise outside editors that support it.

## Type of change

- [x] Feature

## Areas touched

- [x] Frontend (React/TypeScript — `src/`)
- [x] Docs (`docs/`, manual, ADR)

## Domain & docs

- [x] Uses the canonical vocabulary (Connection / Session / Tab / Workspace / Module — not "profile" for a stored Connection)
- [x] Source placement follows `docs/ARCHITECTURE.md` → Frontend Source Map; reused typed wrappers in `src/lib/tauri.ts` where applicable — the new `saveMarkdownFile` wrapper follows the existing `pickAndSaveFile` / `selectPngSavePath` pattern, keeping `plugin-fs` writes inside `src/lib/tauri.ts`
- [x] New/changed behavior in a manual chapter's scope updates the relevant `docs/manual/` chapter — `docs/manual/21-connection-notes.md` gains an "Exporting a note to Markdown" section plus updated grep hints

## i18n

- [x] English keys added first in `src/i18n/locales/en.json`, and pending translation files added under `docs/localization_todo/` per the README flow
- [x] Named `{{…}}` placeholders, one full sentence per key (no concatenated fragments)

Five new keys (`notes.toolbar.exportMarkdown`, `notes.export.dialogTitle`, `notes.export.filterName`, `notes.notice.exported`, `notes.notice.exportFailed`) with best-effort translations in all 14 locales and a matching todo file per key. zh-TW uses 匯出 / 筆記 / 檔案, translated independently of zh-CN.

## UI / design language

- [x] Dialogs built from `src/app/ui/dialog` primitives; colors read from tokens (no hard-coded hex) — no new dialog or CSS; the control reuses the toolbar's existing `ToolButton`
- [x] Transient status uses `showStatusBarNotice` (no one-off toasts); no `window.alert/confirm/prompt`
- [x] Tutorial-capable UI wired with `data-tutorial-id` + nav/metadata mappings (`npm run check` passes) — no new tutorial target added; `notes.openNote` is unchanged

## High-risk invariants

- [x] No frontend close hooks / close-confirmation flows added
- [x] No live Session state added to the durable Connection model
- [x] RDP/VNC/WebView2 surface rules respected — untouched

## Checks

- [x] `npm run check` — `tsc --noEmit` clean; lint clean apart from one pre-existing warning in `RemoteFullscreenApp.tsx`; `i18n:check` passes at 4958 keys across all locales
- [ ] Validated in the real Tauri desktop runtime

Two caveats a reviewer should know:

1. **One pre-existing test failure.** `tests/workspace-shortcut-keymap.test.ts` fails (expects `Ctrl+Alt+Pause`, gets `Ctrl+Alt+PageDown`). It is unrelated to this change and was confirmed pre-existing by stashing these changes and re-running the test — it fails identically without them. Not fixed here.
2. **The save dialog and file write were not exercised.** They only run in the Tauri desktop runtime, so per AGENTS.md that path needs a real desktop run rather than Vite preview. Everything below it — HTML → Markdown conversion and the file-name sanitizer — is covered by `tests/connection-note-markdown-export.test.ts`.

## Notes for reviewers

New tests: `tests/connection-note-markdown-export.test.ts` (behavioral, over the pure `noteMarkdown.ts` module) covers the image reference, checklists/tables/strikethrough/headings/code blocks, Deep Link flattening, and file names built from Connection names that are not valid file names (including CJK, which stays readable rather than collapsing to placeholders). One guard added to `tests/connection-notes-wiring.test.mjs` for the shared-sanitizer invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
